### PR TITLE
Fix skills: default to npx -y, add cookie lock troubleshooting

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -419,7 +419,7 @@ If the package is installed globally, use `agent-discord` directly:
 agent-discord server list
 ```
 
-If the package is NOT installed, run it directly using a package runner. Ask the user which one to use:
+If the package is NOT installed, use `npx -y` by default. **Do NOT ask the user which package runner to use** — just run it:
 
 ```bash
 npx -y agent-messenger discord server list
@@ -427,7 +427,7 @@ bunx agent-messenger discord server list
 pnpm dlx agent-messenger discord server list
 ```
 
-If you already know the user's preferred package runner, use it directly instead of asking.
+> If you already know the user's preferred package runner (e.g., `bunx`, `pnpx`, `pnpm dlx`), use that instead.
 
 **NEVER run `npx agent-discord`, `bunx agent-discord`, or `pnpm dlx agent-discord`** — it will fail or install a wrong package since `agent-discord` is not the npm package name.
 

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -377,7 +377,7 @@ If the package is installed globally, use `agent-discordbot` directly:
 agent-discordbot message send 1234567890123456789 "Hello"
 ```
 
-If the package is NOT installed, run it directly using a package runner. Ask the user which one to use:
+If the package is NOT installed, use `npx -y` by default. **Do NOT ask the user which package runner to use** — just run it:
 
 ```bash
 npx -y agent-messenger discordbot message send 1234567890123456789 "Hello"
@@ -385,7 +385,7 @@ bunx agent-messenger discordbot message send 1234567890123456789 "Hello"
 pnpm dlx agent-messenger discordbot message send 1234567890123456789 "Hello"
 ```
 
-If you already know the user's preferred package runner, use it directly instead of asking.
+> If you already know the user's preferred package runner (e.g., `bunx`, `pnpx`, `pnpm dlx`), use that instead.
 
 **NEVER run `npx agent-discordbot`, `bunx agent-discordbot`, or `pnpm dlx agent-discordbot`** -- it will fail or install a wrong package since `agent-discordbot` is not the npm package name.
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -402,7 +402,7 @@ If the package is installed globally, use `agent-slack` directly:
 agent-slack message list general
 ```
 
-If the package is NOT installed, run it directly using a package runner. Ask the user which one to use:
+If the package is NOT installed, use `npx -y` by default. **Do NOT ask the user which package runner to use** — just run it:
 
 ```bash
 npx -y agent-messenger slack message list general
@@ -410,9 +410,19 @@ bunx agent-messenger slack message list general
 pnpm dlx agent-messenger slack message list general
 ```
 
-If you already know the user's preferred package runner, use it directly instead of asking.
+> If you already know the user's preferred package runner (e.g., `bunx`, `pnpx`, `pnpm dlx`), use that instead.
 
 **NEVER run `npx agent-slack`, `bunx agent-slack`, or `pnpm dlx agent-slack`** — a separate, unrelated npm package named `agent-slack` exists on npm. It will silently install the **wrong package** with different (fewer) commands.
+
+### `Failed to read Slack cookies`
+
+If you see:
+
+```json
+{"error":"Failed to read Slack cookies. The Slack app is currently running and locking the cookie database. Quit the Slack app completely and try again."}
+```
+
+Tell the user you need to quit the Slack app to extract credentials, and ask for confirmation. If the user agrees, quit Slack and retry the command.
 
 For other troubleshooting (auth extraction, token issues, Keychain), see [references/authentication.md](references/authentication.md).
 

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -318,7 +318,7 @@ If the package is installed globally, use `agent-slackbot` directly:
 agent-slackbot message send general "Hello"
 ```
 
-If the package is NOT installed, run it directly using a package runner. Ask the user which one to use:
+If the package is NOT installed, use `npx -y` by default. **Do NOT ask the user which package runner to use** — just run it:
 
 ```bash
 npx -y agent-messenger slackbot message send general "Hello"
@@ -326,7 +326,7 @@ bunx agent-messenger slackbot message send general "Hello"
 pnpm dlx agent-messenger slackbot message send general "Hello"
 ```
 
-If you already know the user's preferred package runner, use it directly instead of asking.
+> If you already know the user's preferred package runner (e.g., `bunx`, `pnpx`, `pnpm dlx`), use that instead.
 
 **NEVER run `npx agent-slackbot`, `bunx agent-slackbot`, or `pnpm dlx agent-slackbot`** — it will fail or install a wrong package since `agent-slackbot` is not the npm package name.
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -366,7 +366,7 @@ If the package is installed globally, use `agent-teams` directly:
 agent-teams team list
 ```
 
-If the package is NOT installed, run it directly using a package runner. Ask the user which one to use:
+If the package is NOT installed, use `npx -y` by default. **Do NOT ask the user which package runner to use** — just run it:
 
 ```bash
 npx -y agent-messenger teams team list
@@ -374,7 +374,7 @@ bunx agent-messenger teams team list
 pnpm dlx agent-messenger teams team list
 ```
 
-If you already know the user's preferred package runner, use it directly instead of asking.
+> If you already know the user's preferred package runner (e.g., `bunx`, `pnpx`, `pnpm dlx`), use that instead.
 
 **NEVER run `npx agent-teams`, `bunx agent-teams`, or `pnpm dlx agent-teams`** — it will fail or install a wrong package since `agent-teams` is not the npm package name.
 


### PR DESCRIPTION
## Summary

Stop skills from asking the user which package runner to use. AI agents should default to `npx -y` and run commands immediately, reducing unnecessary back-and-forth. Also add troubleshooting guidance for the Slack cookie lock error that occurs when the Slack desktop app is running.

## Changes

### Package runner defaults (all 5 skills)

- Change "Ask the user which one to use" → "Do NOT ask the user which package runner to use — just run it" with `npx -y` as the default runner.
- Rephrase the user-preference note as a blockquote: "If you already know the user's preferred package runner (e.g., `bunx`, `pnpx`, `pnpm dlx`), use that instead."

### Slack cookie lock error (`agent-slack`)

- Add a new troubleshooting section for the `Failed to read Slack cookies` error. Instructs the agent to explain the issue to the user, ask for confirmation to quit Slack, then retry the command.

## Context

When an AI agent encounters a skill for the first time and sees "ask the user which package runner to use," it stalls the conversation with an unnecessary question. Most users don't care — they just want the command to run. Defaulting to `npx -y` eliminates this friction while still respecting known preferences.

The Slack cookie lock error is a common failure mode when the Slack desktop app holds a lock on the cookie database. Without guidance, agents either retry endlessly or give up. The new section gives them a clear recovery path.

## Testing

Documentation-only changes to skill Markdown files. No code changes, no tests affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default all skills to run with `npx -y` without asking the user, reducing back-and-forth. Add troubleshooting for Slack cookie lock errors when the Slack desktop app is open.

- **New Features**
  - Default runner is `npx -y` for `agent-discord`, `agent-discordbot`, `agent-slack`, `agent-slackbot`, `agent-teams`. If a preference is known, use `bunx`, `pnpx`, or `pnpm dlx` instead.

- **Bug Fixes**
  - `agent-slack`: Added guidance for `Failed to read Slack cookies`. Explain the lock, ask to quit Slack, confirm, then retry.

<sup>Written for commit 3be5150492832a868ca3054e387ca33fbfd71114. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

