### PR TITLE
Fix Node.js ESM module resolution in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "agent-slackbot": "./src/platforms/slackbot/cli.ts"
   },
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "tsc && tsc-alias --resolve-full-paths",
     "postbuild": "bun scripts/postbuild.ts",
     "test": "bun test src/",
     "test:e2e": "bun test e2e/",


### PR DESCRIPTION
## Summary

Fix `ERR_MODULE_NOT_FOUND` when running CLI via `npx`/`pnpm dlx`/`bunx` on Node.js. The compiled output was missing `.js` extensions on relative imports, which Node.js ESM requires.

## Changes

- Add `--resolve-full-paths` flag to `tsc-alias` in the build script so compiled imports include `.js` extensions (e.g., `./commands/index` → `./commands/index.js`).

## Context

Bun resolves extensionless imports automatically, so this was never caught during local development. Node.js ESM is strict — it requires explicit file extensions on all relative imports. This is the same fix already present in [vibe-notion](https://github.com/devxoul/vibe-notion).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Node.js ESM module resolution by emitting .js extensions for compiled relative imports. Resolves ERR_MODULE_NOT_FOUND when running the CLI via npx, pnpm dlx, or bunx.

- **Bug Fixes**
  - Update build script to use: tsc && tsc-alias --resolve-full-paths, so compiled imports include .js (e.g., ./commands/index → ./commands/index.js).

<sup>Written for commit 266ba45f5d521ce847652d2704aab8babf4a9804. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

