### PR TITLE
fix: omit content field for plain text messages in Webex internal API

### DIFF
--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -419,7 +419,7 @@ describe('WebexClient', () => {
         expect(fetchCalls[0].options?.method).toBe('POST')
       })
 
-      test('body has verb, object type, displayName, and content', async () => {
+      test('body has verb, object type, and displayName (no content for plain text)', async () => {
         mockResponse(mockActivity('Hello world'))
 
         const client = await createExtractedClient()
@@ -429,7 +429,7 @@ describe('WebexClient', () => {
         expect(body.verb).toBe('post')
         expect(body.object.objectType).toBe('comment')
         expect(body.object.displayName).toBe('Hello world')
-        expect(body.object.content).toBe('Hello world')
+        expect(body.object.content).toBeUndefined()
       })
 
       test('body has target with decoded conv UUID and conversation type', async () => {
@@ -488,7 +488,7 @@ describe('WebexClient', () => {
         expect(body.object.markdown).toBeUndefined()
       })
 
-      test('markdown option does not affect plain text messages', async () => {
+      test('plain text messages omit content field', async () => {
         mockResponse(mockActivity('Hello world'))
 
         const client = await createExtractedClient()
@@ -496,7 +496,7 @@ describe('WebexClient', () => {
 
         const body = JSON.parse(fetchCalls[0].options?.body as string)
         expect(body.object.displayName).toBe('Hello world')
-        expect(body.object.content).toBe('Hello world')
+        expect(body.object.content).toBeUndefined()
       })
     })
 
@@ -631,7 +631,7 @@ describe('WebexClient', () => {
         expect(body.parent).toEqual({ id: 'activity-123', type: 'edit' })
       })
 
-      test('body has object with comment type and new text', async () => {
+      test('body has object with comment type and displayName (no content for plain text)', async () => {
         mockResponse(mockActivity('Edited text'))
 
         const client = await createExtractedClient()
@@ -640,7 +640,7 @@ describe('WebexClient', () => {
         const body = JSON.parse(fetchCalls[0].options?.body as string)
         expect(body.object.objectType).toBe('comment')
         expect(body.object.displayName).toBe('Edited text')
-        expect(body.object.content).toBe('Edited text')
+        expect(body.object.content).toBeUndefined()
       })
 
       test('target has decoded conv UUID', async () => {

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -251,7 +251,7 @@ export class WebexClient {
     options?: { markdown?: boolean },
   ): Promise<{ object: Record<string, string>; encryptionKeyUrl?: string }> {
     const displayName = options?.markdown ? stripMarkdown(text) : text
-    const content = options?.markdown ? markdownToHtml(text) : text
+    const content = options?.markdown ? markdownToHtml(text) : undefined
 
     if (this.encryption) {
       const conv = await this.internalRequest<InternalConversation>(
@@ -260,21 +260,25 @@ export class WebexClient {
       const keyUri = conv.defaultActivityEncryptionKeyUrl
       if (keyUri) {
         const encryptedDisplayName = await this.encryption.encryptText(keyUri, displayName)
-        const encryptedContent = await this.encryption.encryptText(keyUri, content)
-        if (encryptedDisplayName && encryptedContent) {
-          return {
-            object: {
-              objectType: 'comment',
-              displayName: encryptedDisplayName,
-              content: encryptedContent,
-            },
-            encryptionKeyUrl: keyUri,
+        const encryptedContent = content ? await this.encryption.encryptText(keyUri, content) : undefined
+        if (encryptedDisplayName) {
+          const object: Record<string, string> = {
+            objectType: 'comment',
+            displayName: encryptedDisplayName,
           }
+          if (encryptedContent) {
+            object.content = encryptedContent
+          }
+          return { object, encryptionKeyUrl: keyUri }
         }
       }
     }
 
-    return { object: { objectType: 'comment', displayName, content } }
+    const object: Record<string, string> = { objectType: 'comment', displayName }
+    if (content) {
+      object.content = content
+    }
+    return { object }
   }
 
   private async sendMessageInternal(


### PR DESCRIPTION
## Summary

Plain text messages sent via the Webex internal conversation API (extracted browser tokens) were rendered incorrectly in two ways:

1. **`--markdown` flag** showed raw HTML source (e.g., `<strong>`, `<br/>` visible as text)
2. **Plain text with URLs** showed raw `<a>` tags instead of clickable links

Root cause: `buildEncryptedObject` was unconditionally setting `content = text` (raw text). The internal conversation API treats the `content` field as HTML — when Webex auto-linked URLs in a raw text `content` value, the `<a>` tags it produced were then rendered as literal text. Similarly, markdown-converted HTML sent to `content` was escaped and displayed as source.

Per the official `webex-js-sdk`, plain text messages should only set `displayName`; the `content` field should only be present for rich (markdown→HTML) messages.

## Changes

### `src/platforms/webex/client.ts`

- `buildEncryptedObject` now sets `content` only when `markdown: true` — plain text messages omit the field entirely, relying solely on `displayName` as the official SDK specifies.

### `src/platforms/webex/client.test.ts`

- Updated test expectations: plain text message assertions now verify `content` is `undefined` in the encrypted object.

## Context

The Webex internal conversation API (`conv.wbx2.com`) used by extracted browser tokens handles the `content` and `displayName` fields differently from what raw string assignment assumes:

| Field | Expected value |
|-------|---------------|
| `displayName` | Plain text (always required) |
| `content` | Pre-rendered HTML (only for rich messages) |

Setting `content` to raw text for plain messages caused Webex's renderer to process it as HTML, corrupting auto-linked URLs and markdown output. Omitting `content` for plain text lets Webex fall back to rendering `displayName` correctly.

This is consistent with the prior fix in the markdown rendering PR, which established the `displayName`-only contract for plain text.

## Testing

- Unit tests: all existing tests pass with updated expectations.
- `bun typecheck`: clean.
- `bun run lint`: 0 errors.

## Review Notes

- The fix is a one-line conditional change in `buildEncryptedObject` — the `content` field is now only included in the payload when `markdown: true`.
- No changes to the public API path (`webexapis.com`), which is unaffected by this bug.
- Test changes are straightforward: assertions that previously checked `content === text` now assert `content === undefined` for the plain text case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit the `content` field for plain-text Webex messages so URLs and markdown no longer render as raw HTML in the internal conversation API. Plain text now uses only `displayName`; `content` is sent only for markdown (HTML) messages per `webex-js-sdk`.

- **Bug Fixes**
  - Updated `buildEncryptedObject` to include `content` only when `markdown: true` (encrypted and unencrypted paths).
  - Adjusted tests to expect `content` to be undefined for plain messages.

- **Migration**
  - No action required; SKILL.md and docs unchanged.

<sup>Written for commit faee7071705f3d30c5083e9c1a7fc6ee6ce164b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

