### PR TITLE
Fix Webex internal API markdown rendering

### DIFF
--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -483,6 +483,29 @@ describe('WebexClient', () => {
         expect(message.personEmail).toBe('test@example.com')
         expect(message.created).toBe('2026-01-01T00:00:00.000Z')
       })
+
+      test('markdown option converts content to HTML and strips displayName', async () => {
+        mockResponse(mockActivity('bold text'))
+
+        const client = await createExtractedClient()
+        await client.sendMessage(TEST_ROOM_ID, '**bold text**', { markdown: true })
+
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body.object.displayName).toBe('bold text')
+        expect(body.object.content).toBe('<strong>bold text</strong>')
+        expect(body.object.markdown).toBeUndefined()
+      })
+
+      test('markdown option does not affect plain text messages', async () => {
+        mockResponse(mockActivity('Hello world'))
+
+        const client = await createExtractedClient()
+        await client.sendMessage(TEST_ROOM_ID, 'Hello world')
+
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body.object.displayName).toBe('Hello world')
+        expect(body.object.content).toBe('Hello world')
+      })
     })
 
     describe('listMessages', () => {
@@ -636,6 +659,18 @@ describe('WebexClient', () => {
 
         const body = JSON.parse(fetchCalls[0].options?.body as string)
         expect(body.target.id).toBe(TEST_CONV_UUID)
+      })
+
+      test('markdown option converts content to HTML and strips displayName', async () => {
+        mockResponse(mockActivity('italic text'))
+
+        const client = await createExtractedClient()
+        await client.editMessage('activity-123', TEST_ROOM_ID, '_italic text_', { markdown: true })
+
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body.object.displayName).toBe('italic text')
+        expect(body.object.content).toBe('<em>italic text</em>')
+        expect(body.object.markdown).toBeUndefined()
       })
     })
 

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -2,6 +2,7 @@ import type { WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './t
 import { WebexError } from './types'
 import { WebexCredentialManager } from './credential-manager'
 import { WebexEncryptionService } from './encryption'
+import { markdownToHtml, stripMarkdown } from './markdown-to-html'
 
 const BASE_URL = 'https://webexapis.com/v1'
 const MAX_RETRIES = 3
@@ -237,7 +238,7 @@ export class WebexClient {
   }
 
   private async activityToMessage(a: InternalActivity, roomId: string): Promise<WebexMessage> {
-    let text = a.object?.content ?? a.object?.displayName
+    let text = a.object?.displayName ?? a.object?.content
 
     if (this.encryption && text?.startsWith('eyJ')) {
       const keyUrl = a.encryptionKeyUrl ?? a.object?.encryptionKeyUrl
@@ -265,10 +266,8 @@ export class WebexClient {
     text: string,
     options?: { markdown?: boolean },
   ): Promise<{ object: Record<string, string>; encryptionKeyUrl?: string }> {
-    const buildObject = (content: string): Record<string, string> =>
-      options?.markdown
-        ? { objectType: 'comment', displayName: content, content, markdown: content }
-        : { objectType: 'comment', displayName: content, content }
+    const displayName = options?.markdown ? stripMarkdown(text) : text
+    const content = options?.markdown ? markdownToHtml(text) : text
 
     if (this.encryption) {
       const conv = await this.internalRequest<InternalConversation>(
@@ -276,14 +275,22 @@ export class WebexClient {
       )
       const keyUri = conv.defaultActivityEncryptionKeyUrl
       if (keyUri) {
-        const encrypted = await this.encryption.encryptText(keyUri, text)
-        if (encrypted) {
-          return { object: buildObject(encrypted), encryptionKeyUrl: keyUri }
+        const encryptedDisplayName = await this.encryption.encryptText(keyUri, displayName)
+        const encryptedContent = await this.encryption.encryptText(keyUri, content)
+        if (encryptedDisplayName && encryptedContent) {
+          return {
+            object: {
+              objectType: 'comment',
+              displayName: encryptedDisplayName,
+              content: encryptedContent,
+            },
+            encryptionKeyUrl: keyUri,
+          }
         }
       }
     }
 
-    return { object: buildObject(text) }
+    return { object: { objectType: 'comment', displayName, content } }
   }
 
   private async sendMessageInternal(

--- a/src/platforms/webex/markdown-to-html.test.ts
+++ b/src/platforms/webex/markdown-to-html.test.ts
@@ -47,6 +47,26 @@ describe('markdownToHtml', () => {
     )
   })
 
+  test('strips unsafe javascript: URLs to plain text', () => {
+    expect(markdownToHtml('[click](javascript:void)')).toBe('click')
+  })
+
+  test('strips unsafe data: URLs to plain text', () => {
+    expect(markdownToHtml('[x](data:text/html,payload)')).toBe('x')
+  })
+
+  test('allows mailto: links', () => {
+    expect(markdownToHtml('[email](mailto:a@b.com)')).toBe(
+      '<a href="mailto:a@b.com">email</a>',
+    )
+  })
+
+  test('escapes quotes in URLs to prevent attribute breakout', () => {
+    expect(markdownToHtml('[x](https://a.com?q="test")')).toBe(
+      '<a href="https://a.com?q=&quot;test&quot;">x</a>',
+    )
+  })
+
   test('converts unordered lists', () => {
     expect(markdownToHtml('- one\n- two')).toBe('<ul><li>one</li><li>two</li></ul>')
   })
@@ -60,11 +80,11 @@ describe('markdownToHtml', () => {
   })
 
   test('converts headings', () => {
-    expect(markdownToHtml('# one\n###### six')).toBe('<h1>one</h1><h6>six</h6>')
+    expect(markdownToHtml('# one\n###### six')).toBe('<h1>one</h1><br/><br/><h6>six</h6>')
   })
 
   test('converts horizontal rules', () => {
-    expect(markdownToHtml('before\n---\nafter')).toBe('before<hr>after')
+    expect(markdownToHtml('before\n---\nafter')).toBe('before<br/><br/><hr><br/><br/>after')
   })
 
   test('converts paragraph newlines to br', () => {
@@ -81,13 +101,13 @@ describe('markdownToHtml', () => {
     expect(markdownToHtml('5 < 7 & 8 > 3')).toBe('5 &lt; 7 &amp; 8 &gt; 3')
   })
 
-  test('renders multiple paragraphs without extra br between blocks', () => {
-    expect(markdownToHtml('first\n\nsecond')).toBe('firstsecond')
+  test('separates multiple paragraphs with br', () => {
+    expect(markdownToHtml('first\n\nsecond')).toBe('first<br/><br/>second')
   })
 
   test('renders mixed content', () => {
     expect(markdownToHtml('Hello **team**\n\n- one\n- two\n\n```js\nconst x = 1\n```')).toBe(
-      'Hello <strong>team</strong><ul><li>one</li><li>two</li></ul><pre><code class="language-js">const x = 1</code></pre>',
+      'Hello <strong>team</strong><br/><br/><ul><li>one</li><li>two</li></ul><br/><br/><pre><code class="language-js">const x = 1</code></pre>',
     )
   })
 

--- a/src/platforms/webex/markdown-to-html.test.ts
+++ b/src/platforms/webex/markdown-to-html.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test'
+
+import { markdownToHtml, stripMarkdown } from './markdown-to-html'
+
+describe('markdownToHtml', () => {
+  test('converts bold text', () => {
+    expect(markdownToHtml('**bold**')).toBe('<strong>bold</strong>')
+  })
+
+  test('converts italic text', () => {
+    expect(markdownToHtml('_italic_')).toBe('<em>italic</em>')
+  })
+
+  test('does not italicize mid-word underscores', () => {
+    expect(markdownToHtml('some_variable_name')).toBe('some_variable_name')
+  })
+
+  test('converts bold and italic text', () => {
+    expect(markdownToHtml('***both***')).toBe('<strong><em>both</em></strong>')
+  })
+
+  test('converts inline code', () => {
+    expect(markdownToHtml('Use `code` here')).toBe('Use <code>code</code> here')
+  })
+
+  test('converts code blocks with language', () => {
+    expect(markdownToHtml('```ts\nconst x = 1 < 2\n```')).toBe(
+      '<pre><code class="language-ts">const x = 1 &lt; 2</code></pre>',
+    )
+  })
+
+  test('converts code blocks without language', () => {
+    expect(markdownToHtml('```\nconst x = 1 & 2\n```')).toBe(
+      '<pre><code>const x = 1 &amp; 2</code></pre>',
+    )
+  })
+
+  test('does not process markdown inside code blocks', () => {
+    expect(markdownToHtml('```\n**bold** _italic_\n```')).toBe(
+      '<pre><code>**bold** _italic_</code></pre>',
+    )
+  })
+
+  test('converts links', () => {
+    expect(markdownToHtml('[Webex](https://example.com?a=1&b=2)')).toBe(
+      '<a href="https://example.com?a=1&amp;b=2">Webex</a>',
+    )
+  })
+
+  test('converts unordered lists', () => {
+    expect(markdownToHtml('- one\n- two')).toBe('<ul><li>one</li><li>two</li></ul>')
+  })
+
+  test('converts ordered lists', () => {
+    expect(markdownToHtml('1. one\n2. two')).toBe('<ol><li>one</li><li>two</li></ol>')
+  })
+
+  test('converts blockquotes', () => {
+    expect(markdownToHtml('> one\n> two')).toBe('<blockquote>one<br/>two</blockquote>')
+  })
+
+  test('converts headings', () => {
+    expect(markdownToHtml('# one\n###### six')).toBe('<h1>one</h1><h6>six</h6>')
+  })
+
+  test('converts horizontal rules', () => {
+    expect(markdownToHtml('before\n---\nafter')).toBe('before<hr>after')
+  })
+
+  test('converts paragraph newlines to br', () => {
+    expect(markdownToHtml('one\ntwo')).toBe('one<br/>two')
+  })
+
+  test('supports nested formatting', () => {
+    expect(markdownToHtml('**bold _and italic_**')).toBe(
+      '<strong>bold <em>and italic</em></strong>',
+    )
+  })
+
+  test('escapes html special characters in text', () => {
+    expect(markdownToHtml('5 < 7 & 8 > 3')).toBe('5 &lt; 7 &amp; 8 &gt; 3')
+  })
+
+  test('renders multiple paragraphs without extra br between blocks', () => {
+    expect(markdownToHtml('first\n\nsecond')).toBe('firstsecond')
+  })
+
+  test('renders mixed content', () => {
+    expect(markdownToHtml('Hello **team**\n\n- one\n- two\n\n```js\nconst x = 1\n```')).toBe(
+      'Hello <strong>team</strong><ul><li>one</li><li>two</li></ul><pre><code class="language-js">const x = 1</code></pre>',
+    )
+  })
+
+  test('returns empty string for empty input', () => {
+    expect(markdownToHtml('')).toBe('')
+  })
+
+  test('returns plain text when there is no markdown', () => {
+    expect(markdownToHtml('hello world')).toBe('hello world')
+  })
+
+  test('preserves whitespace-only input', () => {
+    expect(markdownToHtml('   ')).toBe('   ')
+  })
+})
+
+describe('stripMarkdown', () => {
+  test('strips inline markdown syntax', () => {
+    expect(stripMarkdown('**bold** _italic_ `code`')).toBe('bold italic code')
+  })
+
+  test('strips links to their labels', () => {
+    expect(stripMarkdown('[Webex](https://example.com)')).toBe('Webex')
+  })
+
+  test('strips block markdown syntax', () => {
+    expect(stripMarkdown('# Title\n> quote\n- item\n1. first\n---')).toBe(
+      'Title\nquote\nitem\nfirst\n',
+    )
+  })
+
+  test('keeps code block content', () => {
+    expect(stripMarkdown('```ts\nconst x = 1\n```')).toBe('const x = 1')
+  })
+
+  test('handles nested formatting', () => {
+    expect(stripMarkdown('**bold _and italic_**')).toBe('bold and italic')
+  })
+
+  test('returns plain text unchanged', () => {
+    expect(stripMarkdown('hello world')).toBe('hello world')
+  })
+})

--- a/src/platforms/webex/markdown-to-html.ts
+++ b/src/platforms/webex/markdown-to-html.ts
@@ -1,0 +1,180 @@
+const BLOCK_PLACEHOLDER_PREFIX = '\u0000BLOCK'
+const INLINE_PLACEHOLDER_PREFIX = '\u0000INLINE'
+
+export function markdownToHtml(markdown: string): string {
+  if (markdown.length === 0) {
+    return ''
+  }
+
+  const normalized = markdown.replace(/\r\n?/g, '\n')
+  if (normalized.trim().length === 0) {
+    return normalized
+  }
+
+  const { text, blocks } = extractCodeBlocks(normalized)
+  const lines = text.split('\n')
+  const output: string[] = []
+  let paragraph: string[] = []
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) {
+      return
+    }
+
+    output.push(processInline(paragraph.join('\n')).replace(/\n/g, '<br/>'))
+    paragraph = []
+  }
+
+  for (let index = 0; index < lines.length; ) {
+    const line = lines[index]
+    const trimmed = line.trim()
+
+    if (trimmed.length === 0) {
+      flushParagraph()
+      index++
+      continue
+    }
+
+    if (isBlockPlaceholder(trimmed)) {
+      flushParagraph()
+      output.push(trimmed)
+      index++
+      continue
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/)
+    if (headingMatch) {
+      flushParagraph()
+      output.push(`<h${headingMatch[1].length}>${processInline(headingMatch[2])}</h${headingMatch[1].length}>`)
+      index++
+      continue
+    }
+
+    if (/^---$/.test(trimmed)) {
+      flushParagraph()
+      output.push('<hr>')
+      index++
+      continue
+    }
+
+    if (/^>\s?/.test(line)) {
+      flushParagraph()
+      const quoteLines: string[] = []
+      while (index < lines.length && /^>\s?/.test(lines[index])) {
+        quoteLines.push(lines[index].replace(/^>\s?/, ''))
+        index++
+      }
+      output.push(`<blockquote>${processInline(quoteLines.join('\n')).replace(/\n/g, '<br/>')}</blockquote>`)
+      continue
+    }
+
+    if (/^-\s+/.test(line)) {
+      flushParagraph()
+      const items: string[] = []
+      while (index < lines.length && /^-\s+/.test(lines[index])) {
+        items.push(`<li>${processInline(lines[index].replace(/^-\s+/, ''))}</li>`)
+        index++
+      }
+      output.push(`<ul>${items.join('')}</ul>`)
+      continue
+    }
+
+    if (/^\d+\.\s+/.test(line)) {
+      flushParagraph()
+      const items: string[] = []
+      while (index < lines.length && /^\d+\.\s+/.test(lines[index])) {
+        items.push(`<li>${processInline(lines[index].replace(/^\d+\.\s+/, ''))}</li>`)
+        index++
+      }
+      output.push(`<ol>${items.join('')}</ol>`)
+      continue
+    }
+
+    paragraph.push(line)
+    index++
+  }
+
+  flushParagraph()
+
+  return restorePlaceholders(output.join(''), blocks)
+}
+
+export function stripMarkdown(markdown: string): string {
+  return markdown
+    .replace(/\r\n?/g, '\n')
+    .replace(/```([a-zA-Z0-9_-]+)?\n?([\s\S]*?)```/g, (_, _language: string | undefined, code: string) => {
+      return code.replace(/\n$/, '')
+    })
+    .replace(/^---$/gm, '')
+    .replace(/^(#{1,6})\s+/gm, '')
+    .replace(/^>\s?/gm, '')
+    .replace(/^-\s+/gm, '')
+    .replace(/^\d+\.\s+/gm, '')
+    .replace(/\[([^\]]+)\]\(([^)\n]+)\)/g, '$1')
+    .replace(/`([^`\n]+)`/g, '$1')
+    .replace(/\*\*\*([^*\n]+)\*\*\*/g, '$1')
+    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+    .replace(/(^|[^\w])_([^_\n]+)_(?=[^\w]|$)/g, '$1$2')
+}
+
+function processInline(markdown: string): string {
+  const placeholders: string[] = []
+  let text = markdown
+
+  text = text.replace(/`([^`\n]+)`/g, (_, code: string) => {
+    return createInlinePlaceholder(placeholders, `<code>${escapeHtml(code)}</code>`)
+  })
+
+  text = text.replace(/\[([^\]]+)\]\(([^)\n]+)\)/g, (_, label: string, url: string) => {
+    return createInlinePlaceholder(
+      placeholders,
+      `<a href="${escapeHtml(url)}">${processInline(label)}</a>`,
+    )
+  })
+
+  text = escapeHtml(text)
+  text = text.replace(/\*\*\*([^*\n]+)\*\*\*/g, '<strong><em>$1</em></strong>')
+  text = text.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>')
+  text = text.replace(/(^|[^\w])_([^_\n]+)_(?=[^\w]|$)/g, '$1<em>$2</em>')
+
+  return restorePlaceholders(text, placeholders)
+}
+
+function extractCodeBlocks(markdown: string): { text: string; blocks: string[] } {
+  const blocks: string[] = []
+  const text = markdown.replace(/```([a-zA-Z0-9_-]+)?\n([\s\S]*?)\n```/g, (_, language: string | undefined, code: string) => {
+    const className = language ? ` class="language-${escapeHtml(language)}"` : ''
+    return createBlockPlaceholder(blocks, `<pre><code${className}>${escapeHtml(code)}</code></pre>`)
+  })
+
+  return { text, blocks }
+}
+
+function createBlockPlaceholder(blocks: string[], html: string): string {
+  const token = `${BLOCK_PLACEHOLDER_PREFIX}${blocks.length}\u0000`
+  blocks.push(html)
+  return token
+}
+
+function createInlinePlaceholder(placeholders: string[], html: string): string {
+  const token = `${INLINE_PLACEHOLDER_PREFIX}${placeholders.length}\u0000`
+  placeholders.push(html)
+  return token
+}
+
+function isBlockPlaceholder(value: string): boolean {
+  return new RegExp(`^${BLOCK_PLACEHOLDER_PREFIX}\\d+\\u0000$`).test(value)
+}
+
+function restorePlaceholders(text: string, values: string[]): string {
+  let restored = text
+  for (const [index, value] of values.entries()) {
+    restored = restored.replaceAll(`${BLOCK_PLACEHOLDER_PREFIX}${index}\u0000`, value)
+    restored = restored.replaceAll(`${INLINE_PLACEHOLDER_PREFIX}${index}\u0000`, value)
+  }
+  return restored
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}

--- a/src/platforms/webex/markdown-to-html.ts
+++ b/src/platforms/webex/markdown-to-html.ts
@@ -96,7 +96,7 @@ export function markdownToHtml(markdown: string): string {
 
   flushParagraph()
 
-  return restorePlaceholders(output.join(''), blocks)
+  return restorePlaceholders(output.join('<br/><br/>'), blocks)
 }
 
 export function stripMarkdown(markdown: string): string {
@@ -126,6 +126,9 @@ function processInline(markdown: string): string {
   })
 
   text = text.replace(/\[([^\]]+)\]\(([^)\n]+)\)/g, (_, label: string, url: string) => {
+    if (!isSafeUrl(url)) {
+      return processInline(label)
+    }
     return createInlinePlaceholder(
       placeholders,
       `<a href="${escapeHtml(url)}">${processInline(label)}</a>`,
@@ -175,6 +178,17 @@ function restorePlaceholders(text: string, values: string[]): string {
   return restored
 }
 
+const SAFE_URL_PATTERN = /^(https?:|mailto:|\/|#)/i
+
+function isSafeUrl(url: string): boolean {
+  return SAFE_URL_PATTERN.test(url.trim())
+}
+
 function escapeHtml(value: string): string {
-  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }


### PR DESCRIPTION
## Summary

The Webex internal conversation API (`conv.wbx2.com`) does not render markdown server-side — unlike the public API (`webexapis.com`), it expects pre-rendered HTML in the `content` field and plain text in `displayName`. Previously, `--markdown` with the internal API sent identical raw markdown text to all three fields (`displayName`, `content`, `markdown`), so formatting had no visible effect when using extracted browser tokens.

This fix adds a lightweight markdown→HTML converter and wires it into the encrypted message path, ensuring markdown renders correctly for both internal and public API users.

## Changes

### New: `src/platforms/webex/markdown-to-html.ts`

Lightweight Webex-specific markdown→HTML converter and `stripMarkdown` utility. Supports bold, italic, inline code, fenced code blocks, links, unordered/ordered lists, blockquotes, headings, and horizontal rules. No external dependencies.

### Fixed: `src/platforms/webex/client.ts`

- `buildEncryptedObject` now converts markdown to HTML for `content` and strips it for `displayName` when `--markdown` is used, instead of sending the same raw markdown to all fields.
- Encryption path now encrypts `displayName` and `content` independently — previously both received the same ciphertext, meaning the plain-text field was accidentally encrypted as HTML.
- `activityToMessage` now prefers `displayName` (plain text) over `content` (HTML) when mapping activities back to messages, matching the public API behavior where `text` is always plain.

## Context

The internal Webex API path (used by the browser token extractor) operates differently from the public REST API:

| Field | Public API | Internal API |
|-------|-----------|--------------|
| `displayName` | plain text | plain text (encrypted) |
| `content` | rendered HTML | HTML to be rendered (encrypted) |
| `markdown` | source markdown | not used |

By sending HTML to `content` and plain text to `displayName`, the Webex client renders formatting correctly regardless of which API path is used.

## Testing

- **Unit tests**: 83 pass across `client.test.ts` (55) and `markdown-to-html.test.ts` (28).
- **E2E**: Sent formatted message to agent-messenger Webex space; confirmed rendering and round-trip read-back.
- **Typecheck**: Clean (`tsc --noEmit`).
- **Lint**: 0 errors (7 pre-existing warnings unrelated to this change).

## Review Notes

- The `markdown` field is no longer sent in the internal API path — it was unused by the server and only added noise to the encrypted payload.
- `stripMarkdown` is intentionally simple (regex-based) to avoid pulling in a parser dependency; the output only needs to be readable plain text, not semantically perfect.
- The two encryption calls (one for `displayName`, one for `content`) are sequential by design — the encryption key derivation is stateful and cannot be parallelised safely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdown rendering for the Webex internal API by sending stripped plain text to displayName and HTML to content when --markdown is used. Also hardens the markdown-to-HTML utility to prevent XSS and improves paragraph spacing.

- **Bug Fixes**
  - Added src/platforms/webex/markdown-to-html.ts with lightweight markdown→HTML and stripMarkdown (no deps).
  - Updated buildEncryptedObject to convert markdown for content, strip for displayName, omit unused markdown field, and encrypt both fields separately.
  - Updated activityToMessage to prefer displayName over content for plain-text reads.
  - Secured markdown→HTML: escape quotes, allow only safe URLs (http/https/mailto/relative/hash), drop javascript:/data:, and separate paragraphs with <br/><br/>.

- **Docs**
  - SKILL.md/docs: not updated (no user-visible API changes).

<sup>Written for commit 1e8e5098af7d06e65852208428bea4c5a29b8d0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

