### PR TITLE
Add --type dm to channel list in SKILL.md

### DIFF
--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -194,6 +194,7 @@ agent-slack message delete <channel> <ts> --force
 agent-slack channel list
 agent-slack channel list --type public
 agent-slack channel list --type private
+agent-slack channel list --type dm
 agent-slack channel list --include-archived
 
 # Get channel info


### PR DESCRIPTION
## Summary

Add the missing `--type dm` example to the Channel Commands section of the agent-slack SKILL.md. This documents the DM listing feature added in #55 and refined in #57, which was shipped without a corresponding skill doc update.

## Changes

### Documentation (`skills/agent-slack/SKILL.md`)

- Add `agent-slack channel list --type dm` to the channel list command examples, alongside the existing `--type public` and `--type private` entries.

## Context

PR #55 added DM channel listing support (`channel list --type dm`) and PR #57 improved its type safety, but neither updated the SKILL.md that AI agents use as a command reference. Without this line, agents using the skill have no way to discover the `--type dm` option.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `agent-slack channel list --type dm` example to the `agent-slack` command docs so users can discover how to list DM channels. This aligns `skills/agent-slack/SKILL.md` with the existing DM listing feature.

<sup>Written for commit 59bebaeb2450388b7621eae02856625fdd8fa254. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

