### PR TITLE
feat(slack): Add MSIX (Microsoft Store) package support for Windows

### DIFF
--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -91,10 +91,7 @@ export class TokenExtractor {
   }
 
   private findMsixSlackDir(): string | null {
-    const packagesDir = join(
-      process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'),
-      'Packages',
-    )
+    const packagesDir = join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'Packages')
     if (!existsSync(packagesDir)) {
       this.debug('MSIX Packages directory not found')
       return null


### PR DESCRIPTION
# Summary

  Slack installed via Microsoft Store or GPO (MSIX package) stores user data in a virtualized path under %LOCALAPPDATA%\Packages\, which the token extractor didn't check.

#  Changes

  - Added findMsixSlackDir() — scans %LOCALAPPDATA%\Packages\ for directories containing "Slack", validates that Slack data (storage or Local Storage) exists inside, and picks
  the most recently modified one if multiple candidates are found
  - Updated getSlackDir() to check MSIX paths before falling back to %APPDATA%\Slack
  - Works with any Slack MSIX package ID (enterprise com.tinyspeck.slackdesktop, Store 91750D7E.Slack, etc.)

#  Testing

  Verified on Windows 11:
  - Microsoft Store Slack installed with existing direct download data → correctly falls back to %APPDATA%\Slack
  - No MSIX package installed → falls back to %APPDATA%\Slack
  - Debug logging shows MSIX candidate discovery and fallback decisions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MSIX support for Windows Slack token extraction by scanning %LOCALAPPDATA%\Packages for Slack data, with a safe fallback to %APPDATA%\Slack. Also fixes a minor Biome formatting issue for a join() call.

- **New Features**
  - Added findMsixSlackDir() to locate Slack data under Packages and select the most recent valid directory.
  - Updated getSlackDir() to prefer MSIX paths on Windows before APPDATA.
  - Supports any Slack MSIX package ID (e.g., com.tinyspeck.slackdesktop, 91750D7E.Slack).
  - Debug logs show candidate discovery and fallback decisions.

- **Testing**
  - Windows 11: Store Slack with existing direct download data → falls back to %APPDATA%\Slack.
  - No MSIX installed → falls back to %APPDATA%\Slack.
  - Logs confirm MSIX candidate detection and selection.

<sup>Written for commit a0941bf1ff2b0003fa31fec3253246c7d6e7cdfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

