### PR TITLE
Add Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# Copilot Code Review Instructions
+
+## Documentation Sync
+
+When code under `src/platforms/<platform>/` changes, verify that the corresponding documentation is updated:
+
+| Code Change | Required Doc Update |
+|---|---|
+| New/modified command in `src/platforms/<platform>/commands/` | `skills/agent-<platform>/SKILL.md` — Commands section |
+| Changed output format or fields | `skills/agent-<platform>/SKILL.md` — Output Format section |
+| New/changed error codes or messages | `skills/agent-<platform>/SKILL.md` — Error Handling & Troubleshooting sections |
+| Auth flow changes (`token-extractor.ts`, `credential-manager.ts`) | `skills/agent-<platform>/references/authentication.md` |
+| New workflow patterns or behavioral changes | `skills/agent-<platform>/references/common-patterns.md` |
+| New platform or major feature | `docs/content/docs/integrations/<platform>.mdx` and `README.md` |
+
+Flag any PR that modifies platform source code without corresponding documentation updates.
+
+## Skill File Consistency
+
+Each `skills/agent-<platform>/SKILL.md` must:
+
+- Have frontmatter `version` matching `package.json` version (handled by release automation — do not flag version mismatches in PRs)
+- Document every subcommand available in the CLI
+- Include accurate output format examples that match actual CLI output
+- List all supported flags and options for each command
+
+## Code Quality
+
+- No `as any`, `@ts-ignore`, or `@ts-expect-error` type suppressions
+- No empty `catch` blocks — all errors must be handled or explicitly re-thrown
+- Prefer early returns over deep nesting
+- All public functions should have JSDoc comments describing parameters and return values
+
+## Testing
+
+- New commands or features must include corresponding tests
+- Bug fixes should include a regression test when feasible


### PR DESCRIPTION
## Summary

Add `.github/copilot-instructions.md` to configure GitHub Copilot code review with custom rules for this repository.

## Changes

### `.github/copilot-instructions.md`

- **Documentation sync enforcement** — flags PRs that modify platform source code without updating the corresponding `SKILL.md`, reference docs, or integration docs.
- **Code quality rules** — type safety, error handling, and output format consistency aligned with existing platform conventions.
- **Testing expectations** — coverage requirements for new commands and auth flows.

## Context

Platform implementations often shipped without matching skill documentation updates. This rule gives Copilot a standing instruction to catch that drift at review time rather than after merge.

## Review Notes

- Instructions are intentionally scoped to this repo's conventions (platform source → skill docs mapping).
- No code changes — configuration only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.github/copilot-instructions.md` to guide GitHub Copilot code reviews, enforcing documentation sync for platform changes and basic code quality and testing standards.

- **New Features**
  - Doc sync checks for changes under `src/platforms/<platform>/` (e.g., `SKILL.md`, references, integration docs).
  - Code quality rules: avoid type suppressions, handle errors, prefer early returns, add JSDoc to public functions.
  - Testing expectations for new commands/features and regression tests for fixes.

<sup>Written for commit 4a8836dd938f07599e648aefc6c959d10255cda6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

