### PR TITLE
Fix spy leak and unsafe error cast from PR #32 review

### DIFF
--- a/src/platforms/slack/ensure-auth.ts
+++ b/src/platforms/slack/ensure-auth.ts
@@ -27,7 +27,9 @@ export async function ensureSlackAuth(): Promise<void> {
       await credManager.setCurrentWorkspace(validWorkspaces[0].workspace_id)
     }
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EBUSY' || (error as Error).message.includes('locking the cookie')) {
+    const code = typeof error === 'object' && error !== null ? (error as NodeJS.ErrnoException).code : undefined
+    const message = error instanceof Error ? error.message : String(error)
+    if (code === 'EBUSY' || message.includes('locking the cookie')) {
       throw error
     }
     // Silently ignore other extraction errors (e.g. Slack not installed)

--- a/src/platforms/slack/token-extractor.test.ts
+++ b/src/platforms/slack/token-extractor.test.ts
@@ -153,10 +153,12 @@ describe('TokenExtractor Windows DPAPI', () => {
     })
 
     // when — then
-    const extractor = new TokenExtractor('darwin', slackDir)
-    await expect(extractor.extract()).rejects.toThrow('Quit the Slack app completely and try again')
-
-    copyFileSyncSpy.mockRestore()
+    try {
+      const extractor = new TokenExtractor('darwin', slackDir)
+      await expect(extractor.extract()).rejects.toThrow('Quit the Slack app completely and try again')
+    } finally {
+      copyFileSyncSpy.mockRestore()
+    }
   })
 
   test('extract decrypts Windows v10 cookies end-to-end with mocked DPAPI', async () => {


### PR DESCRIPTION
## Summary

Address review feedback from #32 (identified by cubic).

## Changes

- **`token-extractor.test.ts`** — Wrap `copyFileSyncSpy.mockRestore()` in a `finally` block so the global `fs` mock cannot leak when the assertion throws.
- **`ensure-auth.ts`** — Use defensive type checks (`typeof error === 'object'`, `instanceof Error`) in the catch block instead of bare casts, preventing a secondary throw on non-Error objects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leaking fs spy in tests and hardens ensureSlackAuth error handling to avoid secondary crashes. Improves test isolation and prevents noisy failures when non-Error values are thrown.

- **Bug Fixes**
  - token-extractor.test.ts: Restore copyFileSync spy in a finally block to prevent fs mock leaks on assertion failure.
  - ensure-auth.ts: Use defensive checks for error.code and error.message; only rethrow on EBUSY or “locking the cookie”.

<sup>Written for commit 5ab1bbe92c29fd68373e5774b8cb16a29be9bb83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

