### PR TITLE
Fix CI by installing docs dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install docs dependencies
+        run: cd docs && bun install --frozen-lockfile
+
       - name: Typecheck
         run: bun run typecheck
 


### PR DESCRIPTION
## Summary

The CI pipeline was failing because the `docs/` directory has its own `bun.lock` and dependencies, but the workflow only ran `bun install` at the repo root. This meant doc-related tooling wasn't available during the format check step, causing CI to fail on a clean checkout.

## Changes

### `.github/workflows/ci.yml`
- Add an explicit `Install docs dependencies` step that runs `cd docs && bun install --frozen-lockfile` before the typecheck and format check steps.

## Context

PR #151 attempted to fix this by broadening the `oxfmt` ignore patterns to skip the `docs/` folder entirely. That avoids the symptom but silently stops formatting checks from running on docs source files. The correct fix is to ensure the docs dependencies are installed so the CI environment matches the local dev environment.

## Testing

- CI will pass once this is merged — the root cause (missing `node_modules` in `docs/`) is resolved by running `bun install` in that directory before any checks run.
- Lint, typecheck, and format checks all pass locally.

## Review Notes

- Closes #151 (the workaround that ignored `docs/**` in oxfmt instead of fixing the root cause).
- `--frozen-lockfile` ensures the install is deterministic and will fail fast if `bun.lock` is out of sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI by installing `docs/` dependencies so typecheck and format steps have the required tooling and the pipeline passes on clean checkouts.

- **Bug Fixes**
  - Add a CI step to run `cd docs && bun install --frozen-lockfile` before typecheck/format.
  - Restores formatting checks for `docs/**`. No platform source changes; SKILL.md/docs unchanged.

<sup>Written for commit 19a956a042f5557a4b076112ec25d972830b8bb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

