### PR TITLE
Bump better-sqlite3 to ^12.0.0 for Node 24 compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "agent-slack",
       "dependencies": {
         "@slack/web-api": "^6.9.0",
-        "better-sqlite3": "^9.2.2",
+        "better-sqlite3": "^12.0.0",
         "classic-level": "^1.3.0",
         "commander": "^11.1.0",
         "zod": "^3.22.4",
@@ -127,7 +127,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "better-sqlite3": ["better-sqlite3@9.6.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ=="],
+    "better-sqlite3": ["better-sqlite3@12.6.2", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commander": "^11.1.0",
     "zod": "^3.22.4",
     "classic-level": "^1.3.0",
-    "better-sqlite3": "^9.2.2"
+    "better-sqlite3": "^12.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",


### PR DESCRIPTION
## Summary

Bump `better-sqlite3` from `^9.2.2` (resolved 9.6.0) to `^12.0.0` (resolved 12.6.2). Fixes `bunx -p agent-messenger@latest` failing with C++20 compilation errors on Node 24.

## Changes

- Update `better-sqlite3` version range in `package.json` from `^9.2.2` to `^12.0.0`.
- Regenerate `bun.lock` with resolved version 12.6.2.

## Context

v9.x has no prebuilt binaries for Node 24. When installed via `bunx`/`npx`, `prebuild-install` fails to find binaries and falls back to `node-gyp rebuild`, which errors because Node 24's V8 headers require C++20 and v9.x doesn't configure the correct compiler flags.

v12.x declares `engines: { node: "20.x || 22.x || 23.x || 24.x || 25.x" }` and Bun ships prebuilt binaries for it — installs in <2s with zero compilation. Verified by comparing with [vibe-notion](https://github.com/devxoul/vibe-notion) which uses `better-sqlite3@latest` and works fine.

No code changes needed — the API surface used (`new Database()`, `.prepare().get()`, `.close()`) is unchanged between v9 and v12.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped better-sqlite3 to ^12.0.0 to restore Node 24 compatibility and prevent node-gyp C++20 compilation during bunx/npx installs. No code changes; our API usage stays the same.

- **Dependencies**
  - Updated package.json to better-sqlite3 ^12.0.0 (resolves 12.6.2).
  - Regenerated bun.lock.
  - v12 declares Node 24 support and ships prebuilt binaries.

<sup>Written for commit 2fb67690fcf2f9b45bf67ee089e89b3e46f8b419. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

