### PR TITLE
Fix missing and misleading info in SKILL.md files

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -55,6 +55,20 @@ agent-discord auth status
 
 ## Commands
 
+### Auth Commands
+
+```bash
+# Extract token from Discord desktop app (usually automatic)
+agent-discord auth extract
+agent-discord auth extract --debug
+
+# Check auth status
+agent-discord auth status
+
+# Logout from Discord
+agent-discord auth logout
+```
+
 ### Message Commands
 
 ```bash
@@ -352,13 +366,13 @@ Common causes:
 If the package is installed globally, use `agent-discord` directly:
 
 ```bash
-agent-discord message list general
+agent-discord server list
 ```
 
 If the package is NOT installed, use `bunx agent-messenger discord`:
 
 ```bash
-bunx agent-messenger discord message list general
+bunx agent-messenger discord server list
 ```
 
 **NEVER run `bunx agent-discord`** — it will fail or install a wrong package since `agent-discord` is not the npm package name.

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -49,11 +49,29 @@ agent-slack workspace switch <workspace-id>
 # Show current workspace
 agent-slack workspace current
 
+# Remove a workspace
+agent-slack workspace remove <workspace-id>
+
 # Check auth status
 agent-slack auth status
 ```
 
 ## Commands
+
+### Auth Commands
+
+```bash
+# Extract tokens from Slack desktop app (usually automatic)
+agent-slack auth extract
+agent-slack auth extract --debug
+
+# Check auth status
+agent-slack auth status
+
+# Logout from a workspace (defaults to current)
+agent-slack auth logout
+agent-slack auth logout <workspace-id>
+```
 
 ### Message Commands
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -53,7 +53,37 @@ agent-teams team current
 agent-teams auth status
 ```
 
+### Multi-Account Support (Work / Personal)
+
+```bash
+# Switch between work and personal accounts
+agent-teams auth switch-account work
+agent-teams auth switch-account personal
+
+# Use a specific account for one command (without switching)
+agent-teams snapshot --account work
+```
+
 ## Commands
+
+### Auth Commands
+
+```bash
+# Extract token from Teams desktop app (usually automatic)
+agent-teams auth extract
+agent-teams auth extract --debug
+
+# Check auth status (includes token expiry info)
+agent-teams auth status
+
+# Logout from Microsoft Teams
+agent-teams auth logout
+
+# Switch between work and personal accounts
+agent-teams auth switch-account <account-type>
+agent-teams auth switch-account work
+agent-teams auth switch-account personal
+```
 
 ### Message Commands
 
@@ -101,6 +131,9 @@ agent-teams team switch <team-id>
 
 # Show current team
 agent-teams team current
+
+# Remove a team from config
+agent-teams team remove <team-id>
 ```
 
 ### User Commands
@@ -281,13 +314,13 @@ Common causes:
 If the package is installed globally, use `agent-teams` directly:
 
 ```bash
-agent-teams message list general
+agent-teams team list
 ```
 
 If the package is NOT installed, use `bunx agent-messenger teams`:
 
 ```bash
-bunx agent-messenger teams message list general
+bunx agent-messenger teams team list
 ```
 
 **NEVER run `bunx agent-teams`** — it will fail or install a wrong package since `agent-teams` is not the npm package name.


### PR DESCRIPTION
## Summary

Audit all 5 SKILL.md files against actual CLI implementations (`--help` output + source code). Fix undocumented commands and incorrect examples in 3 of 5 files. `agent-slackbot` and `agent-discordbot` are accurate — no changes needed.

## Changes

### agent-teams SKILL.md (most issues)

- Add Multi-Account Support section — `--account <type>` global option and `auth switch-account` command were completely undocumented.
- Add Auth Commands section — `auth extract`, `auth logout`, `auth status`, and `auth switch-account` now formally documented under Commands.
- Add `team remove` command — existed in CLI but missing from docs.
- Fix troubleshooting example — was `agent-teams message list general` which is wrong on two levels: missing required `<team-id>` argument, and Teams uses UUID channel IDs not names. Changed to `agent-teams team list`.

### agent-slack SKILL.md

- Add `workspace remove` to Workspace Commands — existed in CLI but missing from docs.
- Add Auth Commands section — `auth extract`, `auth logout`, and `auth status` now formally documented under Commands (previously only `auth status` appeared in the Multi-Workspace section, and `auth extract` only in Troubleshooting).

### agent-discord SKILL.md

- Add Auth Commands section — `auth extract`, `auth logout`, and `auth status` now formally documented under Commands.
- Fix troubleshooting example — was `agent-discord message list general` but Discord uses Snowflake IDs, not channel names. Changed to `agent-discord server list`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align SKILL.md docs with actual CLI behavior for Teams, Slack, and Discord by documenting missing auth/remove commands and fixing incorrect examples. This removes misleading guidance and improves onboarding.

- **Bug Fixes**
  - agent-teams: document multi-account support (--account, auth switch-account), add Auth Commands (extract, status, logout), add team remove, fix troubleshooting example to use team list.
  - agent-slack: add Auth Commands (extract, status, logout), document workspace remove.
  - agent-discord: add Auth Commands (extract, status, logout), fix troubleshooting example to use server list.

<sup>Written for commit ff8b962855239b0feb7ec2034c708144b6038015. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

