### PR TITLE
Add Cubic AI review config

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+
+version: 1
+
+reviews:
+  enabled: true
+  sensitivity: medium
+  incremental_commits: true
+  check_drafts: false
+  resolve_threads_when_addressed: true
+  custom_instructions: |
+    This is a multi-platform messaging CLI (agent-messenger) with Agent Skills.
+    Each platform has source code in src/platforms/<platform>/ and corresponding
+    documentation in skills/agent-<platform>/SKILL.md, references/, and
+    docs/content/docs/integrations/<platform>.mdx.
+
+    When reviewing, always check that documentation stays in sync with code changes.
+
+  ignore:
+    files:
+      - docs/node_modules/**
+      - dist/**
+      - "*.lock"
+    head_branches:
+      - wip/*
+
+  custom_rules:
+    - name: Documentation sync
+      description: |
+        When code under src/platforms/<platform>/ changes, verify that the
+        corresponding documentation is updated:
+
+        - New or modified commands in src/platforms/<platform>/commands/ must be
+          reflected in skills/agent-<platform>/SKILL.md (Commands section, flags,
+          output format examples).
+        - Auth flow changes (token-extractor.ts, credential-manager.ts) must be
+          reflected in skills/agent-<platform>/references/authentication.md.
+        - Behavioral or workflow changes must be reflected in
+          skills/agent-<platform>/references/common-patterns.md.
+        - New platforms or major features must update
+          docs/content/docs/integrations/<platform>.mdx and README.md.
+
+        Flag PRs that modify platform source code without corresponding
+        documentation updates. Mention specifically which doc files are missing
+        updates.
+      include:
+        - src/platforms/**
+        - skills/**
+        - docs/content/docs/integrations/**
+
+    - name: SKILL.md completeness
+      description: |
+        Each skills/agent-<platform>/SKILL.md must:
+        - Document every subcommand available in the CLI.
+        - Include accurate output format examples matching actual CLI output.
+        - List all supported flags and options for each command.
+        - Have error handling and troubleshooting sections that cover common
+          failure modes.
+
+        When a SKILL.md is modified, check that it remains complete and accurate
+        relative to the corresponding source code.
+      include:
+        - skills/**/SKILL.md
+
+pr_descriptions:
+  generate: true
+  instructions: |
+    Include a note about whether SKILL.md or docs were updated if any platform
+    source code changed.


### PR DESCRIPTION
## Summary

Add `cubic.yaml` at the repo root to configure Cubic AI (cubic.dev) code reviews. The primary motivation is to enforce documentation hygiene as the project grows: platform source changes in `src/platforms/` frequently outpace their corresponding SKILL.md and integration doc updates, and catching that drift at review time is more reliable than relying on author discipline alone.

## Changes

### `cubic.yaml`

- **Global settings** — Enable reviews at `medium` sensitivity with incremental-commit mode on and draft PR reviews off. Auto-resolve threads when the author marks them addressed.
- **Custom context** — Describes the project layout (`src/platforms/<platform>/` ↔ `skills/agent-<platform>/`) so Cubic understands the relationship between code and docs before applying rules.
- **Ignore patterns** — Skips `docs/node_modules/**`, `dist/**`, `*.lock`, and `wip/*` head branches to avoid noise on generated or work-in-progress files.
- **Custom rule: Documentation sync** — Flags PRs that touch `src/platforms/<platform>/commands/`, auth files, or behavioral code without updating the corresponding `SKILL.md`, `references/authentication.md`, `references/common-patterns.md`, or integration MDX. The rule names the specific missing files rather than issuing a generic warning.
- **Custom rule: SKILL.md completeness** — When a `SKILL.md` is modified, checks that it still documents every subcommand, lists all flags, includes accurate output examples, and has error-handling and troubleshooting coverage.
- **PR description generation** — Instructs Cubic to note whether SKILL.md or docs were updated whenever platform source changed.

## Context

The repo follows a strict 1:1 mapping between platform implementations and skill documentation: `src/platforms/slack/` ↔ `skills/agent-slack/SKILL.md`, `src/platforms/telegram/` ↔ `skills/agent-telegram/SKILL.md`, and so on. Keeping that mapping accurate is important because downstream agents rely on SKILL.md as the source of truth for command flags and output formats.

The documentation sync rule targets exactly the files where drift is most likely: command handlers (new flags, renamed outputs), auth modules (changed credential flows), and the integration MDX pages (new platforms, major behavioral changes). The SKILL.md completeness rule acts as a secondary check — catching edits that remove or silently invalidate existing documentation sections.

## Testing

Configuration only — no runnable tests. The YAML schema is validated against the official Cubic schema (`https://cubic.dev/schema/cubic-repository-config.schema.json` in the `yaml-language-server` header). Rule correctness will be validated by Cubic on the first PR it reviews after merge.

## Review Notes

- **Sensitivity level** — `medium` is the Cubic default and a reasonable starting point. If the custom rules generate too much noise (or too little), it can be tuned to `low` or `high` without changing the rules themselves.
- **`check_drafts: false`** — Intentionally off. Draft PRs are work-in-progress by definition; running doc-sync checks on them would create noise before the author is ready for feedback.
- **`incremental_commits: true`** — Cubic reviews each new commit pushed to an open PR rather than re-reviewing the full diff. This keeps review threads focused on what changed since the last push.
- **Rule scope** — The documentation sync rule uses `include` to limit matching to `src/platforms/**`, `skills/**`, and `docs/content/docs/integrations/**`. PRs that don't touch those paths (e.g. pure CI config changes) won't trigger the rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cubic.yaml` to enable Cubic code reviews with rules that keep platform code and docs in sync. This reduces drift in `SKILL.md` and integration docs when `src/platforms/*` changes.

- **New Features**
  - Enable reviews at `medium` sensitivity with incremental commits, no draft checks, and auto-resolve on addressed threads.
  - Add project context mapping `src/platforms/<platform>/` to `skills/agent-<platform>/` and `docs/...` to guide checks.
  - Ignore noise: `docs/node_modules/**`, `dist/**`, `*.lock`, and `wip/*` branches.
  - Rule: flag platform code changes without matching doc updates; list missing `SKILL.md`, auth refs, or integration MDX.
  - Rule: verify `SKILL.md` completeness (commands, flags, output examples, troubleshooting); PR descriptions note doc updates when source changes.

<sup>Written for commit 127b6a56e86e8c4acae26c4ed6390048c3af423a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

