### PR TITLE
Add Windows DPAPI cookie decryption support

### DIFF
--- a/src/platforms/slack/token-extractor.test.ts
+++ b/src/platforms/slack/token-extractor.test.ts
@@ -31,9 +31,9 @@ function createCookiesDb(
 }
 
 describe('TokenExtractor Windows DPAPI', () => {
-  test('decryptDpapi returns null on non-win32 platform', () => {
+  test('decryptDPAPI returns null on non-win32 platform', () => {
     const extractor = new TokenExtractor('darwin', '/tmp/slack-test')
-    expect(extractor.decryptDpapi(Buffer.from('test'))).toBeNull()
+    expect(extractor.decryptDPAPI(Buffer.from('test'))).toBeNull()
   })
 
   test('decryptV10CookieWindows decrypts AES-256-GCM with master key from Local State', () => {
@@ -65,7 +65,7 @@ describe('TokenExtractor Windows DPAPI', () => {
       override getWindowsMasterKey(): null {
         return null
       }
-      override decryptDpapi(_encrypted: Buffer): Buffer | null {
+      override decryptDPAPI(_encrypted: Buffer): Buffer | null {
         return Buffer.from('xoxd-dpapiDirectCookie%2B')
       }
     }
@@ -78,7 +78,7 @@ describe('TokenExtractor Windows DPAPI', () => {
 
   test('tryDecryptCookie handles Windows pre-v80 cookies without version prefix', () => {
     class TestTokenExtractor extends TokenExtractor {
-      override decryptDpapi(_encrypted: Buffer): Buffer | null {
+      override decryptDPAPI(_encrypted: Buffer): Buffer | null {
         return Buffer.from('xoxd-preV80Cookie%2B')
       }
     }
@@ -101,7 +101,7 @@ describe('TokenExtractor Windows DPAPI', () => {
     writeFileSync(join(slackDir, 'Local State'), JSON.stringify(localState))
 
     class TestTokenExtractor extends TokenExtractor {
-      override decryptDpapi(encrypted: Buffer): Buffer | null {
+      override decryptDPAPI(encrypted: Buffer): Buffer | null {
         if (encrypted.equals(dpapiPayload)) {
           return fakeDecryptedKey
         }
@@ -167,7 +167,7 @@ describe('TokenExtractor Windows DPAPI', () => {
     writeFileSync(join(leveldbDir, '000001.log'), `"${token}"T12345678"name":"test-workspace"`)
 
     class TestTokenExtractor extends TokenExtractor {
-      override decryptDpapi(encrypted: Buffer): Buffer | null {
+      override decryptDPAPI(encrypted: Buffer): Buffer | null {
         if (encrypted.equals(dpapiPayload)) {
           return masterKey
         }

--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -484,7 +484,7 @@ export class TokenExtractor {
 
     // Windows pre-v80: DPAPI applied directly (no version prefix)
     if (this.platform === 'win32' && encrypted.length > 0) {
-      const decrypted = this.decryptDpapi(encrypted)
+      const decrypted = this.decryptDPAPI(encrypted)
       if (decrypted) {
         const text = decrypted.toString('utf8')
         const match = text.match(/xoxd-[A-Za-z0-9%]+/)
@@ -522,7 +522,7 @@ export class TokenExtractor {
     try {
       const masterKey = this.getWindowsMasterKey()
       if (!masterKey) {
-        const decrypted = this.decryptDpapi(encrypted.subarray(3))
+        const decrypted = this.decryptDPAPI(encrypted.subarray(3))
         if (!decrypted) return null
         const text = decrypted.toString('utf8')
         const match = text.match(/xoxd-[A-Za-z0-9%]+/)
@@ -539,7 +539,7 @@ export class TokenExtractor {
       const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8')
 
       const match = decrypted.match(/xoxd-[A-Za-z0-9%]+/)
-      return match ? match[0] : decrypted
+      return match ? match[0] : null
     } catch {
       return null
     }
@@ -565,13 +565,13 @@ export class TokenExtractor {
         return null
       }
 
-      return this.decryptDpapi(encryptedKey.subarray(5))
+      return this.decryptDPAPI(encryptedKey.subarray(5))
     } catch {
       return null
     }
   }
 
-  decryptDpapi(encrypted: Buffer): Buffer | null {
+  decryptDPAPI(encrypted: Buffer): Buffer | null {
     if (this.platform !== 'win32') {
       return null
     }


### PR DESCRIPTION
## Summary

Enable auto-extraction of Slack cookies on Windows by decrypting Chromium cookies via DPAPI. Uses PowerShell `ProtectedData.Unprotect()` — zero native dependencies.

## Changes

### Chromium v80+ decryption (primary path)
- Read `Local State` file → extract `os_crypt.encrypted_key`.
- Base64 decode → strip `DPAPI` prefix → decrypt master key via PowerShell `EncodedCommand`.
- Decrypt cookie values with AES-256-GCM using the master key.
- Cookie format: `v10` prefix (3B) + nonce (12B) + ciphertext + GCM auth tag (16B).

### Pre-v80 fallback
- Direct DPAPI decryption on raw encrypted cookie values (no AES layer, no version prefix).

### PowerShell integration
- Use `-EncodedCommand` (base64 UTF-16LE) to avoid shell quoting issues.
- `-NoProfile -NonInteractive` flags with 10s timeout for reliability.

### Tests
- 8 new tests: AES-256-GCM round-trip, DPAPI fallback, `Local State` parsing, missing/malformed `Local State`, pre-v80 cookies, end-to-end extraction with mocked DPAPI.

## Verified

- `bun run typecheck` — 0 errors.
- `bun run lint` — 0 warnings, 166 files clean.
- `bun test` — 850 pass, 0 fail, 1596 expect() calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows DPAPI decryption for Slack cookies to enable automatic token extraction on Windows without native dependencies. Supports Chromium v80+ “v10” cookies, falls back to direct DPAPI for pre‑v80 cookies, and standardizes DPAPI method naming and return values.

- **New Features**
  - Reads Local State to get os_crypt.encrypted_key, strips DPAPI, and decrypts via PowerShell ProtectedData.Unprotect.
  - Decrypts v10 cookies with AES-256-GCM using the master key and extracts the xoxd- value.
  - Falls back to direct DPAPI when Local State is missing or for legacy cookies without a version prefix.
  - Adds tests for Local State parsing, AES round-trip, DPAPI fallback, and end-to-end extraction.

<sup>Written for commit 50a6a0661274286a35884f31f229b091b62c6b5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

