### PR TITLE
fix: add --debug logging to Teams token extraction and query plaintext cookies

### DIFF
--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -16,7 +16,8 @@ export async function extractAction(options: { pretty?: boolean; debug?: boolean
       return
     }
 
-    const extractor = new TeamsTokenExtractor()
+    const debugLog = options.debug ? (msg: string) => debug(`[debug] ${msg}`) : undefined
+    const extractor = new TeamsTokenExtractor(undefined, undefined, debugLog)
 
     if (process.platform === 'darwin') {
       console.log('')

--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -55,9 +55,11 @@ export class TeamsTokenExtractor {
   private platform: NodeJS.Platform
   private decryptor: ChromiumCookieDecryptor
   private cookieReader: ChromiumCookieReader
+  private debugLog: ((message: string) => void) | null
 
-  constructor(platform?: NodeJS.Platform, keyCache?: DerivedKeyCache) {
+  constructor(platform?: NodeJS.Platform, keyCache?: DerivedKeyCache, debugLog?: (message: string) => void) {
     this.platform = platform ?? process.platform
+    this.debugLog = debugLog ?? null
 
     const resolvedKeyCache = keyCache ?? new DerivedKeyCache()
     this.decryptor = new ChromiumCookieDecryptor({
@@ -67,6 +69,10 @@ export class TeamsTokenExtractor {
       keyCachePlatform: 'teams',
     })
     this.cookieReader = new ChromiumCookieReader()
+  }
+
+  private debug(message: string): void {
+    this.debugLog?.(message)
   }
 
   getDesktopCookiesPaths(): TeamsCookiePath[] {
@@ -197,17 +203,38 @@ export class TeamsTokenExtractor {
   private async extractFromCookiesDB(): Promise<ExtractedTeamsToken[]> {
     const results: ExtractedTeamsToken[] = []
     const seenAccountTypes = new Set<TeamsAccountType>()
+    const allPaths = this.getTeamsCookiesPaths()
 
-    for (const { path: dbPath, accountType } of this.getTeamsCookiesPaths()) {
-      if (!dbPath || !existsSync(dbPath) || seenAccountTypes.has(accountType)) continue
+    this.debug(`Scanning ${allPaths.length} candidate cookie path(s)`)
+
+    for (const { path: dbPath, accountType } of allPaths) {
+      if (!dbPath) continue
+
+      if (!existsSync(dbPath)) {
+        this.debug(`  [skip] ${dbPath} (not found)`)
+        continue
+      }
+
+      if (seenAccountTypes.has(accountType)) {
+        this.debug(`  [skip] ${dbPath} (already have ${accountType} account)`)
+        continue
+      }
+
+      this.debug(`  [try]  ${dbPath} (${accountType})`)
 
       const token = await this.copyAndExtract(dbPath)
       if (token && this.isValidSkypeToken(token)) {
+        this.debug(`  [ok]   Extracted valid token (${token.length} chars)`)
         results.push({ token, accountType })
         seenAccountTypes.add(accountType)
+      } else if (token) {
+        this.debug(`  [fail] Token too short (${token.length} chars, need >=50)`)
+      } else {
+        this.debug(`  [fail] No token extracted`)
       }
     }
 
+    this.debug(`Extraction complete: ${results.length} token(s) found`)
     return results
   }
 
@@ -216,11 +243,26 @@ export class TeamsTokenExtractor {
 
     try {
       tempPath = this.copyDatabaseToTemp(dbPath, dbPath)
-      const localStatePath =
-        this.platform === 'win32' ? (findLocalStatePath(dbPath) ?? this.getLocalStatePath()) : undefined
+
+      let localStatePath: string | undefined
+      if (this.platform === 'win32') {
+        localStatePath = findLocalStatePath(dbPath) ?? undefined
+        if (localStatePath) {
+          this.debug(`    Local State (from cookie path): ${localStatePath}`)
+        } else {
+          localStatePath = this.getLocalStatePath()
+          if (existsSync(localStatePath)) {
+            this.debug(`    Local State (fallback): ${localStatePath}`)
+          } else {
+            this.debug(`    Local State not found (tried fallback: ${localStatePath})`)
+            localStatePath = undefined
+          }
+        }
+      }
 
       return await this.extractFromSQLite(tempPath, localStatePath)
-    } catch {
+    } catch (error) {
+      this.debug(`    Copy/extract error: ${(error as Error).message}`)
       return null
     } finally {
       this.cleanupTempFile(tempPath)
@@ -231,27 +273,50 @@ export class TeamsTokenExtractor {
     try {
       for (const hostPattern of TEAMS_HOST_PATTERNS) {
         const sql = `
-          SELECT encrypted_value 
+          SELECT value, encrypted_value 
           FROM cookies 
           WHERE name = '${SKYPETOKEN_COOKIE_NAME}' 
           AND host_key LIKE '%${hostPattern}%'
           LIMIT 1
         `
 
-        type CookieRow = { encrypted_value?: Uint8Array | Buffer } | null
+        type CookieRow = { value?: string; encrypted_value?: Uint8Array | Buffer } | null
 
         const row = await this.cookieReader.queryFirst<CookieRow>(dbPath, sql)
-        if (!row?.encrypted_value) continue
+        if (!row) continue
 
-        const decryptedBuf = this.decryptor.decryptCookieRaw(Buffer.from(row.encrypted_value), localStatePath)
-        if (!decryptedBuf) continue
+        if (row.value && row.value.length >= 50) {
+          this.debug(`    Found plaintext cookie for ${hostPattern} (${row.value.length} chars)`)
+          return row.value
+        }
 
+        if (!row.encrypted_value || row.encrypted_value.length === 0) {
+          this.debug(`    No cookie data for ${hostPattern}`)
+          continue
+        }
+
+        const encBuf = Buffer.from(row.encrypted_value)
+        const isEncrypted = this.isEncryptedValue(encBuf)
+        this.debug(
+          `    Found cookie for ${hostPattern}: ${encBuf.length} bytes, encrypted=${isEncrypted}, prefix=${encBuf.subarray(0, 3).toString('utf8')}`,
+        )
+
+        const decryptedBuf = this.decryptor.decryptCookieRaw(encBuf, localStatePath)
+        if (!decryptedBuf) {
+          this.debug(`    Decryption failed`)
+          continue
+        }
+
+        this.debug(`    Decrypted: ${decryptedBuf.length} bytes`)
         const token = this.postProcessDecrypted(decryptedBuf)
         if (this.isValidSkypeToken(token)) return token
+
+        this.debug(`    Post-process result not a valid token (${token.length} chars)`)
       }
 
       return null
-    } catch {
+    } catch (error) {
+      this.debug(`    SQLite query error: ${(error as Error).message}`)
       return null
     }
   }


### PR DESCRIPTION
## Summary

- Add diagnostic `--debug` logging throughout `TeamsTokenExtractor` so failures during token extraction are observable instead of silently swallowed.
- Query plaintext `value` column alongside `encrypted_value` in cookie DB, matching Slack's extraction approach.

## Changes

### `src/platforms/teams/token-extractor.ts`
- Accept optional `debugLog` callback (3rd constructor param, backward compatible).
- Add `debug()` calls for: candidate path enumeration (exists/skip/try), Local State resolution (from cookie path vs fallback), cookie query results per host pattern, encryption detection (prefix, byte length), decryption success/failure, post-processing outcomes, final extraction summary.
- Query `value` column alongside `encrypted_value` and check for plaintext tokens first.

### `src/platforms/teams/commands/auth.ts`
- Wire `--debug` flag to extractor via `debugLog` callback (matching Slack's `auth extract` pattern).

## Context

Investigating #156 — `agent-teams auth extract` returns "No Teams token found" on Windows with zero diagnostic information.

Gap analysis against Slack (which works for the same user) revealed:
- Slack's `TokenExtractor` accepts a `debugLog` callback with 30+ logging points covering path discovery, DB reads, decryption outcomes.
- Teams' `TeamsTokenExtractor` had **zero** internal logging — every `catch` block returned `null` silently.
- Slack queries both `value` and `encrypted_value` columns; Teams only queried `encrypted_value`, missing plaintext cookies.

## Example `--debug` output (expected)

```
[debug] Scanning 8 candidate cookie path(s)
[debug]   [skip] C:\Users\...\WV2Profile_tfw\Cookies (not found)
[debug]   [try]  C:\Users\...\Default\Cookies (work)
[debug]     Local State (from cookie path): C:\Users\...\EBWebView\Local State
[debug]     Found cookie for .asyncgw.teams.microsoft.com: 412 bytes, encrypted=true, prefix=v10
[debug]     Decryption failed
[debug]   [fail] No token extracted
[debug]   [try]  C:\Users\...\Google\Chrome\Default\Cookies (work)
[debug]     ...
[debug] Extraction complete: 0 token(s) found
```

## Testing

- `bun typecheck`: clean.
- `bun run lint`: 0 errors.
- `bun run format:check`: clean.
- `bun test`: all tests pass.

## Review Notes

- The `debugLog` callback is the 3rd constructor param and defaults to `undefined` — fully backward compatible; existing call sites are unaffected.
- Plaintext cookie check comes before encrypted check so a `value` hit short-circuits decryption entirely.
- Closes #156 (pending user re-test with `--debug`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add --debug logging to the Teams token extractor and check plaintext cookies to make failures visible and stop missing tokens, especially on Windows. Aligns behavior with the Slack extractor to improve diagnostics for “No Teams token found.”

- **Bug Fixes**
  - Add optional `debugLog` to `TeamsTokenExtractor` and wire `--debug` in `teams auth extract`.
  - Log path discovery, Local State lookup, cookie query per host, encryption/decryption, and extraction summary.
  - Query `value` alongside `encrypted_value`, preferring plaintext before decrypting.
  - Docs: No changes to SKILL.md or docs.

<sup>Written for commit 6fc59c273cac2f136dd50ab7320ac00e50911bc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

