### PR TITLE
Fix Slack user list pagination contract

### DIFF
--- a/docs/content/docs/cli/slack.mdx
+++ b/docs/content/docs/cli/slack.mdx
@@ -181,6 +181,8 @@ agent-slack channel leave <channel>
 ```bash
 # List users
 agent-slack user list
+agent-slack user list --limit 100
+agent-slack user list --cursor <next_cursor>
 agent-slack user list --include-bots
 
 # Get user info
@@ -200,6 +202,22 @@ agent-slack user profile <user-id>
 agent-slack user set-status "In a meeting"
 agent-slack user set-status "In a meeting" --emoji calendar
 agent-slack user set-status "On vacation" --emoji palm_tree --expiration 1700100000
+```
+
+`agent-slack user list` returns paginated output. Use `--limit` to control page size and pass `--cursor` with the previous response's `next_cursor` to fetch the next page.
+
+```json
+{
+  "users": [
+    {
+      "id": "U0ABC123",
+      "name": "alice",
+      "real_name": "Alice Smith"
+    }
+  ],
+  "has_more": true,
+  "next_cursor": "dXNlcjpVMDYx..."
+}
 ```
 
 ### Reaction Commands

--- a/docs/content/docs/sdk/slack.mdx
+++ b/docs/content/docs/sdk/slack.mdx
@@ -155,6 +155,10 @@ await client.leaveChannel(channelId)
 const users = await client.listUsers()
 // → SlackUser[]
 
+// List one page of users with pagination metadata
+const page = await client.listUsersPage({ limit: 100 })
+// → { users: SlackUser[], has_more: boolean, next_cursor?: string }
+
 // Get user info
 const user = await client.getUser(userId)
 // → SlackUser { id, name, real_name, is_admin, is_bot, profile, ... }

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -272,6 +272,8 @@ agent-slack channel leave <channel>
 ```bash
 # List users
 agent-slack user list
+agent-slack user list --limit 100
+agent-slack user list --cursor <next_cursor>
 agent-slack user list --include-bots
 
 # Get user info
@@ -291,6 +293,22 @@ agent-slack user profile <user-id>
 agent-slack user set-status <status-text>
 agent-slack user set-status "In a meeting" --emoji calendar
 agent-slack user set-status "On vacation" --emoji palm_tree --expiration 1700100000
+```
+
+`agent-slack user list` returns paginated output in the shape below. Use `--limit` to fetch a smaller page and `--cursor` with the prior `next_cursor` to continue through large workspaces.
+
+```json
+{
+  "users": [
+    {
+      "id": "U0ABC123",
+      "name": "alice",
+      "real_name": "Alice Smith"
+    }
+  ],
+  "has_more": true,
+  "next_cursor": "dXNlcjpVMDYx..."
+}
 ```
 
 ### Reaction Commands

--- a/skills/agent-slack/references/common-patterns.md
+++ b/skills/agent-slack/references/common-patterns.md
@@ -250,9 +250,30 @@ agent-slack file download "$FILE_ID" ./downloads/
 CHANNEL="general"
 USERNAME="john.doe"
 
-# Get user info
-USERS=$(agent-slack user list)
-USER_ID=$(echo "$USERS" | jq -r ".[] | select(.name==\"$USERNAME\") | .id")
+# Find user across paginated results
+CURSOR=""
+USER_ID=""
+
+while true; do
+  if [ -n "$CURSOR" ]; then
+    USERS_PAGE=$(agent-slack user list --cursor "$CURSOR")
+  else
+    USERS_PAGE=$(agent-slack user list)
+  fi
+
+  USER_ID=$(echo "$USERS_PAGE" | jq -r --arg username "$USERNAME" '
+    .users[]? | select(.name == $username) | .id
+  ' | head -n 1)
+
+  if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+    break
+  fi
+
+  CURSOR=$(echo "$USERS_PAGE" | jq -r '.next_cursor // empty')
+  if [ -z "$CURSOR" ]; then
+    break
+  fi
+done
 
 if [ -z "$USER_ID" ]; then
   echo "User $USERNAME not found"

--- a/src/platforms/slack/client.test.ts
+++ b/src/platforms/slack/client.test.ts
@@ -697,9 +697,7 @@ describe('SlackClient', () => {
       expect(result.users).toHaveLength(1)
       expect(result.has_more).toBe(false)
       expect(result.next_cursor).toBeUndefined()
-      expect(mockWebClient.users.list).toHaveBeenCalledWith(
-        expect.objectContaining({ cursor: 'cursor123', limit: 50 }),
-      )
+      expect(mockWebClient.users.list).toHaveBeenCalledWith(expect.objectContaining({ cursor: 'cursor123', limit: 50 }))
     })
 
     test('throws SlackError on API failure', async () => {

--- a/src/platforms/slack/client.test.ts
+++ b/src/platforms/slack/client.test.ts
@@ -643,6 +643,65 @@ describe('SlackClient', () => {
       expect(mockWebClient.users.list).toHaveBeenCalledTimes(2)
     })
 
+    test('returns pagination info for a single page', async () => {
+      mockWebClient.users.list.mockResolvedValue({
+        ok: true,
+        members: [
+          {
+            id: 'U123',
+            name: 'alice',
+            real_name: 'Alice',
+            is_admin: false,
+            is_owner: false,
+            is_bot: false,
+            is_app_user: false,
+          },
+        ],
+        response_metadata: { next_cursor: 'cursor123' },
+      })
+
+      const client = await new SlackClient().login({ token: 'xoxc-token', cookie: 'xoxd-cookie' })
+      // @ts-expect-error - accessing private property for testing
+      client.client = mockWebClient as unknown as WebClient
+
+      const result = await client.listUsersPage({ limit: 1 })
+
+      expect(result.users).toHaveLength(1)
+      expect(result.has_more).toBe(true)
+      expect(result.next_cursor).toBe('cursor123')
+      expect(mockWebClient.users.list).toHaveBeenCalledWith(expect.objectContaining({ limit: 1 }))
+    })
+
+    test('accepts cursor for paginated user listing', async () => {
+      mockWebClient.users.list.mockResolvedValue({
+        ok: true,
+        members: [
+          {
+            id: 'U456',
+            name: 'bob',
+            real_name: 'Bob',
+            is_admin: false,
+            is_owner: false,
+            is_bot: false,
+            is_app_user: false,
+          },
+        ],
+      })
+
+      const client = await new SlackClient().login({ token: 'xoxc-token', cookie: 'xoxd-cookie' })
+      // @ts-expect-error - accessing private property for testing
+      client.client = mockWebClient as unknown as WebClient
+
+      const result = await client.listUsersPage({ cursor: 'cursor123', limit: 50 })
+
+      expect(result.users).toHaveLength(1)
+      expect(result.has_more).toBe(false)
+      expect(result.next_cursor).toBeUndefined()
+      expect(mockWebClient.users.list).toHaveBeenCalledWith(
+        expect.objectContaining({ cursor: 'cursor123', limit: 50 }),
+      )
+    })
+
     test('throws SlackError on API failure', async () => {
       mockWebClient.users.list.mockResolvedValue({
         ok: false,

--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -312,25 +312,47 @@ export class SlackClient {
     })
   }
 
+  async listUsersPage(options?: {
+    limit?: number
+    cursor?: string
+  }): Promise<{ users: SlackUser[]; has_more: boolean; next_cursor?: string }> {
+    return this.withRetry(async () => {
+      const response = await this.ensureAuth().users.list({
+        cursor: options?.cursor,
+        limit: options?.limit ?? 200,
+      })
+      this.checkResponse(response)
+
+      const users: SlackUser[] = []
+      if (response.members) {
+        for (const member of response.members) {
+          users.push(mapUser(member))
+        }
+      }
+
+      const nextCursor = response.response_metadata?.next_cursor || undefined
+
+      return {
+        users,
+        has_more: Boolean(nextCursor),
+        next_cursor: nextCursor,
+      }
+    })
+  }
+
   async listUsers(): Promise<SlackUser[]> {
     return this.withRetry(async () => {
       const users: SlackUser[] = []
       let cursor: string | undefined
 
       do {
-        const response = await this.ensureAuth().users.list({
+        const response = await this.listUsersPage({
           cursor,
           limit: 200,
         })
-        this.checkResponse(response)
 
-        if (response.members) {
-          for (const member of response.members) {
-            users.push(mapUser(member))
-          }
-        }
-
-        cursor = response.response_metadata?.next_cursor
+        users.push(...response.users)
+        cursor = response.next_cursor
       } while (cursor)
 
       return users

--- a/src/platforms/slack/commands/user.test.ts
+++ b/src/platforms/slack/commands/user.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 
 import { SlackClient } from '@/platforms/slack/client'
-import { userCommand } from '@/platforms/slack/commands/user'
+import { listAction, userCommand } from '@/platforms/slack/commands/user'
+import { CredentialManager } from '@/platforms/slack/credential-manager'
 import type { SlackUser } from '@/platforms/slack/types'
 
 // Mock users
@@ -43,32 +44,103 @@ const mockUsers: SlackUser[] = [
 ]
 
 describe('User Commands', () => {
+  let getWorkspaceSpy: ReturnType<typeof spyOn>
+  let listUsersPageSpy: ReturnType<typeof spyOn>
+  let consoleLogSpy: ReturnType<typeof spyOn>
+  let processExitSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    getWorkspaceSpy = spyOn(CredentialManager.prototype, 'getWorkspace').mockResolvedValue({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      token: 'xoxc-test',
+      cookie: 'test-cookie',
+    })
+    listUsersPageSpy = spyOn(SlackClient.prototype, 'listUsersPage').mockResolvedValue({
+      users: mockUsers,
+      has_more: true,
+      next_cursor: 'cursor123',
+    })
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
+  })
+
+  afterEach(() => {
+    getWorkspaceSpy?.mockRestore()
+    listUsersPageSpy?.mockRestore()
+    consoleLogSpy?.mockRestore()
+    processExitSpy?.mockRestore()
+  })
+
   describe('user list', () => {
-    test('lists all users', async () => {
-      // Given: SlackClient with users
-      const _mockClient = {
-        listUsers: async () => mockUsers,
-      } as unknown as SlackClient
+    test('lists users with pagination metadata', async () => {
+      await listAction({})
 
-      // When: Calling list with all users
-      const result = await (userCommand as any).commands[0].action({ includeBots: false }, userCommand)
-
-      // Then: Should return users
-      expect(result).toBeDefined()
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          users: [
+            {
+              id: 'U001',
+              name: 'alice',
+              real_name: 'Alice Smith',
+              is_admin: true,
+              is_owner: false,
+              is_bot: false,
+              is_app_user: false,
+              profile: {
+                email: 'alice@example.com',
+                title: 'Engineer',
+              },
+            },
+            {
+              id: 'U002',
+              name: 'bob',
+              real_name: 'Bob Jones',
+              is_admin: false,
+              is_owner: false,
+              is_bot: false,
+              is_app_user: false,
+              profile: {
+                email: 'bob@example.com',
+              },
+            },
+          ],
+          has_more: true,
+          next_cursor: 'cursor123',
+        }),
+      )
     })
 
     test('filters out bots by default', async () => {
-      // Given: Users including bots
-      // When: Listing without --include-bots flag
-      // Then: Should exclude bots (is_bot: true)
-      expect(mockUsers.filter((u) => !u.is_bot)).toHaveLength(2)
+      await listAction({})
+
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string)
+      expect(output.users).toHaveLength(2)
+      expect(output.users.every((user: SlackUser) => !user.is_bot)).toBe(true)
     })
 
     test('includes bots with --include-bots flag', async () => {
-      // Given: Users including bots
-      // When: Listing with --include-bots flag
-      // Then: Should include all users
-      expect(mockUsers).toHaveLength(3)
+      await listAction({ includeBots: true })
+
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string)
+      expect(output.users).toHaveLength(3)
+    })
+
+    test('passes pagination params to Slack client', async () => {
+      await listAction({ limit: 50, cursor: 'cursor123' })
+
+      expect(listUsersPageSpy).toHaveBeenCalledWith({
+        limit: 50,
+        cursor: 'cursor123',
+      })
+    })
+
+    test('command exposes pagination options', () => {
+      const listCommand = userCommand.commands.find((command) => command.name() === 'list')
+      const optionFlags = listCommand?.options.map((option) => option.long)
+
+      expect(optionFlags).toContain('--limit')
+      expect(optionFlags).toContain('--cursor')
     })
   })
 

--- a/src/platforms/slack/commands/user.ts
+++ b/src/platforms/slack/commands/user.ts
@@ -18,37 +18,62 @@ async function getClient(pretty?: boolean): Promise<SlackClient | null> {
   return await new SlackClient().login({ token: workspace.token, cookie: workspace.cookie })
 }
 
+type UserListOptions = {
+  includeBots?: boolean
+  limit?: number
+  cursor?: string
+  pretty?: boolean
+}
+
+export async function listAction(options: UserListOptions): Promise<void> {
+  try {
+    const client = await getClient(options.pretty)
+    if (!client) return process.exit(1)
+
+    const result = await client.listUsersPage({
+      limit: options.limit,
+      cursor: options.cursor,
+    })
+
+    const filtered = options.includeBots ? result.users : result.users.filter((user) => !user.is_bot)
+
+    const output = {
+      users: filtered.map((user) => ({
+        id: user.id,
+        name: user.name,
+        real_name: user.real_name,
+        is_admin: user.is_admin,
+        is_owner: user.is_owner,
+        is_bot: user.is_bot,
+        is_app_user: user.is_app_user,
+        profile: user.profile,
+      })),
+      has_more: result.has_more,
+      next_cursor: result.next_cursor,
+    }
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export const userCommand = new Command('user')
   .description('User commands')
   .addCommand(
     new Command('list')
       .description('List workspace users')
+      .option('--limit <n>', 'Number of users to fetch')
+      .option('--cursor <cursor>', 'Pagination cursor')
       .option('--include-bots', 'Include bot users')
       .option('--pretty', 'Pretty print JSON output')
       .action(async (options) => {
-        try {
-          const client = await getClient(options.pretty)
-          if (!client) return process.exit(1)
-
-          const users = await client.listUsers()
-
-          const filtered = options.includeBots ? users : users.filter((u) => !u.is_bot)
-
-          const output = filtered.map((user) => ({
-            id: user.id,
-            name: user.name,
-            real_name: user.real_name,
-            is_admin: user.is_admin,
-            is_owner: user.is_owner,
-            is_bot: user.is_bot,
-            is_app_user: user.is_app_user,
-            profile: user.profile,
-          }))
-
-          console.log(formatOutput(output, options.pretty))
-        } catch (error) {
-          handleError(error as Error)
-        }
+        await listAction({
+          includeBots: options.includeBots,
+          limit: options.limit ? parseInt(options.limit, 10) : undefined,
+          cursor: options.cursor,
+          pretty: options.pretty,
+        })
       }),
   )
   .addCommand(


### PR DESCRIPTION
## Summary
- add an explicit paginated Slack user-list API so callers can pass `limit` and `cursor` and receive `has_more` / `next_cursor`
- update `agent-slack user list` to return `{ users, has_more, next_cursor }` instead of an unstructured flattened array, while preserving bot filtering
- document the new pagination parameters and response shape in the Slack skill, CLI docs, and SDK docs

## Validation
- bun run lint
- bun run format:check
- bun typecheck
- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a paginated Slack user list API and updates the CLI to return `{ users, has_more, next_cursor }`, so large workspaces can fetch pages with `--limit` and `--cursor`.

- **New Features**
  - Added `SlackClient.listUsersPage({ limit, cursor })` → returns `{ users, has_more, next_cursor }`; `listUsers()` now auto-paginates via this.
  - Updated `agent-slack user list` to accept `--limit` and `--cursor` and return the same paginated shape; bots are filtered by default, use `--include-bots` to include them.
  - Docs updated: `skills/agent-slack/SKILL.md`, CLI docs, SDK docs, and `skills/agent-slack/references/common-patterns.md` now include pagination examples and a shell loop pattern.

- **Migration**
  - If you parsed `agent-slack user list` as an array, read `output.users` and handle `has_more`/`next_cursor`. Use `--limit` and `--cursor` to page.
  - SDK users who need pagination metadata should use `listUsersPage()`; `listUsers()` still returns the full list.

<sup>Written for commit 31907954af6d5e920cbaf73f1096eece95db944a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

