### PR TITLE
feat(slack): add DM channel listing support

### DIFF
--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -135,7 +135,9 @@ export class SlackClient {
     })
   }
 
-  async listDMs(): Promise<{ id: string; user: string; is_mpim: boolean }[]> {
+  async listDMs(
+    options: { excludeArchived?: boolean } = {}
+  ): Promise<{ id: string; user: string; is_mpim: boolean }[]> {
     return this.withRetry(async () => {
       const dms: { id: string; user: string; is_mpim: boolean }[] = []
       let cursor: string | undefined
@@ -145,6 +147,7 @@ export class SlackClient {
           cursor,
           limit: 200,
           types: 'im,mpim',
+          exclude_archived: options.excludeArchived ?? false,
         })
         this.checkResponse(response)
 

--- a/src/platforms/slack/commands/channel.ts
+++ b/src/platforms/slack/commands/channel.ts
@@ -17,6 +17,18 @@ async function listAction(options: { type?: string; includeArchived?: boolean; p
     }
 
     const client = new SlackClient(workspace.token, workspace.cookie)
+
+    if (options.type === 'dm') {
+      const dms = await client.listDMs({ excludeArchived: !options.includeArchived })
+      const dmOutput = dms.map((dm) => ({
+        id: dm.id,
+        user: dm.user,
+        is_mpim: dm.is_mpim,
+      }))
+      console.log(formatOutput(dmOutput, options.pretty))
+      return
+    }
+
     let channels = await client.listChannels()
 
     if (!options.includeArchived) {
@@ -27,15 +39,6 @@ async function listAction(options: { type?: string; includeArchived?: boolean; p
       channels = channels.filter((c) => !c.is_private)
     } else if (options.type === 'private') {
       channels = channels.filter((c) => c.is_private)
-    } else if (options.type === 'dm') {
-      const dms = await client.listDMs()
-      const dmOutput = dms.map((dm) => ({
-        id: dm.id,
-        user: dm.user,
-        is_mpim: dm.is_mpim,
-      }))
-      console.log(formatOutput(dmOutput, options.pretty))
-      return
     }
 
     const output = channels.map((ch) => ({


### PR DESCRIPTION
## Problem

`agent-slack channel list --type dm` returns an empty array because:
1. `listChannels()` only requests `types: 'public_channel,private_channel'` — `im` and `mpim` are not included
2. The `--type dm` branch in `channel.ts` hardcodes `channels = []`

## Solution

- Added `listDMs()` method to `SlackClient` that calls `conversations.list` with `types: 'im,mpim'`
- Updated `channel list --type dm` to call `listDMs()` and return actual DM channels with `id`, `user`, and `is_mpim` fields

## Notes

- `conversations.history` already works for DM channels (cookie is passed via `WebClient` headers), so `message list <DM_ID>` needs no changes
- All existing tests pass (`bun test`)

## Changes

- `src/platforms/slack/client.ts`: Added `listDMs()` method
- `src/platforms/slack/commands/channel.ts`: Implemented `--type dm` listing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DM and multi-person DM channel listing to the Slack integration. `agent-slack channel list --type dm` now returns real channels with `id`, `user`, and `is_mpim`, and respects `--include-archived`.

- **New Features**
  - Added `listDMs()` in `SlackClient` using `conversations.list` with `types: 'im,mpim'` and pagination.
  - Updated `channel list --type dm` to call `listDMs()` and print results.

- **Bug Fixes**
  - Fixed DM listing: include `'im,mpim'` and remove empty result; skip public/private fetch for `--type dm`; respect `--include-archived` via Slack `exclude_archived`.

<sup>Written for commit 1fbd12b137d96d84a70bb92d0fbd0119349cf96c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

