### PR TITLE
docs: add slackbot integration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ npm install -g agent-messenger
 Or use your favorite package manager.
 
 This installs:
-- `agent-slack` — Slack CLI
+- `agent-slack` — Slack CLI (user token, zero-config)
+- `agent-slackbot` — Slack Bot CLI (bot token, for server-side/CI/CD)
 - `agent-discord` — Discord CLI
 - `agent-teams` — Microsoft Teams CLI
 
@@ -92,13 +93,14 @@ That's it. No OAuth flows. No API tokens. No configuration files.
 | File uploads | ✅ | ✅ | ✅ |
 | Workspace snapshots | ✅ | ✅ | ✅ |
 | Multi-workspace | ✅ | ✅ | ✅ |
-| Bot support | 🏗️ | 🏗️ | 🏗️ |
+| Bot support | ✅ | 🏗️ | 🏗️ |
 
 > **Note**: Teams tokens expire in 60-90 minutes. See [Teams Guide](docs/teams.md) for token refresh patterns.
 
 ## 📚 Platform Guides
 
 - **[Slack Guide](docs/slack.md)** — Full command reference for Slack
+- **[Slack Bot Guide](docs/slackbot.md)** — Bot token integration for server-side and CI/CD
 - **[Discord Guide](docs/discord.md)** — Full command reference for Discord
 - **[Teams Guide](docs/teams.md)** — Full command reference for Microsoft Teams
 
@@ -123,7 +125,7 @@ That's it. No OAuth flows. No API tokens. No configuration files.
 
 **Why not MCP?** MCP servers expose all tools at once, bloating context and confusing agents. **[Agent Skills](https://agentskills.io/) + agent-friendly CLI** offer a better approach—load what you need, when you need it. Fewer tokens, cleaner context, better output.
 
-**Why not OAuth?** OAuth requires an app and it requires workspace admin approval to install, which can take days. This tool just works—zero setup required. Bot support is on the roadmap for those who prefer it.
+**Why not OAuth?** OAuth requires an app and it requires workspace admin approval to install, which can take days. This tool just works—zero setup required. For those who prefer bot tokens (e.g., server-side or CI/CD), see [`agent-slackbot`](docs/slackbot.md).
 
 Inspired by [agent-browser](https://github.com/vercel-labs/agent-browser) from Vercel Labs.
 


### PR DESCRIPTION
## Summary

The README didn't mention the slackbot integration added in #10. This updates the README to reflect it.

## Changes

- Add `agent-slackbot` to installation section (bot token CLI for server-side/CI/CD)
- Update supported platforms table: Slack bot support ✅ (was 🏗️)
- Add Slack Bot Guide link to platform guides
- Update philosophy section to reference `agent-slackbot` instead of "bot support is on the roadmap"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to document Slack bot (agent-slackbot) support and bot-token workflows for server-side/CI/CD. Adds agent-slackbot to installation, marks Slack bot support as available, links the Slack Bot Guide, and updates the philosophy section.

<sup>Written for commit 3001efeccdd05e78e392f1646036f7738d00b309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

