### PR TITLE
reduce webex snapshot to lightweight spaces-only overview

### DIFF
--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -176,21 +176,13 @@ agent-webex member list abc123 --limit 100
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace spaces overview for AI agents:
 
 ```bash
-# Full snapshot (spaces, members, recent messages)
 agent-webex snapshot
-
-# Filtered snapshots
-agent-webex snapshot --spaces-only
-agent-webex snapshot --members-only
-
-# Limit messages per space
-agent-webex snapshot --limit 10
 ```
 
-> **Note**: `--members-only` fetches members from the first 10 spaces only (to avoid excessive API calls). Use `member list <space-id>` for specific spaces.
+Returns only the spaces you're a member of, with id, title, type, and lastActivity. Use `message list <space-id>` or `member list <space-id>` for details.
 
 ## Global Options
 
@@ -296,7 +288,7 @@ if ! agent-webex auth status | jq -e '.authenticated' > /dev/null 2>&1; then
 fi
 
 # 2. Get workspace context
-agent-webex snapshot --limit 5 > /tmp/webex-context.json
+agent-webex snapshot > /tmp/webex-context.json
 
 # 3. Send standup reminder
 agent-webex message send $STANDUP_SPACE "Good morning! Time for standup."

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -116,7 +116,7 @@ At the **start of every task**, read `~/.config/agent-messenger/MEMORY.md` using
 After discovering useful information, update `~/.config/agent-messenger/MEMORY.md` using the `Write` tool. Write triggers include:
 
 - After discovering space IDs and titles (from `space list`, `snapshot`, etc.)
-- After discovering member IDs and names (from `member list`, `snapshot`, etc.)
+- After discovering member IDs and names (from `member list`, etc.)
 - After the user gives you an alias or preference ("call this the standup space", "my main space is X")
 - After discovering space structure (group vs direct spaces)
 
@@ -247,25 +247,17 @@ agent-webex member list <space-id> --limit 100
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace spaces overview for AI agents:
 
 ```bash
-# Full snapshot
 agent-webex snapshot
-
-# Filtered snapshots
-agent-webex snapshot --spaces-only
-agent-webex snapshot --members-only
-
-# Limit messages per space
-agent-webex snapshot --limit 10
 ```
 
 Returns JSON with:
 
-- Spaces (id, title, type, created)
-- Recent messages (id, text, personEmail, created)
-- Members (id, personDisplayName, personEmail)
+- Spaces (id, title, type, lastActivity) — only spaces you're a member of
+
+For messages or members, use `message list <space-id>` or `member list <space-id>`.
 
 ## Output Format
 

--- a/skills/agent-webex/references/common-patterns.md
+++ b/skills/agent-webex/references/common-patterns.md
@@ -323,9 +323,9 @@ echo "Found: $(echo "$MATCH" | jq -r '.personDisplayName') ($(echo "$MATCH" | jq
 
 ## Snapshot Patterns
 
-### Pattern 19: Full Workspace Snapshot
+### Pattern 19: Workspace Snapshot
 
-**Use case**: Get complete workspace state for AI context
+**Use case**: Get spaces overview for AI context
 
 ```bash
 #!/bin/bash
@@ -339,36 +339,7 @@ echo "Total spaces: $SPACE_COUNT"
 echo "$SNAPSHOT" | jq -r '.spaces[] | "  \(.title) (\(.type))"'
 ```
 
-### Pattern 20: Spaces-Only Snapshot
-
-**Use case**: Quick overview without messages or members
-
-```bash
-#!/bin/bash
-
-agent-webex snapshot --spaces-only
-```
-
-### Pattern 21: Members-Only Snapshot
-
-**Use case**: Get member lists across all spaces
-
-```bash
-#!/bin/bash
-
-agent-webex snapshot --members-only
-```
-
-### Pattern 22: Snapshot with Message Limit
-
-**Use case**: Control how many messages per space
-
-```bash
-#!/bin/bash
-
-# Get snapshot with last 5 messages per space
-agent-webex snapshot --limit 5
-```
+**When to use**: Quick workspace overview to discover space IDs and titles. Use `message list <space-id>` or `member list <space-id>` for details.
 
 ## Pipeline Patterns
 

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -438,6 +438,16 @@ export class WebexClient {
     return data.items
   }
 
+  async listMyMemberships(options?: { max?: number }): Promise<WebexMembership[]> {
+    const params = new URLSearchParams()
+    params.set('max', String(options?.max ?? 100))
+    const data = await this.request<{ items: WebexMembership[] }>(
+      'GET',
+      `/memberships?${params}`,
+    )
+    return data.items
+  }
+
   async listMemberships(
     roomId: string,
     options?: { max?: number },

--- a/src/platforms/webex/commands/snapshot.test.ts
+++ b/src/platforms/webex/commands/snapshot.test.ts
@@ -11,24 +11,19 @@ mock.module('@/shared/utils/error-handler', () => ({
 
 const mockSpaces = [
   { id: 'space-1', title: 'General', type: 'group', isLocked: false, lastActivity: '2024-01-15T00:00:00.000Z', created: '2024-01-01T00:00:00.000Z', creatorId: 'person-1' },
+  { id: 'space-2', title: 'Random', type: 'group', isLocked: false, lastActivity: '2024-01-14T00:00:00.000Z', created: '2024-01-01T00:00:00.000Z', creatorId: 'person-1' },
 ]
 
-const mockMessages = [
-  { id: 'msg-1', roomId: 'space-1', roomType: 'group', text: 'Hello', personId: 'person-1', personEmail: 'alice@example.com', created: '2024-01-15T00:00:00.000Z' },
-]
-
-const mockMembers = [
+const mockMyMemberships = [
   { id: 'mem-1', roomId: 'space-1', personId: 'person-1', personEmail: 'alice@example.com', personDisplayName: 'Alice', isModerator: true, created: '2024-01-01T00:00:00.000Z' },
 ]
 
 const mockListSpaces = mock(() => Promise.resolve(mockSpaces as any))
-const mockListMessages = mock(() => Promise.resolve(mockMessages as any))
-const mockListMemberships = mock(() => Promise.resolve(mockMembers as any))
+const mockListMyMemberships = mock(() => Promise.resolve(mockMyMemberships as any))
 
 const mockClient = {
   listSpaces: mockListSpaces,
-  listMessages: mockListMessages,
-  listMemberships: mockListMemberships,
+  listMyMemberships: mockListMyMemberships,
 }
 
 const mockLogin = mock(() => Promise.resolve(mockClient))
@@ -46,8 +41,7 @@ describe('snapshot command', () => {
 
   beforeEach(() => {
     mockListSpaces.mockReset().mockImplementation(() => Promise.resolve(mockSpaces as any))
-    mockListMessages.mockReset().mockImplementation(() => Promise.resolve(mockMessages as any))
-    mockListMemberships.mockReset().mockImplementation(() => Promise.resolve(mockMembers as any))
+    mockListMyMemberships.mockReset().mockImplementation(() => Promise.resolve(mockMyMemberships as any))
     mockLogin.mockReset().mockImplementation(() => Promise.resolve(mockClient))
     mockHandleError.mockReset().mockImplementation((err: Error) => {
       throw err
@@ -60,40 +54,24 @@ describe('snapshot command', () => {
     consoleSpy.mockRestore()
   })
 
-  test('full snapshot includes spaces, recent_messages, members', async () => {
+  test('returns spaces with id, title, type, lastActivity', async () => {
     await snapshotAction({})
 
     expect(consoleSpy).toHaveBeenCalled()
     const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
-    expect(output.spaces).toBeDefined()
+    expect(output.spaces).toHaveLength(1)
     expect(output.spaces[0].id).toBe('space-1')
     expect(output.spaces[0].title).toBe('General')
-    expect(output.recent_messages).toBeDefined()
-    expect(output.recent_messages[0].id).toBe('msg-1')
-    expect(output.recent_messages[0].author).toBe('alice@example.com')
-    expect(output.members).toBeDefined()
-    expect(output.members[0].personEmail).toBe('alice@example.com')
+    expect(output.spaces[0].type).toBe('group')
+    expect(output.spaces[0].lastActivity).toBe('2024-01-15T00:00:00.000Z')
   })
 
-  test('--spaces-only includes only spaces (no messages, no members)', async () => {
-    await snapshotAction({ spacesOnly: true })
+  test('filters spaces to only those in my memberships', async () => {
+    await snapshotAction({})
 
-    expect(consoleSpy).toHaveBeenCalled()
     const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
-    expect(output.spaces).toBeDefined()
-    expect(output.recent_messages).toBeUndefined()
-    expect(output.members).toBeUndefined()
-  })
-
-  test('--members-only includes only members (no spaces, no messages)', async () => {
-    await snapshotAction({ membersOnly: true })
-
-    expect(consoleSpy).toHaveBeenCalled()
-    const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
-    expect(output.spaces).toBeUndefined()
-    expect(output.recent_messages).toBeUndefined()
-    expect(output.members).toBeDefined()
-    expect(output.members[0].personEmail).toBe('alice@example.com')
+    expect(output.spaces).toHaveLength(1)
+    expect(output.spaces[0].id).toBe('space-1')
   })
 
   test('not authenticated outputs error', async () => {
@@ -104,11 +82,5 @@ describe('snapshot command', () => {
     await expect(snapshotAction({})).rejects.toThrow('No Webex credentials found.')
 
     expect(mockHandleError).toHaveBeenCalledWith(expect.any(WebexError))
-  })
-
-  test('passes limit option to listMessages', async () => {
-    await snapshotAction({ limit: 5 })
-
-    expect(mockListMessages).toHaveBeenCalledWith('space-1', { max: 5 })
   })
 })

--- a/src/platforms/webex/commands/snapshot.ts
+++ b/src/platforms/webex/commands/snapshot.ts
@@ -1,72 +1,27 @@
 import { Command } from 'commander'
-import { parallelMap } from '@/shared/utils/concurrency'
 import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 import { WebexClient } from '../client'
-import type { WebexSpace } from '../types'
 
 export async function snapshotAction(options: {
-  spacesOnly?: boolean
-  membersOnly?: boolean
-  limit?: number
   pretty?: boolean
 }): Promise<void> {
   try {
     const client = await new WebexClient().login()
-    const messageLimit = options.limit || 20
-    const snapshot: Record<string, unknown> = {}
 
-    if (!options.membersOnly) {
-      const spaces = await client.listSpaces({ max: 50 })
-      snapshot.spaces = spaces.map((s) => ({
+    const myMemberships = await client.listMyMemberships({ max: 100 })
+    const myRoomIds = new Set(myMemberships.map((m) => m.roomId))
+
+    const allSpaces = await client.listSpaces({ max: 100 })
+    const spaces = allSpaces.filter((s) => myRoomIds.has(s.id))
+
+    const snapshot = {
+      spaces: spaces.map((s) => ({
         id: s.id,
         title: s.title,
         type: s.type,
         lastActivity: s.lastActivity,
-      }))
-
-      if (!options.spacesOnly) {
-        const spaceMessages = await parallelMap(
-          spaces,
-          async (space: WebexSpace) => {
-            const messages = await client.listMessages(space.id, { max: messageLimit })
-            return messages.map((msg) => ({
-              ...msg,
-              space_title: space.title,
-            }))
-          },
-          5,
-        )
-
-        snapshot.recent_messages = spaceMessages.flat().map((msg) => ({
-          space_id: msg.roomId,
-          space_title: msg.space_title,
-          id: msg.id,
-          author: msg.personEmail,
-          text: msg.text || msg.markdown || '',
-          created: msg.created,
-        }))
-      }
-    }
-
-    if (!options.spacesOnly) {
-      // Get members for the first few spaces (avoid massive API calls)
-      const spaces = await client.listSpaces({ max: 10 })
-      const spaceMembers = await parallelMap(
-        spaces,
-        async (space: WebexSpace) => {
-          const members = await client.listMemberships(space.id, { max: 100 })
-          return members.map((m) => ({
-            space_id: space.id,
-            space_title: space.title,
-            personEmail: m.personEmail,
-            personDisplayName: m.personDisplayName,
-            isModerator: m.isModerator,
-          }))
-        },
-        5,
-      )
-      snapshot.members = spaceMembers.flat()
+      })),
     }
 
     console.log(formatOutput(snapshot, options.pretty))
@@ -76,16 +31,10 @@ export async function snapshotAction(options: {
 }
 
 export const snapshotCommand = new Command('snapshot')
-  .description('Get comprehensive workspace state for AI agents')
-  .option('--spaces-only', 'Include only spaces (exclude messages and members)')
-  .option('--members-only', 'Include only members (exclude spaces and messages)')
-  .option('--limit <n>', 'Number of recent messages per space (default: 20)', '20')
+  .description('Get workspace spaces overview for AI agents')
   .option('--pretty', 'Pretty print JSON output')
   .action(async (options) => {
     await snapshotAction({
-      spacesOnly: options.spacesOnly,
-      membersOnly: options.membersOnly,
-      limit: parseInt(options.limit, 10),
       pretty: options.pretty,
     })
   })


### PR DESCRIPTION
## Summary
- Filter snapshot to only show spaces the authenticated user is a member of via new `listMyMemberships` client method
- Remove message and member fetching from snapshot — use `message list` and `member list` commands on demand instead
- Reduces API calls from N+2 (where N = number of spaces) to just 2, avoiding HTTP 429 rate limiting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Webex snapshot to a spaces-only overview filtered to the authenticated user’s memberships. This cuts API calls to 2 and helps avoid HTTP 429s.

- **Refactors**
  - Added `listMyMemberships`; snapshot now filters to my rooms and returns only spaces (id, title, type, lastActivity).
  - Removed message/member fetching; tests and command description updated.

- **Migration**
  - Removed flags: `--spaces-only`, `--members-only`, `--limit` (only `--pretty` remains). Use `message list` and `member list` for details.
  - Docs updated: `docs/cli/webex.mdx`, `SKILL.md`, and common patterns to reflect spaces-only output.

<sup>Written for commit 376fefd816a052930d5add4f1bbbd6ed8b949609. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

