### PR TITLE
Add --unsafely-show-secrets flag to auth extract

### DIFF
--- a/src/platforms/slack/commands/auth.test.ts
+++ b/src/platforms/slack/commands/auth.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { mkdirSync, rmSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getExtractionErrorMessage } from '@/platforms/slack/commands/auth'
+import { formatCredentialDebug, getExtractionErrorMessage } from '@/platforms/slack/commands/auth'
 import { CredentialManager } from '@/platforms/slack/credential-manager'
 import { type ExtractedWorkspace, TokenExtractor } from '@/platforms/slack/token-extractor'
 
@@ -349,6 +349,50 @@ describe('Output Formatting', () => {
 
     // Then: Should be valid JSON
     expect(JSON.parse(json)).toEqual(output)
+  })
+})
+
+describe('formatCredentialDebug', () => {
+  const ws = {
+    workspace_id: 'T123ABC',
+    workspace_name: 'test-workspace',
+    token:
+      'xoxc-1234567890123-4567890123456-7890123456789-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    cookie: 'xoxd-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz',
+  }
+
+  test('truncates token and hides cookie by default', () => {
+    const result = formatCredentialDebug(ws)
+
+    expect(result).toContain('T123ABC')
+    expect(result).toContain(`${ws.token.substring(0, 20)}...`)
+    expect(result).not.toContain(ws.token)
+    expect(result).toContain('cookie=present')
+    expect(result).not.toContain(ws.cookie)
+  })
+
+  test('shows full token and cookie when showSecrets is true', () => {
+    const result = formatCredentialDebug(ws, true)
+
+    expect(result).toContain(ws.token)
+    expect(result).toContain(ws.cookie)
+    expect(result).not.toContain('...')
+    expect(result).not.toContain('present')
+  })
+
+  test('shows cookie=missing when cookie is empty and secrets hidden', () => {
+    const wsNoCookie = { ...ws, cookie: '' }
+    const result = formatCredentialDebug(wsNoCookie)
+
+    expect(result).toContain('cookie=missing')
+  })
+
+  test('shows empty cookie value when cookie is empty and secrets shown', () => {
+    const wsNoCookie = { ...ws, cookie: '' }
+    const result = formatCredentialDebug(wsNoCookie, true)
+
+    expect(result).toContain('cookie=')
+    expect(result).not.toContain('cookie=missing')
   })
 })
 

--- a/src/platforms/slack/commands/auth.ts
+++ b/src/platforms/slack/commands/auth.ts
@@ -4,10 +4,23 @@ import { formatOutput } from '@/shared/utils/output'
 import { SlackClient, SlackError } from '../client'
 import { CredentialManager } from '../credential-manager'
 import { refreshCookie } from '../ensure-auth'
-import { TokenExtractor } from '../token-extractor'
+import { type ExtractedWorkspace, TokenExtractor } from '../token-extractor'
 
-async function extractAction(options: { pretty?: boolean; debug?: boolean }): Promise<void> {
+export function formatCredentialDebug(ws: ExtractedWorkspace, showSecrets?: boolean): string {
+  const tokenDisplay = showSecrets ? ws.token : `${ws.token.substring(0, 20)}...`
+  const cookieDisplay = showSecrets ? ws.cookie : ws.cookie ? 'present' : 'missing'
+  return `${ws.workspace_id}: token=${tokenDisplay}, cookie=${cookieDisplay}`
+}
+
+async function extractAction(options: {
+  pretty?: boolean
+  debug?: boolean
+  unsafelyShowSecrets?: boolean
+}): Promise<void> {
   try {
+    if (options.unsafelyShowSecrets) {
+      options.debug = true
+    }
     const debugLog = options.debug ? (msg: string) => console.error(`[debug] ${msg}`) : undefined
     const extractor = new TokenExtractor(undefined, undefined, undefined, debugLog)
 
@@ -37,9 +50,7 @@ async function extractAction(options: { pretty?: boolean; debug?: boolean }): Pr
     if (options.debug) {
       console.error(`[debug] Found ${workspaces.length} workspace(s)`)
       for (const ws of workspaces) {
-        console.error(
-          `[debug] - ${ws.workspace_id}: token=${ws.token.substring(0, 20)}..., cookie=${ws.cookie ? 'present' : 'missing'}`,
-        )
+        console.error(`[debug] - ${formatCredentialDebug(ws, options.unsafelyShowSecrets)}`)
       }
     }
 
@@ -206,6 +217,7 @@ export const authCommand = new Command('auth')
       .description('Extract tokens from Slack desktop app')
       .option('--pretty', 'Pretty print JSON output')
       .option('--debug', 'Show debug output for troubleshooting')
+      .option('--unsafely-show-secrets', 'Show full token and cookie values in debug output')
       .action(extractAction),
   )
   .addCommand(


### PR DESCRIPTION
## Summary

- Add `--unsafely-show-secrets` flag to `agent-slack auth extract` that displays full token and cookie values in debug output, enabling diagnosis of credential extraction issues (e.g. truncated cookies, stale tokens)
- The flag implies `--debug`, so no need to pass both
- Extract `formatCredentialDebug()` helper for testable credential display formatting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds --unsafely-show-secrets to agent-slack auth extract to show full token and cookie values in debug output for easier credential debugging. The flag implies --debug and uses a new formatter for consistent, testable logs.

- **New Features**
  - --unsafely-show-secrets prints full xoxc token and cookie per workspace; default debug still truncates tokens and shows cookie as present/missing.
  - Introduced formatCredentialDebug() and tests; all debug logs now use it.

<sup>Written for commit 3ac5ad4029f1413b1e91a223a1be6a2ecff85f48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

