### PR TITLE
auto-detect Teams regional msg endpoint

### DIFF
--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -55,18 +55,18 @@ describe('TeamsClient', () => {
 
   describe('login', () => {
     test('requires token', async () => {
-      await expect(new TeamsClient().login({ token: '' })).rejects.toThrow(TeamsError)
-      await expect(new TeamsClient().login({ token: '' })).rejects.toThrow('Token is required')
+      await expect(new TeamsClient().login({ token: '', region: 'emea' })).rejects.toThrow(TeamsError)
+      await expect(new TeamsClient().login({ token: '', region: 'emea' })).rejects.toThrow('Token is required')
     })
 
     test('accepts valid token', async () => {
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       expect(client).toBeInstanceOf(TeamsClient)
     })
 
     test('accepts token with expiry time', async () => {
       const expiresAt = new Date(Date.now() + 3600000).toISOString()
-      const client = await new TeamsClient().login({ token: 'test-token', tokenExpiresAt: expiresAt })
+      const client = await new TeamsClient().login({ token: 'test-token', tokenExpiresAt: expiresAt, region: 'emea' })
       expect(client).toBeInstanceOf(TeamsClient)
     })
   })
@@ -74,7 +74,11 @@ describe('TeamsClient', () => {
   describe('token expiry', () => {
     test('throws when token is expired', async () => {
       const expiredAt = new Date(Date.now() - 1000).toISOString()
-      const client = await new TeamsClient().login({ token: 'expired-token', tokenExpiresAt: expiredAt })
+      const client = await new TeamsClient().login({
+        token: 'expired-token',
+        tokenExpiresAt: expiredAt,
+        region: 'emea',
+      })
 
       await expect(client.testAuth()).rejects.toThrow(TeamsError)
       await expect(client.testAuth()).rejects.toThrow('Token has expired')
@@ -87,7 +91,7 @@ describe('TeamsClient', () => {
         locale: 'en-us',
       })
 
-      const client = await new TeamsClient().login({ token: 'valid-token', tokenExpiresAt: expiresAt })
+      const client = await new TeamsClient().login({ token: 'valid-token', tokenExpiresAt: expiresAt, region: 'emea' })
       const user = await client.testAuth()
 
       expect(user.id).toBe('ME')
@@ -102,7 +106,7 @@ describe('TeamsClient', () => {
         locale: 'en-us',
       })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const user = await client.testAuth()
 
       expect(user.id).toBe('ME')
@@ -117,7 +121,7 @@ describe('TeamsClient', () => {
     test('throws TeamsError on API error', async () => {
       mockResponse({ message: 'Unauthorized', code: 'unauthorized' }, 401)
 
-      const client = await new TeamsClient().login({ token: 'bad-token' })
+      const client = await new TeamsClient().login({ token: 'bad-token', region: 'emea' })
       await expect(client.testAuth()).rejects.toThrow(TeamsError)
     })
   })
@@ -153,7 +157,7 @@ describe('TeamsClient', () => {
         ],
       })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const teams = await client.listTeams()
 
       expect(teams).toHaveLength(2)
@@ -169,7 +173,7 @@ describe('TeamsClient', () => {
     test('returns team info', async () => {
       mockResponse({ id: '111', name: 'Test Team', description: 'A test team' })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const team = await client.getTeam('111')
 
       expect(team.id).toBe('111')
@@ -185,7 +189,7 @@ describe('TeamsClient', () => {
         { id: 'ch2', team_id: '111', name: 'Random', type: 'standard' },
       ])
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const channels = await client.listChannels('111')
 
       expect(channels).toHaveLength(2)
@@ -198,7 +202,7 @@ describe('TeamsClient', () => {
     test('returns channel info', async () => {
       mockResponse({ id: 'ch1', team_id: '111', name: 'General', type: 'standard' })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const channel = await client.getChannel('111', 'ch1')
 
       expect(channel.id).toBe('ch1')
@@ -217,7 +221,7 @@ describe('TeamsClient', () => {
         timestamp: '2024-01-01T00:00:00.000Z',
       })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const message = await client.sendMessage('111', 'ch1', 'Hello world')
 
       expect(message.content).toBe('Hello world')
@@ -239,7 +243,7 @@ describe('TeamsClient', () => {
         },
       ])
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const messages = await client.getMessages('111', 'ch1', 50)
 
       expect(messages).toHaveLength(1)
@@ -252,7 +256,7 @@ describe('TeamsClient', () => {
     test('uses default limit of 50', async () => {
       mockResponse([])
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await client.getMessages('111', 'ch1')
 
       expect(fetchCalls[0].url).toBe(
@@ -271,7 +275,7 @@ describe('TeamsClient', () => {
         timestamp: '2024-01-01T00:00:00.000Z',
       })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const message = await client.getMessage('111', 'ch1', 'msg1')
 
       expect(message.id).toBe('msg1')
@@ -285,7 +289,7 @@ describe('TeamsClient', () => {
     test('deletes message', async () => {
       mockResponse(null, 204)
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await client.deleteMessage('111', 'ch1', 'msg1')
 
       expect(fetchCalls[0].url).toBe(
@@ -299,7 +303,7 @@ describe('TeamsClient', () => {
     test('adds reaction to message', async () => {
       mockResponse(null, 204)
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await client.addReaction('111', 'ch1', 'msg1', 'like')
 
       expect(fetchCalls[0].url).toBe(
@@ -314,7 +318,7 @@ describe('TeamsClient', () => {
     test('removes reaction from message', async () => {
       mockResponse(null, 204)
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await client.removeReaction('111', 'ch1', 'msg1', 'like')
 
       expect(fetchCalls[0].url).toBe(
@@ -331,7 +335,7 @@ describe('TeamsClient', () => {
         { id: 'u2', displayName: 'User 2', email: 'user2@example.com' },
       ])
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const users = await client.listUsers('111')
 
       expect(users).toHaveLength(2)
@@ -344,7 +348,7 @@ describe('TeamsClient', () => {
     test('returns user info', async () => {
       mockResponse({ id: 'u1', displayName: 'Test User', email: 'test@example.com' })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const user = await client.getUser('u1')
 
       expect(user.id).toBe('u1')
@@ -365,7 +369,7 @@ describe('TeamsClient', () => {
         url: 'https://teams.microsoft.com/files/file1',
       })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const file = await client.uploadFile('111', 'ch1', tempFile)
 
       expect(file.name).toBe('test-teams-upload.txt')
@@ -381,7 +385,7 @@ describe('TeamsClient', () => {
         { id: 'file2', name: 'image.png', size: 2048, url: 'https://example.com/image.png' },
       ])
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const files = await client.listFiles('111', 'ch1')
 
       expect(files).toHaveLength(2)
@@ -401,7 +405,7 @@ describe('TeamsClient', () => {
         'X-RateLimit-Reset': String(Date.now() / 1000 + 60),
       })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await client.testAuth()
 
       const startTime = Date.now()
@@ -416,7 +420,7 @@ describe('TeamsClient', () => {
       mockResponse({ message: 'Rate limited' }, 429, { 'Retry-After': '0.1' })
       mockResponse({ userDetails: JSON.stringify({ name: 'User' }), locale: 'en-us' })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const user = await client.testAuth()
 
       expect(user.id).toBe('ME')
@@ -428,7 +432,7 @@ describe('TeamsClient', () => {
         mockResponse({ message: 'Rate limited' }, 429, { 'Retry-After': '0.01' })
       }
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await expect(client.testAuth()).rejects.toThrow(TeamsError)
       expect(fetchCalls.length).toBeLessThanOrEqual(4)
     })
@@ -439,7 +443,7 @@ describe('TeamsClient', () => {
       mockResponse({ message: 'Internal Server Error' }, 500)
       mockResponse({ userDetails: JSON.stringify({ name: 'User' }), locale: 'en-us' })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const user = await client.testAuth()
 
       expect(user.id).toBe('ME')
@@ -449,7 +453,7 @@ describe('TeamsClient', () => {
     test('does not retry on 4xx client errors (except 429)', async () => {
       mockResponse({ message: 'Not Found' }, 404)
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await expect(client.testAuth()).rejects.toThrow(TeamsError)
       expect(fetchCalls.length).toBe(1)
     })
@@ -459,7 +463,7 @@ describe('TeamsClient', () => {
       mockResponse({ message: 'Error' }, 500)
       mockResponse({ userDetails: JSON.stringify({ name: 'User' }), locale: 'en-us' })
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       const startTime = Date.now()
       await client.testAuth()
       const elapsed = Date.now() - startTime
@@ -474,7 +478,7 @@ describe('TeamsClient', () => {
       mockResponse([])
       mockResponse([])
 
-      const client = await new TeamsClient().login({ token: 'test-token' })
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
       await client.getMessages('team1', 'ch1')
       await client.getMessages('team2', 'ch2')
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -2,7 +2,15 @@ import { readFile } from 'node:fs/promises'
 import { basename } from 'node:path'
 
 import { TeamsCredentialManager } from './credential-manager'
-import type { TeamsAccountType, TeamsChannel, TeamsFile, TeamsMessage, TeamsRegion, TeamsTeam, TeamsUser } from './types'
+import type {
+  TeamsAccountType,
+  TeamsChannel,
+  TeamsFile,
+  TeamsMessage,
+  TeamsRegion,
+  TeamsTeam,
+  TeamsUser,
+} from './types'
 import { TeamsError } from './types'
 
 interface RateLimitBucket {

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { basename } from 'node:path'
 
 import { TeamsCredentialManager } from './credential-manager'
-import type { TeamsAccountType, TeamsChannel, TeamsFile, TeamsMessage, TeamsTeam, TeamsUser } from './types'
+import type { TeamsAccountType, TeamsChannel, TeamsFile, TeamsMessage, TeamsRegion, TeamsTeam, TeamsUser } from './types'
 import { TeamsError } from './types'
 
 interface RateLimitBucket {
@@ -10,20 +10,28 @@ interface RateLimitBucket {
   resetAt: number
 }
 
-const WORK_MSG_API_BASE = 'https://emea.ng.msg.teams.microsoft.com/v1'
 const PERSONAL_MSG_API_BASE = 'https://msgapi.teams.live.com/v1'
 const CSA_API_BASE = 'https://teams.microsoft.com/api'
 const MAX_RETRIES = 3
 const BASE_BACKOFF_MS = 100
+const DEFAULT_REGION: TeamsRegion = 'amer'
+const REGIONS: TeamsRegion[] = ['amer', 'emea', 'apac']
 
 export class TeamsClient {
   private token: string | null = null
   private tokenExpiresAt?: Date
-  private msgApiBase: string = WORK_MSG_API_BASE
+  private isPersonalAccount: boolean = false
+  private region: TeamsRegion = DEFAULT_REGION
+  private regionDiscovered: boolean = false
   private buckets: Map<string, RateLimitBucket> = new Map()
   private globalRateLimitUntil: number = 0
 
-  async login(credentials?: { token: string; tokenExpiresAt?: string; accountType?: TeamsAccountType }): Promise<this> {
+  async login(credentials?: {
+    token: string
+    tokenExpiresAt?: string
+    accountType?: TeamsAccountType
+    region?: TeamsRegion
+  }): Promise<this> {
     if (credentials) {
       if (!credentials.token) {
         throw new TeamsError('Token is required', 'missing_token')
@@ -32,7 +40,11 @@ export class TeamsClient {
       if (credentials.tokenExpiresAt) {
         this.tokenExpiresAt = new Date(credentials.tokenExpiresAt)
       }
-      this.msgApiBase = credentials.accountType === 'personal' ? PERSONAL_MSG_API_BASE : WORK_MSG_API_BASE
+      this.isPersonalAccount = credentials.accountType === 'personal'
+      if (credentials.region) {
+        this.region = credentials.region
+        this.regionDiscovered = true
+      }
       return this
     }
 
@@ -46,7 +58,16 @@ export class TeamsClient {
         'no_credentials',
       )
     }
-    return this.login({ token: creds.token, tokenExpiresAt: creds.tokenExpiresAt, accountType: creds.accountType })
+    return this.login({
+      token: creds.token,
+      tokenExpiresAt: creds.tokenExpiresAt,
+      accountType: creds.accountType,
+      region: creds.region,
+    })
+  }
+
+  getRegion(): TeamsRegion {
+    return this.region
   }
 
   private ensureAuth(): string {
@@ -111,13 +132,47 @@ export class TeamsClient {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
+  private getMsgApiBase(): string {
+    if (this.isPersonalAccount) return PERSONAL_MSG_API_BASE
+    return `https://${this.region}.ng.msg.teams.microsoft.com/v1`
+  }
+
+  private async discoverRegion(): Promise<void> {
+    if (this.isPersonalAccount) {
+      this.regionDiscovered = true
+      return
+    }
+
+    const token = this.ensureAuth()
+
+    for (const region of REGIONS) {
+      try {
+        const response = await fetch(`https://${region}.ng.msg.teams.microsoft.com/v1/users/ME/properties`, {
+          headers: {
+            'X-Skypetoken': token,
+          },
+        })
+
+        if (response.ok || response.status !== 403) {
+          this.region = region
+          break
+        }
+      } catch {}
+    }
+
+    this.regionDiscovered = true
+  }
+
   private async request<T>(method: string, path: string, body?: unknown, baseUrl?: string): Promise<T> {
-    baseUrl ??= this.msgApiBase
     if (this.isTokenExpired()) {
       throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
     }
 
-    const url = `${baseUrl}${path}`
+    if (baseUrl === undefined && !this.regionDiscovered) {
+      await this.discoverRegion()
+    }
+
+    const url = `${baseUrl ?? this.getMsgApiBase()}${path}`
     const bucketKey = this.getBucketKey(method, path)
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -178,12 +233,15 @@ export class TeamsClient {
   }
 
   private async requestFormData<T>(path: string, formData: FormData, baseUrl?: string): Promise<T> {
-    baseUrl ??= this.msgApiBase
     if (this.isTokenExpired()) {
       throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
     }
 
-    const url = `${baseUrl}${path}`
+    if (baseUrl === undefined && !this.regionDiscovered) {
+      await this.discoverRegion()
+    }
+
+    const url = `${baseUrl ?? this.getMsgApiBase()}${path}`
     const bucketKey = this.getBucketKey('POST', path)
 
     await this.waitForRateLimit(bucketKey)
@@ -278,7 +336,7 @@ export class TeamsClient {
   async sendMessage(teamId: string, channelId: string, content: string): Promise<TeamsMessage> {
     return this.request<TeamsMessage>(
       'POST',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/messages`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages`,
       { content },
       CSA_API_BASE,
     )
@@ -287,7 +345,7 @@ export class TeamsClient {
   async getMessages(teamId: string, channelId: string, limit: number = 50): Promise<TeamsMessage[]> {
     return this.request<TeamsMessage[]>(
       'GET',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/messages?limit=${limit}`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages?limit=${limit}`,
       undefined,
       CSA_API_BASE,
     )
@@ -296,7 +354,7 @@ export class TeamsClient {
   async getMessage(teamId: string, channelId: string, messageId: string): Promise<TeamsMessage> {
     return this.request<TeamsMessage>(
       'GET',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}`,
       undefined,
       CSA_API_BASE,
     )
@@ -305,7 +363,7 @@ export class TeamsClient {
   async deleteMessage(teamId: string, channelId: string, messageId: string): Promise<void> {
     return this.request<void>(
       'DELETE',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}`,
       undefined,
       CSA_API_BASE,
     )
@@ -314,7 +372,7 @@ export class TeamsClient {
   async addReaction(teamId: string, channelId: string, messageId: string, emoji: string): Promise<void> {
     return this.request<void>(
       'POST',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}/reactions`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}/reactions`,
       { emoji },
       CSA_API_BASE,
     )
@@ -323,7 +381,7 @@ export class TeamsClient {
   async removeReaction(teamId: string, channelId: string, messageId: string, emoji: string): Promise<void> {
     return this.request<void>(
       'DELETE',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}/reactions/${emoji}`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages/${messageId}/reactions/${emoji}`,
       undefined,
       CSA_API_BASE,
     )
@@ -345,7 +403,7 @@ export class TeamsClient {
     formData.append('file', new Blob([fileBuffer]), filename)
 
     return this.requestFormData<TeamsFile>(
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/files`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/files`,
       formData,
       CSA_API_BASE,
     )
@@ -354,7 +412,7 @@ export class TeamsClient {
   async listFiles(teamId: string, channelId: string): Promise<TeamsFile[]> {
     return this.request<TeamsFile[]>(
       'GET',
-      `/csa/emea/api/v2/teams/${teamId}/channels/${channelId}/files`,
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/files`,
       undefined,
       CSA_API_BASE,
     )

--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -12,6 +12,7 @@ let credManagerLoadConfigSpy: ReturnType<typeof spyOn>
 let credManagerSaveConfigSpy: ReturnType<typeof spyOn>
 let credManagerClearCredentialsSpy: ReturnType<typeof spyOn>
 let credManagerIsTokenExpiredSpy: ReturnType<typeof spyOn>
+let clientGetRegionSpy: ReturnType<typeof spyOn>
 
 beforeEach(() => {
   extractorExtractSpy = spyOn(TeamsTokenExtractor.prototype, 'extract').mockResolvedValue([
@@ -28,6 +29,8 @@ beforeEach(() => {
     { id: 'team-1', name: 'Team One' },
     { id: 'team-2', name: 'Team Two' },
   ])
+
+  clientGetRegionSpy = spyOn(TeamsClient.prototype, 'getRegion').mockReturnValue('emea')
 
   credManagerLoadConfigSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue(null)
 
@@ -48,6 +51,7 @@ afterEach(() => {
   credManagerSaveConfigSpy?.mockRestore()
   credManagerClearCredentialsSpy?.mockRestore()
   credManagerIsTokenExpiredSpy?.mockRestore()
+  clientGetRegionSpy?.mockRestore()
 })
 
 test('extract: calls TeamsTokenExtractor', async () => {
@@ -59,7 +63,7 @@ test('extract: calls TeamsTokenExtractor', async () => {
 })
 
 test('extract: validates token with TeamsClient', async () => {
-  const client = await new TeamsClient().login({ token: 'test-skype-token-123' })
+  const client = await new TeamsClient().login({ token: 'test-skype-token-123', region: 'emea' })
   const authInfo = await client.testAuth()
   expect(authInfo).toBeDefined()
   expect(authInfo.id).toBe('user-123')
@@ -67,7 +71,7 @@ test('extract: validates token with TeamsClient', async () => {
 })
 
 test('extract: discovers teams', async () => {
-  const client = await new TeamsClient().login({ token: 'test-skype-token-123' })
+  const client = await new TeamsClient().login({ token: 'test-skype-token-123', region: 'emea' })
   const teams = await client.listTeams()
   expect(teams).toHaveLength(2)
   expect(teams[0].id).toBe('team-1')

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -89,6 +89,7 @@ export async function extractAction(options: { pretty?: boolean; debug?: boolean
         const account: TeamsAccount = {
           token,
           token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          region: client.getRegion(),
           account_type: accountType,
           user_name: authInfo.displayName,
           current_team: teams[0]?.id ?? null,
@@ -192,6 +193,7 @@ async function extractManualToken(token: string, options: { pretty?: boolean; de
     const account: TeamsAccount = {
       token,
       token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      region: client.getRegion(),
       account_type: accountType,
       user_name: authInfo.displayName,
       current_team: teams[0].id,
@@ -297,6 +299,7 @@ export async function statusAction(options: { pretty?: boolean }): Promise<void>
             token: account.token,
             tokenExpiresAt: account.token_expires_at ?? undefined,
             accountType: account.account_type,
+            region: account.region,
           })
           const authInfo = await client.testAuth()
           displayName = authInfo.displayName

--- a/src/platforms/teams/commands/channel.test.ts
+++ b/src/platforms/teams/commands/channel.test.ts
@@ -67,7 +67,7 @@ afterEach(() => {
 
 test('list: returns channels from team', async () => {
   // given
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
 
   // when
   const channels = await client.listChannels('team-1')
@@ -80,7 +80,7 @@ test('list: returns channels from team', async () => {
 
 test('list: includes channel metadata', async () => {
   // given
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
   const channels = await client.listChannels('team-1')
 
   // when
@@ -95,7 +95,7 @@ test('list: includes channel metadata', async () => {
 
 test('info: returns channel details', async () => {
   // given
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
 
   // when
   const channel = await client.getChannel('team-1', 'ch-1')
@@ -108,7 +108,7 @@ test('info: returns channel details', async () => {
 
 test('info: throws error for non-existent channel', async () => {
   // given
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
 
   // when/then
   try {
@@ -121,7 +121,7 @@ test('info: throws error for non-existent channel', async () => {
 
 test('history: returns messages', async () => {
   // given
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
 
   // when
   const messages = await client.getMessages('team-1', 'ch-1', 50)
@@ -136,7 +136,7 @@ test('history: returns messages', async () => {
 
 test('history: includes message metadata', async () => {
   // given
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
   const messages = await client.getMessages('team-1', 'ch-1', 50)
 
   // when

--- a/src/platforms/teams/commands/channel.ts
+++ b/src/platforms/teams/commands/channel.ts
@@ -20,6 +20,7 @@ export async function listAction(teamId: string, options: { pretty?: boolean }):
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const channels = await client.listChannels(teamId)
 
@@ -50,6 +51,7 @@ export async function infoAction(teamId: string, channelId: string, options: { p
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const channel = await client.getChannel(teamId, channelId)
 
@@ -84,6 +86,7 @@ export async function historyAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const messages = await client.getMessages(teamId, channelId, options.limit || 50)
 

--- a/src/platforms/teams/commands/file.ts
+++ b/src/platforms/teams/commands/file.ts
@@ -28,6 +28,7 @@ export async function uploadAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const filePath = resolve(path)
     const file = await client.uploadFile(teamId, channelId, filePath)
@@ -60,6 +61,7 @@ export async function listAction(teamId: string, channelId: string, options: { p
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const files = await client.listFiles(teamId, channelId)
 
@@ -96,6 +98,7 @@ export async function infoAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const files = await client.listFiles(teamId, channelId)
     const fileData = files.find((f) => f.id === fileId)

--- a/src/platforms/teams/commands/message.ts
+++ b/src/platforms/teams/commands/message.ts
@@ -26,6 +26,7 @@ export async function sendAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const message = await client.sendMessage(teamId, channelId, content)
 
@@ -60,6 +61,7 @@ export async function listAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const limit = options.limit || 50
     const messages = await client.getMessages(teamId, channelId, limit)
@@ -96,6 +98,7 @@ export async function getAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const message = await client.getMessage(teamId, channelId, messageId)
 
@@ -141,6 +144,7 @@ export async function deleteAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     await client.deleteMessage(teamId, channelId, messageId)
 

--- a/src/platforms/teams/commands/reaction.ts
+++ b/src/platforms/teams/commands/reaction.ts
@@ -27,6 +27,7 @@ export async function addAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     await client.addReaction(teamId, channelId, messageId, emoji)
 
@@ -68,6 +69,7 @@ export async function removeAction(
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     await client.removeReaction(teamId, channelId, messageId, emoji)
 

--- a/src/platforms/teams/commands/snapshot.ts
+++ b/src/platforms/teams/commands/snapshot.ts
@@ -38,6 +38,7 @@ export async function snapshotAction(options: {
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
 
     const snapshot: Record<string, unknown> = {}

--- a/src/platforms/teams/commands/team.test.ts
+++ b/src/platforms/teams/commands/team.test.ts
@@ -90,7 +90,7 @@ test('list: marks current team', async () => {
 
 test('info: returns team details', async () => {
   // given: teams client with team data
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
   const team = await client.getTeam('team-1')
 
   // when: getting team info
@@ -104,7 +104,7 @@ test('info: returns team details', async () => {
 
 test('info: throws error for non-existent team', async () => {
   // given: teams client
-  const client = await new TeamsClient().login({ token: 'test-token' })
+  const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
 
   // when: getting non-existent team
   // then: error is thrown

--- a/src/platforms/teams/commands/team.ts
+++ b/src/platforms/teams/commands/team.ts
@@ -38,6 +38,7 @@ export async function infoAction(teamId: string, options: { pretty?: boolean }):
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const team = await client.getTeam(teamId)
 

--- a/src/platforms/teams/commands/user.ts
+++ b/src/platforms/teams/commands/user.ts
@@ -20,6 +20,7 @@ async function listAction(teamId: string, options: { pretty?: boolean }): Promis
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const users = await client.listUsers(teamId)
 
@@ -50,6 +51,7 @@ async function infoAction(userId: string, options: { pretty?: boolean }): Promis
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const user = await client.getUser(userId)
 
@@ -80,6 +82,7 @@ async function meAction(options: { pretty?: boolean }): Promise<void> {
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const user = await client.testAuth()
 

--- a/src/platforms/teams/commands/whoami.ts
+++ b/src/platforms/teams/commands/whoami.ts
@@ -20,6 +20,7 @@ export async function whoamiAction(options: { pretty?: boolean }): Promise<void>
       token: cred.token,
       tokenExpiresAt: cred.tokenExpiresAt,
       accountType: cred.accountType,
+      region: cred.region,
     })
     const user = await client.testAuth()
 

--- a/src/platforms/teams/credential-manager.test.ts
+++ b/src/platforms/teams/credential-manager.test.ts
@@ -88,6 +88,30 @@ describe('TeamsCredentialManager', () => {
     expect(team).toBeNull()
   })
 
+  test('getTokenWithExpiry includes region', async () => {
+    const manager = setup()
+    await manager.saveConfig({
+      current_account: 'work',
+      accounts: {
+        work: {
+          token: 'test-token',
+          token_expires_at: '2025-12-31T23:59:59Z',
+          region: 'emea',
+          account_type: 'work',
+          current_team: null,
+          teams: {},
+        },
+      },
+    })
+
+    const token = await manager.getTokenWithExpiry()
+    expect(token).toEqual({
+      token: 'test-token',
+      tokenExpiresAt: '2025-12-31T23:59:59Z',
+      region: 'emea',
+    })
+  })
+
   test('getCurrentTeam returns null when current_team is set but team not in teams record', async () => {
     const manager = setup()
     await manager.setToken('test-token', 'work')

--- a/src/platforms/teams/credential-manager.test.ts
+++ b/src/platforms/teams/credential-manager.test.ts
@@ -108,6 +108,7 @@ describe('TeamsCredentialManager', () => {
     expect(token).toEqual({
       token: 'test-token',
       tokenExpiresAt: '2025-12-31T23:59:59Z',
+      accountType: 'work',
       region: 'emea',
     })
   })

--- a/src/platforms/teams/credential-manager.ts
+++ b/src/platforms/teams/credential-manager.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-import type { TeamsAccount, TeamsAccountType, TeamsConfig, TeamsConfigLegacy } from './types'
+import type { TeamsAccount, TeamsAccountType, TeamsConfig, TeamsConfigLegacy, TeamsRegion } from './types'
 
 export class TeamsCredentialManager {
   static accountOverride?: TeamsAccountType
@@ -82,12 +82,18 @@ export class TeamsCredentialManager {
     token: string
     tokenExpiresAt?: string
     accountType?: TeamsAccountType
+    region?: TeamsRegion
   } | null> {
     const config = await this.loadConfig()
     if (!config) return null
     const account = this.resolveCurrentAccount(config)
     if (!account?.token) return null
-    return { token: account.token, tokenExpiresAt: account.token_expires_at, accountType: account.account_type }
+    return {
+      token: account.token,
+      tokenExpiresAt: account.token_expires_at,
+      accountType: account.account_type,
+      region: account.region,
+    }
   }
 
   async setToken(token: string, accountType: TeamsAccountType, expiresAt?: string): Promise<void> {

--- a/src/platforms/teams/ensure-auth.test.ts
+++ b/src/platforms/teams/ensure-auth.test.ts
@@ -10,6 +10,7 @@ let extractSpy: ReturnType<typeof spyOn>
 let testAuthSpy: ReturnType<typeof spyOn>
 let listTeamsSpy: ReturnType<typeof spyOn>
 let saveConfigSpy: ReturnType<typeof spyOn>
+let getRegionSpy: ReturnType<typeof spyOn>
 
 beforeEach(() => {
   loadConfigSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue(null)
@@ -28,6 +29,8 @@ beforeEach(() => {
     { id: 'team-2', name: 'Team Two' },
   ])
 
+  getRegionSpy = spyOn(TeamsClient.prototype, 'getRegion').mockReturnValue('emea')
+
   saveConfigSpy = spyOn(TeamsCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
 })
 
@@ -37,6 +40,7 @@ afterEach(() => {
   testAuthSpy?.mockRestore()
   listTeamsSpy?.mockRestore()
   saveConfigSpy?.mockRestore()
+  getRegionSpy?.mockRestore()
 })
 
 describe('ensureTeamsAuth', () => {
@@ -78,6 +82,7 @@ describe('ensureTeamsAuth', () => {
         accounts: expect.objectContaining({
           work: expect.objectContaining({
             token: 'test-teams-token',
+            region: 'emea',
             current_team: 'team-1',
             teams: {
               'team-1': { team_id: 'team-1', team_name: 'Team One' },
@@ -215,7 +220,7 @@ describe('ensureTeamsAuth', () => {
         current_account: 'work',
         accounts: expect.objectContaining({
           work: expect.objectContaining({ token: 'work-token', current_team: 'team-w' }),
-          personal: expect.objectContaining({ token: 'personal-token', current_team: 'team-p' }),
+          personal: expect.objectContaining({ token: 'personal-token', region: 'emea', current_team: 'team-p' }),
         }),
       }),
     )

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -23,7 +23,7 @@ export async function ensureTeamsAuth(): Promise<void> {
 
     for (const { token, accountType } of extracted) {
       try {
-        const client = await new TeamsClient().login({ token, accountType })
+        const client = await new TeamsClient().login({ token, accountType, region: config?.accounts[accountType]?.region })
         await client.testAuth()
 
         const teams = await client.listTeams()
@@ -38,6 +38,7 @@ export async function ensureTeamsAuth(): Promise<void> {
         const account: TeamsAccount = {
           token,
           token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          region: client.getRegion(),
           account_type: accountType,
           user_name: existing?.user_name,
           current_team: existing?.current_team ?? teams[0].id,

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -23,7 +23,11 @@ export async function ensureTeamsAuth(): Promise<void> {
 
     for (const { token, accountType } of extracted) {
       try {
-        const client = await new TeamsClient().login({ token, accountType, region: config?.accounts[accountType]?.region })
+        const client = await new TeamsClient().login({
+          token,
+          accountType,
+          region: config?.accounts[accountType]?.region,
+        })
         await client.testAuth()
 
         const teams = await client.listTeams()

--- a/src/platforms/teams/types.test.ts
+++ b/src/platforms/teams/types.test.ts
@@ -203,6 +203,7 @@ test('TeamsConfigSchema validates config with multiple accounts', () => {
       work: {
         token: 'work_token',
         token_expires_at: '2024-01-01T00:00:00.000Z',
+        region: 'emea',
         account_type: 'work',
         user_name: 'Work User',
         current_team: '19:abc123@thread.tacv2',
@@ -222,6 +223,22 @@ test('TeamsConfigSchema validates config with multiple accounts', () => {
     },
   })
   expect(result.success).toBe(true)
+})
+
+test('TeamsConfigSchema rejects invalid region', () => {
+  const result = TeamsConfigSchema.safeParse({
+    current_account: 'work',
+    accounts: {
+      work: {
+        token: 'token_value',
+        region: 'invalid',
+        account_type: 'work',
+        current_team: null,
+        teams: {},
+      },
+    },
+  })
+  expect(result.success).toBe(false)
 })
 
 test('TeamsConfigSchema rejects missing required fields', () => {

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -55,9 +55,12 @@ export interface TeamsCredentials {
 
 export type TeamsAccountType = 'work' | 'personal'
 
+export type TeamsRegion = 'amer' | 'emea' | 'apac'
+
 export interface TeamsAccount {
   token: string
   token_expires_at?: string
+  region?: TeamsRegion
   account_type: TeamsAccountType
   user_name?: string
   current_team: string | null
@@ -141,9 +144,12 @@ export const TeamsCredentialsSchema = z.object({
 
 export const TeamsAccountTypeSchema = z.enum(['work', 'personal'])
 
+export const TeamsRegionSchema = z.enum(['amer', 'emea', 'apac'])
+
 export const TeamsAccountSchema = z.object({
   token: z.string(),
   token_expires_at: z.string().optional(),
+  region: TeamsRegionSchema.optional(),
   account_type: TeamsAccountTypeSchema,
   user_name: z.string().optional(),
   current_team: z.string().nullable(),


### PR DESCRIPTION
## Summary
- add persisted Teams region metadata so work-account credentials can reuse the discovered regional endpoint across runs
- auto-detect the Teams msg API region on first work-account request and use the detected region for msg API and CSA v2 URLs
- thread the saved region through Teams auth/command flows and update Teams tests to keep URL assertions stable

## Checks
- bun run lint
- bun run format:check
- bun typecheck
- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detects and persists the Teams message API region for work accounts, and threads it through auth and CLI so requests hit the right regional endpoints. Personal accounts use the global API; CSA v2 and msg API URLs are now region-aware to reduce 403s.

- **New Features**
  - Auto-discovers region on first request for work accounts (`amer`, `emea`, `apac`); defaults to `amer` until discovery.
  - Persists `region` in credentials via `TeamsCredentialManager` and `TeamsAccount.region`; added `TeamsClient.getRegion()`.
  - `TeamsClient.login` accepts optional `region`; personal accounts use `https://msgapi.teams.live.com/v1`.
  - CSA v2 URLs use `/csa/{region}/...`; all CLI commands pass the stored `region`.
  - Schemas validate `region`; tests updated for region-aware URLs and persistence.

- **Migration**
  - Backwards compatible. Existing configs without `region` will auto-detect on first use and save during auth.
  - Recommended: run your usual auth step to populate `region`.
  - Docs: No SKILL.md/docs changes in this PR.

<sup>Written for commit 211376828fdd0414a36860c06d6a8353f8d9df72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

