### PR TITLE
Add JSON import attribute for Node.js ESM compatibility

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Command } from 'commander'
-import pkg from '../package.json'
+import pkg from '../package.json' with { type: 'json' }
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/src/platforms/discord/cli.ts
+++ b/src/platforms/discord/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander'
-import pkg from '../../../package.json'
+import pkg from '../../../package.json' with { type: 'json' }
 import {
   authCommand,
   channelCommand,

--- a/src/platforms/slack/cli.test.ts
+++ b/src/platforms/slack/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { spawn } from 'bun'
 import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
-import pkg from '../../../package.json'
+import pkg from '../../../package.json' with { type: 'json' }
 
 describe('CLI Framework', () => {
   describe('formatOutput utility', () => {

--- a/src/platforms/slack/cli.ts
+++ b/src/platforms/slack/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander'
-import pkg from '../../../package.json'
+import pkg from '../../../package.json' with { type: 'json' }
 import {
   activityCommand,
   authCommand,

--- a/src/platforms/slackbot/cli.ts
+++ b/src/platforms/slackbot/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander'
-import pkg from '../../../package.json'
+import pkg from '../../../package.json' with { type: 'json' }
 import { authCommand, channelCommand, messageCommand, reactionCommand, userCommand } from './commands/index'
 
 const program = new Command()

--- a/src/platforms/teams/cli.ts
+++ b/src/platforms/teams/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander'
-import pkg from '../../../package.json'
+import pkg from '../../../package.json' with { type: 'json' }
 import {
   authCommand,
   channelCommand,


### PR DESCRIPTION
## Summary

Fix `ERR_IMPORT_ATTRIBUTE_MISSING` when running CLI via `bunx` on Node.js v24. Node.js ESM requires `with { type: 'json' }` on JSON imports; Bun does not, so this was missed.

## Changes

- Add `with { type: 'json' }` import attribute to all `package.json` imports across 6 CLI entry points (`cli.ts`, `slack/cli.ts`, `discord/cli.ts`, `teams/cli.ts`, `slackbot/cli.ts`, `slack/cli.test.ts`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ERR_IMPORT_ATTRIBUTE_MISSING on Node.js v24 by adding with { type: 'json' } to package.json imports across six CLI entry points and one test. This restores bunx CLI usage under Node.js ESM and aligns with Node’s JSON import rules without affecting Bun.

<sup>Written for commit cc40f74f5191348e392951da0da1393f37879810. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

