### PR TITLE
Migrate zod from v3 to v4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "commander": "^11.1.0",
         "pino": "^10.3.1",
         "ws": "^8.19.0",
-        "zod": "^3.22.4",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.8",
@@ -629,7 +629,7 @@
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@slack/logger/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "commander": "^11.1.0",
     "pino": "^10.3.1",
     "ws": "^8.19.0",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "optionalDependencies": {
     "koffi": "^2.15.2",

--- a/src/platforms/channeltalk/types.ts
+++ b/src/platforms/channeltalk/types.ts
@@ -338,7 +338,7 @@ export const ChannelSearchResponseSchema = z.object({
   directChats: z.array(ChannelDirectChatSchema).optional(),
   groups: z.array(ChannelGroupSchema).optional(),
   userChats: z.array(ChannelUserChatSchema).optional(),
-  users: z.array(z.object({ id: z.string() }).passthrough()).optional(),
+  users: z.array(z.looseObject({ id: z.string() })).optional(),
 })
 
 export const ExtractedChannelTokenSchema = z.object({


### PR DESCRIPTION
## Summary

Upgrade zod from v3 to v4 (4.3.6) across the codebase. The migration is minimal — only one code change was required — and brings significant performance and bundle-size improvements to all schema validation paths.

## Changes

### Dependency
- Bump `zod` from `^3.22.4` to `^4.3.6` in `package.json` and `bun.lock`.

### Schema migration (`src/platforms/channeltalk/types.ts`)
- Replace `.passthrough()` with `z.looseObject()` — the only breaking change in v4 that affected the codebase.
- `z.looseObject()` is the v4 equivalent of `.passthrough()`: it passes through unknown keys rather than stripping them. The Channel Talk response schemas need this because the API returns additional undocumented fields.

## Context

Zod v4 is a ground-up rewrite with a focus on performance and bundle size:

- **~14× faster** string parsing
- **~7× faster** array parsing
- **~2.3× smaller** bundle (12.5kb → 5.4kb gzipped)

The migration was straightforward because the codebase already used v4-compatible patterns:
- All `z.record()` calls already provided two type arguments (required by v4).
- No `.transform()` / `.refine()` chains, `ZodError` handling, or custom error maps.
- No `z.infer` usage that would be affected by type inference changes.

The `zod-v3-to-v4` codemod was run first and identified `.passthrough()` as the only migration target across all 9 schema files (~71 schemas total).

## Testing

- **1,580 tests pass** — zero regressions across all platforms.
- `bun typecheck` clean — zero type errors.
- `bun build` (tsc + tsc-alias) passes cleanly.
- All platform CLIs load and run correctly at runtime.
- Zod runtime behavior verified: `safeParse`, `startsWith`, and `z.looseObject()` all produce correct results.