### PR TITLE
Scan IndexedDB blob files for workspace tokens

### DIFF
--- a/src/platforms/slack/token-extractor.test.ts
+++ b/src/platforms/slack/token-extractor.test.ts
@@ -503,6 +503,108 @@ describe('TokenExtractor Windows DPAPI', () => {
   })
 })
 
+describe('TokenExtractor IndexedDB blob files', () => {
+  test('extracts token from blob file when not in LevelDB', async () => {
+    // given — token only exists in an IndexedDB blob file, not in LevelDB
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-blob-'))
+    tempDirs.push(slackDir)
+
+    const hex64 = 'a'.repeat(64)
+    const token = `xoxc-1111111111-2222222222-3333333333-${hex64}`
+
+    const blobDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.blob', '2', '05')
+    mkdirSync(blobDir, { recursive: true })
+    writeFileSync(join(blobDir, '584'), `"team_name":"blob-workspace"T12345678"token":"${token}"`)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(token)
+    expect(result[0].workspace_id).toBe('T12345678')
+  })
+
+  test('extracts tokens from both LevelDB and blob files for different teams', async () => {
+    // given — one workspace token in LevelDB, another in blob file
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-blob-multi-'))
+    tempDirs.push(slackDir)
+
+    const hex64a = 'a'.repeat(64)
+    const hex64b = 'b'.repeat(64)
+    const tokenA = `xoxc-1111111111-2222222222-3333333333-${hex64a}`
+    const tokenB = `xoxc-4444444444-5555555555-6666666666-${hex64b}`
+
+    const leveldbDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.leveldb')
+    mkdirSync(leveldbDir, { recursive: true })
+    writeFileSync(join(leveldbDir, '000001.log'), `"${tokenA}"TAAAAAAAA"name":"leveldb-ws"`)
+
+    const blobDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.blob', '2', '05')
+    mkdirSync(blobDir, { recursive: true })
+    writeFileSync(join(blobDir, '584'), `"team_name":"blob-ws"TBBBBBBBBB"token":"${tokenB}"`)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then — both workspaces are extracted
+    expect(result.length).toBe(2)
+    const teamIds = result.map((r) => r.workspace_id).sort()
+    expect(teamIds).toEqual(['TAAAAAAAA', 'TBBBBBBBBB'])
+  })
+
+  test('LevelDB token wins over blob file token for same team', async () => {
+    // given — same team in both LevelDB (.log = highest raw priority) and blob file
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-blob-dedup-'))
+    tempDirs.push(slackDir)
+
+    const hex64ldb = 'a'.repeat(64)
+    const hex64blob = 'b'.repeat(64)
+    const ldbToken = `xoxc-1111111111-2222222222-3333333333-${hex64ldb}`
+    const blobToken = `xoxc-4444444444-5555555555-6666666666-${hex64blob}`
+
+    const leveldbDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.leveldb')
+    mkdirSync(leveldbDir, { recursive: true })
+    writeFileSync(join(leveldbDir, '000001.log'), `"${ldbToken}"T12345678"name":"ldb-workspace"`)
+
+    const blobDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.blob', '2', '05')
+    mkdirSync(blobDir, { recursive: true })
+    writeFileSync(join(blobDir, '584'), `"team_name":"blob-workspace"T12345678"token":"${blobToken}"`)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then — .log source (priority 3) beats blob-file (priority 1)
+    expect(result.length).toBe(1)
+    expect(result[0].token).toBe(ldbToken)
+  })
+
+  test('skips blob files larger than 10MB', async () => {
+    // given — blob file exceeds size limit
+    const slackDir = mkdtempSync(join(tmpdir(), 'slack-blob-large-'))
+    tempDirs.push(slackDir)
+
+    const hex64 = 'a'.repeat(64)
+    const token = `xoxc-1111111111-2222222222-3333333333-${hex64}`
+
+    const blobDir = join(slackDir, 'IndexedDB', 'https_app.slack.com_0.indexeddb.blob', '1', '00')
+    mkdirSync(blobDir, { recursive: true })
+
+    const largeContent = Buffer.alloc(11 * 1024 * 1024)
+    Buffer.from(`"team_name":"large"T12345678"${token}"`).copy(largeContent)
+    writeFileSync(join(blobDir, '1'), largeContent)
+
+    // when
+    const extractor = new TokenExtractor('darwin', slackDir)
+    const result = await extractor.extract()
+
+    // then
+    expect(result.length).toBe(0)
+  })
+})
+
 describe('TokenExtractor getWorkspaceDomains', () => {
   test('reads workspace domains from root-state.json', () => {
     // given

--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -16,7 +16,7 @@ export interface ExtractedWorkspace {
   cookie: string
 }
 
-type TokenSource = 'json-teams' | 'json-single' | 'log-file' | 'ldb-file' | 'classic-level'
+type TokenSource = 'json-teams' | 'json-single' | 'log-file' | 'ldb-file' | 'classic-level' | 'blob-file'
 type TokenDirTier = 'storage' | 'local-storage' | 'indexeddb'
 
 interface RawTokenInfo {
@@ -36,6 +36,7 @@ const SOURCE_PRIORITY: Record<TokenSource, number> = {
   'json-single': 4,
   'log-file': 3,
   'classic-level': 2,
+  'blob-file': 1,
   'ldb-file': 1,
 }
 
@@ -188,6 +189,10 @@ export class TokenExtractor {
           tokens.push(...extracted)
         } catch {}
       }
+
+      // Chromium offloads large IndexedDB values to external *.indexeddb.blob/ files
+      const blobTokens = this.extractTokensFromBlobFiles(baseDir, tier)
+      tokens.push(...blobTokens)
     }
 
     return this.deduplicateTokens(tokens)
@@ -309,6 +314,56 @@ export class TokenExtractor {
       }
     }
     return tokens
+  }
+
+  private extractTokensFromBlobFiles(baseDir: string, dirTier: TokenDirTier): TokenInfo[] {
+    const tokens: TokenInfo[] = []
+    try {
+      const entries = readdirSync(baseDir, { withFileTypes: true })
+      for (const entry of entries) {
+        if (!entry.isDirectory() || !entry.name.endsWith('.indexeddb.blob')) continue
+
+        const blobDir = join(baseDir, entry.name)
+        this.debug(`Scanning blob directory: ${blobDir}`)
+        const files = this.findFilesRecursive(blobDir)
+
+        for (const filePath of files) {
+          try {
+            const stat = statSync(filePath)
+            if (stat.size > 10 * 1024 * 1024) continue
+
+            const content = readFileSync(filePath)
+            const xoxcMarker = Buffer.from('xoxc-')
+            let idx = content.indexOf(xoxcMarker, 0)
+            while (idx !== -1) {
+              const tokenData = this.extractTokenFromBuffer(content, idx)
+              if (tokenData) {
+                this.debug(`Found token in blob file: ${filePath}`)
+                tokens.push({ ...tokenData, source: 'blob-file', dirTier })
+              }
+              idx = content.indexOf(xoxcMarker, idx + 5)
+            }
+          } catch {}
+        }
+      }
+    } catch {}
+    return tokens
+  }
+
+  private findFilesRecursive(dir: string): string[] {
+    const files: string[] = []
+    try {
+      const entries = readdirSync(dir, { withFileTypes: true })
+      for (const entry of entries) {
+        const fullPath = join(dir, entry.name)
+        if (entry.isDirectory()) {
+          files.push(...this.findFilesRecursive(fullPath))
+        } else if (entry.isFile()) {
+          files.push(fullPath)
+        }
+      }
+    } catch {}
+    return files
   }
 
   private extractTokensFromLDBFiles(dbPath: string, dirTier: TokenDirTier): TokenInfo[] {


### PR DESCRIPTION
## Summary

- Fixes multi-workspace detection failure where only a subset of workspaces were found during `auth extract`
- Chromium offloads large IndexedDB values to external blob files under `*.indexeddb.blob/` directories. The token extractor only scanned LevelDB databases (`.ldb`/`.log` files), completely missing these blob files
- Adds `extractTokensFromBlobFiles()` to scan blob directories alongside LevelDB, using the same buffer-scanning approach for `xoxc-` token extraction
- Blob file tokens (`blob-file` source) have the same priority as `ldb-file`, so higher-quality sources (structured JSON, `.log` files) still win during deduplication

## Root Cause

When Slack stores workspace data in IndexedDB, Chromium may store large values as external blob files rather than inline in LevelDB. The existing extractor used `findLevelDBDirs()` which only matched directories containing `.ldb`/`.log`/`CURRENT` files — the `*.indexeddb.blob/` directories (containing plain numbered files) were invisible.

This meant users signed into multiple workspaces could see only the workspace(s) whose tokens happened to be inline in LevelDB, while other workspaces stored as blobs were silently skipped.

## Testing

- 4 new tests covering: blob-only extraction, multi-source (LevelDB + blob), deduplication priority, and 10MB size limit skip
- All 28 tests pass, typecheck and lint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Slack workspaces in auth extract by scanning Chromium IndexedDB blob files for xoxc tokens. Ensures multi-workspace accounts are fully detected, not just those stored in LevelDB.

- **Bug Fixes**
  - Scan *.indexeddb.blob directories and extract xoxc tokens using buffer scanning.
  - Add extractTokensFromBlobFiles with a 10MB per-file cap; recursive file search.
  - Set blob-file priority equal to ldb-file; .log and JSON remain higher for dedupe.
  - Add tests for blob-only, mixed sources, dedupe precedence, and large-file skip.

<sup>Written for commit fe404ac69a9495398298cf3004c2c4b963f99ccd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

