### PR TITLE
Add slackbot subcommand to main CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,10 @@ program.command('teams', 'Interact with Microsoft Teams', {
   executableFile: join(__dirname, 'platforms', 'teams', `cli${ext}`),
 })
 
+program.command('slackbot', 'Interact with Slack using bot tokens', {
+  executableFile: join(__dirname, 'platforms', 'slackbot', `cli${ext}`),
+})
+
 program.parse(process.argv)
 
 export default program


### PR DESCRIPTION
## Summary

Register `slackbot` as a subcommand of the main `agent-messenger` CLI, matching the existing pattern for `slack`, `discord`, and `teams`.

## Changes

- Add `slackbot` subcommand to `src/cli.ts` pointing to `platforms/slackbot/cli`, so `agent-messenger slackbot` (or `amsg slackbot`) works as an alternative to the standalone `agent-slackbot` binary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a slackbot subcommand to the main agent-messenger CLI. You can now run the Slack bot with agent-messenger slackbot or amsg slackbot without using the standalone agent-slackbot binary.

- **New Features**
  - Registered slackbot subcommand pointing to platforms/slackbot/cli with the description “Interact with Slack using bot tokens.”

<sup>Written for commit 1e4f5a2bdafd64ee3d450c4024f4a987ea0fa641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

