### PR TITLE
Fix --pretty flag ignored in command output

### DIFF
--- a/src/platforms/discord/cli.ts
+++ b/src/platforms/discord/cli.ts
@@ -38,7 +38,6 @@ program
   .name('agent-discord')
   .description('CLI tool for Discord communication')
   .version(pkg.version)
-  .option('--pretty', 'Pretty-print JSON output')
   .option('--server <id>', 'Use specific server')
 
 program.hook('preAction', async (_thisCommand, actionCommand) => {

--- a/src/platforms/discordbot/cli.ts
+++ b/src/platforms/discordbot/cli.ts
@@ -21,7 +21,6 @@ program
   .name('agent-discordbot')
   .description('CLI tool for Discord bot integration using bot tokens')
   .version(pkg.version)
-  .option('--pretty', 'Pretty-print JSON output')
   .option('--bot <id>', 'Bot ID to use')
   .option('--server <id>', 'Server ID to use')
 

--- a/src/platforms/slack/cli.test.ts
+++ b/src/platforms/slack/cli.test.ts
@@ -80,7 +80,6 @@ describe('CLI Framework', () => {
       expect(output).toContain('reaction')
       expect(output).toContain('file')
       expect(output).toContain('snapshot')
-      expect(output).toContain('--pretty')
       expect(output).toContain('--workspace')
     })
 

--- a/src/platforms/slack/cli.ts
+++ b/src/platforms/slack/cli.ts
@@ -36,7 +36,6 @@ program
   .name('agent-slack')
   .description('CLI tool for Slack communication with token extraction from Slack desktop app')
   .version(pkg.version)
-  .option('--pretty', 'Pretty-print JSON output')
   .option('--workspace <id>', 'Use specific workspace')
 
 program.hook('preAction', async (_thisCommand, actionCommand) => {

--- a/src/platforms/slackbot/cli.ts
+++ b/src/platforms/slackbot/cli.ts
@@ -11,7 +11,6 @@ program
   .name('agent-slackbot')
   .description('CLI tool for Slack bot integration using bot tokens (xoxb-)')
   .version(pkg.version)
-  .option('--pretty', 'Pretty-print JSON output')
   .option('--bot <id>', 'Use specific bot (default: current)')
 
 program.addCommand(authCommand)

--- a/src/platforms/teams/cli.ts
+++ b/src/platforms/teams/cli.ts
@@ -33,7 +33,6 @@ program
   .name('agent-teams')
   .description('CLI tool for Microsoft Teams communication')
   .version(pkg.version)
-  .option('--pretty', 'Pretty-print JSON output')
   .option('--team <id>', 'Use specific team')
   .option('--account <type>', 'Use specific account (work or personal)')
 


### PR DESCRIPTION
## Summary

Fix the `--pretty` flag being silently ignored across all 5 platform CLIs. The flag was defined on both root commands and leaf subcommands, causing Commander.js to consume it at the root level before subcommands could parse it. Remove the duplicate root-level definitions so leaf subcommands correctly receive the flag.

Fixes #61.

## Changes

### Platform CLIs (`src/platforms/*/cli.ts`)

- Remove `.option('--pretty', 'Pretty-print JSON output')` from the root command in all 5 platform CLIs: slack, slackbot, discord, discordbot, teams. Each leaf subcommand already defines its own `--pretty` option and now correctly receives the flag.

### Tests (`src/platforms/slack/cli.test.ts`)

- Remove `expect(output).toContain('--pretty')` assertion from the root help output test, since `--pretty` no longer appears in root-level help.

## Context

Commander.js scans the full `argv` for known options regardless of their position. When `--pretty` was defined on both the root command and a leaf subcommand, the root command consumed `--pretty` from `argv` before the leaf subcommand could parse it — even when `--pretty` appeared after the subcommand name (e.g., `agent-slack channel list --pretty`). This left `options.pretty` as `undefined` in every action handler, making the flag effectively dead.

## Testing

All existing tests pass after the change. The single affected test assertion (checking for `--pretty` in root help output) is removed since the flag now only appears on subcommands where it belongs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `--pretty` flag being ignored by removing the root-level `--pretty` option from all platform CLIs. Leaf subcommands now receive the flag (it’s no longer consumed by `commander`), and the Slack root help test no longer expects `--pretty`.

<sup>Written for commit 34fbaf60d63fa7faeb6606f6ccedff9d135e3ad0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

