### PR TITLE
Slim SKILL.md files by removing duplicated auth content

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -392,23 +392,7 @@ Common errors:
 
 ## Configuration
 
-Credentials stored in: `~/.config/agent-messenger/discord-credentials.json`
-
-Format:
-```json
-{
-  "token": "user_token_here",
-  "current_server": "1234567890123456789",
-  "servers": {
-    "1234567890123456789": {
-      "server_id": "1234567890123456789",
-      "server_name": "My Server"
-    }
-  }
-}
-```
-
-**Security**: File permissions set to 0600 (owner read/write only)
+Credentials stored in `~/.config/agent-messenger/discord-credentials.json` (0600 permissions). See [references/authentication.md](references/authentication.md) for format and security details.
 
 ## Limitations
 
@@ -421,19 +405,6 @@ Format:
 - User tokens only (no bot tokens)
 
 ## Troubleshooting
-
-### Authentication fails or no token found
-
-Credentials are normally extracted automatically. If auto-extraction fails, run it manually with debug output:
-
-```bash
-agent-discord auth extract --debug
-```
-
-Common causes:
-- Discord desktop app is not installed or not logged in
-- macOS Keychain access was denied (re-run and approve the prompt)
-- Discord is not running and LevelDB files are stale
 
 ### `agent-discord: command not found`
 
@@ -452,6 +423,8 @@ bunx agent-messenger discord server list
 ```
 
 **NEVER run `bunx agent-discord`** — it will fail or install a wrong package since `agent-discord` is not the npm package name.
+
+For other troubleshooting (auth extraction, token issues, permissions), see [references/authentication.md](references/authentication.md).
 
 ## References
 

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -54,59 +54,7 @@ agent-discordbot auth status
 agent-discordbot auth clear
 ```
 
-### Getting a Bot Token
-
-1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
-2. Click **New Application**, give it a name, and create
-3. Go to **Bot** in the left sidebar
-4. Click **Reset Token** (or **Copy** if the token is still visible)
-5. Copy the token and store it securely
-
-### Inviting the Bot to a Server
-
-After creating the application:
-
-1. Go to **OAuth2** > **URL Generator** in the left sidebar
-2. Under **Scopes**, select `bot`
-3. Under **Bot Permissions**, select the permissions your bot needs (Send Messages, Read Message History, etc.)
-4. Copy the generated URL and open it in your browser
-5. Select the server and authorize
-
-### Message Content Privileged Intent
-
-Bots in 100 or more servers require verification (you can apply once you reach 75+ servers), and verified bots must apply for access to the Message Content intent. Enable it to read message content:
-
-1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
-2. Select your application
-3. Go to **Bot** in the left sidebar
-4. Under **Privileged Gateway Intents**, enable **Message Content Intent**
-5. Save changes
-
-Without this, verified bots receive empty `content` fields (DMs and mentions are exempt).
-
-### Multi-Bot Management
-
-Store multiple bot tokens and switch between them:
-
-```bash
-# Add multiple bots
-agent-discordbot auth set deploy-bot-token --bot deploy --name "Deploy Bot"
-agent-discordbot auth set alert-bot-token --bot alert --name "Alert Bot"
-
-# List all stored bots
-agent-discordbot auth list
-
-# Switch active bot
-agent-discordbot auth use deploy
-
-# Use a specific bot for one command (without switching)
-agent-discordbot message send 1234567890123456789 "Alert!" --bot alert
-
-# Remove a stored bot
-agent-discordbot auth remove deploy
-```
-
-The `--bot <id>` flag is available on all commands to override the active bot for a single invocation.
+For bot token setup, server invite flow, Message Content Intent, and multi-bot management, see [references/authentication.md](references/authentication.md).
 
 ## Memory
 
@@ -380,46 +328,11 @@ All commands return consistent error format:
 }
 ```
 
-Common errors:
-- `missing_token`: No credentials configured
-- `invalid_token`: Token is invalid or expired
-- `Missing Access`: Bot lacks permission for this action
-- `Unknown Channel`: Invalid channel ID
-- `Missing Permissions`: Bot role doesn't have the required permission
+Common errors: `missing_token`, `invalid_token`, `Missing Access`, `Unknown Channel`, `Missing Permissions`.
 
 ## Configuration
 
-Credentials stored in: `~/.config/agent-messenger/discordbot-credentials.json`
-
-Format:
-```json
-{
-  "current": {
-    "server_id": "1234567890123456789",
-    "bot_id": "deploy"
-  },
-  "bots": {
-    "deploy": {
-      "bot_id": "deploy",
-      "bot_name": "Deploy Bot",
-      "token": "MTIz..."
-    },
-    "alert": {
-      "bot_id": "alert",
-      "bot_name": "Alert Bot",
-      "token": "NDU2..."
-    }
-  },
-  "servers": {
-    "1234567890123456789": {
-      "server_id": "1234567890123456789",
-      "server_name": "My Server"
-    }
-  }
-}
-```
-
-**Security**: File permissions set to 0600 (owner read/write only)
+Credentials stored in `~/.config/agent-messenger/discordbot-credentials.json` (0600 permissions). See [references/authentication.md](references/authentication.md) for format and security details.
 
 ## Key Differences from agent-discord
 
@@ -470,37 +383,7 @@ bunx agent-messenger discordbot message send 1234567890123456789 "Hello"
 
 **NEVER run `bunx agent-discordbot`** -- it will fail or install a wrong package since `agent-discordbot` is not the npm package name.
 
-### Bot can't read messages in large servers
-
-Enable the **Message Content Intent** in the Developer Portal:
-
-1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
-2. Select your application > **Bot**
-3. Enable **Message Content Intent** under Privileged Gateway Intents
-4. Save changes
-
-This is required for verified bots (those in 100 or more servers).
-
-### "Missing Access" or "Missing Permissions"
-
-The bot's role doesn't have the required permissions in that channel:
-
-1. Check the bot's role permissions in Server Settings > Roles
-2. Check channel-specific permission overrides
-3. Make sure the bot can see and send messages in the target channel
-
-### "Unknown Channel"
-
-The channel ID is invalid, or the bot doesn't have access to it. Use `channel list` to find valid channel IDs.
-
-### Token expired or invalid
-
-Bot tokens don't expire on their own, but they can be reset:
-
-1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
-2. Select your application > **Bot** > **Reset Token**
-3. Copy the new token
-4. Run `agent-discordbot auth set <new-token>`
+For other troubleshooting (permissions, token issues, Message Content Intent), see [references/authentication.md](references/authentication.md).
 
 ## References
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -366,24 +366,7 @@ Common errors:
 
 ## Configuration
 
-Credentials stored in: `~/.config/agent-messenger/slack-credentials.json`
-
-Format:
-```json
-{
-  "current_workspace": "T123456",
-  "workspaces": {
-    "T123456": {
-      "workspace_id": "T123456",
-      "workspace_name": "My Workspace",
-      "token": "xoxc-...",
-      "cookie": "xoxd-..."
-    }
-  }
-}
-```
-
-**Security**: File permissions set to 0600 (owner read/write only)
+Credentials stored in `~/.config/agent-messenger/slack-credentials.json` (0600 permissions). See [references/authentication.md](references/authentication.md) for format and security details.
 
 ## Limitations
 
@@ -395,19 +378,6 @@ Format:
 - Plain text messages only (no blocks/formatting in v1)
 
 ## Troubleshooting
-
-### Authentication fails or no workspace found
-
-Credentials are normally extracted automatically. If auto-extraction fails, run it manually with debug output:
-
-```bash
-agent-slack auth extract --debug
-```
-
-Common causes:
-- Slack desktop app is not installed or not logged in
-- macOS Keychain access was denied (re-run and approve the prompt)
-- Slack was installed via a method that uses a different storage path
 
 ### `agent-slack: command not found`
 
@@ -426,6 +396,8 @@ bunx agent-messenger slack message list general
 ```
 
 **NEVER run `bunx agent-slack`** — a separate, unrelated npm package named `agent-slack` exists on npm. It will silently install the **wrong package** with different (fewer) commands.
+
+For other troubleshooting (auth extraction, token issues, Keychain), see [references/authentication.md](references/authentication.md).
 
 ## References
 

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -84,39 +84,7 @@ agent-slackbot auth use T123456/deploy
 
 The `--bot <id>` flag is available on all commands to override the active bot for a single invocation.
 
-### Getting a Bot Token
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps)
-2. Create New App (or select existing)
-3. Go to **OAuth & Permissions**
-4. Add required bot token scopes (see below)
-5. Install app to workspace
-6. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
-
-### Required Bot Token Scopes
-
-| Scope | Used For |
-|-------|----------|
-| `chat:write` | Sending messages |
-| `channels:history` | Reading public channel messages |
-| `channels:read` | Listing public channels |
-| `channels:join` | Joining public channels |
-| `groups:history` | Reading private channel messages |
-| `groups:read` | Listing private channels |
-| `users:read` | Listing users |
-| `users:read.email` | Reading user email addresses |
-| `reactions:write` | Adding/removing reactions |
-| `reactions:read` | Listing reactions |
-
-### Environment Variables (CI/CD)
-
-For CI/CD pipelines, set these environment variables instead of using `auth set`:
-
-```bash
-export E2E_SLACKBOT_TOKEN=xoxb-your-bot-token
-export E2E_SLACKBOT_WORKSPACE_ID=T123456
-export E2E_SLACKBOT_WORKSPACE_NAME="My Workspace"
-```
+For bot token setup (Slack App creation, required scopes, app manifest) and CI/CD environment variables, see [references/authentication.md](references/authentication.md).
 
 ## Memory
 
@@ -310,37 +278,7 @@ Common errors:
 
 ## Configuration
 
-Credentials stored in: `~/.config/agent-messenger/slackbot-credentials.json`
-
-Format:
-```json
-{
-  "current": {
-    "workspace_id": "T123456",
-    "bot_id": "deploy"
-  },
-  "workspaces": {
-    "T123456": {
-      "workspace_id": "T123456",
-      "workspace_name": "My Workspace",
-      "bots": {
-        "deploy": {
-          "bot_id": "deploy",
-          "bot_name": "Deploy Bot",
-          "token": "xoxb-..."
-        },
-        "alert": {
-          "bot_id": "alert",
-          "bot_name": "Alert Bot",
-          "token": "xoxb-..."
-        }
-      }
-    }
-  }
-}
-```
-
-**Security**: File permissions set to 0600 (owner read/write only)
+Credentials stored in `~/.config/agent-messenger/slackbot-credentials.json` (0600 permissions). See [references/authentication.md](references/authentication.md) for format and security details.
 
 ## Key Differences from agent-slack
 
@@ -385,6 +323,8 @@ bunx agent-messenger slackbot message send general "Hello"
 ```
 
 **NEVER run `bunx agent-slackbot`** — it will fail or install a wrong package since `agent-slackbot` is not the npm package name.
+
+For other troubleshooting (token issues, scopes, permissions), see [references/authentication.md](references/authentication.md).
 
 ## References
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -338,24 +338,7 @@ Common errors:
 
 ## Configuration
 
-Credentials stored in: `~/.config/agent-messenger/teams-credentials.json`
-
-Format:
-```json
-{
-  "token": "skypetoken_asm_value_here",
-  "token_extracted_at": "2024-01-15T10:00:00.000Z",
-  "current_team": "team-uuid-here",
-  "teams": {
-    "team-uuid-here": {
-      "team_id": "team-uuid-here",
-      "team_name": "My Team"
-    }
-  }
-}
-```
-
-**Security**: File permissions set to 0600 (owner read/write only)
+Credentials stored in `~/.config/agent-messenger/teams-credentials.json` (0600 permissions). See [references/authentication.md](references/authentication.md) for format and security details.
 
 ## Limitations
 
@@ -369,19 +352,6 @@ Format:
 - **Token expires in 60-90 minutes** - auto-refreshed, but requires Teams desktop app to be logged in
 
 ## Troubleshooting
-
-### Authentication fails or token expired
-
-Credentials and token refresh are normally handled automatically. If auto-extraction fails, run it manually with debug output:
-
-```bash
-agent-teams auth extract --debug
-```
-
-Common causes:
-- Teams desktop app is not installed or not logged in
-- Teams Cookies database is locked or inaccessible
-- Token expired and Teams desktop app session also expired (re-login to Teams)
 
 ### `agent-teams: command not found`
 
@@ -400,6 +370,8 @@ bunx agent-messenger teams team list
 ```
 
 **NEVER run `bunx agent-teams`** — it will fail or install a wrong package since `agent-teams` is not the npm package name.
+
+For other troubleshooting (auth extraction, token expiry, permissions), see [references/authentication.md](references/authentication.md).
 
 ## References
 


### PR DESCRIPTION
## Summary

Remove detailed auth setup steps, credential storage JSON, and verbose troubleshooting from each SKILL.md — this content already exists in `references/authentication.md`. Replace removed sections with brief one-liner pointers to the reference files. Keep all essential content that agents need on every invocation (Quick Start, Memory, Commands, Output Format, "command not found" troubleshooting).

## Changes

### Bot skills (larger reductions)

- **agent-discordbot**: Remove bot token setup walkthrough, server invite flow, Message Content Intent instructions, multi-bot management examples, credential JSON format, and detailed troubleshooting for permissions/token issues. Replace with single-line references.
- **agent-slackbot**: Remove bot token creation steps, required scopes table, CI/CD env var instructions, credential JSON format. Replace with references.

### User-token skills (smaller reductions)

- **agent-discord**, **agent-slack**, **agent-teams**: Remove credential JSON format blocks, auth extraction troubleshooting sections, and security notes. Replace with compact one-liners pointing to the reference doc.

### What stays

All five SKILL.md files retain Quick Start, Memory, Commands, Output Format, error code lists, and the "command not found" troubleshooting (platform-specific `bunx` trap).

## Impact

| Skill | Before | After | Saved |
|---|---|---|---|
| agent-discordbot | 508 | 391 | -117 (23%) |
| agent-slackbot | 392 | 332 | -60 (15%) |
| agent-slack | 433 | 405 | -28 (6%) |
| agent-teams | 407 | 379 | -28 (7%) |
| agent-discord | 459 | 432 | -27 (6%) |
| **Total** | **2199** | **1939** | **-260 (12%)** |

Bot skills had bigger reductions since they had verbose manual setup steps. User-token skills were already leaner because auto-extraction requires less setup documentation. No reference files were modified — they already contained complete coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slimmed all SKILL.md files by removing duplicated auth setup, credential JSON, and verbose troubleshooting, replacing them with one-line links to `references/authentication.md`. Kept Quick Start, Memory, Commands, Output Format, and command-not-found troubleshooting intact.

- **Refactors**
  - Bot skills (`agent-discordbot`, `agent-slackbot`): removed token setup, permissions/intent steps, multi-bot/CI notes; added brief links to the reference.
  - User-token skills (`agent-discord`, `agent-slack`, `agent-teams`): removed credential JSON blocks and auth troubleshooting; added brief links to the reference.
  - Configuration notes now show only file paths with 0600 perms and point to the reference for format/security. Total reduction: -260 lines (~12%) across 5 files.

<sup>Written for commit 4b1095bdea9a4a5e68a1fbf32d6a1bf2ba2bece4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

