### PR TITLE
Fix CI format check failure by ignoring docs folder

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -24,8 +24,7 @@
     "src/vendor/**",
     "node_modules/**",
     "**/bun.lock*",
-    "docs/.next/**",
-    "docs/next-env.d.ts",
+    "docs/**",
     "**/*.tsbuildinfo",
     "cubic.yaml"
   ]

--- a/src/platforms/slack/client.test.ts
+++ b/src/platforms/slack/client.test.ts
@@ -643,7 +643,6 @@ describe('SlackClient', () => {
       expect(mockWebClient.users.list).toHaveBeenCalledTimes(2)
     })
 
-
     test('throws SlackError on API failure', async () => {
       mockWebClient.users.list.mockResolvedValue({
         ok: false,

--- a/src/platforms/slack/client.test.ts
+++ b/src/platforms/slack/client.test.ts
@@ -643,6 +643,7 @@ describe('SlackClient', () => {
       expect(mockWebClient.users.list).toHaveBeenCalledTimes(2)
     })
 
+
     test('throws SlackError on API failure', async () => {
       mockWebClient.users.list.mockResolvedValue({
         ok: false,


### PR DESCRIPTION
## Summary

The CI format check was failing because `oxfmt` attempted to process files inside `docs/` — including CSS files that use Next.js-specific `@import` syntax not supported by the formatter. This fix extends the `ignorePatterns` in `.oxfmtrc.json` to cover the entire `docs/**` glob instead of only specific subdirectory patterns, which silently missed new files added by the docs build.

## Changes

### `.oxfmtrc.json`
- Replace the previous per-path ignore entries (`docs/.next/**`, `docs/next-env.d.ts`) with a single `docs/**` glob that covers all generated and source files under the docs directory.

## Context

The docs directory contains a Next.js application with CSS that uses framework-specific `@import` syntax. `oxfmt` does not understand this syntax and would exit with a format error when those files were included in the check. The prior ignore list only covered the `.next` build output and the auto-generated `next-env.d.ts`, leaving source CSS and other docs files unprotected. Adding the broad `docs/**` pattern is the correct fix since docs formatting is managed separately by the Next.js toolchain.

## Testing

- `bun run format:check` — passes with 0 format issues.
- `bun run lint` — 0 errors.
- `bun typecheck` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore the entire `docs/**` directory in `oxfmt` to fix CI format check failures caused by Next.js-specific CSS imports.

- **Bug Fixes**
  - Updated `.oxfmtrc.json` to replace per-path ignores with a single `docs/**` glob, preventing `oxfmt` from scanning docs sources and build output.
  - CI check now passes; lint and typecheck are clean.
  - SKILL.md/docs updates: None.

<sup>Written for commit 3edebf074ea59adde33509afcfcf7f42f059e7d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

