### PR TITLE
Fix Teams auth extraction failing in npm-published version

### DIFF
--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -1,9 +1,12 @@
 import { execSync } from 'node:child_process'
 import { createDecipheriv, pbkdf2Sync } from 'node:crypto'
 import { copyFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DerivedKeyCache } from '@/shared/utils/derived-key-cache'
+
+const require = createRequire(import.meta.url)
 
 export interface ExtractedTeamsToken {
   token: string


### PR DESCRIPTION
## Summary

Fix `agent-teams auth extract` returning "No Teams token found" when installed via npm, while working correctly from source.

## Changes

- Add `createRequire` from `node:module` to `src/platforms/teams/token-extractor.ts`, matching the existing pattern in the Slack token extractor.

## Context

The Teams token extractor uses runtime `require()` to load `bun:sqlite` or `better-sqlite3`. The project is ESM (`"type": "module"`), and Node.js does not provide `require()` in ESM — causing a silent `ReferenceError` caught by try-catch → `null` → "No Teams token found".

Bun supports `require()` in ESM natively, so `bun run src/cli.ts` works fine. The npm-published version runs with `#!/usr/bin/env node` (Node.js), where it fails.

Same class of issue as #19 — Bun is lenient about things Node.js is strict about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Teams token extraction failing in the npm-published CLI on Node.js (ESM). Uses createRequire to load SQLite drivers so it no longer returns "No Teams token found".

<sup>Written for commit ab1eddfcac8fcfaae10ebc006d8fc6f27622b7d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

