### PR TITLE
Fix Slack token extraction failing on newer LevelDB fragmentation markers

### DIFF
--- a/src/platforms/slack/token-extractor.test.ts
+++ b/src/platforms/slack/token-extractor.test.ts
@@ -31,6 +31,91 @@ function createCookiesDb(
   db.close()
 }
 
+describe('TokenExtractor LevelDB fragmentation markers', () => {
+  function buildFragmentedLdbContent(tokenParts: string[], marker: number[]): Buffer {
+    // given — build binary content simulating LevelDB fragmentation:
+    // token segments joined by 4-byte marker instead of hyphens
+    const segments: Buffer[] = []
+    for (let i = 0; i < tokenParts.length; i++) {
+      segments.push(Buffer.from(tokenParts[i]))
+      if (i < tokenParts.length - 1) {
+        segments.push(Buffer.from(marker))
+      }
+    }
+    // Surround with team ID context and a terminator
+    const prefix = Buffer.from('"team_name":"test-workspace"T12345678')
+    const suffix = Buffer.from('"')
+    return Buffer.concat([prefix, segments[0] ? Buffer.concat(segments) : Buffer.alloc(0), suffix])
+  }
+
+  test('extracts token with old fragmentation marker [19 0d f0 NN]', async () => {
+    // given
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-marker-old-'))
+    tempDirs.push(slackDir)
+
+    const hex64 = 'a'.repeat(64)
+    const tokenParts = ['xoxc-1111111111', '2222222222', '3333333333', hex64]
+    const content = buildFragmentedLdbContent(tokenParts, [0x19, 0x0d, 0xf0, 0x5e])
+
+    const leveldbDir = join(slackDir, 'Local Storage', 'leveldb')
+    mkdirSync(leveldbDir, { recursive: true })
+    writeFileSync(join(leveldbDir, '000001.ldb'), content)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(`xoxc-1111111111-2222222222-3333333333-${hex64}`)
+  })
+
+  test('extracts token with new fragmentation marker [15 0b f0 43]', async () => {
+    // given — marker whose 4th byte (0x43 = "C") is a valid hex char
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-marker-new-'))
+    tempDirs.push(slackDir)
+
+    const hex64 = 'b'.repeat(64)
+    const tokenParts = ['xoxc-4063338523', '4063338531', '8150876260673', hex64]
+    const content = buildFragmentedLdbContent(tokenParts, [0x15, 0x0b, 0xf0, 0x43])
+
+    const leveldbDir = join(slackDir, 'Local Storage', 'leveldb')
+    mkdirSync(leveldbDir, { recursive: true })
+    writeFileSync(join(leveldbDir, '000001.ldb'), content)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then — 0x43 ("C") must NOT leak into the token
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(`xoxc-4063338523-4063338531-8150876260673-${hex64}`)
+    expect(result[0].token).not.toContain('C')
+  })
+
+  test('extracts token with new fragmentation marker [15 0b f0 58]', async () => {
+    // given — marker whose 4th byte (0x58 = "X") is not a valid hex char
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-marker-58-'))
+    tempDirs.push(slackDir)
+
+    const hex64 = 'c'.repeat(64)
+    const tokenParts = ['xoxc-5555555555', '6666666666', '7777777777', hex64]
+    const content = buildFragmentedLdbContent(tokenParts, [0x15, 0x0b, 0xf0, 0x58])
+
+    const leveldbDir = join(slackDir, 'Local Storage', 'leveldb')
+    mkdirSync(leveldbDir, { recursive: true })
+    writeFileSync(join(leveldbDir, '000001.ldb'), content)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(`xoxc-5555555555-6666666666-7777777777-${hex64}`)
+  })
+})
+
 describe('TokenExtractor Windows DPAPI', () => {
   test('decryptDPAPI returns null on non-win32 platform', () => {
     const extractor = new TokenExtractor('darwin', '/tmp/slack-test')

--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -305,8 +305,10 @@ export class TokenExtractor {
         i++
       } else {
         // Check for 4-byte fragmentation marker pattern
-        // Pattern: 0x19 0x0d 0xf0 0xNN (where NN varies)
-        if (i + 3 < chunk.length && chunk[i] === 0x19 && chunk[i + 1] === 0x0d && chunk[i + 2] === 0xf0) {
+        // LevelDB compaction inserts 4-byte markers where hyphens should be.
+        // Known patterns: [19 0d f0 NN], [15 0b f0 NN] — the 3rd byte (0xf0) is consistent.
+        // Match any 4-byte sequence where byte at offset +2 is 0xf0.
+        if (i + 3 < chunk.length && chunk[i + 2] === 0xf0) {
           // Skip the 4 garbage bytes and insert a hyphen
           result.push(0x2d) // hyphen
           i += 4


### PR DESCRIPTION
## Summary

Fix `invalid_auth` errors caused by corrupted token reconstruction from newer LevelDB `.ldb` files. The parser hardcoded one fragmentation marker pattern (`0x19 0x0d 0xf0`) but newer compacted files use different prefixes (e.g. `0x15 0x0b 0xf0`). When an unrecognized marker's 4th byte happened to be a valid hex character (e.g. `0x43` = `C`), it leaked into the reconstructed token, corrupting it silently.

## Changes

### `token-extractor.ts`

- Generalize the fragmentation marker check in `extractTokenFromBuffer()` to match any 4-byte sequence where the 3rd byte is `0xf0`, instead of requiring exact `0x19 0x0d` prefix bytes. This handles both known marker variants and future ones.

### `token-extractor.test.ts`

- Add 3 tests covering old marker (`[19 0d f0 5e]`), new marker with hex-valid 4th byte (`[15 0b f0 43]`), and new marker with non-hex 4th byte (`[15 0b f0 58]`).

## Verified

- `bun test` — 12 pass, 0 fail.
- `bun typecheck` — clean.
- `bun lint` — clean, 166 files checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid_auth errors when parsing Slack tokens from LevelDB by handling newer fragmentation markers. The parser now treats any 4-byte marker with 0xf0 as the third byte as a hyphen, preventing stray bytes from corrupting tokens.

- **Bug Fixes**
  - Generalized marker detection in extractTokenFromBuffer to match any 4-byte sequence where byte 3 is 0xf0.
  - Added tests for old marker and new markers (with hex-valid and non-hex 4th bytes).

<sup>Written for commit d3be0b0c1cfc79d08f807dbccaeb968da46008ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

