### PR TITLE
Show specific error messages for Slack auth extraction failures

### DIFF
--- a/src/platforms/slack/commands/auth.test.ts
+++ b/src/platforms/slack/commands/auth.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { mkdirSync, rmSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { getExtractionErrorMessage } from '@/platforms/slack/commands/auth'
 import { CredentialManager } from '@/platforms/slack/credential-manager'
 import { type ExtractedWorkspace, TokenExtractor } from '@/platforms/slack/token-extractor'
 
@@ -348,6 +349,28 @@ describe('Output Formatting', () => {
 
     // Then: Should be valid JSON
     expect(JSON.parse(json)).toEqual(output)
+  })
+})
+
+describe('getExtractionErrorMessage', () => {
+  test('returns cookie failure message for missing_cookie', () => {
+    expect(getExtractionErrorMessage(['missing_cookie'])).toContain('Cookie extraction failed')
+  })
+
+  test('returns session expired message for invalid_auth', () => {
+    expect(getExtractionErrorMessage(['invalid_auth'])).toContain('session has expired')
+  })
+
+  test('prioritizes missing_cookie over invalid_auth', () => {
+    expect(getExtractionErrorMessage(['invalid_auth', 'missing_cookie'])).toContain('Cookie extraction failed')
+  })
+
+  test('returns generic message for unknown error codes', () => {
+    expect(getExtractionErrorMessage(['unknown_error'])).toContain('Extracted tokens are invalid')
+  })
+
+  test('returns generic message for empty failure list', () => {
+    expect(getExtractionErrorMessage([])).toContain('Extracted tokens are invalid')
   })
 })
 

--- a/src/platforms/slack/commands/auth.ts
+++ b/src/platforms/slack/commands/auth.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander'
 import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
-import { SlackClient } from '../client'
+import { SlackClient, SlackError } from '../client'
 import { CredentialManager } from '../credential-manager'
 import { TokenExtractor } from '../token-extractor'
 
@@ -58,6 +58,7 @@ async function extractAction(options: { pretty?: boolean; debug?: boolean }): Pr
     const config = await credManager.load()
 
     const validWorkspaces = []
+    const failureReasons: string[] = []
     for (const ws of workspaces) {
       if (options.debug) {
         console.error(`[debug] Testing credentials for ${ws.workspace_id}...`)
@@ -74,6 +75,10 @@ async function extractAction(options: { pretty?: boolean; debug?: boolean }): Pr
           console.error(`[debug] ✓ Valid: ${authInfo.team} (${authInfo.user})`)
         }
       } catch (error) {
+        const code = error instanceof SlackError ? error.code : undefined
+        if (code && !failureReasons.includes(code)) {
+          failureReasons.push(code)
+        }
         if (options.debug) {
           console.error(`[debug] ✗ Invalid: ${(error as Error).message}`)
         }
@@ -81,11 +86,13 @@ async function extractAction(options: { pretty?: boolean; debug?: boolean }): Pr
     }
 
     if (validWorkspaces.length === 0) {
+      const errorMessage = getExtractionErrorMessage(failureReasons)
       console.log(
         formatOutput(
           {
-            error: 'Extracted tokens are invalid. Make sure you are logged into the Slack desktop app.',
+            error: errorMessage,
             extracted_count: workspaces.length,
+            hint: options.debug ? undefined : 'Run with --debug for more details.',
           },
           options.pretty,
         ),
@@ -169,6 +176,16 @@ async function statusAction(options: { pretty?: boolean }): Promise<void> {
   } catch (error) {
     handleError(error as Error)
   }
+}
+
+export function getExtractionErrorMessage(failureReasons: string[]): string {
+  if (failureReasons.includes('missing_cookie')) {
+    return 'Cookie extraction failed. Make sure the Slack desktop app is installed and grant Keychain access when prompted.'
+  }
+  if (failureReasons.includes('invalid_auth')) {
+    return 'Slack session has expired. Sign into the Slack desktop app, wait a few seconds, then re-run this command.'
+  }
+  return 'Extracted tokens are invalid. Make sure you are logged into the Slack desktop app.'
 }
 
 export const authCommand = new Command('auth')


### PR DESCRIPTION
## Summary

- Replace the generic "Extracted tokens are invalid" message with cause-specific errors so users can self-diagnose. Tracks `SlackError.code` from each failed workspace validation and maps it to an actionable message.

## Changes

### `src/platforms/slack/commands/auth.ts`

- Collect `SlackError.code` from each failed workspace validation.
- Add `getExtractionErrorMessage()` that maps failure codes to specific messages:
  - `missing_cookie` → "Cookie extraction failed. Make sure the Slack desktop app is installed and grant Keychain access when prompted."
  - `invalid_auth` → "Slack session has expired. Sign into the Slack desktop app, wait a few seconds, then re-run this command."
  - Default → original generic message (fallback).
- Add `hint` field suggesting `--debug` when not already enabled.

### `src/platforms/slack/commands/auth.test.ts`

- Add 5 tests for `getExtractionErrorMessage()` covering each code, priority order, and edge cases.

## Verified

- `bun test` — 28 pass, 0 fail.
- `bun typecheck` — clean.
- `bun lint` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show cause-specific error messages during Slack auth token extraction so users can diagnose issues without the generic failure message.

- **New Features**
  - Map SlackError.code to actionable messages: missing_cookie (cookie/Keychain guidance), invalid_auth (session expired/sign-in guidance), with a generic fallback.
  - Track unique failure reasons during workspace validation and add a hint to run with --debug when not already enabled.
  - Add tests for getExtractionErrorMessage covering codes, priority order, and edge cases.

<sup>Written for commit 3b0ee0cdbf152bc4373b2328e52623dfecd73e42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

