### PR TITLE
fix: support personal Microsoft account tokens in Teams

### DIFF
--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -144,7 +144,7 @@ export class TeamsClient {
         const errorBody = (await response.json().catch(() => null)) as {
           message?: string
         } | null
-        throw new TeamsError(errorBody?.message ?? 'Rate limited', 'rate_limited')
+        throw new TeamsError(errorBody?.message || 'Rate limited', 'rate_limited')
       }
 
       if (response.status >= 500 && attempt < MAX_RETRIES) {
@@ -158,7 +158,7 @@ export class TeamsClient {
           code?: string | number
         } | null
         throw new TeamsError(
-          errorBody?.message ?? `HTTP ${response.status}`,
+          errorBody?.message || `HTTP ${response.status}`,
           errorBody?.code?.toString() ?? `http_${response.status}`,
         )
       }
@@ -199,7 +199,7 @@ export class TeamsClient {
         code?: string | number
       } | null
       throw new TeamsError(
-        errorBody?.message ?? `HTTP ${response.status}`,
+        errorBody?.message || `HTTP ${response.status}`,
         errorBody?.code?.toString() ?? `http_${response.status}`,
       )
     }

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { basename } from 'node:path'
 
 import { TeamsCredentialManager } from './credential-manager'
-import type { TeamsChannel, TeamsFile, TeamsMessage, TeamsTeam, TeamsUser } from './types'
+import type { TeamsAccountType, TeamsChannel, TeamsFile, TeamsMessage, TeamsTeam, TeamsUser } from './types'
 import { TeamsError } from './types'
 
 interface RateLimitBucket {
@@ -10,7 +10,8 @@ interface RateLimitBucket {
   resetAt: number
 }
 
-const MSG_API_BASE = 'https://emea.ng.msg.teams.microsoft.com/v1'
+const WORK_MSG_API_BASE = 'https://emea.ng.msg.teams.microsoft.com/v1'
+const PERSONAL_MSG_API_BASE = 'https://msgapi.teams.live.com/v1'
 const CSA_API_BASE = 'https://teams.microsoft.com/api'
 const MAX_RETRIES = 3
 const BASE_BACKOFF_MS = 100
@@ -18,10 +19,11 @@ const BASE_BACKOFF_MS = 100
 export class TeamsClient {
   private token: string | null = null
   private tokenExpiresAt?: Date
+  private msgApiBase: string = WORK_MSG_API_BASE
   private buckets: Map<string, RateLimitBucket> = new Map()
   private globalRateLimitUntil: number = 0
 
-  async login(credentials?: { token: string; tokenExpiresAt?: string }): Promise<this> {
+  async login(credentials?: { token: string; tokenExpiresAt?: string; accountType?: TeamsAccountType }): Promise<this> {
     if (credentials) {
       if (!credentials.token) {
         throw new TeamsError('Token is required', 'missing_token')
@@ -30,6 +32,7 @@ export class TeamsClient {
       if (credentials.tokenExpiresAt) {
         this.tokenExpiresAt = new Date(credentials.tokenExpiresAt)
       }
+      this.msgApiBase = credentials.accountType === 'personal' ? PERSONAL_MSG_API_BASE : WORK_MSG_API_BASE
       return this
     }
 
@@ -43,7 +46,7 @@ export class TeamsClient {
         'no_credentials',
       )
     }
-    return this.login({ token: creds.token, tokenExpiresAt: creds.tokenExpiresAt })
+    return this.login({ token: creds.token, tokenExpiresAt: creds.tokenExpiresAt, accountType: creds.accountType })
   }
 
   private ensureAuth(): string {
@@ -108,7 +111,8 @@ export class TeamsClient {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
-  private async request<T>(method: string, path: string, body?: unknown, baseUrl: string = MSG_API_BASE): Promise<T> {
+  private async request<T>(method: string, path: string, body?: unknown, baseUrl?: string): Promise<T> {
+    baseUrl ??= this.msgApiBase
     if (this.isTokenExpired()) {
       throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
     }
@@ -173,7 +177,8 @@ export class TeamsClient {
     throw new TeamsError('Request failed after retries', 'max_retries')
   }
 
-  private async requestFormData<T>(path: string, formData: FormData, baseUrl: string = MSG_API_BASE): Promise<T> {
+  private async requestFormData<T>(path: string, formData: FormData, baseUrl?: string): Promise<T> {
+    baseUrl ??= this.msgApiBase
     if (this.isTokenExpired()) {
       throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
     }
@@ -210,13 +215,14 @@ export class TeamsClient {
   async testAuth(): Promise<TeamsUser> {
     interface UserProperties {
       userDetails?: string
+      primaryMemberName?: string
       locale?: string
     }
     const props = await this.request<UserProperties>('GET', '/users/ME/properties')
     const userDetails = props.userDetails ? JSON.parse(props.userDetails) : {}
     return {
       id: 'ME',
-      displayName: userDetails.name || 'Teams User',
+      displayName: userDetails.name || props.primaryMemberName || 'Teams User',
     }
   }
 

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -72,7 +72,7 @@ export async function extractAction(options: { pretty?: boolean; debug?: boolean
       }
 
       try {
-        const client = await new TeamsClient().login({ token })
+        const client = await new TeamsClient().login({ token, accountType })
         const authInfo = await client.testAuth()
         const teams = await client.listTeams()
 
@@ -295,6 +295,7 @@ export async function statusAction(options: { pretty?: boolean }): Promise<void>
           const client = await new TeamsClient().login({
             token: account.token,
             tokenExpiresAt: account.token_expires_at ?? undefined,
+            accountType: account.account_type,
           })
           const authInfo = await client.testAuth()
           displayName = authInfo.displayName

--- a/src/platforms/teams/commands/channel.ts
+++ b/src/platforms/teams/commands/channel.ts
@@ -16,7 +16,11 @@ export async function listAction(teamId: string, options: { pretty?: boolean }):
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const channels = await client.listChannels(teamId)
 
     const output = channels.map((ch) => ({
@@ -42,7 +46,11 @@ export async function infoAction(teamId: string, channelId: string, options: { p
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const channel = await client.getChannel(teamId, channelId)
 
     const output = {
@@ -72,7 +80,11 @@ export async function historyAction(
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const messages = await client.getMessages(teamId, channelId, options.limit || 50)
 
     const output = messages.map((msg) => ({

--- a/src/platforms/teams/commands/file.ts
+++ b/src/platforms/teams/commands/file.ts
@@ -24,7 +24,11 @@ export async function uploadAction(
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const filePath = resolve(path)
     const file = await client.uploadFile(teamId, channelId, filePath)
 
@@ -52,7 +56,11 @@ export async function listAction(teamId: string, channelId: string, options: { p
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const files = await client.listFiles(teamId, channelId)
 
     const output = files.map((file: TeamsFile) => ({
@@ -84,7 +92,11 @@ export async function infoAction(
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const files = await client.listFiles(teamId, channelId)
     const fileData = files.find((f) => f.id === fileId)
 

--- a/src/platforms/teams/commands/message.ts
+++ b/src/platforms/teams/commands/message.ts
@@ -22,7 +22,11 @@ export async function sendAction(
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const message = await client.sendMessage(teamId, channelId, content)
 
     const output = {
@@ -52,7 +56,11 @@ export async function listAction(
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const limit = options.limit || 50
     const messages = await client.getMessages(teamId, channelId, limit)
 
@@ -84,7 +92,11 @@ export async function getAction(
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const message = await client.getMessage(teamId, channelId, messageId)
 
     if (!message) {
@@ -125,7 +137,11 @@ export async function deleteAction(
       process.exit(0)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     await client.deleteMessage(teamId, channelId, messageId)
 
     console.log(formatOutput({ deleted: messageId }, options.pretty))

--- a/src/platforms/teams/commands/reaction.ts
+++ b/src/platforms/teams/commands/reaction.ts
@@ -23,7 +23,11 @@ export async function addAction(
       return
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     await client.addReaction(teamId, channelId, messageId, emoji)
 
     console.log(
@@ -60,7 +64,11 @@ export async function removeAction(
       return
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     await client.removeReaction(teamId, channelId, messageId, emoji)
 
     console.log(

--- a/src/platforms/teams/commands/snapshot.ts
+++ b/src/platforms/teams/commands/snapshot.ts
@@ -34,7 +34,11 @@ export async function snapshotAction(options: {
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
 
     const snapshot: Record<string, unknown> = {}
 

--- a/src/platforms/teams/commands/team.ts
+++ b/src/platforms/teams/commands/team.ts
@@ -34,7 +34,11 @@ export async function infoAction(teamId: string, options: { pretty?: boolean }):
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const team = await client.getTeam(teamId)
 
     const output = {

--- a/src/platforms/teams/commands/user.ts
+++ b/src/platforms/teams/commands/user.ts
@@ -16,7 +16,11 @@ async function listAction(teamId: string, options: { pretty?: boolean }): Promis
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const users = await client.listUsers(teamId)
 
     const output = users.map((user) => ({
@@ -42,7 +46,11 @@ async function infoAction(userId: string, options: { pretty?: boolean }): Promis
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const user = await client.getUser(userId)
 
     const output = {
@@ -68,7 +76,11 @@ async function meAction(options: { pretty?: boolean }): Promise<void> {
       process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const user = await client.testAuth()
 
     const output = {

--- a/src/platforms/teams/commands/whoami.ts
+++ b/src/platforms/teams/commands/whoami.ts
@@ -16,7 +16,11 @@ export async function whoamiAction(options: { pretty?: boolean }): Promise<void>
       return process.exit(1)
     }
 
-    const client = await new TeamsClient().login({ token: cred.token, tokenExpiresAt: cred.tokenExpiresAt })
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+    })
     const user = await client.testAuth()
 
     const output = {

--- a/src/platforms/teams/credential-manager.ts
+++ b/src/platforms/teams/credential-manager.ts
@@ -78,12 +78,16 @@ export class TeamsCredentialManager {
     return this.resolveCurrentAccount(config)?.token ?? null
   }
 
-  async getTokenWithExpiry(): Promise<{ token: string; tokenExpiresAt?: string } | null> {
+  async getTokenWithExpiry(): Promise<{
+    token: string
+    tokenExpiresAt?: string
+    accountType?: TeamsAccountType
+  } | null> {
     const config = await this.loadConfig()
     if (!config) return null
     const account = this.resolveCurrentAccount(config)
     if (!account?.token) return null
-    return { token: account.token, tokenExpiresAt: account.token_expires_at }
+    return { token: account.token, tokenExpiresAt: account.token_expires_at, accountType: account.account_type }
   }
 
   async setToken(token: string, accountType: TeamsAccountType, expiresAt?: string): Promise<void> {

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -23,11 +23,11 @@ export async function ensureTeamsAuth(): Promise<void> {
 
     for (const { token, accountType } of extracted) {
       try {
-        const client = await new TeamsClient().login({ token })
+        const client = await new TeamsClient().login({ token, accountType })
         await client.testAuth()
 
         const teams = await client.listTeams()
-        if (teams.length === 0) continue
+        if (accountType !== 'personal' && teams.length === 0) continue
 
         const teamMap: Record<string, { team_id: string; team_name: string }> = {}
         for (const team of teams) {


### PR DESCRIPTION
## Summary

- Fix empty error messages when Teams API returns `{"message": ""}` by using `||` instead of `??` for fallback.
- Route personal Microsoft account tokens to `msgapi.teams.live.com` instead of the work-only `emea.ng.msg.teams.microsoft.com`.

## Changes

### Fix empty error message fallback
- `client.ts`: Change `??` to `||` in 3 error message fallbacks so empty string `""` properly falls through to the HTTP status fallback.

### Route personal account tokens
- `client.ts`: Replace single `MSG_API_BASE` constant with `WORK_MSG_API_BASE` and `PERSONAL_MSG_API_BASE`, set dynamically via `this.msgApiBase` based on `accountType` passed to `login()`.
- `credential-manager.ts`: Include `accountType` in `getTokenWithExpiry()` return value.
- `ensure-auth.ts`: Pass `accountType` to `login()`, allow personal accounts with 0 teams.
- `commands/auth.ts`: Pass `accountType` when validating extracted tokens and checking auth status.
- All command files (channel, file, message, reaction, snapshot, team, user, whoami): Pass `accountType` from credentials to `login()`.

## Context

Debugging revealed that `agent-teams auth extract` successfully extracts tokens from personal Microsoft accounts (WV2Profile_tfl), but validation always fails because:

1. Personal account tokens hit `emea.ng.msg.teams.microsoft.com` which returns HTTP 403 with `{"errorCode": 209, "message": ""}`.
2. The `??` nullish coalescing doesn't catch empty strings, so the error message shown to users is blank.

Testing against different endpoints:
- `emea.ng.msg.teams.microsoft.com` → 403 (work accounts only)
- `amer.ng.msg.teams.microsoft.com` → 403 (work accounts only)
- `apac.ng.msg.teams.microsoft.com` → 403 (work accounts only)
- **`msgapi.teams.live.com` → 200 ✅** (personal accounts)

## Testing

- `bun typecheck`: clean.
- `bun run lint`: 0 errors.
- `bun run format:check`: clean.
- `bun test src/platforms/teams/`: 184 pass, 0 fail.

## Review Notes

- `accountType` is propagated from credential extraction through `login()` to URL selection — reviewers should verify the full data flow from `credential-manager.ts` → `ensure-auth.ts` → `client.ts`.
- Personal accounts with 0 teams are now allowed through `ensure-auth.ts`; previously this would cause a validation failure even with a valid token.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for personal Microsoft account tokens in Teams and fixes blank error messages. Personal tokens now use `msgapi.teams.live.com`; work/school tokens stay on regional `*.ng.msg.teams.microsoft.com`.

- **New Features**
  - Route by `accountType`: set the base URL in `login()` and propagate via credential manager and all commands.
  - Allow personal accounts with 0 teams during validation.

- **Bug Fixes**
  - Use `||` for error message fallbacks so empty API messages fall back to HTTP status (including rate-limit errors).
  - Improve `whoami` name detection by falling back to `primaryMemberName` when `userDetails.name` is missing.

Docs: No changes to SKILL.md or docs.

<sup>Written for commit 0fbca2c77ec493ec1ab701f1b602b6c51897d702. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

