### PR TITLE
fix: strip PowerShell CLIXML from DPAPI output and tighten Teams token validation

### DIFF
--- a/src/platforms/teams/token-extractor.test.ts
+++ b/src/platforms/teams/token-extractor.test.ts
@@ -271,6 +271,28 @@ describe('TeamsTokenExtractor', () => {
       expect(extractor.isValidSkypeToken(null as unknown as string)).toBe(false)
       expect(extractor.isValidSkypeToken(undefined as unknown as string)).toBe(false)
     })
+
+    // Regression for #156: PowerShell CLIXML leaks into DPAPI output on Windows.
+    it('rejects CLIXML progress-stream contamination', () => {
+      // given: the exact shape of the leak reported in #156
+      const clixml =
+        '#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+        '<Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T>' +
+        '<T>System.Object</T></TN><MS><I64 N="SourceId">1</I64></MS></Obj></Objs>'
+
+      // then
+      expect(extractor.isValidSkypeToken(clixml)).toBe(false)
+    })
+
+    it('rejects anything containing angle brackets or whitespace', () => {
+      expect(extractor.isValidSkypeToken('a'.repeat(60) + '<div>')).toBe(false)
+      expect(extractor.isValidSkypeToken('a'.repeat(40) + ' ' + 'b'.repeat(40))).toBe(false)
+      expect(extractor.isValidSkypeToken('a'.repeat(40) + '\n' + 'b'.repeat(40))).toBe(false)
+    })
+
+    it('rejects a bare 36-char UUID', () => {
+      expect(extractor.isValidSkypeToken('12345678-1234-1234-1234-123456789012')).toBe(false)
+    })
   })
 
   describe('isEncryptedValue', () => {
@@ -377,6 +399,44 @@ describe('TeamsTokenExtractor', () => {
       // the Network/Cookies sibling was tried, and the token was returned.
       expect(tried).toEqual([networkCookiesPath])
       expect(results).toEqual([{ token: mockToken, accountType: 'personal' }])
+
+      getPathsSpy.mockRestore()
+      copyAndExtractSpy.mockRestore()
+      cleanup()
+    })
+
+    // Regression for #156: CLIXML-contaminated decrypt output must not short-circuit
+    // the work account, leaving other valid paths unvisited.
+    it('does not mark accountType seen when the first path yields CLIXML garbage', async () => {
+      // given: first work path returns CLIXML garbage, second work path returns a real token
+      const clixmlGarbage =
+        '#< CLIXML\r\n<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+        '<Obj S="progress"><TN><T>Progress</T></TN></Obj></Objs>\r\n' +
+        'a'.repeat(80)
+      const realToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature_here'
+
+      const winExtractor = new TeamsTokenExtractor('win32')
+      const firstPath = join(workDir, 'WV2Profile_tfw', 'Cookies')
+      const secondPath = join(workDir, 'Default', 'Network', 'Cookies')
+      const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
+        { path: firstPath, accountType: 'work' },
+        { path: secondPath, accountType: 'work' },
+      ])
+      mkdirSync(join(workDir, 'WV2Profile_tfw'), { recursive: true })
+      mkdirSync(join(workDir, 'Default', 'Network'), { recursive: true })
+      writeFileSync(firstPath, '')
+      writeFileSync(secondPath, '')
+
+      const copyAndExtractSpy = spyOn(winExtractor as any, 'copyAndExtract')
+        .mockResolvedValueOnce(clixmlGarbage)
+        .mockResolvedValueOnce(realToken)
+
+      // when
+      const results = await (winExtractor as any).extractFromCookiesDB()
+
+      // then: garbage was rejected, loop continued to the real token
+      expect(copyAndExtractSpy).toHaveBeenCalledTimes(2)
+      expect(results).toEqual([{ token: realToken, accountType: 'work' }])
 
       getPathsSpy.mockRestore()
       copyAndExtractSpy.mockRestore()

--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -189,8 +189,13 @@ export class TeamsTokenExtractor {
   }
 
   isValidSkypeToken(token: string): boolean {
-    if (!token || token.length === 0) return false
-    return token.length >= 50
+    if (!token || token.length < 50) return false
+    // Real skype tokens are JWT-shaped or long base64url-ish strings. Reject anything
+    // containing XML/CLIXML artifacts (e.g. leaked PowerShell progress stream) or
+    // other non-token characters up front to stop garbage from being reported as valid.
+    if (/[<>{}\s"'`]/.test(token)) return false
+    if (token.startsWith('eyJ')) return /^[A-Za-z0-9._-]+$/.test(token)
+    return /^[A-Za-z0-9._~+/=-]+$/.test(token)
   }
 
   isEncryptedValue(value: Buffer): boolean {

--- a/src/shared/chromium/decryptor.test.ts
+++ b/src/shared/chromium/decryptor.test.ts
@@ -307,6 +307,71 @@ describe('ChromiumCookieDecryptor', () => {
     })
   })
 
+  describe('extractDPAPIPayload', () => {
+    it('extracts payload wrapped in markers', () => {
+      // given
+      const b64 = Buffer.from('hello').toString('base64')
+      const stdout = `<<<B64>>>${b64}<<<END>>>\r\n`
+
+      // when
+      const result = ChromiumCookieDecryptor.extractDPAPIPayload(stdout)
+
+      // then
+      expect(result).toBe(b64)
+    })
+
+    it('strips CLIXML progress-stream contamination before the payload', () => {
+      // given: PowerShell emits CLIXML on first module auto-load
+      const b64 = Buffer.from('secret-token').toString('base64')
+      const stdout =
+        '#< CLIXML\r\n' +
+        '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+        '<Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T>' +
+        '<T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record">' +
+        '<AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC>' +
+        '<T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>' +
+        `<<<B64>>>${b64}<<<END>>>\r\n`
+
+      // when
+      const result = ChromiumCookieDecryptor.extractDPAPIPayload(stdout)
+
+      // then
+      expect(result).toBe(b64)
+    })
+
+    it('tolerates whitespace and line breaks inside the payload', () => {
+      // given
+      const b64 = Buffer.from('hello').toString('base64')
+      const chunked = b64.slice(0, 3) + '\r\n' + b64.slice(3)
+      const stdout = `<<<B64>>>${chunked}<<<END>>>`
+
+      // when
+      const result = ChromiumCookieDecryptor.extractDPAPIPayload(stdout)
+
+      // then
+      expect(result).toBe(b64)
+    })
+
+    it('returns null when markers are missing', () => {
+      // given: stdout contains only CLIXML noise, no real payload
+      const stdout = '#< CLIXML\r\n<Objs></Objs>\r\n'
+
+      // when
+      const result = ChromiumCookieDecryptor.extractDPAPIPayload(stdout)
+
+      // then
+      expect(result).toBeNull()
+    })
+
+    it('returns null when payload between markers is empty', () => {
+      // when
+      const result = ChromiumCookieDecryptor.extractDPAPIPayload('<<<B64>>><<<END>>>')
+
+      // then
+      expect(result).toBeNull()
+    })
+  })
+
   describe('stripIntegrityHash', () => {
     it('returns input unchanged when length <= 32', () => {
       // given

--- a/src/shared/chromium/decryptor.ts
+++ b/src/shared/chromium/decryptor.ts
@@ -187,20 +187,41 @@ export class ChromiumCookieDecryptor {
     if (this.platform !== 'win32') return null
     try {
       const b64Input = encrypted.toString('base64')
+      // Silence progress/information/warning streams so PowerShell doesn't emit CLIXML
+      // ("#< CLIXML ...") alongside our base64 payload when modules auto-load on first use.
+      // Wrap the payload in explicit markers so we can recover it even if stray output leaks in.
       const script = [
+        "$ProgressPreference='SilentlyContinue'",
+        "$InformationPreference='SilentlyContinue'",
+        "$WarningPreference='SilentlyContinue'",
         'Add-Type -AssemblyName System.Security',
         `$d=[System.Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String("${b64Input}"),$null,[System.Security.Cryptography.DataProtectionScope]::CurrentUser)`,
-        '[Convert]::ToBase64String($d)',
+        "Write-Host ('<<<B64>>>'+[Convert]::ToBase64String($d)+'<<<END>>>')",
       ].join(';')
       const encodedCommand = Buffer.from(script, 'utf16le').toString('base64')
-      const result = execSync(`powershell -NoProfile -NonInteractive -EncodedCommand ${encodedCommand}`, {
-        encoding: 'utf8',
-        timeout: 10000,
-      }).trim()
-      return Buffer.from(result, 'base64')
+      const rawResult = execSync(
+        `powershell -NoProfile -NonInteractive -OutputFormat Text -EncodedCommand ${encodedCommand}`,
+        { encoding: 'utf8', timeout: 10000 },
+      )
+      const b64 = ChromiumCookieDecryptor.extractDPAPIPayload(rawResult)
+      if (!b64) return null
+      return Buffer.from(b64, 'base64')
     } catch {
       return null
     }
+  }
+
+  /**
+   * Extract the base64-encoded DPAPI payload from PowerShell stdout, stripping any
+   * CLIXML progress-stream contamination or other stray output. Returns null if
+   * no valid payload is found.
+   */
+  static extractDPAPIPayload(stdout: string): string | null {
+    const match = stdout.match(/<<<B64>>>([A-Za-z0-9+/=\r\n]*)<<<END>>>/)
+    if (!match) return null
+    const b64 = match[1].replace(/\s+/g, '')
+    if (!b64) return null
+    return b64
   }
 
   static stripIntegrityHash(decrypted: Buffer): Buffer {


### PR DESCRIPTION
## Summary

Fixes #156 — `agent-teams auth extract` was returning either \"No Teams token found\" or a bogus token on Windows because PowerShell CLIXML progress-stream XML was leaking into the DPAPI decryption output. The length-only validator (`length >= 50`) then accepted the contaminated bytes as a valid token, causing the extractor to mark the work account as seen and skip the other cookie paths.

Context from the reporter's debug trace (comment [#4269422616](https://github.com/agent-messenger/agent-messenger/issues/156#issuecomment-4269422616)):

\`\`\`
[debug]     Found cookie for .asyncgw.teams.microsoft.com: 99 bytes, encrypted=true, prefix=v10
#< CLIXML
<Objs Version=\"1.1.0.1\" xmlns=\"...\"><Obj S=\"progress\" ...><AV>Preparing modules for first use.</AV>...</Obj></Objs>
[debug]     Decrypted: 68 bytes
[debug]   [ok]   Extracted valid token (36 chars)
\`\`\`

## Fixes

1. **Suppress CLIXML at the source** (`src/shared/chromium/decryptor.ts`)
   PowerShell emits CLIXML on stdout when modules auto-load on first use. The DPAPI script now sets `\$ProgressPreference`, `\$InformationPreference`, and `\$WarningPreference` to `SilentlyContinue`, runs with `-OutputFormat Text`, and wraps the base64 payload in explicit `<<<B64>>>...<<<END>>>` markers.

2. **Defensive marker-based extraction** (`ChromiumCookieDecryptor.extractDPAPIPayload`)
   New static method that extracts the base64 payload between the markers, tolerates whitespace/line breaks inside, and ignores any CLIXML or other stray output that still leaks in. Returns `null` when no valid payload is present so downstream code fails closed.

3. **Tighter token validation** (`TeamsTokenExtractor.isValidSkypeToken`)
   Real Skype tokens are JWT-shaped (`eyJ...` with `[A-Za-z0-9._-]`) or long base64url-ish strings. The validator now rejects anything containing \`<\`, \`>\`, \`{\`, \`}\`, whitespace, or quotes — which drops the CLIXML payload up front. Because `accountType` is only added to `seenAccountTypes` on validation success, the loop now keeps scanning remaining cookie paths instead of short-circuiting on a bogus work token.

## Tests

- **`src/shared/chromium/decryptor.test.ts`**: 5 new cases for \`extractDPAPIPayload\` — basic marker extraction, CLIXML contamination, whitespace inside payload, missing markers, empty payload.
- **`src/platforms/teams/token-extractor.test.ts`**:
  - 3 new cases for \`isValidSkypeToken\`: rejects CLIXML, rejects strings with angle brackets/whitespace, rejects bare 36-char UUIDs.
  - 1 new regression test for \`extractFromCookiesDB\`: when the first work cookie yields CLIXML garbage and the second yields a real JWT, the loop continues past the garbage and returns the real token.

\`\`\`
bun typecheck  →  0 errors
bun lint       →  0 warnings, 0 errors
bun run format:check →  All matched files use the correct format
bun test       →  exit 0 (276 pass in src/shared + src/platforms/teams targeted run)
\`\`\`

## Risk

- The PowerShell script change is Windows-only and is guarded by \`this.platform !== 'win32'\`; no behavior change on macOS/Linux.
- Token validator became stricter. The only previously-accepted strings that are now rejected are: < 50 chars (already rejected), strings containing non-token characters (those were never valid Skype tokens in the first place).

Closes #156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows-only bug where PowerShell CLIXML polluted DPAPI decryption, causing `agent-teams auth extract` to return bogus or missing Teams tokens. Adds marker-based extraction and stricter token validation to avoid false positives and continue scanning cookie paths. Fixes #156.

- **Bug Fixes**
  - Silence PowerShell progress/info/warning streams, set `-OutputFormat Text`, and wrap DPAPI output in `<<<B64>>>...<<<END>>>` markers to strip CLIXML.
  - Add `ChromiumCookieDecryptor.extractDPAPIPayload()` to parse the marked payload, tolerate whitespace, ignore noise, and fail closed when missing.
  - Tighten `TeamsTokenExtractor.isValidSkypeToken()` to accept JWT/base64-ish tokens only and reject `<, >, {}, whitespace, quotes, backtick`; prevents marking accounts as seen on garbage and keeps scanning.
  - Add targeted tests for CLIXML contamination, payload extraction edge cases, and token validator regressions; Windows-only behavior, no change on macOS/Linux.
  - Docs/SKILL.md: No updates.

<sup>Written for commit 183b97f08a86bd57e08bcb23b2feabfcf86c6aa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

