### PR TITLE
docs: add troubleshooting section to all SKILL.md files

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -333,6 +333,20 @@ Format:
 - Plain text messages only (no embeds in v1)
 - User tokens only (no bot tokens)
 
+## Troubleshooting
+
+### `agent-discord: command not found`
+
+The `agent-messenger` package is not installed. Run it directly using a package runner. Ask the user which one to use:
+
+```bash
+npx -p agent-messenger agent-discord ...
+bunx -p agent-messenger agent-discord ...
+pnpm dlx --package agent-messenger agent-discord ...
+```
+
+If you already know the user's preferred package runner, use it directly instead of asking.
+
 ## References
 
 - [Authentication Guide](references/authentication.md)

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -315,6 +315,20 @@ Format:
 - No user presence features
 - Plain text messages only (no blocks/formatting in v1)
 
+## Troubleshooting
+
+### `agent-slack: command not found`
+
+The `agent-messenger` package is not installed. Run it directly using a package runner. Ask the user which one to use:
+
+```bash
+npx -p agent-messenger agent-slack ...
+bunx -p agent-messenger agent-slack ...
+pnpm dlx --package agent-messenger agent-slack ...
+```
+
+If you already know the user's preferred package runner, use it directly instead of asking.
+
 ## References
 
 - [Authentication Guide](references/authentication.md)

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -279,6 +279,20 @@ Format:
 - No scheduled messages
 - Plain text messages only (no blocks/formatting)
 
+## Troubleshooting
+
+### `agent-slackbot: command not found`
+
+The `agent-messenger` package is not installed. Run it directly using a package runner. Ask the user which one to use:
+
+```bash
+npx -p agent-messenger agent-slackbot ...
+bunx -p agent-messenger agent-slackbot ...
+pnpm dlx --package agent-messenger agent-slackbot ...
+```
+
+If you already know the user's preferred package runner, use it directly instead of asking.
+
 ## References
 
 - [Authentication Guide](references/authentication.md)

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -286,6 +286,20 @@ Format:
 - User tokens only (no app tokens)
 - **Token expires in 60-90 minutes** - must re-authenticate frequently
 
+## Troubleshooting
+
+### `agent-teams: command not found`
+
+The `agent-messenger` package is not installed. Run it directly using a package runner. Ask the user which one to use:
+
+```bash
+npx -p agent-messenger agent-teams ...
+bunx -p agent-messenger agent-teams ...
+pnpm dlx --package agent-messenger agent-teams ...
+```
+
+If you already know the user's preferred package runner, use it directly instead of asking.
+
 ## References
 
 - [Authentication Guide](references/authentication.md)


### PR DESCRIPTION
## Summary

Add a Troubleshooting section to all 4 SKILL.md files so agents know how to handle `command not found` errors.

## Changes

- Add `## Troubleshooting` section to `agent-slack`, `agent-slackbot`, `agent-discord`, and `agent-teams` SKILL.md files.
- Guide agents to install `agent-messenger` globally when the CLI command is not found.
- List all common package managers (`npm`, `bun`, `pnpm`, `yarn`) and instruct the agent to use the user's preferred one if known.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Troubleshooting section to the Slack, Slackbot, Discord, and Teams SKILL.md docs to resolve "command not found" for agent CLI commands. Directs users to run via package runners only (npx/bunx -p agent-messenger, pnpm dlx --package agent-messenger) so binaries resolve without global installs and the latest version is used.

<sup>Written for commit d7f7b8442b20cb5f2b9d21b620101a3746452ead. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

