### PR TITLE
fix: use apiCall for Slack unread/activity endpoints

### DIFF
--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -475,7 +475,7 @@ export class SlackClient {
 
   async getUnreadCounts(): Promise<SlackUnreadCounts> {
     return this.withRetry(async () => {
-      const response = await (this.client as any).client.counts()
+      const response = await this.client.apiCall('client.counts') as unknown as { channels?: any[]; ok?: boolean; error?: string }
       this.checkResponse(response)
 
       const channels = (response.channels || []).map((ch: any) => ({
@@ -524,11 +524,11 @@ export class SlackClient {
 
   async getActivityFeed(options?: { types?: string; mode?: string; limit?: number }): Promise<SlackActivityItem[]> {
     return this.withRetry(async () => {
-      const response = await (this.client as any).activity.feed({
+      const response = (await this.client.apiCall('activity.feed', {
         types: options?.types,
         mode: options?.mode || 'chrono_reads_and_unreads',
         limit: options?.limit || 20,
-      })
+      })) as unknown as { items?: any[]; ok?: boolean; error?: string }
       this.checkResponse(response)
 
       const items = (response.items || []).map((item: any) => ({


### PR DESCRIPTION
Fixes runtime errors when calling:
- `agent-slack unread counts`
- `agent-slack activity list`

The Slack WebClient does not expose `client.counts()` or `activity.feed` via direct methods in this SDK surface, so these calls now use:
- `apiCall('client.counts')`
- `apiCall('activity.feed', {...})`

Validation:
- `bun test src/platforms/slack/client.test.ts src/platforms/slack/commands/unread.test.ts src/platforms/slack/commands/activity.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime errors in Slack unread counts and activity feed by using Slack Web API apiCall for methods not exposed by the SDK. Restores the `agent-slack unread counts` and `agent-slack activity list` commands.

- **Bug Fixes**
  - Replaced direct WebClient calls with apiCall('client.counts') and apiCall('activity.feed', {...}).
  - Verified with tests for client, unread, and activity commands.

<sup>Written for commit 29b2f73ae0f3345b6af89fd4c1e7bab372b992b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

