### PR TITLE
Fix stale token selection in Slack credential extraction

### DIFF
--- a/src/platforms/slack/token-extractor.test.ts
+++ b/src/platforms/slack/token-extractor.test.ts
@@ -58,6 +58,83 @@ describe('TokenExtractor token deduplication', () => {
     expect(result[0].workspace_name).toBe('workspace-name')
   })
 
+  test('prefers Local Storage token over IndexedDB token for same team', async () => {
+    // given — same team in Local Storage (valid) and IndexedDB (stale)
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-dedup-tier-'))
+    tempDirs.push(slackDir)
+
+    const hex64valid = 'aa'.repeat(32)
+    const hex64stale = 'bb'.repeat(32)
+    const validToken = `xoxc-1111111111-2222222222-3333333333-${hex64valid}`
+    const staleToken = `xoxc-9999999999-8888888888-7777777777-${hex64stale}`
+
+    const localStorageDir = join(slackDir, 'Local Storage', 'leveldb')
+    mkdirSync(localStorageDir, { recursive: true })
+    writeFileSync(join(localStorageDir, '000001.log'), `"${validToken}"T12345678"name":"valid-workspace"`)
+
+    const indexedDbDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.leveldb')
+    mkdirSync(indexedDbDir, { recursive: true })
+    writeFileSync(join(indexedDbDir, '000001.log'), `"${staleToken}"T12345678"name":"stale-workspace"`)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then — Local Storage token wins regardless of scan order
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(validToken)
+    expect(result[0].workspace_name).toBe('valid-workspace')
+  })
+
+  test('prefers IndexedDB token when Local Storage has no token for team', async () => {
+    // given — token only in IndexedDB
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-dedup-idb-only-'))
+    tempDirs.push(slackDir)
+
+    const hex64 = 'a'.repeat(64)
+    const token = `xoxc-1111111111-2222222222-3333333333-${hex64}`
+
+    const indexedDbDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.leveldb')
+    mkdirSync(indexedDbDir, { recursive: true })
+    writeFileSync(join(indexedDbDir, '000001.log'), `"${token}"T12345678"name":"only-workspace"`)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then — IndexedDB token is used since there's no better source
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(token)
+  })
+
+  test('prefers storage dir token over IndexedDB token for same team', async () => {
+    // given — structured JSON in storage dir vs raw token in IndexedDB
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-dedup-storage-'))
+    tempDirs.push(slackDir)
+
+    const hex64storage = 'cc'.repeat(32)
+    const hex64idb = 'dd'.repeat(32)
+    const storageToken = `xoxc-1111111111-2222222222-3333333333-${hex64storage}`
+    const idbToken = `xoxc-9999999999-8888888888-7777777777-${hex64idb}`
+
+    const storageDir = join(slackDir, 'storage')
+    mkdirSync(storageDir, { recursive: true })
+    writeFileSync(join(storageDir, '000001.log'), `"${storageToken}"T12345678"name":"storage-workspace"`)
+
+    const indexedDbDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.leveldb')
+    mkdirSync(indexedDbDir, { recursive: true })
+    writeFileSync(join(indexedDbDir, '000001.log'), `"${idbToken}"T12345678"name":"idb-workspace"`)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then — storage dir token wins
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(storageToken)
+    expect(result[0].workspace_name).toBe('storage-workspace')
+  })
+
   test('prefers .log tokens over .ldb tokens for same team', async () => {
     // given — same team ID in both .log (fresh) and .ldb (stale)
     const slackDir = mkdtempSync(join(tmpdir(), 'slack-dedup-order-'))

--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -16,10 +16,33 @@ export interface ExtractedWorkspace {
   cookie: string
 }
 
-interface TokenInfo {
+type TokenSource = 'json-teams' | 'json-single' | 'log-file' | 'ldb-file' | 'classic-level'
+type TokenDirTier = 'storage' | 'local-storage' | 'indexeddb'
+
+interface RawTokenInfo {
   token: string
   teamId: string
   teamName: string
+  source: TokenSource
+}
+
+interface TokenInfo extends RawTokenInfo {
+  dirTier: TokenDirTier
+}
+
+// Higher = better. Structured JSON from the teams object is the most reliable source.
+const SOURCE_PRIORITY: Record<TokenSource, number> = {
+  'json-teams': 5,
+  'json-single': 4,
+  'log-file': 3,
+  'classic-level': 2,
+  'ldb-file': 1,
+}
+
+const DIR_TIER_PRIORITY: Record<TokenDirTier, number> = {
+  storage: 3,
+  'local-storage': 2,
+  indexeddb: 1,
 }
 
 export class TokenExtractor {
@@ -141,27 +164,27 @@ export class TokenExtractor {
   }
 
   private async extractTokensFromLevelDB(): Promise<TokenInfo[]> {
-    const possibleDirs = [
-      join(this.slackDir, 'storage'),
-      join(this.slackDir, 'Local Storage', 'leveldb'),
-      join(this.slackDir, 'IndexedDB'),
+    const tieredDirs: { dir: string; tier: TokenDirTier }[] = [
+      { dir: join(this.slackDir, 'storage'), tier: 'storage' },
+      { dir: join(this.slackDir, 'Local Storage', 'leveldb'), tier: 'local-storage' },
+      { dir: join(this.slackDir, 'IndexedDB'), tier: 'indexeddb' },
     ]
 
     const tokens: TokenInfo[] = []
 
-    for (const baseDir of possibleDirs) {
+    for (const { dir: baseDir, tier } of tieredDirs) {
       if (!existsSync(baseDir)) {
         continue
       }
 
       const levelDbDirs = this.findLevelDBDirs(baseDir)
-      if (baseDir.endsWith('leveldb') && this.isLevelDBDir(baseDir)) {
+      if (this.isLevelDBDir(baseDir)) {
         levelDbDirs.push(baseDir)
       }
 
       for (const dbDir of levelDbDirs) {
         try {
-          const extracted = await this.extractFromLevelDB(dbDir)
+          const extracted = await this.extractFromLevelDB(dbDir, tier)
           tokens.push(...extracted)
         } catch {}
       }
@@ -176,8 +199,17 @@ export class TokenExtractor {
       const existing = seen.get(token.teamId)
       if (!existing) {
         seen.set(token.teamId, token)
+        continue
+      }
+
+      const existingScore = SOURCE_PRIORITY[existing.source] * 10 + DIR_TIER_PRIORITY[existing.dirTier]
+      const candidateScore = SOURCE_PRIORITY[token.source] * 10 + DIR_TIER_PRIORITY[token.dirTier]
+
+      if (candidateScore > existingScore) {
+        const teamName = token.teamName !== 'unknown' ? token.teamName : existing.teamName
+        seen.set(token.teamId, { ...token, teamName })
       } else if (existing.teamName === 'unknown' && token.teamName !== 'unknown') {
-        seen.set(token.teamId, { ...token, token: existing.token })
+        seen.set(token.teamId, { ...existing, teamName: token.teamName })
       }
     }
     return Array.from(seen.values())
@@ -213,23 +245,21 @@ export class TokenExtractor {
     }
   }
 
-  private async extractFromLevelDB(dbPath: string): Promise<TokenInfo[]> {
-    // ClassicLevel on a copy avoids LevelDB prefix-compression artifacts
-    // that corrupt tokens when reading raw .ldb files
-    const classicLevelTokens = await this.extractViaClassicLevelCopy(dbPath)
+  private async extractFromLevelDB(dbPath: string, dirTier: TokenDirTier): Promise<TokenInfo[]> {
+    const classicLevelTokens = await this.extractViaClassicLevelCopy(dbPath, dirTier)
     if (classicLevelTokens.length > 0) {
       return classicLevelTokens
     }
 
-    const directTokens = this.extractTokensFromLDBFiles(dbPath)
+    const directTokens = this.extractTokensFromLDBFiles(dbPath, dirTier)
     if (directTokens.length > 0) {
       return directTokens
     }
 
-    return this.extractViaClassicLevel(dbPath)
+    return this.extractViaClassicLevel(dbPath, dirTier)
   }
 
-  private async extractViaClassicLevelCopy(dbPath: string): Promise<TokenInfo[]> {
+  private async extractViaClassicLevelCopy(dbPath: string, dirTier: TokenDirTier): Promise<TokenInfo[]> {
     const tempDir = join(tmpdir(), `slack-leveldb-${Date.now()}-${Math.random().toString(36).slice(2)}`)
 
     try {
@@ -246,7 +276,7 @@ export class TokenExtractor {
         } catch {}
       }
 
-      return await this.extractViaClassicLevel(tempDir)
+      return await this.extractViaClassicLevel(tempDir, dirTier)
     } catch {
       return []
     } finally {
@@ -256,7 +286,7 @@ export class TokenExtractor {
     }
   }
 
-  private async extractViaClassicLevel(dbPath: string): Promise<TokenInfo[]> {
+  private async extractViaClassicLevel(dbPath: string, dirTier: TokenDirTier): Promise<TokenInfo[]> {
     const tokens: TokenInfo[] = []
     let db: ClassicLevel<string, string> | null = null
     try {
@@ -264,7 +294,10 @@ export class TokenExtractor {
 
       for await (const [key, value] of db.iterator()) {
         if (typeof value === 'string' && value.includes('xoxc-')) {
-          tokens.push(...this.parseTokenValue(key, value))
+          const parsed = this.parseTokenValue(key, value)
+          for (const t of parsed) {
+            tokens.push({ ...t, dirTier })
+          }
         }
       }
     } catch {
@@ -278,7 +311,7 @@ export class TokenExtractor {
     return tokens
   }
 
-  private extractTokensFromLDBFiles(dbPath: string): TokenInfo[] {
+  private extractTokensFromLDBFiles(dbPath: string, dirTier: TokenDirTier): TokenInfo[] {
     const tokens: TokenInfo[] = []
     try {
       // Prioritize .log files (not compacted, have clean data)
@@ -305,7 +338,7 @@ export class TokenExtractor {
             ? this.extractTokenFromLogFile(content, idx)
             : this.extractTokenFromBuffer(content, idx)
           if (tokenData) {
-            tokens.push(tokenData)
+            tokens.push({ ...tokenData, dirTier })
           }
           idx = content.indexOf(xoxcMarker, idx + 5)
         }
@@ -314,7 +347,7 @@ export class TokenExtractor {
     return tokens
   }
 
-  private extractTokenFromLogFile(buffer: Buffer, startIdx: number): TokenInfo | null {
+  private extractTokenFromLogFile(buffer: Buffer, startIdx: number): RawTokenInfo | null {
     // LOG files have clean (non-fragmented) JSON data
     const chunk = buffer.subarray(startIdx, startIdx + 300)
     const str = chunk.toString('utf8')
@@ -346,10 +379,10 @@ export class TokenExtractor {
       teamName = teamNameMatch[1]
     }
 
-    return { token, teamId, teamName }
+    return { token, teamId, teamName, source: 'log-file' }
   }
 
-  private extractTokenFromBuffer(buffer: Buffer, startIdx: number): TokenInfo | null {
+  private extractTokenFromBuffer(buffer: Buffer, startIdx: number): RawTokenInfo | null {
     const chunk = buffer.subarray(startIdx, startIdx + 200)
 
     // LevelDB fragmentation pattern observed:
@@ -440,10 +473,10 @@ export class TokenExtractor {
       teamName = teamNameMatch[1]
     }
 
-    return { token, teamId, teamName }
+    return { token, teamId, teamName, source: 'ldb-file' }
   }
 
-  private parseTokenValue(_key: string, value: string): TokenInfo[] {
+  private parseTokenValue(_key: string, value: string): RawTokenInfo[] {
     // LevelDB values may have leading control characters (e.g. 0x01).
     // Built dynamically to satisfy biome's noControlCharactersInRegex.
     const controlChars = new RegExp(
@@ -462,20 +495,21 @@ export class TokenExtractor {
     return single ? [single] : []
   }
 
-  private parseTeamsObject(teams: Record<string, any>): TokenInfo[] {
-    const tokens: TokenInfo[] = []
+  private parseTeamsObject(teams: Record<string, any>): RawTokenInfo[] {
+    const tokens: RawTokenInfo[] = []
     for (const [teamId, team] of Object.entries(teams)) {
       if (!team?.token || typeof team.token !== 'string' || !team.token.startsWith('xoxc-')) continue
       tokens.push({
         token: team.token,
         teamId: team.id || teamId,
         teamName: team.name || 'unknown',
+        source: 'json-teams',
       })
     }
     return tokens
   }
 
-  private parseSingleToken(value: string): TokenInfo | null {
+  private parseSingleToken(value: string): RawTokenInfo | null {
     const tokenMatch = value.match(/xoxc-[a-zA-Z0-9-]+/)
     if (!tokenMatch) return null
 
@@ -493,7 +527,7 @@ export class TokenExtractor {
       if (domainMatch) teamName = domainMatch[1]
     }
 
-    return { token: tokenMatch[0], teamId, teamName }
+    return { token: tokenMatch[0], teamId, teamName, source: 'json-single' }
   }
 
   private async extractCookieFromSQLite(): Promise<string> {


### PR DESCRIPTION
## Summary

- Fix token deduplication to prefer higher-quality sources (structured JSON > raw binary, Local Storage > IndexedDB) instead of first-seen wins
- Root cause: on some machines, stale tokens from IndexedDB blobs won the dedup race over valid tokens from Local Storage, causing `invalid_auth` errors despite the Slack desktop app working fine

## Changes

- Add `source` and `dirTier` metadata to token extraction pipeline to track where each token came from
- Replace naive first-seen dedup with score-based selection: `SOURCE_PRIORITY[source] * 10 + DIR_TIER_PRIORITY[dirTier]`
- Source priority: `json-teams` (5) > `json-single` (4) > `log-file` (3) > `classic-level` (2) > `ldb-file` (1)
- Directory tier priority: `storage` (3) > `local-storage` (2) > `indexeddb` (1)
- Also fix `isLevelDBDir` check to include base dirs that are themselves LevelDB databases (not just `**/leveldb` suffixed dirs)

## Tests

- Added: Local Storage token wins over IndexedDB token for same team
- Added: IndexedDB-only token still works when no better source exists
- Added: storage dir token wins over IndexedDB token for same team
- All 283 existing Slack tests pass, 0 regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack token deduplication to prefer valid tokens from higher-quality sources (structured JSON and Local Storage) over stale IndexedDB tokens, eliminating invalid_auth errors. Adds source/tier-aware scoring and fixes LevelDB dir detection.

- **Bug Fixes**
  - Dedup uses scoring by source and directory tier:
    - Source: JSON teams > JSON single > log > classic-level > ldb
    - Dir: storage > Local Storage > IndexedDB
  - Track token source and dirTier throughout extraction and pick the best per team.
  - Include base LevelDB directories in detection, not only “.../leveldb” paths.
  - Tests added for Local Storage vs IndexedDB, IndexedDB-only, and storage vs IndexedDB; all Slack tests pass.

<sup>Written for commit 2db44ab3d9d3cea1d87c02a17c806b6462df9c35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

