### PR TITLE
Add npx and pnpm dlx as package runner options in skills

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -429,7 +429,7 @@ pnpm dlx agent-messenger discord server list
 
 If you already know the user's preferred package runner, use it directly instead of asking.
 
-**NEVER run `npx agent-discord` or `bunx agent-discord`** — it will fail or install a wrong package since `agent-discord` is not the npm package name.
+**NEVER run `npx agent-discord`, `bunx agent-discord`, or `pnpm dlx agent-discord`** — it will fail or install a wrong package since `agent-discord` is not the npm package name.
 
 For other troubleshooting (auth extraction, token issues, permissions), see [references/authentication.md](references/authentication.md).
 

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -387,7 +387,7 @@ pnpm dlx agent-messenger discordbot message send 1234567890123456789 "Hello"
 
 If you already know the user's preferred package runner, use it directly instead of asking.
 
-**NEVER run `npx agent-discordbot` or `bunx agent-discordbot`** -- it will fail or install a wrong package since `agent-discordbot` is not the npm package name.
+**NEVER run `npx agent-discordbot`, `bunx agent-discordbot`, or `pnpm dlx agent-discordbot`** -- it will fail or install a wrong package since `agent-discordbot` is not the npm package name.
 
 For other troubleshooting (permissions, token issues, Message Content Intent), see [references/authentication.md](references/authentication.md).
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -407,7 +407,7 @@ pnpm dlx agent-messenger slack message list general
 
 If you already know the user's preferred package runner, use it directly instead of asking.
 
-**NEVER run `npx agent-slack` or `bunx agent-slack`** — a separate, unrelated npm package named `agent-slack` exists on npm. It will silently install the **wrong package** with different (fewer) commands.
+**NEVER run `npx agent-slack`, `bunx agent-slack`, or `pnpm dlx agent-slack`** — a separate, unrelated npm package named `agent-slack` exists on npm. It will silently install the **wrong package** with different (fewer) commands.
 
 For other troubleshooting (auth extraction, token issues, Keychain), see [references/authentication.md](references/authentication.md).
 

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -328,7 +328,7 @@ pnpm dlx agent-messenger slackbot message send general "Hello"
 
 If you already know the user's preferred package runner, use it directly instead of asking.
 
-**NEVER run `npx agent-slackbot` or `bunx agent-slackbot`** — it will fail or install a wrong package since `agent-slackbot` is not the npm package name.
+**NEVER run `npx agent-slackbot`, `bunx agent-slackbot`, or `pnpm dlx agent-slackbot`** — it will fail or install a wrong package since `agent-slackbot` is not the npm package name.
 
 For other troubleshooting (token issues, scopes, permissions), see [references/authentication.md](references/authentication.md).
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -376,7 +376,7 @@ pnpm dlx agent-messenger teams team list
 
 If you already know the user's preferred package runner, use it directly instead of asking.
 
-**NEVER run `npx agent-teams` or `bunx agent-teams`** — it will fail or install a wrong package since `agent-teams` is not the npm package name.
+**NEVER run `npx agent-teams`, `bunx agent-teams`, or `pnpm dlx agent-teams`** — it will fail or install a wrong package since `agent-teams` is not the npm package name.
 
 For other troubleshooting (auth extraction, token expiry, permissions), see [references/authentication.md](references/authentication.md).
 


### PR DESCRIPTION
## Summary
- Update all 5 skill SKILL.md files to list `npx -y`, `bunx`, and `pnpm dlx` as package runner options in the "command not found" troubleshooting sections (matching vibe-notion pattern)
- Extend the "never run" warning to also cover `npx <cli-name>` (not just `bunx`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `npx -y` and `pnpm dlx` as package runner options (alongside `bunx`) in the troubleshooting sections for `agent-discord`, `agent-discordbot`, `agent-slack`, `agent-slackbot`, and `agent-teams`.
Expanded the warning to never run `npx agent-...`/`bunx agent-...`/`pnpm dlx agent-...`; use `agent-messenger <platform>` instead, and ask for or use the user's preferred runner.

<sup>Written for commit 871855c16c7be26310c376e9f11e1256d06d91df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

