### PR TITLE
fix(slack): include reactions in message list, get, and replies output

### DIFF
--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -509,6 +509,7 @@ export class SlackClient {
               ts: msg.edited.ts || '',
             }
           : undefined,
+        reactions: msg.reactions,
         files: msg.files?.map((f: any) => ({
           id: f.id!,
           name: f.name!,

--- a/src/platforms/slack/commands/message.ts
+++ b/src/platforms/slack/commands/message.ts
@@ -64,6 +64,7 @@ async function listAction(
       thread_ts: msg.thread_ts,
       reply_count: msg.reply_count,
       edited: msg.edited,
+      reactions: msg.reactions,
       files: msg.files,
     }))
 
@@ -101,6 +102,7 @@ async function getAction(channelInput: string, ts: string, options: { pretty?: b
       thread_ts: message.thread_ts,
       reply_count: message.reply_count,
       edited: message.edited,
+      reactions: message.reactions,
       files: message.files,
     }
 
@@ -239,6 +241,7 @@ async function repliesAction(
       thread_ts: msg.thread_ts,
       reply_count: msg.reply_count,
       edited: msg.edited,
+      reactions: msg.reactions,
       files: msg.files,
     }))
 


### PR DESCRIPTION
## Summary

Reactions were silently dropped from `message list`, `message get`, and `message replies` output. The Slack API returns reactions in both `conversations.history` and `conversations.replies` responses, but the code stripped them at two layers.

## Changes

### Client mapping (`src/platforms/slack/client.ts`)

- Add `reactions: msg.reactions` to `getThreadReplies()` message mapping, matching the existing pattern in `getMessages()` and `getMessage()`.

### CLI output (`src/platforms/slack/commands/message.ts`)

- Include `reactions` field in output for `listAction`, `getAction`, and `repliesAction`. Previously all three mapped every field except reactions.

## Verification

- `bun typecheck` — clean.
- `bun test` — 72 tests pass across `client.test.ts` and `message.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Slack reactions in message list, get, and replies outputs. Reactions are now mapped in getThreadReplies and included in the CLI output for all three commands.

<sup>Written for commit 932f13a52c672efea6373e533fdbc1e7280bc9d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

