### PR TITLE
Make snapshot brief by default, add --full for verbose output

### DIFF
--- a/docs/content/docs/cli/channeltalk.mdx
+++ b/docs/content/docs/cli/channeltalk.mdx
@@ -170,21 +170,31 @@ agent-channeltalk bot list --limit 50
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot of current workspace
+# Brief snapshot (default) — fast, minimal API calls
 agent-channeltalk snapshot
 
-# Filtered snapshots
-agent-channeltalk snapshot --groups-only
-agent-channeltalk snapshot --chats-only
+# Full snapshot — includes messages, managers, bots (slow, large output)
+agent-channeltalk snapshot --full
 
-# Limit messages per group/chat
-agent-channeltalk snapshot --limit 10
+# Filtered full snapshots
+agent-channeltalk snapshot --full --groups-only
+agent-channeltalk snapshot --full --chats-only
+
+# Limit messages per group/chat (only with --full)
+agent-channeltalk snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Workspace metadata (id, name)
+- Groups (id, name)
+- UserChat summary (total count, by state)
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Workspace metadata (id, name)
 - Groups with recent messages (id, name, messages)

--- a/docs/content/docs/cli/channeltalkbot.mdx
+++ b/docs/content/docs/cli/channeltalkbot.mdx
@@ -205,9 +205,9 @@ agent-channeltalkbot snapshot
 # Full snapshot — includes messages, managers, bots (slow, large output)
 agent-channeltalkbot snapshot --full
 
-# Filtered full snapshots
-agent-channeltalkbot snapshot --full --groups-only
-agent-channeltalkbot snapshot --full --chats-only
+# Filtered snapshots (work in both brief and full mode)
+agent-channeltalkbot snapshot --groups-only
+agent-channeltalkbot snapshot --chats-only
 
 # Limit messages per group/chat (only with --full)
 agent-channeltalkbot snapshot --full --limit 10

--- a/docs/content/docs/cli/channeltalkbot.mdx
+++ b/docs/content/docs/cli/channeltalkbot.mdx
@@ -196,21 +196,31 @@ agent-channeltalkbot bot delete <bot-id> --force
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot of current workspace
+# Brief snapshot (default) — fast, minimal API calls
 agent-channeltalkbot snapshot
 
-# Filtered snapshots
-agent-channeltalkbot snapshot --groups-only
-agent-channeltalkbot snapshot --chats-only
+# Full snapshot — includes messages, managers, bots (slow, large output)
+agent-channeltalkbot snapshot --full
 
-# Limit messages per group/chat
-agent-channeltalkbot snapshot --limit 10
+# Filtered full snapshots
+agent-channeltalkbot snapshot --full --groups-only
+agent-channeltalkbot snapshot --full --chats-only
+
+# Limit messages per group/chat (only with --full)
+agent-channeltalkbot snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Workspace metadata (id, name, homepage_url, description)
+- Groups (id, name)
+- UserChat summary (opened/snoozed/closed counts)
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Workspace metadata (id, name, homepage_url, description)
 - Groups with recent messages (id, name, messages)

--- a/docs/content/docs/cli/discord.mdx
+++ b/docs/content/docs/cli/discord.mdx
@@ -179,19 +179,35 @@ agent-discord file info <channel-id> <file-id>
 
 ### Snapshot Command
 
-Get comprehensive server state for AI agents:
+Get server overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot (channels, members, recent messages)
+# Brief snapshot (default) — fast, minimal API calls
 agent-discord snapshot
 
-# Filtered snapshots
-agent-discord snapshot --channels-only
-agent-discord snapshot --users-only
+# Full snapshot — includes messages and members (slow, large output)
+agent-discord snapshot --full
 
-# Limit messages per channel
-agent-discord snapshot --limit 10
+# Filtered full snapshots
+agent-discord snapshot --full --channels-only
+agent-discord snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-discord snapshot --full --limit 10
 ```
+
+Default returns brief JSON with:
+
+- Server metadata (id, name)
+- Channels (id, name) — text channels only
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
+
+- Server metadata (id, name)
+- Channels (id, name, type, topic)
+- Recent messages (id, content, author, timestamp)
+- Members (id, username, global_name)
 
 ### DM Commands
 

--- a/docs/content/docs/cli/discordbot.mdx
+++ b/docs/content/docs/cli/discordbot.mdx
@@ -231,19 +231,35 @@ agent-discordbot thread archive <thread-id>
 
 ### Snapshot Command
 
-Get comprehensive server state for AI agents:
+Get server overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot of current server
+# Brief snapshot (default) — fast, minimal API calls
 agent-discordbot snapshot
 
-# Filtered snapshots
-agent-discordbot snapshot --channels-only
-agent-discordbot snapshot --users-only
+# Full snapshot — includes messages and members (slow, large output)
+agent-discordbot snapshot --full
 
-# Limit messages per channel
-agent-discordbot snapshot --limit 10
+# Filtered full snapshots
+agent-discordbot snapshot --full --channels-only
+agent-discordbot snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-discordbot snapshot --full --limit 10
 ```
+
+Default returns brief JSON with:
+
+- Server ID
+- Channels (id, name) — text channels only
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
+
+- Server metadata (id, name)
+- Channels (id, name, type, topic)
+- Recent messages (id, content, author, timestamp)
+- Members (id, username, global_name)
 
 ## Key Differences from agent-discord
 

--- a/docs/content/docs/cli/discordbot.mdx
+++ b/docs/content/docs/cli/discordbot.mdx
@@ -256,10 +256,10 @@ Default returns brief JSON with:
 
 With `--full`, returns comprehensive JSON with:
 
-- Server metadata (id, name)
-- Channels (id, name, type, topic)
-- Recent messages (id, content, author, timestamp)
-- Members (id, username, global_name)
+- Server ID
+- Channels with messages (id, name, messages)
+- Use `--full --channels-only` for channel type info
+- Use `--full --users-only` for members (id, username, global_name)
 
 ## Key Differences from agent-discord
 

--- a/docs/content/docs/cli/slack.mdx
+++ b/docs/content/docs/cli/slack.mdx
@@ -241,19 +241,36 @@ agent-slack file delete <file-id>
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot
+# Brief snapshot (default) — fast, minimal API calls
 agent-slack snapshot
 
-# Filtered snapshots
-agent-slack snapshot --channels-only
-agent-slack snapshot --users-only
+# Full snapshot — includes messages, users, user groups (slow, large output)
+agent-slack snapshot --full
 
-# Limit messages per channel
-agent-slack snapshot --limit 10
+# Filtered full snapshots
+agent-slack snapshot --full --channels-only
+agent-slack snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-slack snapshot --full --limit 10
 ```
+
+Default returns brief JSON with:
+
+- Workspace metadata
+- Channels (id, name) — non-archived only
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
+
+- Workspace metadata
+- Channels (id, name, topic, purpose, is_private, is_archived)
+- Recent messages (ts, text, user, channel)
+- Users (id, name, profile)
+- User groups (id, name, handle, description, user_count, users)
 
 ### Activity Commands
 

--- a/docs/content/docs/cli/teams.mdx
+++ b/docs/content/docs/cli/teams.mdx
@@ -209,19 +209,35 @@ agent-teams file download <file-id> <output-path>
 
 ### Snapshot Command
 
-Get comprehensive team state for AI agents:
+Get team overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot (channels, members, recent messages)
+# Brief snapshot (default) — fast, minimal API calls
 agent-teams snapshot
 
-# Filtered snapshots
-agent-teams snapshot --channels-only
-agent-teams snapshot --users-only
+# Full snapshot — includes messages and members (slow, large output)
+agent-teams snapshot --full
 
-# Limit messages per channel
-agent-teams snapshot --limit 10
+# Filtered full snapshots
+agent-teams snapshot --full --channels-only
+agent-teams snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-teams snapshot --full --limit 10
 ```
+
+Default returns brief JSON with:
+
+- Team metadata (id, name)
+- Channels (id, name)
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
+
+- Team metadata (id, name)
+- Channels (id, name, type, description)
+- Recent messages (id, content, author, timestamp)
+- Members (id, displayName, email)
 
 ## Global Options
 

--- a/docs/content/docs/cli/teams.mdx
+++ b/docs/content/docs/cli/teams.mdx
@@ -337,7 +337,7 @@ if ! agent-teams auth status | grep -q "valid"; then
 fi
 
 # 2. Get team context
-agent-teams snapshot --limit 5 > /tmp/teams-context.json
+agent-teams snapshot > /tmp/teams-context.json
 
 # 3. Send standup reminder
 agent-teams message send $STANDUP_CHANNEL "Good morning! Time for standup."

--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -176,13 +176,26 @@ agent-webex member list abc123 --limit 100
 
 ### Snapshot Command
 
-Get workspace spaces overview for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
+# Brief snapshot (default) — fast, minimal output
 agent-webex snapshot
+
+# Full snapshot — includes type and lastActivity
+agent-webex snapshot --full
 ```
 
-Returns only the spaces you're a member of, with id, title, type, and lastActivity. Use `message list <space-id>` or `member list <space-id>` for details.
+Default returns brief JSON with:
+
+- Spaces (id, title) — only spaces you're a member of
+- Hint for next commands
+
+With `--full`, returns:
+
+- Spaces (id, title, type, lastActivity)
+
+For messages or members, use `message list <space-id>` or `member list <space-id>`.
 
 ## Global Options
 

--- a/skills/agent-channeltalk/SKILL.md
+++ b/skills/agent-channeltalk/SKILL.md
@@ -267,21 +267,31 @@ agent-channeltalk bot list --limit 50
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot of current workspace
+# Brief snapshot (default) — fast, minimal API calls
 agent-channeltalk snapshot
 
-# Filtered snapshots
-agent-channeltalk snapshot --groups-only
-agent-channeltalk snapshot --chats-only
+# Full snapshot — includes messages, managers, bots (slow, large output)
+agent-channeltalk snapshot --full
 
-# Limit messages per group/chat
-agent-channeltalk snapshot --limit 10
+# Filtered full snapshots
+agent-channeltalk snapshot --full --groups-only
+agent-channeltalk snapshot --full --chats-only
+
+# Limit messages per group/chat (only with --full)
+agent-channeltalk snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Workspace metadata (id, name)
+- Groups (id, name)
+- UserChat summary (total count, by state)
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Workspace metadata (id, name)
 - Groups with recent messages (id, name, messages)

--- a/skills/agent-channeltalk/references/common-patterns.md
+++ b/skills/agent-channeltalk/references/common-patterns.md
@@ -92,28 +92,29 @@ done
 ```bash
 #!/bin/bash
 
-# Full snapshot for comprehensive context
+# Get brief snapshot (default — fast, minimal output)
 SNAPSHOT=$(agent-channeltalk snapshot)
 
 # Extract key info
 WORKSPACE=$(echo "$SNAPSHOT" | jq -r '.workspace.name')
 GROUP_COUNT=$(echo "$SNAPSHOT" | jq '.groups | length')
 OPEN_CHATS=$(echo "$SNAPSHOT" | jq '.user_chats.by_state.opened')
-MANAGER_COUNT=$(echo "$SNAPSHOT" | jq '.managers | length')
-BOT_COUNT=$(echo "$SNAPSHOT" | jq '.bots | length')
 
 echo "Workspace: $WORKSPACE"
 echo "Groups: $GROUP_COUNT"
 echo "Open chats: $OPEN_CHATS"
-echo "Managers: $MANAGER_COUNT"
-echo "Bots: $BOT_COUNT"
 
-# For focused views
-agent-channeltalk snapshot --groups-only    # Just groups and messages
-agent-channeltalk snapshot --chats-only     # Just UserChat summary
+# List all groups
+echo -e "\nGroups:"
+echo "$SNAPSHOT" | jq -r '.groups[] | "  \(.name) (\(.id))"'
+
+# Then drill into specific resources for details
+agent-channeltalk chat list --state opened --limit 10
+agent-channeltalk manager list --limit 20
+agent-channeltalk bot list --limit 20
 ```
 
-**When to use**: Start of every AI agent session, periodic context refresh, workspace audits.
+**When to use**: Start of every AI agent session, periodic context refresh, workspace audits. Start with brief snapshot, then use targeted list commands for messages, managers, or bots.
 
 ## Pattern 5: Find Group by Name
 

--- a/skills/agent-channeltalkbot/SKILL.md
+++ b/skills/agent-channeltalkbot/SKILL.md
@@ -274,21 +274,31 @@ agent-channeltalkbot bot delete <bot-id> --force
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot of current workspace
+# Brief snapshot (default) — fast, minimal API calls
 agent-channeltalkbot snapshot
 
-# Filtered snapshots
-agent-channeltalkbot snapshot --groups-only
-agent-channeltalkbot snapshot --chats-only
+# Full snapshot — includes messages, managers, bots (slow, large output)
+agent-channeltalkbot snapshot --full
 
-# Limit messages per group/chat
-agent-channeltalkbot snapshot --limit 10
+# Filtered full snapshots
+agent-channeltalkbot snapshot --full --groups-only
+agent-channeltalkbot snapshot --full --chats-only
+
+# Limit messages per group/chat (only with --full)
+agent-channeltalkbot snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Workspace metadata (id, name, homepage_url, description)
+- Groups (id, name)
+- UserChat summary (opened/snoozed/closed counts)
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Workspace metadata (id, name, homepage_url, description)
 - Groups with recent messages (id, name, messages)

--- a/skills/agent-channeltalkbot/references/common-patterns.md
+++ b/skills/agent-channeltalkbot/references/common-patterns.md
@@ -112,28 +112,29 @@ fi
 ```bash
 #!/bin/bash
 
-# Full snapshot for comprehensive context
+# Get brief snapshot (default — fast, minimal output)
 SNAPSHOT=$(agent-channeltalkbot snapshot)
 
 # Extract key info
 WORKSPACE=$(echo "$SNAPSHOT" | jq -r '.workspace.name')
 GROUP_COUNT=$(echo "$SNAPSHOT" | jq '.groups | length')
 OPEN_CHATS=$(echo "$SNAPSHOT" | jq '.user_chats.opened_count')
-MANAGER_COUNT=$(echo "$SNAPSHOT" | jq '.managers | length')
-BOT_COUNT=$(echo "$SNAPSHOT" | jq '.bots | length')
 
 echo "Workspace: $WORKSPACE"
 echo "Groups: $GROUP_COUNT"
 echo "Open chats: $OPEN_CHATS"
-echo "Managers: $MANAGER_COUNT"
-echo "Bots: $BOT_COUNT"
 
-# For focused views
-agent-channeltalkbot snapshot --groups-only    # Just groups and messages
-agent-channeltalkbot snapshot --chats-only     # Just UserChat summary
+# List all groups
+echo -e "\nGroups:"
+echo "$SNAPSHOT" | jq -r '.groups[] | "  \(.name) (\(.id))"'
+
+# Then drill into specific resources for details
+agent-channeltalkbot chat list --state opened --limit 10
+agent-channeltalkbot manager list
+agent-channeltalkbot bot list
 ```
 
-**When to use**: Start of every AI agent session, periodic context refresh, workspace audits.
+**When to use**: Start of every AI agent session, periodic context refresh, workspace audits. Start with brief snapshot, then use targeted list commands for chats, managers, or bots.
 
 ## Pattern 6: Search Messages Across Chats
 

--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -318,21 +318,30 @@ agent-discord file info <channel-id> <file-id>
 
 ### Snapshot Command
 
-Get comprehensive server state for AI agents:
+Get server overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot
+# Brief snapshot (default) — fast, minimal API calls
 agent-discord snapshot
 
-# Filtered snapshots
-agent-discord snapshot --channels-only
-agent-discord snapshot --users-only
+# Full snapshot — includes messages and members (slow, large output)
+agent-discord snapshot --full
 
-# Limit messages per channel
-agent-discord snapshot --limit 10
+# Filtered full snapshots
+agent-discord snapshot --full --channels-only
+agent-discord snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-discord snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Server metadata (id, name)
+- Channels (id, name) — text channels only
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Server metadata (id, name)
 - Channels (id, name, type, topic)

--- a/skills/agent-discord/references/common-patterns.md
+++ b/skills/agent-discord/references/common-patterns.md
@@ -77,28 +77,29 @@ done
 ```bash
 #!/bin/bash
 
-# Get full snapshot
+# Get brief snapshot (default — fast, minimal output)
 SNAPSHOT=$(agent-discord snapshot)
 
 # Extract key information
 SERVER_NAME=$(echo "$SNAPSHOT" | jq -r '.server.name')
 CHANNEL_COUNT=$(echo "$SNAPSHOT" | jq -r '.channels | length')
-MEMBER_COUNT=$(echo "$SNAPSHOT" | jq -r '.members | length')
 
 echo "Server: $SERVER_NAME"
 echo "Channels: $CHANNEL_COUNT"
-echo "Members: $MEMBER_COUNT"
 
 # List all text channels
 echo -e "\nChannels:"
 echo "$SNAPSHOT" | jq -r '.channels[] | "  #\(.name) (\(.id))"'
 
-# List recent activity
-echo -e "\nRecent messages:"
-echo "$SNAPSHOT" | jq -r '.recent_messages[] | "  [\(.channel_name)] \(.author): \(.content[0:50])"'
+# Then drill into a specific channel for recent activity
+CHANNEL_ID=$(echo "$SNAPSHOT" | jq -r '.channels[0].id // empty')
+if [ -n "$CHANNEL_ID" ]; then
+  echo -e "\nRecent messages:"
+  agent-discord message list "$CHANNEL_ID" --limit 10
+fi
 ```
 
-**When to use**: Initial context gathering, status reports, server summaries.
+**When to use**: Initial context gathering, status reports, server summaries. Start with brief snapshot, then use `message list <channel-id>` or `user list` for details.
 
 ## Pattern 4: Find Channel by Name
 

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -284,7 +284,7 @@ agent-discordbot snapshot --full --limit 10
 
 Default returns brief JSON with:
 
-- Server metadata (id, name)
+- Server ID
 - Channels (id, name) — text channels only
 - Hint for next commands
 

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -265,21 +265,30 @@ agent-discordbot thread archive <thread-id>
 
 ### Snapshot Command
 
-Get comprehensive server state for AI agents:
+Get server overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot of current server
+# Brief snapshot (default) — fast, minimal API calls
 agent-discordbot snapshot
 
-# Filtered snapshots
-agent-discordbot snapshot --channels-only
-agent-discordbot snapshot --users-only
+# Full snapshot — includes messages and members (slow, large output)
+agent-discordbot snapshot --full
 
-# Limit messages per channel
-agent-discordbot snapshot --limit 10
+# Filtered full snapshots
+agent-discordbot snapshot --full --channels-only
+agent-discordbot snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-discordbot snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Server metadata (id, name)
+- Channels (id, name) — text channels only
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Server metadata (id, name)
 - Channels (id, name, type, topic)

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -473,24 +473,33 @@ agent-slack emoji list --pretty
 
 ### Snapshot Command
 
-Get comprehensive workspace state for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot
+# Brief snapshot (default) — fast, minimal API calls
 agent-slack snapshot
 
-# Filtered snapshots
-agent-slack snapshot --channels-only
-agent-slack snapshot --users-only
+# Full snapshot — includes messages, users, user groups (slow, large output)
+agent-slack snapshot --full
 
-# Limit messages per channel
-agent-slack snapshot --limit 10
+# Filtered full snapshots
+agent-slack snapshot --full --channels-only
+agent-slack snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-slack snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
 
 - Workspace metadata
-- Channels (id, name, topic, purpose)
+- Channels (id, name) — non-archived only
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
+
+- Workspace metadata
+- Channels (id, name, topic, purpose, is_private, is_archived)
 - Recent messages (ts, text, user, channel)
 - Users (id, name, profile)
 - User groups (id, name, handle, description, user_count, users)

--- a/skills/agent-slack/references/common-patterns.md
+++ b/skills/agent-slack/references/common-patterns.md
@@ -71,28 +71,25 @@ done
 ```bash
 #!/bin/bash
 
-# Get full snapshot
+# Get brief snapshot (default — fast, minimal output)
 SNAPSHOT=$(agent-slack snapshot)
 
 # Extract key information
 WORKSPACE_NAME=$(echo "$SNAPSHOT" | jq -r '.workspace.name')
 CHANNEL_COUNT=$(echo "$SNAPSHOT" | jq -r '.channels | length')
-USER_COUNT=$(echo "$SNAPSHOT" | jq -r '.users | length')
 
 echo "Workspace: $WORKSPACE_NAME"
 echo "Channels: $CHANNEL_COUNT"
-echo "Users: $USER_COUNT"
 
 # List all channels
 echo -e "\nChannels:"
 echo "$SNAPSHOT" | jq -r '.channels[] | "  \(.name) (\(.id))"'
 
-# List recent activity
-echo -e "\nRecent messages:"
-echo "$SNAPSHOT" | jq -r '.recent_messages[] | "  \(.channel_name): \(.text[0:50])"'
+# Then drill into specific channels for messages
+agent-slack message list general --limit 10
 ```
 
-**When to use**: Initial context gathering, status reports, workspace summaries.
+**When to use**: Initial context gathering, status reports, workspace summaries. Start with brief snapshot, then use targeted commands for details.
 
 ## Pattern 4: Thread Conversation
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -262,21 +262,30 @@ agent-teams file info <team-id> <channel-id> <file-id>
 
 ### Snapshot Command
 
-Get comprehensive team state for AI agents:
+Get team overview for AI agents (brief by default):
 
 ```bash
-# Full snapshot
+# Brief snapshot (default) — fast, minimal API calls
 agent-teams snapshot
 
-# Filtered snapshots
-agent-teams snapshot --channels-only
-agent-teams snapshot --users-only
+# Full snapshot — includes messages and members (slow, large output)
+agent-teams snapshot --full
 
-# Limit messages per channel
-agent-teams snapshot --limit 10
+# Filtered full snapshots
+agent-teams snapshot --full --channels-only
+agent-teams snapshot --full --users-only
+
+# Limit messages per channel (only with --full)
+agent-teams snapshot --full --limit 10
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
+
+- Team metadata (id, name)
+- Channels (id, name)
+- Hint for next commands
+
+With `--full`, returns comprehensive JSON with:
 
 - Team metadata (id, name)
 - Channels (id, name, type, description)

--- a/skills/agent-teams/references/common-patterns.md
+++ b/skills/agent-teams/references/common-patterns.md
@@ -127,28 +127,30 @@ done
 # Ensure fresh token
 agent-teams auth extract 2>/dev/null || true
 
-# Get full snapshot
+# Get brief snapshot (default — fast, minimal output)
 SNAPSHOT=$(agent-teams snapshot)
 
 # Extract key information
 TEAM_NAME=$(echo "$SNAPSHOT" | jq -r '.team.name // "Unknown"')
 CHANNEL_COUNT=$(echo "$SNAPSHOT" | jq -r '.channels | length')
-MEMBER_COUNT=$(echo "$SNAPSHOT" | jq -r '.members | length')
 
 echo "Team: $TEAM_NAME"
 echo "Channels: $CHANNEL_COUNT"
-echo "Members: $MEMBER_COUNT"
 
 # List all channels
 echo -e "\nChannels:"
 echo "$SNAPSHOT" | jq -r '.channels[] | "  #\(.name) (\(.id))"'
 
-# List recent activity
-echo -e "\nRecent messages:"
-echo "$SNAPSHOT" | jq -r '.recent_messages[] | "  [\(.channel_name)] \(.author): \(.content[0:50])"'
+# Then drill into a specific channel for recent activity
+CHANNEL_ID=$(echo "$SNAPSHOT" | jq -r '.channels[0].id // empty')
+TEAM_ID=$(echo "$SNAPSHOT" | jq -r '.team.id // empty')
+if [ -n "$TEAM_ID" ] && [ -n "$CHANNEL_ID" ]; then
+  echo -e "\nRecent messages:"
+  agent-teams message list "$TEAM_ID" "$CHANNEL_ID" --limit 10
+fi
 ```
 
-**When to use**: Initial context gathering, status reports, team summaries.
+**When to use**: Initial context gathering, status reports, team summaries. Start with brief snapshot, then use `message list <team-id> <channel-id>` or `member list <team-id>` for details.
 
 ## Pattern 4: Find Channel by Name
 

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -247,15 +247,24 @@ agent-webex member list <space-id> --limit 100
 
 ### Snapshot Command
 
-Get workspace spaces overview for AI agents:
+Get workspace overview for AI agents (brief by default):
 
 ```bash
+# Brief snapshot (default) — fast, minimal output
 agent-webex snapshot
+
+# Full snapshot — includes type and lastActivity
+agent-webex snapshot --full
 ```
 
-Returns JSON with:
+Default returns brief JSON with:
 
-- Spaces (id, title, type, lastActivity) — only spaces you're a member of
+- Spaces (id, title) — only spaces you're a member of
+- Hint for next commands
+
+With `--full`, returns:
+
+- Spaces (id, title, type, lastActivity)
 
 For messages or members, use `message list <space-id>` or `member list <space-id>`.
 

--- a/skills/agent-webex/references/common-patterns.md
+++ b/skills/agent-webex/references/common-patterns.md
@@ -336,10 +336,16 @@ SPACE_COUNT=$(echo "$SNAPSHOT" | jq -r '.spaces | length')
 echo "Total spaces: $SPACE_COUNT"
 
 # List all spaces
-echo "$SNAPSHOT" | jq -r '.spaces[] | "  \(.title) (\(.type))"'
+echo "$SNAPSHOT" | jq -r '.spaces[] | "  \(.title) (\(.id))"'
+
+# Then drill into a specific space for details
+SPACE_ID=$(echo "$SNAPSHOT" | jq -r '.spaces[0].id // empty')
+if [ -n "$SPACE_ID" ]; then
+  agent-webex message list "$SPACE_ID" --limit 10
+fi
 ```
 
-**When to use**: Quick workspace overview to discover space IDs and titles. Use `message list <space-id>` or `member list <space-id>` for details.
+**When to use**: Quick workspace overview to discover space IDs and titles. Start with brief snapshot, then use `message list <space-id>` or `member list <space-id>` for details.
 
 ## Pipeline Patterns
 

--- a/src/platforms/channeltalk/commands/snapshot.test.ts
+++ b/src/platforms/channeltalk/commands/snapshot.test.ts
@@ -81,8 +81,53 @@ describe('snapshot command', () => {
     mockListUserChats.mockClear()
   })
 
-  test('returns workspace, managers, bots, groups, and user chats', async () => {
+  test('brief snapshot returns workspace, groups (name only), chat counts, and hint', async () => {
     const result = await snapshotAction()
+
+    expect(result.error).toBeUndefined()
+    expect(result.workspace).toEqual({ id: 'ws-1', name: 'Workspace One' })
+    expect(result.groups).toEqual([
+      { id: 'grp-1', name: 'Support' },
+      { id: 'grp-2', name: 'Sales' },
+    ])
+    expect(result.user_chats).toEqual({
+      total: 4,
+      by_state: { opened: 2, snoozed: 1, closed: 1 },
+    })
+    expect(result.hint).toBeDefined()
+    expect(result.managers).toBeUndefined()
+    expect(result.bots).toBeUndefined()
+    expect(mockGetGroupMessages).not.toHaveBeenCalled()
+  })
+
+  test('brief groups-only returns group names without messages', async () => {
+    const result = await snapshotAction({ groupsOnly: true })
+
+    expect(result.workspace).toEqual({ id: 'ws-1', name: 'Workspace One' })
+    expect(result.groups).toHaveLength(2)
+    expect(result.groups?.[0]).toEqual({ id: 'grp-1', name: 'Support' })
+    expect(result.hint).toBeDefined()
+    expect(result.user_chats).toBeUndefined()
+    expect(mockGetGroupMessages).not.toHaveBeenCalled()
+    expect(mockListUserChats).not.toHaveBeenCalled()
+  })
+
+  test('brief chats-only returns counts without recent details', async () => {
+    const result = await snapshotAction({ chatsOnly: true })
+
+    expect(result.workspace).toEqual({ id: 'ws-1', name: 'Workspace One' })
+    expect(result.groups).toBeUndefined()
+    expect(result.user_chats).toEqual({
+      total: 4,
+      by_state: { opened: 2, snoozed: 1, closed: 1 },
+    })
+    expect(result.hint).toBeDefined()
+    expect(mockListGroups).not.toHaveBeenCalled()
+    expect(mockGetGroupMessages).not.toHaveBeenCalled()
+  })
+
+  test('full snapshot returns workspace, managers, bots, groups, and user chats', async () => {
+    const result = await snapshotAction({ full: true })
 
     expect(result.error).toBeUndefined()
     expect(result).toEqual({
@@ -156,19 +201,21 @@ describe('snapshot command', () => {
     })
   })
 
-  test('groups-only skips user chats', async () => {
-    const result = await snapshotAction({ groupsOnly: true })
+  test('full groups-only includes messages', async () => {
+    const result = await snapshotAction({ full: true, groupsOnly: true, limit: 3 })
 
-    expect(result.workspace).toEqual({ id: 'ws-1', name: 'Workspace One' })
-    expect(result.groups).toHaveLength(2)
-    expect(result.user_chats).toBeUndefined()
-    expect(result.managers).toBeUndefined()
-    expect(result.bots).toBeUndefined()
-    expect(mockListUserChats).not.toHaveBeenCalled()
+    expect(mockGetGroupMessages).toHaveBeenCalledWith('ws-1', 'grp-1', { limit: 3, sortOrder: 'desc' })
+    expect(mockGetGroupMessages).toHaveBeenCalledWith('ws-1', 'grp-2', { limit: 3, sortOrder: 'desc' })
+    expect(result.groups?.[0].recent_messages?.[0]).toEqual({
+      id: 'grp-1-msg-1',
+      person_type: 'manager',
+      plain_text: 'Message for grp-1',
+      created_at: 1000,
+    })
   })
 
-  test('chats-only skips groups', async () => {
-    const result = await snapshotAction({ chatsOnly: true, limit: 1 })
+  test('full chats-only includes recent details', async () => {
+    const result = await snapshotAction({ full: true, chatsOnly: true, limit: 1 })
 
     expect(result.workspace).toEqual({ id: 'ws-1', name: 'Workspace One' })
     expect(result.groups).toBeUndefined()
@@ -188,21 +235,6 @@ describe('snapshot command', () => {
           updated_at: 200,
         },
       ],
-    })
-    expect(mockListGroups).not.toHaveBeenCalled()
-    expect(mockGetGroupMessages).not.toHaveBeenCalled()
-  })
-
-  test('includes recent messages for each group with requested limit', async () => {
-    const result = await snapshotAction({ groupsOnly: true, limit: 3 })
-
-    expect(mockGetGroupMessages).toHaveBeenCalledWith('ws-1', 'grp-1', { limit: 3, sortOrder: 'desc' })
-    expect(mockGetGroupMessages).toHaveBeenCalledWith('ws-1', 'grp-2', { limit: 3, sortOrder: 'desc' })
-    expect(result.groups?.[0].recent_messages[0]).toEqual({
-      id: 'grp-1-msg-1',
-      person_type: 'manager',
-      plain_text: 'Message for grp-1',
-      created_at: 1000,
     })
   })
 })

--- a/src/platforms/channeltalk/commands/snapshot.ts
+++ b/src/platforms/channeltalk/commands/snapshot.ts
@@ -10,6 +10,7 @@ interface SnapshotOptions {
   pretty?: boolean
   groupsOnly?: boolean
   chatsOnly?: boolean
+  full?: boolean
   limit?: number | string
 }
 
@@ -33,7 +34,7 @@ interface SnapshotResult {
   groups?: Array<{
     id: string
     name: string
-    recent_messages: Array<{
+    recent_messages?: Array<{
       id: string
       person_type?: string
       plain_text?: string
@@ -43,7 +44,7 @@ interface SnapshotResult {
   user_chats?: {
     total: number
     by_state: Record<string, number>
-    recent: Array<{
+    recent?: Array<{
       id: string
       state?: string
       assignee_id?: string
@@ -51,6 +52,7 @@ interface SnapshotResult {
       updated_at?: number
     }>
   }
+  hint?: string
   error?: string
 }
 
@@ -58,7 +60,6 @@ export async function snapshotAction(options: SnapshotOptions = {}): Promise<Sna
   try {
     const client = await getClient(options)
     const workspaceId = await getCurrentWorkspaceId(options)
-    const limit = parseLimit(options.limit)
 
     const channel = await client.getChannel(workspaceId)
     const workspace = {
@@ -66,42 +67,114 @@ export async function snapshotAction(options: SnapshotOptions = {}): Promise<Sna
       name: channel.name,
     }
 
-    if (options.groupsOnly) {
-      const groups = await buildGroupsSnapshot(client, workspaceId, limit)
-      return { workspace, groups }
+    if (options.full) {
+      return buildFullSnapshot(client, workspaceId, workspace, options)
     }
 
-    if (options.chatsOnly) {
-      const userChats = await buildUserChatsSnapshot(client, workspaceId, limit)
-      return { workspace, user_chats: userChats }
-    }
-
-    const [managers, bots, groups, userChats] = await Promise.all([
-      client.listManagers(workspaceId, { limit: 50 }),
-      client.listBots(workspaceId, { limit: 50 }),
-      buildGroupsSnapshot(client, workspaceId, limit),
-      buildUserChatsSnapshot(client, workspaceId, limit),
-    ])
-
-    return {
-      workspace,
-      managers: managers.map((manager) => ({
-        id: manager.id,
-        name: manager.name,
-        email: manager.email,
-        account_id: manager.accountId,
-        role_id: manager.roleId,
-      })),
-      bots: bots.map((bot) => ({
-        id: bot.id,
-        name: bot.name,
-        avatar_url: bot.avatarUrl,
-      })),
-      groups,
-      user_chats: userChats,
-    }
+    return buildBriefSnapshot(client, workspaceId, workspace, options)
   } catch (error) {
     return { error: (error as Error).message }
+  }
+}
+
+async function buildBriefSnapshot(
+  client: Awaited<ReturnType<typeof getClient>>,
+  workspaceId: string,
+  workspace: { id: string; name: string },
+  options: SnapshotOptions,
+): Promise<SnapshotResult> {
+  if (options.groupsOnly) {
+    const groups = await client.listGroups(workspaceId, { limit: 20 })
+    return {
+      workspace,
+      groups: groups.map((g) => ({ id: g.id, name: g.name })),
+      hint: "Use 'group messages <group>' for messages.",
+    }
+  }
+
+  if (options.chatsOnly) {
+    const [openedChats, snoozedChats, closedChats] = await Promise.all([
+      client.listUserChats(workspaceId, { state: 'opened', limit: 100 }),
+      client.listUserChats(workspaceId, { state: 'snoozed', limit: 100 }),
+      client.listUserChats(workspaceId, { state: 'closed', limit: 100 }),
+    ])
+    return {
+      workspace,
+      user_chats: {
+        total: openedChats.length + snoozedChats.length + closedChats.length,
+        by_state: {
+          opened: openedChats.length,
+          snoozed: snoozedChats.length,
+          closed: closedChats.length,
+        },
+      },
+      hint: "Use 'chat list --state opened' for chat details, 'chat messages <chat>' for messages.",
+    }
+  }
+
+  const [groups, openedChats, snoozedChats, closedChats] = await Promise.all([
+    client.listGroups(workspaceId, { limit: 20 }),
+    client.listUserChats(workspaceId, { state: 'opened', limit: 100 }),
+    client.listUserChats(workspaceId, { state: 'snoozed', limit: 100 }),
+    client.listUserChats(workspaceId, { state: 'closed', limit: 100 }),
+  ])
+
+  return {
+    workspace,
+    groups: groups.map((g) => ({ id: g.id, name: g.name })),
+    user_chats: {
+      total: openedChats.length + snoozedChats.length + closedChats.length,
+      by_state: {
+        opened: openedChats.length,
+        snoozed: snoozedChats.length,
+        closed: closedChats.length,
+      },
+    },
+    hint: "Use 'group messages <group>' for group messages, 'chat list --state opened' for chats, 'manager list' for managers.",
+  }
+}
+
+async function buildFullSnapshot(
+  client: Awaited<ReturnType<typeof getClient>>,
+  workspaceId: string,
+  workspace: { id: string; name: string },
+  options: SnapshotOptions,
+): Promise<SnapshotResult> {
+  const limit = parseLimit(options.limit)
+
+  if (options.groupsOnly) {
+    const groups = await buildGroupsSnapshot(client, workspaceId, limit)
+    return { workspace, groups }
+  }
+
+  if (options.chatsOnly) {
+    const userChats = await buildUserChatsSnapshot(client, workspaceId, limit)
+    return { workspace, user_chats: userChats }
+  }
+
+  const [managers, bots, groups, userChats] = await Promise.all([
+    client.listManagers(workspaceId, { limit: 50 }),
+    client.listBots(workspaceId, { limit: 50 }),
+    buildGroupsSnapshot(client, workspaceId, limit),
+    buildUserChatsSnapshot(client, workspaceId, limit),
+  ])
+
+  return {
+    workspace,
+    managers: managers.map((manager) => ({
+      id: manager.id,
+      name: manager.name,
+      email: manager.email,
+      account_id: manager.accountId,
+      role_id: manager.roleId,
+    })),
+    bots: bots.map((bot) => ({
+      id: bot.id,
+      name: bot.name,
+      avatar_url: bot.avatarUrl,
+    })),
+    groups,
+    user_chats: userChats,
   }
 }
 
@@ -178,10 +251,11 @@ function cliOutput(result: SnapshotResult, pretty?: boolean): void {
 
 export function createSnapshotCommand(): Command {
   return new Command('snapshot')
-    .description('Workspace overview for AI agent context')
+    .description('Workspace overview for AI agents (brief by default, use --full for comprehensive data)')
+    .option('--full', 'Include messages, managers, and bots (verbose)')
     .option('--groups-only', 'List groups only, skip user chats')
     .option('--chats-only', 'List user chats only, skip groups')
-    .option('--limit <n>', 'Messages per group and recent opened chats', '5')
+    .option('--limit <n>', 'Messages per group and recent opened chats with --full', '5')
     .option('--workspace <id>', 'Workspace ID')
     .option('--pretty', 'Pretty print JSON output')
     .action(async (options: SnapshotOptions) => {

--- a/src/platforms/channeltalkbot/commands/snapshot.test.ts
+++ b/src/platforms/channeltalkbot/commands/snapshot.test.ts
@@ -67,9 +67,27 @@ describe('snapshot command', () => {
   })
 
   describe('snapshotAction', () => {
-    test('returns workspace, groups, user_chats, managers, bots', async () => {
+    test('brief snapshot returns workspace, groups (names), chat counts, and hint', async () => {
       const manager = new ChannelBotCredentialManager(tempDir)
       const result = await snapshotAction({ _credManager: manager })
+
+      expect(result.error).toBeUndefined()
+      expect(result.workspace).toBeDefined()
+      expect(result.workspace?.id).toBe('ch1')
+      expect(result.workspace?.name).toBe('Test Workspace')
+      expect(result.groups).toBeDefined()
+      expect(result.groups?.[0]).toEqual({ id: 'grp1', name: 'Team Alpha' })
+      expect(result.user_chats).toBeDefined()
+      expect(result.user_chats?.opened_count).toBe(1)
+      expect(result.hint).toBeDefined()
+      expect(result.managers).toBeUndefined()
+      expect(result.bots).toBeUndefined()
+      expect(mockGetGroupMessages).not.toHaveBeenCalled()
+    })
+
+    test('full snapshot returns workspace, groups, user_chats, managers, bots', async () => {
+      const manager = new ChannelBotCredentialManager(tempDir)
+      const result = await snapshotAction({ full: true, _credManager: manager })
 
       expect(result.error).toBeUndefined()
       expect(result.workspace).toBeDefined()
@@ -83,7 +101,7 @@ describe('snapshot command', () => {
 
     test('groups-only flag skips user_chats, managers, bots', async () => {
       const manager = new ChannelBotCredentialManager(tempDir)
-      const result = await snapshotAction({ groupsOnly: true, _credManager: manager })
+      const result = await snapshotAction({ full: true, groupsOnly: true, _credManager: manager })
 
       expect(result.error).toBeUndefined()
       expect(result.workspace).toBeDefined()
@@ -95,7 +113,7 @@ describe('snapshot command', () => {
 
     test('chats-only flag skips groups, managers, bots', async () => {
       const manager = new ChannelBotCredentialManager(tempDir)
-      const result = await snapshotAction({ chatsOnly: true, _credManager: manager })
+      const result = await snapshotAction({ full: true, chatsOnly: true, _credManager: manager })
 
       expect(result.error).toBeUndefined()
       expect(result.workspace).toBeDefined()
@@ -105,21 +123,21 @@ describe('snapshot command', () => {
       expect(result.bots).toBeUndefined()
     })
 
-    test('groups include recent messages', async () => {
+    test('full groups include recent messages', async () => {
       const manager = new ChannelBotCredentialManager(tempDir)
-      const result = await snapshotAction({ groupsOnly: true, limit: 3, _credManager: manager })
+      const result = await snapshotAction({ full: true, groupsOnly: true, limit: 3, _credManager: manager })
 
       expect(result.groups?.[0].messages).toBeDefined()
       expect(result.groups?.[0].messages?.[0].id).toBe('msg1')
     })
 
-    test('user_chats includes counts and recent opened', async () => {
+    test('full user_chats includes counts and recent opened', async () => {
       const manager = new ChannelBotCredentialManager(tempDir)
-      const result = await snapshotAction({ chatsOnly: true, _credManager: manager })
+      const result = await snapshotAction({ full: true, chatsOnly: true, _credManager: manager })
 
       expect(result.user_chats?.opened_count).toBe(1)
       expect(result.user_chats?.recent_opened).toHaveLength(1)
-      expect(result.user_chats?.recent_opened[0].id).toBe('chat1')
+      expect(result.user_chats?.recent_opened?.[0].id).toBe('chat1')
     })
   })
 })

--- a/src/platforms/channeltalkbot/commands/snapshot.ts
+++ b/src/platforms/channeltalkbot/commands/snapshot.ts
@@ -9,6 +9,7 @@ import { getClient } from './shared'
 interface SnapshotOption extends WorkspaceOption {
   groupsOnly?: boolean
   chatsOnly?: boolean
+  full?: boolean
   limit?: number
 }
 
@@ -33,7 +34,7 @@ interface SnapshotResult {
     opened_count: number
     snoozed_count: number
     closed_count: number
-    recent_opened: Array<{
+    recent_opened?: Array<{
       id: string
       name?: string
       user_id?: string
@@ -46,13 +47,13 @@ interface SnapshotResult {
   }
   managers?: Array<{ id: string; name: string; description?: string }>
   bots?: Array<{ id: string; name: string }>
+  hint?: string
   error?: string
 }
 
 export async function snapshotAction(options: SnapshotOption): Promise<SnapshotResult> {
   try {
     const client = await getClient(options)
-    const limit = options.limit ?? 5
 
     const channel = await client.getChannel()
     const workspace = {
@@ -62,71 +63,75 @@ export async function snapshotAction(options: SnapshotOption): Promise<SnapshotR
       description: channel.description,
     }
 
-    if (options.groupsOnly) {
-      const groups = await client.listGroups({ limit: 20 })
-      const groupsWithMessages = await Promise.all(
-        groups.map(async (g) => {
-          const messages = await client.getGroupMessages(g.id, { limit, sortOrder: 'desc' })
-          return {
-            id: g.id,
-            name: g.name,
-            messages: messages.map((m) => ({
-              id: m.id,
-              person_type: m.personType,
-              plain_text: m.plainText,
-              created_at: m.createdAt,
-            })),
-          }
-        }),
-      )
-      return { workspace, groups: groupsWithMessages }
+    if (options.full) {
+      return buildFullSnapshot(client, workspace, options)
     }
 
-    if (options.chatsOnly) {
-      const [openedChats, snoozedChats, closedChats] = await Promise.all([
-        client.listUserChats({ state: 'opened', limit: 10, sortOrder: 'desc' }),
-        client.listUserChats({ state: 'snoozed', limit: 1 }),
-        client.listUserChats({ state: 'closed', limit: 1 }),
-      ])
+    return buildBriefSnapshot(client, workspace, options)
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
 
-      const recentOpened = await Promise.all(
-        openedChats.slice(0, 5).map(async (chat) => {
-          const messages = await client.getUserChatMessages(chat.id, { limit: 1, sortOrder: 'desc' })
-          return {
-            id: chat.id,
-            name: chat.name,
-            user_id: chat.userId,
-            last_message: messages[0]
-              ? {
-                  id: messages[0].id,
-                  plain_text: messages[0].plainText,
-                  created_at: messages[0].createdAt,
-                }
-              : undefined,
-          }
-        }),
-      )
-
-      return {
-        workspace,
-        user_chats: {
-          opened_count: openedChats.length,
-          snoozed_count: snoozedChats.length,
-          closed_count: closedChats.length,
-          recent_opened: recentOpened,
-        },
-      }
+async function buildBriefSnapshot(
+  client: Awaited<ReturnType<typeof getClient>>,
+  workspace: SnapshotResult['workspace'],
+  options: SnapshotOption,
+): Promise<SnapshotResult> {
+  if (options.groupsOnly) {
+    const groups = await client.listGroups({ limit: 20 })
+    return {
+      workspace,
+      groups: groups.map((g) => ({ id: g.id, name: g.name })),
+      hint: "Use 'group messages <group>' for messages.",
     }
+  }
 
-    const [groups, openedChats, snoozedChats, closedChats, managers, bots] = await Promise.all([
-      client.listGroups({ limit: 20 }),
+  if (options.chatsOnly) {
+    const [openedChats, snoozedChats, closedChats] = await Promise.all([
       client.listUserChats({ state: 'opened', limit: 10, sortOrder: 'desc' }),
       client.listUserChats({ state: 'snoozed', limit: 1 }),
       client.listUserChats({ state: 'closed', limit: 1 }),
-      client.listManagers({ limit: 50 }),
-      client.listBots({ limit: 50 }),
     ])
+    return {
+      workspace,
+      user_chats: {
+        opened_count: openedChats.length,
+        snoozed_count: snoozedChats.length,
+        closed_count: closedChats.length,
+      },
+      hint: "Use 'chat list --state opened' for chat details, 'chat messages <chat>' for messages.",
+    }
+  }
 
+  const [groups, openedChats, snoozedChats, closedChats] = await Promise.all([
+    client.listGroups({ limit: 20 }),
+    client.listUserChats({ state: 'opened', limit: 10, sortOrder: 'desc' }),
+    client.listUserChats({ state: 'snoozed', limit: 1 }),
+    client.listUserChats({ state: 'closed', limit: 1 }),
+  ])
+
+  return {
+    workspace,
+    groups: groups.map((g) => ({ id: g.id, name: g.name })),
+    user_chats: {
+      opened_count: openedChats.length,
+      snoozed_count: snoozedChats.length,
+      closed_count: closedChats.length,
+    },
+    hint: "Use 'group messages <group>' for group messages, 'chat list --state opened' for chats, 'manager list' for managers.",
+  }
+}
+
+async function buildFullSnapshot(
+  client: Awaited<ReturnType<typeof getClient>>,
+  workspace: SnapshotResult['workspace'],
+  options: SnapshotOption,
+): Promise<SnapshotResult> {
+  const limit = options.limit ?? 5
+
+  if (options.groupsOnly) {
+    const groups = await client.listGroups({ limit: 20 })
     const groupsWithMessages = await Promise.all(
       groups.map(async (g) => {
         const messages = await client.getGroupMessages(g.id, { limit, sortOrder: 'desc' })
@@ -142,6 +147,15 @@ export async function snapshotAction(options: SnapshotOption): Promise<SnapshotR
         }
       }),
     )
+    return { workspace, groups: groupsWithMessages }
+  }
+
+  if (options.chatsOnly) {
+    const [openedChats, snoozedChats, closedChats] = await Promise.all([
+      client.listUserChats({ state: 'opened', limit: 10, sortOrder: 'desc' }),
+      client.listUserChats({ state: 'snoozed', limit: 1 }),
+      client.listUserChats({ state: 'closed', limit: 1 }),
+    ])
 
     const recentOpened = await Promise.all(
       openedChats.slice(0, 5).map(async (chat) => {
@@ -163,26 +177,78 @@ export async function snapshotAction(options: SnapshotOption): Promise<SnapshotR
 
     return {
       workspace,
-      groups: groupsWithMessages,
       user_chats: {
         opened_count: openedChats.length,
         snoozed_count: snoozedChats.length,
         closed_count: closedChats.length,
         recent_opened: recentOpened,
       },
-      managers: managers.map((m) => ({ id: m.id, name: m.name, description: m.description })),
-      bots: bots.map((b) => ({ id: b.id, name: b.name })),
     }
-  } catch (error) {
-    return { error: (error as Error).message }
+  }
+
+  const [groups, openedChats, snoozedChats, closedChats, managers, bots] = await Promise.all([
+    client.listGroups({ limit: 20 }),
+    client.listUserChats({ state: 'opened', limit: 10, sortOrder: 'desc' }),
+    client.listUserChats({ state: 'snoozed', limit: 1 }),
+    client.listUserChats({ state: 'closed', limit: 1 }),
+    client.listManagers({ limit: 50 }),
+    client.listBots({ limit: 50 }),
+  ])
+
+  const groupsWithMessages = await Promise.all(
+    groups.map(async (g) => {
+      const messages = await client.getGroupMessages(g.id, { limit, sortOrder: 'desc' })
+      return {
+        id: g.id,
+        name: g.name,
+        messages: messages.map((m) => ({
+          id: m.id,
+          person_type: m.personType,
+          plain_text: m.plainText,
+          created_at: m.createdAt,
+        })),
+      }
+    }),
+  )
+
+  const recentOpened = await Promise.all(
+    openedChats.slice(0, 5).map(async (chat) => {
+      const messages = await client.getUserChatMessages(chat.id, { limit: 1, sortOrder: 'desc' })
+      return {
+        id: chat.id,
+        name: chat.name,
+        user_id: chat.userId,
+        last_message: messages[0]
+          ? {
+              id: messages[0].id,
+              plain_text: messages[0].plainText,
+              created_at: messages[0].createdAt,
+            }
+          : undefined,
+      }
+    }),
+  )
+
+  return {
+    workspace,
+    groups: groupsWithMessages,
+    user_chats: {
+      opened_count: openedChats.length,
+      snoozed_count: snoozedChats.length,
+      closed_count: closedChats.length,
+      recent_opened: recentOpened,
+    },
+    managers: managers.map((m) => ({ id: m.id, name: m.name, description: m.description })),
+    bots: bots.map((b) => ({ id: b.id, name: b.name })),
   }
 }
 
 export const snapshotCommand = new Command('snapshot')
-  .description('Workspace overview for AI agent context')
+  .description('Workspace overview for AI agents (brief by default, use --full for comprehensive data)')
+  .option('--full', 'Include messages, managers, and bots (verbose)')
   .option('--groups-only', 'List groups only, skip user chats')
   .option('--chats-only', 'List user chats only, skip groups')
-  .option('--limit <n>', 'Messages per group/chat (default: 5)', '5')
+  .option('--limit <n>', 'Messages per group/chat with --full (default: 5)', '5')
   .option('--workspace <id>', 'Workspace ID')
   .option('--bot <name>', 'Bot name')
   .option('--pretty', 'Pretty print JSON output')
@@ -190,6 +256,7 @@ export const snapshotCommand = new Command('snapshot')
     try {
       const result = await snapshotAction({
         ...options,
+        full: options.full,
         limit: parseInt(options.limit, 10),
       })
       console.log(formatOutput(result, options.pretty))

--- a/src/platforms/discord/commands/snapshot.test.ts
+++ b/src/platforms/discord/commands/snapshot.test.ts
@@ -8,7 +8,7 @@ test('snapshot: command is defined', () => {
 })
 
 test('snapshot: command has correct description', () => {
-  expect(snapshotCommand.description()).toContain('server state')
+  expect(snapshotCommand.description()).toContain('server overview')
 })
 
 test('snapshot: command has --channels-only option', () => {

--- a/src/platforms/discord/commands/snapshot.ts
+++ b/src/platforms/discord/commands/snapshot.ts
@@ -35,7 +35,8 @@ export async function snapshotAction(options: {
       name: server.name,
     }
 
-    if (options.full) {
+    const isFull = options.full || options.channelsOnly || options.usersOnly
+    if (isFull) {
       const messageLimit = options.limit || 20
 
       if (!options.usersOnly) {

--- a/src/platforms/discord/commands/snapshot.ts
+++ b/src/platforms/discord/commands/snapshot.ts
@@ -11,6 +11,7 @@ import type { DiscordChannel } from '../types'
 export async function snapshotAction(options: {
   channelsOnly?: boolean
   usersOnly?: boolean
+  full?: boolean
   limit?: number
   pretty?: boolean
 }): Promise<void> {
@@ -25,7 +26,6 @@ export async function snapshotAction(options: {
 
     const client = await new DiscordClient().login({ token: config.token as string })
     const serverId = config.current_server as string
-    const messageLimit = options.limit || 20
 
     const snapshot: Record<string, any> = {}
 
@@ -35,51 +35,64 @@ export async function snapshotAction(options: {
       name: server.name,
     }
 
-    if (!options.usersOnly) {
-      const channels = await client.listChannels(serverId)
+    if (options.full) {
+      const messageLimit = options.limit || 20
 
-      snapshot.channels = channels.map((ch) => ({
-        id: ch.id,
-        name: ch.name,
-        type: ch.type,
-        topic: ch.topic,
-      }))
+      if (!options.usersOnly) {
+        const channels = await client.listChannels(serverId)
+
+        snapshot.channels = channels.map((ch) => ({
+          id: ch.id,
+          name: ch.name,
+          type: ch.type,
+          topic: ch.topic,
+        }))
+
+        if (!options.channelsOnly) {
+          const isTextChannel = (ch: DiscordChannel) => ch.type === 0 || ch.type === 5
+          const textChannels = channels.filter(isTextChannel)
+
+          const channelMessages = await parallelMap(
+            textChannels,
+            async (channel: DiscordChannel) => {
+              const messages = await client.getMessages(channel.id, messageLimit)
+              return messages.map((msg) => ({
+                ...msg,
+                channel_name: channel.name,
+              }))
+            },
+            5,
+          )
+
+          snapshot.recent_messages = channelMessages.flat().map((msg) => ({
+            channel_id: msg.channel_id,
+            channel_name: msg.channel_name,
+            id: msg.id,
+            author: msg.author.username,
+            content: msg.content,
+            timestamp: msg.timestamp,
+          }))
+        }
+      }
 
       if (!options.channelsOnly) {
-        const isTextChannel = (ch: DiscordChannel) => ch.type === 0 || ch.type === 5
-        const textChannels = channels.filter(isTextChannel)
+        const users = await client.listUsers(serverId)
 
-        const channelMessages = await parallelMap(
-          textChannels,
-          async (channel: DiscordChannel) => {
-            const messages = await client.getMessages(channel.id, messageLimit)
-            return messages.map((msg) => ({
-              ...msg,
-              channel_name: channel.name,
-            }))
-          },
-          5,
-        )
-
-        snapshot.recent_messages = channelMessages.flat().map((msg) => ({
-          channel_id: msg.channel_id,
-          channel_name: msg.channel_name,
-          id: msg.id,
-          author: msg.author.username,
-          content: msg.content,
-          timestamp: msg.timestamp,
+        snapshot.members = users.map((u) => ({
+          id: u.id,
+          username: u.username,
+          global_name: u.global_name || null,
         }))
       }
-    }
+    } else {
+      if (!options.usersOnly) {
+        const channels = await client.listChannels(serverId)
+        const textChannels = channels.filter((ch: DiscordChannel) => ch.type === 0 || ch.type === 5)
+        snapshot.channels = textChannels.map((ch) => ({ id: ch.id, name: ch.name }))
+      }
 
-    if (!options.channelsOnly) {
-      const users = await client.listUsers(serverId)
-
-      snapshot.members = users.map((u) => ({
-        id: u.id,
-        username: u.username,
-        global_name: u.global_name || null,
-      }))
+      snapshot.hint =
+        "Use 'message list <channel>' for messages, 'channel info <channel>' for channel details, 'user list' for members."
     }
 
     console.log(formatOutput(snapshot, options.pretty))
@@ -89,14 +102,16 @@ export async function snapshotAction(options: {
 }
 
 export const snapshotCommand = new Command('snapshot')
-  .description('Get comprehensive server state for AI agents')
+  .description('Get server overview for AI agents (brief by default, use --full for comprehensive data)')
+  .option('--full', 'Include messages and members (verbose)')
   .option('--channels-only', 'Include only channels (exclude messages and members)')
   .option('--users-only', 'Include only members (exclude channels and messages)')
-  .option('--limit <n>', 'Number of recent messages per channel (default: 20)', '20')
+  .option('--limit <n>', 'Number of recent messages per channel with --full (default: 20)', '20')
   .action(async (options) => {
     await snapshotAction({
       channelsOnly: options.channelsOnly,
       usersOnly: options.usersOnly,
+      full: options.full,
       limit: parseInt(options.limit, 10),
       pretty: options.pretty,
     })

--- a/src/platforms/discordbot/commands/snapshot.test.ts
+++ b/src/platforms/discordbot/commands/snapshot.test.ts
@@ -86,11 +86,42 @@ describe('snapshot command', () => {
     process.env = originalEnv
   })
 
-  describe('default (channels + messages)', () => {
-    test('returns channels with recent messages', async () => {
+  describe('default (brief)', () => {
+    test('returns channels with id and name only', async () => {
       const manager = await setupManager(tempDir)
 
       const result = await snapshotAction({ _credManager: manager })
+
+      expect(result.server_id).toBe('guild1')
+      expect(result.channels).toHaveLength(2)
+      expect(result.channels?.[0]).toEqual({ id: 'ch1', name: 'general' })
+      expect(result.channels?.[1]).toEqual({ id: 'ch2', name: 'random' })
+      expect(result.hint).toBeDefined()
+    })
+
+    test('filters out non-text channels', async () => {
+      const manager = await setupManager(tempDir)
+
+      const result = await snapshotAction({ _credManager: manager })
+
+      const channelNames = result.channels?.map((ch) => ch.name)
+      expect(channelNames).not.toContain('voice')
+    })
+
+    test('does not fetch messages', async () => {
+      const manager = await setupManager(tempDir)
+
+      await snapshotAction({ _credManager: manager })
+
+      expect(mockGetMessages).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('--full (channels + messages)', () => {
+    test('returns channels with recent messages', async () => {
+      const manager = await setupManager(tempDir)
+
+      const result = await snapshotAction({ _credManager: manager, full: true })
 
       expect(result.server_id).toBe('guild1')
       expect(result.channels).toHaveLength(2)
@@ -105,19 +136,10 @@ describe('snapshot command', () => {
       })
     })
 
-    test('filters out non-text channels', async () => {
-      const manager = await setupManager(tempDir)
-
-      const result = await snapshotAction({ _credManager: manager })
-
-      const channelNames = result.channels?.map((ch) => ch.name)
-      expect(channelNames).not.toContain('voice')
-    })
-
     test('fetches messages in parallel for all text channels', async () => {
       const manager = await setupManager(tempDir)
 
-      await snapshotAction({ _credManager: manager })
+      await snapshotAction({ _credManager: manager, full: true })
 
       expect(mockGetMessages).toHaveBeenCalledTimes(2)
       expect(mockGetMessages).toHaveBeenCalledWith('ch1', 5)
@@ -127,7 +149,7 @@ describe('snapshot command', () => {
     test('respects --limit option', async () => {
       const manager = await setupManager(tempDir)
 
-      await snapshotAction({ _credManager: manager, limit: 10 })
+      await snapshotAction({ _credManager: manager, full: true, limit: 10 })
 
       expect(mockGetMessages).toHaveBeenCalledWith('ch1', 10)
       expect(mockGetMessages).toHaveBeenCalledWith('ch2', 10)
@@ -136,17 +158,17 @@ describe('snapshot command', () => {
     test('defaults limit to 5', async () => {
       const manager = await setupManager(tempDir)
 
-      await snapshotAction({ _credManager: manager })
+      await snapshotAction({ _credManager: manager, full: true })
 
       expect(mockGetMessages).toHaveBeenCalledWith('ch1', 5)
     })
   })
 
-  describe('--channels-only', () => {
+  describe('--full --channels-only', () => {
     test('returns only channel list without messages', async () => {
       const manager = await setupManager(tempDir)
 
-      const result = await snapshotAction({ _credManager: manager, channelsOnly: true })
+      const result = await snapshotAction({ _credManager: manager, full: true, channelsOnly: true })
 
       expect(result.server_id).toBe('guild1')
       expect(result.channels).toHaveLength(2)
@@ -156,11 +178,11 @@ describe('snapshot command', () => {
     })
   })
 
-  describe('--users-only', () => {
+  describe('--full --users-only', () => {
     test('returns only user list', async () => {
       const manager = await setupManager(tempDir)
 
-      const result = await snapshotAction({ _credManager: manager, usersOnly: true })
+      const result = await snapshotAction({ _credManager: manager, full: true, usersOnly: true })
 
       expect(result.server_id).toBe('guild1')
       expect(result.users).toHaveLength(3)

--- a/src/platforms/discordbot/commands/snapshot.ts
+++ b/src/platforms/discordbot/commands/snapshot.ts
@@ -46,7 +46,8 @@ export async function snapshotAction(options: SnapshotOption): Promise<SnapshotR
 
     const client = await getClient(options)
 
-    if (options.full) {
+    const isFull = options.full || options.channelsOnly || options.usersOnly
+    if (isFull) {
       const limit = options.limit ?? 5
 
       if (options.usersOnly) {

--- a/src/platforms/discordbot/commands/snapshot.ts
+++ b/src/platforms/discordbot/commands/snapshot.ts
@@ -10,6 +10,7 @@ import { getClient } from './shared'
 interface SnapshotOption extends BotOption {
   channelsOnly?: boolean
   usersOnly?: boolean
+  full?: boolean
   limit?: number
 }
 
@@ -31,6 +32,7 @@ interface SnapshotResult {
     username: string
     global_name: string | null
   }>
+  hint?: string
   error?: string
 }
 
@@ -43,53 +45,65 @@ export async function snapshotAction(options: SnapshotOption): Promise<SnapshotR
     }
 
     const client = await getClient(options)
-    const limit = options.limit ?? 5
 
-    if (options.usersOnly) {
-      const users = await client.listUsers(serverId)
+    if (options.full) {
+      const limit = options.limit ?? 5
+
+      if (options.usersOnly) {
+        const users = await client.listUsers(serverId)
+        return {
+          server_id: serverId,
+          users: users.map((u) => ({
+            id: u.id,
+            username: u.username,
+            global_name: u.global_name ?? null,
+          })),
+        }
+      }
+
+      const allChannels = await client.listChannels(serverId)
+      const textChannels = allChannels.filter((ch) => ch.type === 0)
+
+      if (options.channelsOnly) {
+        return {
+          server_id: serverId,
+          channels: textChannels.map((ch) => ({
+            id: ch.id,
+            name: ch.name,
+            type: ch.type,
+          })),
+        }
+      }
+
+      const channelsWithMessages = await Promise.all(
+        textChannels.map(async (ch) => {
+          const messages = await client.getMessages(ch.id, limit)
+          return {
+            id: ch.id,
+            name: ch.name,
+            messages: messages.map((msg) => ({
+              id: msg.id,
+              author: msg.author.username,
+              content: msg.content,
+              timestamp: msg.timestamp,
+            })),
+          }
+        }),
+      )
+
       return {
         server_id: serverId,
-        users: users.map((u) => ({
-          id: u.id,
-          username: u.username,
-          global_name: u.global_name ?? null,
-        })),
+        channels: channelsWithMessages,
       }
     }
 
     const allChannels = await client.listChannels(serverId)
     const textChannels = allChannels.filter((ch) => ch.type === 0)
 
-    if (options.channelsOnly) {
-      return {
-        server_id: serverId,
-        channels: textChannels.map((ch) => ({
-          id: ch.id,
-          name: ch.name,
-          type: ch.type,
-        })),
-      }
-    }
-
-    const channelsWithMessages = await Promise.all(
-      textChannels.map(async (ch) => {
-        const messages = await client.getMessages(ch.id, limit)
-        return {
-          id: ch.id,
-          name: ch.name,
-          messages: messages.map((msg) => ({
-            id: msg.id,
-            author: msg.author.username,
-            content: msg.content,
-            timestamp: msg.timestamp,
-          })),
-        }
-      }),
-    )
-
     return {
       server_id: serverId,
-      channels: channelsWithMessages,
+      channels: textChannels.map((ch) => ({ id: ch.id, name: ch.name })),
+      hint: "Use 'message list <channel>' for messages, 'channel info <channel>' for channel details, 'user list' for members.",
     }
   } catch (error) {
     return { error: (error as Error).message }
@@ -97,10 +111,11 @@ export async function snapshotAction(options: SnapshotOption): Promise<SnapshotR
 }
 
 export const snapshotCommand = new Command('snapshot')
-  .description('Server overview for AI agent context')
+  .description('Server overview for AI agents (brief by default, use --full for comprehensive data)')
+  .option('--full', 'Include messages and members (verbose)')
   .option('--channels-only', 'List channels only, skip messages')
   .option('--users-only', 'List users only')
-  .option('--limit <n>', 'Messages per channel (default: 5)', '5')
+  .option('--limit <n>', 'Messages per channel with --full (default: 5)', '5')
   .option('--server <id>', 'Use specific server')
   .option('--bot <id>', 'Use specific bot')
   .option('--pretty', 'Pretty print JSON output')
@@ -108,6 +123,7 @@ export const snapshotCommand = new Command('snapshot')
     try {
       const result = await snapshotAction({
         ...options,
+        full: options.full,
         limit: parseInt(options.limit, 10),
       })
       console.log(formatOutput(result, options.pretty))

--- a/src/platforms/slack/commands/snapshot.test.ts
+++ b/src/platforms/slack/commands/snapshot.test.ts
@@ -34,6 +34,12 @@ test('snapshot command has --limit option', () => {
   expect(hasLimit).toBe(true)
 })
 
+test('snapshot command has --full option', () => {
+  const options = snapshotCommand.options
+  const hasFull = options.some((opt: any) => opt.long === '--full')
+  expect(hasFull).toBe(true)
+})
+
 // Test snapshot logic using spyOn (no global mock pollution)
 let credManagerSpy: ReturnType<typeof spyOn>
 let clientTestAuthSpy: ReturnType<typeof spyOn>
@@ -147,11 +153,66 @@ afterEach(() => {
   clientGetMessagesSpy?.mockRestore()
 })
 
-test('full snapshot returns workspace, channels, messages, and users', async () => {
-  const credManager = new CredentialManager()
+test('brief snapshot (default) returns workspace, channels as {id, name}, and hint', async () => {
   const client = await new SlackClient().login({ token: 'xoxc-test', cookie: 'test-cookie' })
 
-  const _workspace = await credManager.getWorkspace()
+  const auth = await client.testAuth()
+  const channels = await client.listChannels()
+  const active = channels.filter((ch) => !ch.is_archived)
+
+  const snapshot = {
+    workspace: {
+      id: auth.team_id,
+      name: auth.team,
+    },
+    channels: active.map((ch) => ({ id: ch.id, name: ch.name })),
+    hint: "Use 'message list <channel>' for messages, 'channel info <channel>' for channel details, 'user list' for users, 'usergroup list' for groups.",
+  }
+
+  expect(snapshot.workspace).toBeDefined()
+  expect(snapshot.workspace.id).toBe('T123')
+  expect(snapshot.workspace.name).toBe('Test Workspace')
+
+  expect(snapshot.channels).toBeDefined()
+  expect(snapshot.channels.length).toBe(2)
+  expect(snapshot.channels[0]).toEqual({ id: 'C123', name: 'general' })
+  expect(snapshot.channels[1]).toEqual({ id: 'C456', name: 'random' })
+
+  expect((snapshot as any).recent_messages).toBeUndefined()
+  expect((snapshot as any).users).toBeUndefined()
+  expect((snapshot as any).usergroups).toBeUndefined()
+
+  expect(snapshot.hint).toContain('message list')
+})
+
+test('brief snapshot excludes archived channels', async () => {
+  const channelsWithArchived: SlackChannel[] = [
+    ...mockChannels,
+    {
+      id: 'C789',
+      name: 'old-channel',
+      is_private: false,
+      is_archived: true,
+      created: 1234567800,
+      creator: 'U123',
+      topic: { value: 'Archived', creator: 'U123', last_set: 1234567800 },
+      purpose: { value: 'Old channel', creator: 'U123', last_set: 1234567800 },
+    },
+  ]
+
+  clientListChannelsSpy.mockResolvedValue(channelsWithArchived)
+
+  const client = await new SlackClient().login({ token: 'xoxc-test', cookie: 'test-cookie' })
+  const channels = await client.listChannels()
+  const active = channels.filter((ch) => !ch.is_archived)
+
+  expect(active.length).toBe(2)
+  expect(active.every((ch) => !ch.is_archived)).toBe(true)
+})
+
+test('full snapshot returns workspace, channels, messages, and users', async () => {
+  const client = await new SlackClient().login({ token: 'xoxc-test', cookie: 'test-cookie' })
+
   const auth = await client.testAuth()
   const channels = await client.listChannels()
   const users = await client.listUsers()
@@ -218,10 +279,8 @@ test('full snapshot returns workspace, channels, messages, and users', async () 
 })
 
 test('snapshot with --channels-only excludes messages and users', async () => {
-  const credManager = new CredentialManager()
   const client = await new SlackClient().login({ token: 'xoxc-test', cookie: 'test-cookie' })
 
-  const _workspace = await credManager.getWorkspace()
   const auth = await client.testAuth()
   const channels = await client.listChannels()
 
@@ -249,10 +308,8 @@ test('snapshot with --channels-only excludes messages and users', async () => {
 })
 
 test('snapshot with --users-only excludes channels and messages', async () => {
-  const credManager = new CredentialManager()
   const client = await new SlackClient().login({ token: 'xoxc-test', cookie: 'test-cookie' })
 
-  const _workspace = await credManager.getWorkspace()
   const auth = await client.testAuth()
   const users = await client.listUsers()
 
@@ -279,10 +336,8 @@ test('snapshot with --users-only excludes channels and messages', async () => {
 })
 
 test('snapshot respects --limit option for messages', async () => {
-  const credManager = new CredentialManager()
   const client = await new SlackClient().login({ token: 'xoxc-test', cookie: 'test-cookie' })
 
-  const _workspace = await credManager.getWorkspace()
   const auth = await client.testAuth()
   const channels = await client.listChannels()
 

--- a/src/platforms/slack/commands/snapshot.ts
+++ b/src/platforms/slack/commands/snapshot.ts
@@ -35,7 +35,8 @@ async function snapshotAction(options: {
       },
     }
 
-    if (options.full) {
+    const isFull = options.full || options.channelsOnly || options.usersOnly
+    if (isFull) {
       await buildFullSnapshot(client, snapshot, options)
     } else {
       await buildBriefSnapshot(client, snapshot, options)

--- a/src/platforms/slack/commands/snapshot.ts
+++ b/src/platforms/slack/commands/snapshot.ts
@@ -11,6 +11,7 @@ import type { SlackChannel } from '../types'
 async function snapshotAction(options: {
   channelsOnly?: boolean
   usersOnly?: boolean
+  full?: boolean
   limit?: number
   pretty?: boolean
 }): Promise<void> {
@@ -26,7 +27,6 @@ async function snapshotAction(options: {
     const client = await new SlackClient().login({ token: workspace.token, cookie: workspace.cookie })
 
     const auth = await client.testAuth()
-    const messageLimit = options.limit || 20
 
     const snapshot: Record<string, any> = {
       workspace: {
@@ -35,71 +35,10 @@ async function snapshotAction(options: {
       },
     }
 
-    if (!options.usersOnly) {
-      const channels = await client.listChannels()
-
-      snapshot.channels = channels.map((ch) => ({
-        id: ch.id,
-        name: ch.name,
-        is_private: ch.is_private,
-        is_archived: ch.is_archived,
-        created: ch.created,
-        topic: ch.topic?.value,
-        purpose: ch.purpose?.value,
-      }))
-
-      if (!options.channelsOnly) {
-        const activeChannels = channels.filter((ch) => !ch.is_archived)
-
-        const channelMessages = await parallelMap(
-          activeChannels,
-          async (channel: SlackChannel) => {
-            const messages = await client.getMessages(channel.id, messageLimit)
-            return messages.map((msg) => ({
-              ...msg,
-              channel_id: channel.id,
-              channel_name: channel.name,
-            }))
-          },
-          5,
-        )
-
-        snapshot.recent_messages = channelMessages.flat().map((msg) => ({
-          channel_id: msg.channel_id,
-          channel_name: msg.channel_name,
-          ts: msg.ts,
-          text: msg.text,
-          user: msg.user,
-          username: msg.username,
-          thread_ts: msg.thread_ts,
-        }))
-      }
-    }
-
-    if (!options.channelsOnly) {
-      const users = await client.listUsers()
-
-      snapshot.users = users.map((u) => ({
-        id: u.id,
-        name: u.name,
-        real_name: u.real_name,
-        is_admin: u.is_admin,
-        is_bot: u.is_bot,
-        profile: u.profile,
-      }))
-    }
-
-    if (!options.channelsOnly && !options.usersOnly) {
-      const usergroups = await client.listUsergroups({ includeUsers: true, includeCount: true })
-
-      snapshot.usergroups = usergroups.map((ug) => ({
-        id: ug.id,
-        name: ug.name,
-        handle: ug.handle,
-        description: ug.description,
-        user_count: ug.user_count,
-        users: ug.users,
-      }))
+    if (options.full) {
+      await buildFullSnapshot(client, snapshot, options)
+    } else {
+      await buildBriefSnapshot(client, snapshot, options)
     }
 
     console.log(formatOutput(snapshot, options.pretty))
@@ -108,15 +47,107 @@ async function snapshotAction(options: {
   }
 }
 
+async function buildBriefSnapshot(
+  client: SlackClient,
+  snapshot: Record<string, any>,
+  options: { channelsOnly?: boolean; usersOnly?: boolean },
+): Promise<void> {
+  if (!options.usersOnly) {
+    const channels = await client.listChannels()
+    const active = channels.filter((ch) => !ch.is_archived)
+    snapshot.channels = active.map((ch) => ({ id: ch.id, name: ch.name }))
+  }
+
+  snapshot.hint =
+    "Use 'message list <channel>' for messages, 'channel info <channel>' for channel details, 'user list' for users, 'usergroup list' for groups."
+}
+
+async function buildFullSnapshot(
+  client: SlackClient,
+  snapshot: Record<string, any>,
+  options: { channelsOnly?: boolean; usersOnly?: boolean; limit?: number },
+): Promise<void> {
+  const messageLimit = options.limit || 20
+
+  if (!options.usersOnly) {
+    const channels = await client.listChannels()
+
+    snapshot.channels = channels.map((ch) => ({
+      id: ch.id,
+      name: ch.name,
+      is_private: ch.is_private,
+      is_archived: ch.is_archived,
+      created: ch.created,
+      topic: ch.topic?.value,
+      purpose: ch.purpose?.value,
+    }))
+
+    if (!options.channelsOnly) {
+      const activeChannels = channels.filter((ch) => !ch.is_archived)
+
+      const channelMessages = await parallelMap(
+        activeChannels,
+        async (channel: SlackChannel) => {
+          const messages = await client.getMessages(channel.id, messageLimit)
+          return messages.map((msg) => ({
+            ...msg,
+            channel_id: channel.id,
+            channel_name: channel.name,
+          }))
+        },
+        5,
+      )
+
+      snapshot.recent_messages = channelMessages.flat().map((msg) => ({
+        channel_id: msg.channel_id,
+        channel_name: msg.channel_name,
+        ts: msg.ts,
+        text: msg.text,
+        user: msg.user,
+        username: msg.username,
+        thread_ts: msg.thread_ts,
+      }))
+    }
+  }
+
+  if (!options.channelsOnly) {
+    const users = await client.listUsers()
+
+    snapshot.users = users.map((u) => ({
+      id: u.id,
+      name: u.name,
+      real_name: u.real_name,
+      is_admin: u.is_admin,
+      is_bot: u.is_bot,
+      profile: u.profile,
+    }))
+  }
+
+  if (!options.channelsOnly && !options.usersOnly) {
+    const usergroups = await client.listUsergroups({ includeUsers: true, includeCount: true })
+
+    snapshot.usergroups = usergroups.map((ug) => ({
+      id: ug.id,
+      name: ug.name,
+      handle: ug.handle,
+      description: ug.description,
+      user_count: ug.user_count,
+      users: ug.users,
+    }))
+  }
+}
+
 export const snapshotCommand = new Command('snapshot')
-  .description('Get comprehensive workspace state for AI agents')
+  .description('Get workspace overview for AI agents (brief by default, use --full for comprehensive data)')
+  .option('--full', 'Include messages, users, and user groups (verbose)')
   .option('--channels-only', 'Include only channels (exclude messages and users)')
   .option('--users-only', 'Include only users (exclude channels and messages)')
-  .option('--limit <n>', 'Number of recent messages per channel (default: 20)', '20')
+  .option('--limit <n>', 'Number of recent messages per channel with --full (default: 20)', '20')
   .action(async (options) => {
     await snapshotAction({
       channelsOnly: options.channelsOnly,
       usersOnly: options.usersOnly,
+      full: options.full,
       limit: parseInt(options.limit, 10),
       pretty: options.pretty,
     })

--- a/src/platforms/teams/commands/snapshot.test.ts
+++ b/src/platforms/teams/commands/snapshot.test.ts
@@ -8,7 +8,7 @@ test('snapshot: command is defined', () => {
 })
 
 test('snapshot: command has correct description', () => {
-  expect(snapshotCommand.description()).toContain('team state')
+  expect(snapshotCommand.description()).toContain('team overview')
 })
 
 test('snapshot: command has --channels-only option', () => {

--- a/src/platforms/teams/commands/snapshot.ts
+++ b/src/platforms/teams/commands/snapshot.ts
@@ -11,6 +11,7 @@ import type { TeamsChannel } from '../types'
 export async function snapshotAction(options: {
   channelsOnly?: boolean
   usersOnly?: boolean
+  full?: boolean
   limit?: number
   teamId?: string
   pretty?: boolean
@@ -34,7 +35,6 @@ export async function snapshotAction(options: {
     }
 
     const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
-    const messageLimit = options.limit || 20
 
     const snapshot: Record<string, unknown> = {}
 
@@ -45,47 +45,59 @@ export async function snapshotAction(options: {
       description: team.description,
     }
 
-    if (!options.usersOnly) {
-      const channels = await client.listChannels(teamId)
+    if (options.full) {
+      const messageLimit = options.limit || 20
 
-      snapshot.channels = channels.map((ch) => ({
-        id: ch.id,
-        name: ch.name,
-        type: ch.type,
-      }))
+      if (!options.usersOnly) {
+        const channels = await client.listChannels(teamId)
+
+        snapshot.channels = channels.map((ch) => ({
+          id: ch.id,
+          name: ch.name,
+          type: ch.type,
+        }))
+
+        if (!options.channelsOnly) {
+          const channelMessages = await parallelMap(
+            channels,
+            async (channel: TeamsChannel) => {
+              const messages = await client.getMessages(teamId, channel.id, messageLimit)
+              return messages.map((msg) => ({
+                ...msg,
+                channel_name: channel.name,
+              }))
+            },
+            5,
+          )
+
+          snapshot.recent_messages = channelMessages.flat().map((msg) => ({
+            channel_id: msg.channel_id,
+            channel_name: msg.channel_name,
+            id: msg.id,
+            author: msg.author.displayName,
+            content: msg.content,
+            timestamp: msg.timestamp,
+          }))
+        }
+      }
 
       if (!options.channelsOnly) {
-        const channelMessages = await parallelMap(
-          channels,
-          async (channel: TeamsChannel) => {
-            const messages = await client.getMessages(teamId, channel.id, messageLimit)
-            return messages.map((msg) => ({
-              ...msg,
-              channel_name: channel.name,
-            }))
-          },
-          5,
-        )
+        const users = await client.listUsers(teamId)
 
-        snapshot.recent_messages = channelMessages.flat().map((msg) => ({
-          channel_id: msg.channel_id,
-          channel_name: msg.channel_name,
-          id: msg.id,
-          author: msg.author.displayName,
-          content: msg.content,
-          timestamp: msg.timestamp,
+        snapshot.members = users.map((u) => ({
+          id: u.id,
+          displayName: u.displayName,
+          email: u.email || null,
         }))
       }
-    }
+    } else {
+      if (!options.usersOnly) {
+        const channels = await client.listChannels(teamId)
+        snapshot.channels = channels.map((ch) => ({ id: ch.id, name: ch.name }))
+      }
 
-    if (!options.channelsOnly) {
-      const users = await client.listUsers(teamId)
-
-      snapshot.members = users.map((u) => ({
-        id: u.id,
-        displayName: u.displayName,
-        email: u.email || null,
-      }))
+      snapshot.hint =
+        "Use 'message list <channel>' for messages, 'channel info <channel>' for channel details, 'user list' for members."
     }
 
     console.log(formatOutput(snapshot, options.pretty))
@@ -95,16 +107,18 @@ export async function snapshotAction(options: {
 }
 
 export const snapshotCommand = new Command('snapshot')
-  .description('Get comprehensive team state for AI agents')
+  .description('Get team overview for AI agents (brief by default, use --full for comprehensive data)')
+  .option('--full', 'Include messages and members (verbose)')
   .option('--channels-only', 'Include only channels (exclude messages and members)')
   .option('--users-only', 'Include only members (exclude channels and messages)')
-  .option('--limit <n>', 'Number of recent messages per channel (default: 20)', '20')
+  .option('--limit <n>', 'Number of recent messages per channel with --full (default: 20)', '20')
   .option('--team-id <id>', 'Team ID (defaults to current team)')
   .option('--pretty', 'Pretty print JSON output')
   .action(async (options) => {
     await snapshotAction({
       channelsOnly: options.channelsOnly,
       usersOnly: options.usersOnly,
+      full: options.full,
       limit: parseInt(options.limit, 10),
       teamId: options.teamId,
       pretty: options.pretty,

--- a/src/platforms/teams/commands/snapshot.ts
+++ b/src/platforms/teams/commands/snapshot.ts
@@ -45,7 +45,8 @@ export async function snapshotAction(options: {
       description: team.description,
     }
 
-    if (options.full) {
+    const isFull = options.full || options.channelsOnly || options.usersOnly
+    if (isFull) {
       const messageLimit = options.limit || 20
 
       if (!options.usersOnly) {

--- a/src/platforms/webex/commands/snapshot.test.ts
+++ b/src/platforms/webex/commands/snapshot.test.ts
@@ -79,8 +79,20 @@ describe('snapshot command', () => {
     consoleSpy.mockRestore()
   })
 
-  test('returns spaces with id, title, type, lastActivity', async () => {
+  test('brief snapshot returns spaces with id and title only', async () => {
     await snapshotAction({})
+
+    expect(consoleSpy).toHaveBeenCalled()
+    const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
+    expect(output.spaces).toHaveLength(1)
+    expect(output.spaces[0].id).toBe('space-1')
+    expect(output.spaces[0].title).toBe('General')
+    expect(output.spaces[0].type).toBeUndefined()
+    expect(output.hint).toBeDefined()
+  })
+
+  test('full snapshot returns spaces with id, title, type, lastActivity', async () => {
+    await snapshotAction({ full: true })
 
     expect(consoleSpy).toHaveBeenCalled()
     const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
@@ -89,6 +101,7 @@ describe('snapshot command', () => {
     expect(output.spaces[0].title).toBe('General')
     expect(output.spaces[0].type).toBe('group')
     expect(output.spaces[0].lastActivity).toBe('2024-01-15T00:00:00.000Z')
+    expect(output.hint).toBeUndefined()
   })
 
   test('filters spaces to only those in my memberships', async () => {

--- a/src/platforms/webex/commands/snapshot.ts
+++ b/src/platforms/webex/commands/snapshot.ts
@@ -5,7 +5,7 @@ import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
 
-export async function snapshotAction(options: { pretty?: boolean }): Promise<void> {
+export async function snapshotAction(options: { full?: boolean; pretty?: boolean }): Promise<void> {
   try {
     const client = await new WebexClient().login()
 
@@ -15,13 +15,19 @@ export async function snapshotAction(options: { pretty?: boolean }): Promise<voi
     const allSpaces = await client.listSpaces({ max: 100 })
     const spaces = allSpaces.filter((s) => myRoomIds.has(s.id))
 
-    const snapshot = {
-      spaces: spaces.map((s) => ({
-        id: s.id,
-        title: s.title,
-        type: s.type,
-        lastActivity: s.lastActivity,
-      })),
+    const snapshot: Record<string, any> = {
+      spaces: options.full
+        ? spaces.map((s) => ({
+            id: s.id,
+            title: s.title,
+            type: s.type,
+            lastActivity: s.lastActivity,
+          }))
+        : spaces.map((s) => ({ id: s.id, title: s.title })),
+    }
+
+    if (!options.full) {
+      snapshot.hint = "Use 'message list <space>' for messages, 'space info <space>' for space details."
     }
 
     console.log(formatOutput(snapshot, options.pretty))
@@ -31,10 +37,12 @@ export async function snapshotAction(options: { pretty?: boolean }): Promise<voi
 }
 
 export const snapshotCommand = new Command('snapshot')
-  .description('Get workspace spaces overview for AI agents')
+  .description('Get workspace overview for AI agents (brief by default, use --full for comprehensive data)')
+  .option('--full', 'Include full space details (verbose)')
   .option('--pretty', 'Pretty print JSON output')
   .action(async (options) => {
     await snapshotAction({
+      full: options.full,
       pretty: options.pretty,
     })
   })


### PR DESCRIPTION
## Summary

The `snapshot` command was returning massive output across all 7 platforms — Slack alone generated ~3.6MB over ~108 API calls, making it completely unusable for AI agents whose context windows would overflow. This PR makes `snapshot` brief by default, reducing output to only what agents need to orient themselves, while preserving full access via `--full`.

## Changes

### Core behavior change (all 7 platforms)
- `snapshot` now returns only workspace metadata, channel/group IDs+names, and a `hint` field pointing agents to the right targeted commands
- `--full` flag restores the previous verbose behavior (messages, users, usergroups, profiles)
- `--limit` now only applies when used with `--full`

### Platform-specific improvements
- **Slack**: API calls reduced from ~108 to 2-3; output reduced from ~3.6MB to ~50KB
- **Discord / DiscordBot**: Snapshot returns guild metadata + channel list only
- **Teams**: Snapshot returns team + channel list only
- **Webex**: Snapshot returns spaces list only (aligns with previous Webex-specific simplification)
- **ChannelTalk / ChannelTalkBot**: Snapshot returns workspace metadata + group list only

### Tests
- All snapshot tests updated across all 7 platforms to cover both brief (default) and `--full` output shapes
- 51 snapshot unit tests pass

### Docs
- `skills/agent-*/SKILL.md` updated for all 7 platforms to document brief default and `--full` flag
- `skills/agent-slack/references/common-patterns.md` updated with new snapshot usage patterns

## Context

Agents call `snapshot` to orient themselves in a workspace before doing targeted work. A 3.6MB blob of raw message history is worse than useless — it fills context and still doesn't give agents the structured overview they need. The right pattern is: `snapshot` to discover channel IDs, then `message list --channel <id>` to fetch actual content. The new `hint` field in the response reinforces exactly this workflow.

This follows the same philosophy as the earlier Webex simplification (#155), which proved effective.

## Testing

- Unit tests: 51 snapshot tests across all 7 platforms pass (`bun test src/platforms/*/commands/snapshot.test.ts`)
- Typecheck: clean (`bun typecheck`)
- Lint: 0 errors (`bun run lint`)
- Format: clean (`bun run format:check`)

## Review Notes

**Breaking change**: Default `snapshot` output no longer includes `messages`, `users`, or `usergroups`. Any agent prompt or automation that relies on these fields in snapshot output needs to add `--full` to the invocation.

The `--full` flag is an escape hatch for backward compatibility and debugging — it is not intended for routine agent use. The brief output is the right default going forward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `snapshot` brief by default across Slack, Discord, DiscordBot, Teams, Webex, ChannelTalk, and ChannelTalkBot to cut output size and API calls. Add `--full` for detailed output; on Slack/Discord/Teams/DiscordBot, `--channels-only`/`--users-only` imply full; `--limit` applies only with `--full`.

- **New Features**
  - Default snapshot returns workspace/server metadata, channel/group IDs+names, and a helpful `hint`.
  - `--full` restores messages, users/members, and richer metadata; `--limit` works only with `--full`.
  - On Slack/Discord/Teams/DiscordBot, `--channels-only`/`--users-only` now use full mode automatically.
  - Performance: Slack API calls drop from ~108 to 2–3; output shrinks from ~3.6MB to ~50KB.
  - Tests updated for brief and full modes; 51 snapshot unit tests pass.
  - Docs and SKILL.md updated across all 7 platforms; corrected CLI docs for DiscordBot/Teams/ChannelTalkBot.

- **Migration**
  - Breaking change: default snapshot no longer includes messages or users/members. Use `--full` to keep old behavior.
  - If you use `--limit`, pair it with `--full`. On ChannelTalk/ChannelTalkBot, `--groups-only`/`--chats-only` are brief by default; add `--full` for messages/details.

<sup>Written for commit 394d320bfa3b783a155765d3e4a9250324397ba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

