### PR TITLE
Fix agent-messenger subcommands broken when installed via npm

### DIFF
--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -4,6 +4,8 @@ const cliFiles = [
   'dist/src/cli.js',
   'dist/src/platforms/slack/cli.js',
   'dist/src/platforms/discord/cli.js',
+  'dist/src/platforms/teams/cli.js',
+  'dist/src/platforms/slackbot/cli.js',
 ]
 
 for (const file of cliFiles) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import pkg from '../package.json' with { type: 'json' }
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
+const ext = __filename.endsWith('.ts') ? '.ts' : '.js'
 
 const program = new Command()
 
@@ -14,15 +15,15 @@ program.name('agent-messenger').description('Multi-platform messaging CLI for AI
 
 // Use absolute paths for CWD-independence
 program.command('slack', 'Interact with Slack workspaces', {
-  executableFile: join(__dirname, 'platforms', 'slack', 'cli.ts'),
+  executableFile: join(__dirname, 'platforms', 'slack', `cli${ext}`),
 })
 
 program.command('discord', 'Interact with Discord guilds', {
-  executableFile: join(__dirname, 'platforms', 'discord', 'cli.ts'),
+  executableFile: join(__dirname, 'platforms', 'discord', `cli${ext}`),
 })
 
 program.command('teams', 'Interact with Microsoft Teams', {
-  executableFile: join(__dirname, 'platforms', 'teams', 'cli.ts'),
+  executableFile: join(__dirname, 'platforms', 'teams', `cli${ext}`),
 })
 
 program.parse(process.argv)


### PR DESCRIPTION
## Summary

Fix `bunx agent-messenger slack` (and `discord`, `teams`) failing with `MODULE_NOT_FOUND` when installed via npm. The compiled CLI was trying to load `.ts` files that don't exist in `dist/`.

## Changes

- Detect file extension dynamically in `src/cli.ts` so Commander's `executableFile` resolves `.ts` under Bun (dev) and `.js` under Node (published).
- Add missing `teams/cli.js` and `slackbot/cli.js` to `postbuild.ts` shebang replacement list.

## Context

`src/cli.ts` hardcoded `.ts` in `executableFile` paths (e.g., `join(__dirname, 'platforms', 'slack', 'cli.ts')`). After `tsc` compiles to `dist/`, the string literal stays `.ts` but the actual files are `.js`. Node.js then fails with `Cannot find module ...dist/src/platforms/slack/cli.ts`.

Same class of issue as #18 — Bun is lenient about things Node.js is strict about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix agent-messenger subcommands (slack, discord, teams) failing with MODULE_NOT_FOUND when installed via npm. The CLI now detects .ts vs .js at runtime for subcommand entry paths and updates postbuild to include teams and slackbot shebang replacements, so Node loads the compiled files correctly.

<sup>Written for commit a27b0c1c227b2b78d57ff08cb2274f911cdf5f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

