### PR TITLE
Refactor v11 keyring decryption: extract shared helpers

### DIFF
--- a/src/platforms/discord/token-extractor.ts
+++ b/src/platforms/discord/token-extractor.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 
 import { DerivedKeyCache } from '@/shared/utils/derived-key-cache'
+import { lookupLinuxKeyringPassword } from '@/shared/utils/linux-keyring'
 
 export interface ExtractedDiscordToken {
   token: string
@@ -350,10 +351,7 @@ export class DiscordTokenExtractor {
   }
 
   private getLinuxKeyringPassword(appName: string): string {
-    return execSync(
-      `secret-tool lookup xdg:schema chrome_libsecret_os_crypt_password_v2 application ${appName}`,
-      { timeout: 5000, encoding: 'utf8' },
-    ).trim()
+    return lookupLinuxKeyringPassword(appName)
   }
 
   private decryptV11LinuxToken(encryptedData: Buffer): string | null {

--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import { ClassicLevel } from 'classic-level'
 
 import { DerivedKeyCache } from '@/shared/utils/derived-key-cache'
+import { lookupLinuxKeyringPassword } from '@/shared/utils/linux-keyring'
 
 const require = createRequire(import.meta.url)
 
@@ -770,6 +771,7 @@ export class TokenExtractor {
       if (this.platform === 'linux') {
         return this.decryptV11CookieLinux(encrypted)
       }
+      // TODO: macOS v11 uses keychain (not yet implemented)
     }
 
     // Windows pre-v80: DPAPI applied directly (no version prefix)
@@ -808,9 +810,8 @@ export class TokenExtractor {
     }
   }
 
-  private decryptV10CookieLinux(encrypted: Buffer): string | null {
+  private decryptLinuxCookieWithKey(encrypted: Buffer, key: Buffer): string | null {
     try {
-      const key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1')
       const iv = Buffer.alloc(16, ' ')
       const ciphertext = encrypted.subarray(3)
 
@@ -825,11 +826,13 @@ export class TokenExtractor {
     }
   }
 
+  private decryptV10CookieLinux(encrypted: Buffer): string | null {
+    const key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1')
+    return this.decryptLinuxCookieWithKey(encrypted, key)
+  }
+
   private getLinuxKeyringPassword(appName: string): string {
-    return execSync(
-      `secret-tool lookup xdg:schema chrome_libsecret_os_crypt_password_v2 application ${appName}`,
-      { timeout: 5000, encoding: 'utf8' },
-    ).trim()
+    return lookupLinuxKeyringPassword(appName)
   }
 
   private decryptV11CookieLinux(encrypted: Buffer): string | null {
@@ -838,13 +841,8 @@ export class TokenExtractor {
       try {
         const keyringPassword = this.getLinuxKeyringPassword(appName)
         const key = pbkdf2Sync(keyringPassword, 'saltysalt', 1, 16, 'sha1')
-        const iv = Buffer.alloc(16, ' ')
-        const ciphertext = encrypted.subarray(3)
-        const decipher = createDecipheriv('aes-128-cbc', key, iv)
-        const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-        const result = decrypted.toString('utf8')
-        const match = result.match(/xoxd-[A-Za-z0-9%]+/)
-        if (match) return match[0]
+        const result = this.decryptLinuxCookieWithKey(encrypted, key)
+        if (result) return result
       } catch {}
     }
     // Fall back to v10 peanuts key

--- a/src/shared/utils/linux-keyring.ts
+++ b/src/shared/utils/linux-keyring.ts
@@ -1,0 +1,8 @@
+import { execSync } from 'node:child_process'
+
+export function lookupLinuxKeyringPassword(appName: string): string {
+  return execSync(
+    `secret-tool lookup xdg:schema chrome_libsecret_os_crypt_password_v2 application ${appName}`,
+    { timeout: 5000, encoding: 'utf8' },
+  ).trim()
+}


### PR DESCRIPTION
## Summary

Extract shared Linux keyring helpers and DRY up duplicated decryption logic introduced in PR #56. The v11 gnome-keyring support added identical `getLinuxKeyringPassword` private methods to both Slack and Discord token extractors, and Slack's `decryptV11CookieLinux` duplicated the AES-CBC + xoxd matching logic already in `decryptV10CookieLinux`. This cleans that up without changing behavior.

## Changes

### Shared linux-keyring utility (`src/shared/utils/linux-keyring.ts`)

- Extract `lookupLinuxKeyringPassword(appName)` — both Slack and Discord token extractors now delegate to this single implementation for `secret-tool lookup`. Each class keeps a thin `getLinuxKeyringPassword` private wrapper so tests can `spyOn` it without importing the shared module.

### Slack token extractor

- Extract `decryptLinuxCookieWithKey(encrypted, key)` — the AES-CBC decryption + xoxd validation logic that was duplicated between `decryptV10CookieLinux` and `decryptV11CookieLinux`. Both now delegate to this shared helper.
- Add `// TODO: macOS v11 uses keychain (not yet implemented)` in `tryDecryptCookie` to make the gap explicit.

### Discord token extractor

- Import and delegate to `lookupLinuxKeyringPassword` instead of inlining the `execSync` call.

## Context

Follow-up to #56 which added Linux v11 gnome-keyring/libsecret cookie and token decryption for Slack and Discord. This PR is code cleanup only — no functional changes. All 72 tests pass, typecheck and lint are clean.

Also includes changes from PR #55 (Slack DM listing) and #56 (v11 keyring decryption, Discord token regex fix) which haven't been merged to main yet.

## Testing

No test changes needed — the refactoring preserves behavior. Existing v10 and v11 decryption tests cover both extractors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Linux v11 keyring decryption by extracting shared helpers and removing duplicate logic in Slack and Discord. No behavior changes.

- **Refactors**
  - Added shared `lookupLinuxKeyringPassword(appName)` in `src/shared/utils/linux-keyring.ts`; Slack and Discord now use it for `secret-tool` lookup.
  - Slack: extracted `decryptLinuxCookieWithKey(encrypted, key)` and routed both v10 (peanuts) and v11 (keyring-derived) paths through it.
  - Added a TODO noting macOS v11 uses Keychain in `tryDecryptCookie`.

<sup>Written for commit 68f3937194019bd4a07c4d0bbcce1bbf736dc191. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

