### PR TITLE
fix(slack): parse doubly-nested files.uploadV2 response correctly

### DIFF
--- a/src/platforms/slack/client.test.ts
+++ b/src/platforms/slack/client.test.ts
@@ -699,16 +699,23 @@ describe('SlackClient', () => {
     test('uploads file to channels', async () => {
       mockWebClient.files.uploadV2.mockResolvedValue({
         ok: true,
-        file: {
-          id: 'F123',
-          name: 'test.txt',
-          title: 'test.txt',
-          mimetype: 'text/plain',
-          size: 100,
-          url_private: 'https://...',
-          created: 1234567890,
-          user: 'U123',
-        },
+        files: [
+          {
+            ok: true,
+            files: [
+              {
+                id: 'F123',
+                name: 'test.txt',
+                title: 'test.txt',
+                mimetype: 'text/plain',
+                size: 100,
+                url_private: 'https://...',
+                created: 1234567890,
+                user: 'U123',
+              },
+            ],
+          },
+        ],
       })
 
       const client = new SlackClient('xoxc-token', 'xoxd-cookie')
@@ -726,6 +733,32 @@ describe('SlackClient', () => {
       mockWebClient.files.uploadV2.mockResolvedValue({
         ok: false,
         error: 'file_upload_failed',
+      })
+
+      const client = new SlackClient('xoxc-token', 'xoxd-cookie')
+      // @ts-expect-error - accessing private property for testing
+      client.client = mockWebClient as unknown as WebClient
+
+      await expect(client.uploadFile(['C123'], Buffer.from('test'), 'test.txt')).rejects.toThrow(SlackError)
+    })
+
+    test('throws SlackError when response has empty files array', async () => {
+      mockWebClient.files.uploadV2.mockResolvedValue({
+        ok: true,
+        files: [],
+      })
+
+      const client = new SlackClient('xoxc-token', 'xoxd-cookie')
+      // @ts-expect-error - accessing private property for testing
+      client.client = mockWebClient as unknown as WebClient
+
+      await expect(client.uploadFile(['C123'], Buffer.from('test'), 'test.txt')).rejects.toThrow(SlackError)
+    })
+
+    test('throws SlackError when completion has no inner files', async () => {
+      mockWebClient.files.uploadV2.mockResolvedValue({
+        ok: true,
+        files: [{ ok: true, files: [] }],
       })
 
       const client = new SlackClient('xoxc-token', 'xoxd-cookie')

--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -415,7 +415,11 @@ export class SlackClient {
       })
       this.checkResponse(response)
 
-      const f = response.file as any
+      const completionFiles = (response as any).files?.[0]?.files
+      const f = completionFiles?.[0]
+      if (!f) {
+        throw new SlackError('No file returned in upload response', 'file_not_found')
+      }
       return {
         id: f.id!,
         name: f.name!,


### PR DESCRIPTION
## Summary

Fix `Cannot read properties of undefined (reading 'id')` error on `file upload`. The Slack SDK's `files.uploadV2` returns a doubly-nested response (`{ files: [{ files: [File] }] }`), but the code accessed `response.file` (singular, non-existent property) which was always `undefined`.

## Changes

- **`src/platforms/slack/client.ts`** — Navigate the doubly-nested response with safe optional chaining. Throw a clear `SlackError` when no file object is found in the response.
- **`src/platforms/slack/client.test.ts`** — Update existing upload mock to match the real API response shape. Add tests for empty outer `files` array and missing inner `files`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix file uploads by correctly parsing Slack files.uploadV2’s doubly-nested response. Prevents “Cannot read properties of undefined (reading 'id')” and returns the uploaded file reliably.

- **Bug Fixes**
  - Read file from response.files[0].files[0] with safe optional chaining.
  - Throw SlackError (file_not_found) when no file is returned.
  - Update tests to match real API shape and cover empty/missing files cases.

<sup>Written for commit 342bf8bb097f60a2803a77a84270cb64e2e97c5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

