### PR TITLE
Fix type safety and consistency in Slack DM listing

### DIFF
--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -4,6 +4,7 @@ import type {
   SlackActivityItem,
   SlackChannel,
   SlackChannelSection,
+  SlackDM,
   SlackDraft,
   SlackFile,
   SlackMessage,
@@ -135,11 +136,9 @@ export class SlackClient {
     })
   }
 
-  async listDMs(
-    options: { excludeArchived?: boolean } = {}
-  ): Promise<{ id: string; user: string; is_mpim: boolean }[]> {
+  async listDMs(options: { includeArchived?: boolean } = {}): Promise<SlackDM[]> {
     return this.withRetry(async () => {
-      const dms: { id: string; user: string; is_mpim: boolean }[] = []
+      const dms: SlackDM[] = []
       let cursor: string | undefined
 
       do {
@@ -147,7 +146,7 @@ export class SlackClient {
           cursor,
           limit: 200,
           types: 'im,mpim',
-          exclude_archived: options.excludeArchived ?? false,
+          exclude_archived: !options.includeArchived,
         })
         this.checkResponse(response)
 
@@ -155,7 +154,7 @@ export class SlackClient {
           for (const ch of response.channels) {
             dms.push({
               id: ch.id!,
-              user: ch.user || (ch as any).name || '',
+              user: ch.user || ch.name || '',
               is_mpim: ch.is_mpim || false,
             })
           }

--- a/src/platforms/slack/commands/channel.ts
+++ b/src/platforms/slack/commands/channel.ts
@@ -19,7 +19,7 @@ async function listAction(options: { type?: string; includeArchived?: boolean; p
     const client = new SlackClient(workspace.token, workspace.cookie)
 
     if (options.type === 'dm') {
-      const dms = await client.listDMs({ excludeArchived: !options.includeArchived })
+      const dms = await client.listDMs({ includeArchived: options.includeArchived })
       const dmOutput = dms.map((dm) => ({
         id: dm.id,
         user: dm.user,

--- a/src/platforms/slack/types.ts
+++ b/src/platforms/slack/types.ts
@@ -125,6 +125,12 @@ export interface SlackActivityItem {
   created: number
 }
 
+export interface SlackDM {
+  id: string
+  user: string
+  is_mpim: boolean
+}
+
 export interface SlackDraft {
   id: string
   channel_id: string


### PR DESCRIPTION
## Summary

Follow-up to #55 (DM channel listing support). Fix type safety issues and improve API consistency in the Slack DM listing implementation.

## Changes

### Type safety (`types.ts`, `client.ts`)

- Add `SlackDM` interface to `types.ts` — follow the existing pattern where every entity (channel, message, user, etc.) has a named type.
- Use `SlackDM` as the return type of `listDMs()` and for the local accumulator variable in `client.ts`, replacing untyped inline objects.
- Remove `as any` cast on `ch.name` — the property is already typed on the Slack SDK's `Channel` type, so the cast was unnecessary.

### API consistency (`client.ts`, `commands/channel.ts`)

- Rename `excludeArchived` parameter to `includeArchived` to eliminate double-negation (`exclude_archived: !options.includeArchived` reads more clearly than `exclude_archived: options.excludeArchived` which inverts the caller's intent). This aligns with the existing `--include-archived` CLI flag naming.

## Context

These issues were identified during code review of #55. Separated into a follow-up PR to keep the original feature merge clean.

## Review Notes

- The `SlackDM` interface intentionally has a minimal surface (`id`, `user`, `is_mpim`) matching what the command output uses.
- The `includeArchived` rename is a breaking change to the internal API but `listDMs()` was just added in #55 and has no other callers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves type safety and cleans up API naming for Slack DM listing. Returns a typed `SlackDM[]` and switches to `includeArchived` to match the `--include-archived` flag, with no user-facing changes.

- **Refactors**
  - Adds `SlackDM` type and returns it from `listDMs()`.
  - Renames `excludeArchived` to `includeArchived` to align with CLI naming.
  - Removes the unnecessary cast on `ch.name`.

- **Migration**
  - No user action required. CLI flags are unchanged.

<sup>Written for commit 9efb68b0204717edb53f61be07ea5fbf070b8aae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

