### PR TITLE
fix: probe both Teams endpoints for browser-sourced tokens

### DIFF
--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -16,7 +16,7 @@ let clientGetRegionSpy: ReturnType<typeof spyOn>
 
 beforeEach(() => {
   extractorExtractSpy = spyOn(TeamsTokenExtractor.prototype, 'extract').mockResolvedValue([
-    { token: 'test-skype-token-123', accountType: 'work' as const },
+    { token: 'test-skype-token-123', accountType: 'work' as const, accountTypeKnown: true },
   ])
 
   clientTestAuthSpy = spyOn(TeamsClient.prototype, 'testAuth').mockResolvedValue({

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -9,6 +9,40 @@ import { TeamsCredentialManager } from '../credential-manager'
 import { TeamsTokenExtractor } from '../token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from '../types'
 
+interface ValidatedTeamsToken {
+  client: TeamsClient
+  accountType: TeamsAccountType
+  authInfo: { id: string; displayName: string }
+}
+
+async function validateTokenWithProbe(
+  token: string,
+  accountType: TeamsAccountType,
+  accountTypeKnown: boolean,
+  debugLog?: (msg: string) => void,
+): Promise<ValidatedTeamsToken> {
+  const primaryTypes: TeamsAccountType[] = [accountType]
+  if (!accountTypeKnown) {
+    primaryTypes.push(accountType === 'work' ? 'personal' : 'work')
+  }
+
+  let lastError: Error | null = null
+  for (const candidateType of primaryTypes) {
+    try {
+      const client = await new TeamsClient().login({ token, accountType: candidateType })
+      const authInfo = await client.testAuth()
+      if (candidateType !== accountType) {
+        debugLog?.(`[debug] Reclassified ${accountType} → ${candidateType} via API probe`)
+      }
+      return { client, accountType: candidateType, authInfo }
+    } catch (error) {
+      lastError = error as Error
+      debugLog?.(`[debug] Probe ${candidateType} failed: ${lastError.message}`)
+    }
+  }
+  throw lastError ?? new Error('Token validation failed')
+}
+
 export async function extractAction(options: { pretty?: boolean; debug?: boolean; token?: string }): Promise<void> {
   try {
     if (options.token) {
@@ -67,18 +101,31 @@ export async function extractAction(options: { pretty?: boolean; debug?: boolean
       teams: string[]
     }> = []
 
-    for (const { token, accountType } of extracted) {
+    for (const { token, accountType: extractedType, accountTypeKnown } of extracted) {
       if (options.debug) {
-        debug(`[debug] Validating ${accountType} account token...`)
+        const label = accountTypeKnown ? extractedType : `${extractedType} (probing)`
+        debug(`[debug] Validating ${label} account token...`)
       }
 
       try {
-        const client = await new TeamsClient().login({ token, accountType })
-        const authInfo = await client.testAuth()
+        const debugLog = options.debug ? (msg: string) => debug(msg) : undefined
+        const { client, accountType, authInfo } = await validateTokenWithProbe(
+          token,
+          extractedType,
+          accountTypeKnown,
+          debugLog,
+        )
         const teams = await client.listTeams()
 
         if (options.debug) {
           debug(`[debug] ✓ ${accountType}: ${authInfo.displayName} (${teams.length} team(s))`)
+        }
+
+        if (config.accounts[accountType]) {
+          if (options.debug) {
+            debug(`[debug] Skipping duplicate ${accountType} account`)
+          }
+          continue
         }
 
         const teamMap: Record<string, { team_id: string; team_name: string }> = {}
@@ -110,7 +157,7 @@ export async function extractAction(options: { pretty?: boolean; debug?: boolean
         const errorMessage = (error as Error).message
         const is401 = errorMessage.includes('401') || errorMessage.includes('Unauthorized')
         if (options.debug) {
-          debug(`[debug] ✗ ${accountType}: ${errorMessage}`)
+          debug(`[debug] ✗ ${extractedType}: ${errorMessage}`)
         }
         if (extracted.length === 1) {
           console.log(

--- a/src/platforms/teams/ensure-auth.test.ts
+++ b/src/platforms/teams/ensure-auth.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
   loadConfigSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue(null)
 
   extractSpy = spyOn(TeamsTokenExtractor.prototype, 'extract').mockResolvedValue([
-    { token: 'test-teams-token', accountType: 'work' },
+    { token: 'test-teams-token', accountType: 'work', accountTypeKnown: true },
   ])
 
   testAuthSpy = spyOn(TeamsClient.prototype, 'testAuth').mockResolvedValue({
@@ -199,8 +199,8 @@ describe('ensureTeamsAuth', () => {
   it('extracts and saves multiple accounts', async () => {
     // given
     extractSpy.mockResolvedValue([
-      { token: 'work-token', accountType: 'work' },
-      { token: 'personal-token', accountType: 'personal' },
+      { token: 'work-token', accountType: 'work', accountTypeKnown: true },
+      { token: 'personal-token', accountType: 'personal', accountTypeKnown: true },
     ])
 
     testAuthSpy
@@ -229,8 +229,8 @@ describe('ensureTeamsAuth', () => {
   it('skips failed account but saves successful ones', async () => {
     // given
     extractSpy.mockResolvedValue([
-      { token: 'work-token', accountType: 'work' },
-      { token: 'bad-token', accountType: 'personal' },
+      { token: 'work-token', accountType: 'work', accountTypeKnown: true },
+      { token: 'bad-token', accountType: 'personal', accountTypeKnown: true },
     ])
 
     testAuthSpy
@@ -246,6 +246,57 @@ describe('ensureTeamsAuth', () => {
     const savedConfig = saveConfigSpy.mock.calls[0][0]
     expect(savedConfig.accounts.work).toBeDefined()
     expect(savedConfig.accounts.personal).toBeUndefined()
+  })
+
+  // Regression for #163: browser-sourced tokens arrive with accountTypeKnown=false and
+  // a guessed accountType of 'work'. If the work endpoint rejects them, we must probe
+  // the personal endpoint before giving up — otherwise personal accounts logged in via
+  // browser would always fail validation.
+  it('reclassifies browser-sourced token from work to personal when work probe fails', async () => {
+    // given: extractor returns a token guessed as work but with unknown flag
+    extractSpy.mockResolvedValue([{ token: 'browser-token', accountType: 'work', accountTypeKnown: false }])
+
+    // first testAuth call (work) fails, second (personal) succeeds
+    testAuthSpy
+      .mockRejectedValueOnce(new Error('HTTP 403'))
+      .mockResolvedValueOnce({ id: 'user-p', displayName: 'Personal User' })
+
+    listTeamsSpy.mockResolvedValueOnce([{ id: 'team-p', name: 'Personal Chat' }])
+
+    // when
+    await ensureTeamsAuth()
+
+    // then: saved under 'personal', not 'work'
+    const savedConfig = saveConfigSpy.mock.calls[0][0]
+    expect(savedConfig.accounts.personal).toBeDefined()
+    expect(savedConfig.accounts.personal.account_type).toBe('personal')
+    expect(savedConfig.accounts.personal.token).toBe('browser-token')
+    expect(savedConfig.accounts.work).toBeUndefined()
+  })
+
+  // Regression for #163: when a known-type desktop token and an unknown-type browser
+  // token are both extracted, the loop must not overwrite the desktop account's data.
+  it('does not overwrite existing account when a later token reclassifies to same type', async () => {
+    // given: desktop personal token and browser token that probes to personal
+    extractSpy.mockResolvedValue([
+      { token: 'desktop-personal-token', accountType: 'personal', accountTypeKnown: true },
+      { token: 'browser-token', accountType: 'work', accountTypeKnown: false },
+    ])
+
+    testAuthSpy
+      .mockResolvedValueOnce({ id: 'user-p', displayName: 'Desktop Personal' })
+      .mockRejectedValueOnce(new Error('HTTP 403'))
+      .mockResolvedValueOnce({ id: 'user-p', displayName: 'Browser Personal' })
+
+    listTeamsSpy.mockResolvedValueOnce([{ id: 'team-p', name: 'Personal' }])
+
+    // when
+    await ensureTeamsAuth()
+
+    // then: desktop token wins; browser token is skipped because personal already exists
+    const savedConfig = saveConfigSpy.mock.calls[0][0]
+    expect(savedConfig.accounts.personal.token).toBe('desktop-personal-token')
+    expect(savedConfig.accounts.work).toBeUndefined()
   })
 
   it('re-extracts when token is empty string', async () => {

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -3,7 +3,7 @@ import { warn } from '@/shared/utils/stderr'
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
 import { TeamsTokenExtractor } from './token-extractor'
-import type { TeamsAccount, TeamsConfig } from './types'
+import type { TeamsAccount, TeamsAccountType, TeamsConfig } from './types'
 
 export async function ensureTeamsAuth(): Promise<void> {
   try {
@@ -20,15 +20,14 @@ export async function ensureTeamsAuth(): Promise<void> {
       current_account: config?.current_account ?? null,
       accounts: { ...config?.accounts },
     }
+    const addedTypes = new Set<TeamsAccountType>()
 
-    for (const { token, accountType } of extracted) {
+    for (const { token, accountType: extractedType, accountTypeKnown } of extracted) {
       try {
-        const client = await new TeamsClient().login({
-          token,
-          accountType,
-          region: config?.accounts[accountType]?.region,
-        })
-        await client.testAuth()
+        const resolved = await resolveAccountType(token, extractedType, accountTypeKnown, config)
+        const { client, accountType } = resolved
+
+        if (addedTypes.has(accountType)) continue
 
         const teams = await client.listTeams()
         if (accountType !== 'personal' && teams.length === 0) continue
@@ -38,23 +37,24 @@ export async function ensureTeamsAuth(): Promise<void> {
           teamMap[team.id] = { team_id: team.id, team_name: team.name }
         }
 
-        const existing = newConfig.accounts[accountType]
+        const existing: TeamsAccount | undefined = newConfig.accounts[accountType]
         const account: TeamsAccount = {
           token,
           token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
           region: client.getRegion(),
           account_type: accountType,
           user_name: existing?.user_name,
-          current_team: existing?.current_team ?? teams[0].id,
+          current_team: existing?.current_team ?? teams[0]?.id ?? null,
           teams: teamMap,
         }
 
         newConfig.accounts[accountType] = account
+        addedTypes.add(accountType)
         if (!newConfig.current_account) {
           newConfig.current_account = accountType
         }
       } catch (error) {
-        warn(`[agent-teams] Skipping ${accountType} account: ${(error as Error).message}`)
+        warn(`[agent-teams] Skipping ${extractedType} account: ${(error as Error).message}`)
       }
     }
 
@@ -62,6 +62,34 @@ export async function ensureTeamsAuth(): Promise<void> {
       await credManager.saveConfig(newConfig)
     }
   } catch {}
+}
+
+async function resolveAccountType(
+  token: string,
+  extractedType: TeamsAccountType,
+  accountTypeKnown: boolean,
+  config: TeamsConfig | null,
+): Promise<{ client: TeamsClient; accountType: TeamsAccountType }> {
+  const candidates: TeamsAccountType[] = [extractedType]
+  if (!accountTypeKnown) {
+    candidates.push(extractedType === 'work' ? 'personal' : 'work')
+  }
+
+  let lastError: Error | null = null
+  for (const candidate of candidates) {
+    try {
+      const client = await new TeamsClient().login({
+        token,
+        accountType: candidate,
+        region: config?.accounts[candidate]?.region,
+      })
+      await client.testAuth()
+      return { client, accountType: candidate }
+    } catch (error) {
+      lastError = error as Error
+    }
+  }
+  throw lastError ?? new Error('Token validation failed')
 }
 
 function hasValidToken(config: TeamsConfig): boolean {

--- a/src/platforms/teams/token-extractor.test.ts
+++ b/src/platforms/teams/token-extractor.test.ts
@@ -30,15 +30,28 @@ describe('TeamsTokenExtractor', () => {
         'EBWebView',
       )
       expect(paths).toEqual([
-        { path: join(darwinEbWebView, 'WV2Profile_tfw', 'Cookies'), accountType: 'work' },
-        { path: join(darwinEbWebView, 'WV2Profile_tfw', 'Network', 'Cookies'), accountType: 'work' },
-        { path: join(darwinEbWebView, 'WV2Profile_tfl', 'Cookies'), accountType: 'personal' },
-        { path: join(darwinEbWebView, 'WV2Profile_tfl', 'Network', 'Cookies'), accountType: 'personal' },
-        { path: join(darwinEbWebView, 'Default', 'Cookies'), accountType: 'work' },
-        { path: join(darwinEbWebView, 'Default', 'Network', 'Cookies'), accountType: 'work' },
+        { path: join(darwinEbWebView, 'WV2Profile_tfw', 'Cookies'), accountType: 'work', accountTypeKnown: true },
+        {
+          path: join(darwinEbWebView, 'WV2Profile_tfw', 'Network', 'Cookies'),
+          accountType: 'work',
+          accountTypeKnown: true,
+        },
+        {
+          path: join(darwinEbWebView, 'WV2Profile_tfl', 'Cookies'),
+          accountType: 'personal',
+          accountTypeKnown: true,
+        },
+        {
+          path: join(darwinEbWebView, 'WV2Profile_tfl', 'Network', 'Cookies'),
+          accountType: 'personal',
+          accountTypeKnown: true,
+        },
+        { path: join(darwinEbWebView, 'Default', 'Cookies'), accountType: 'work', accountTypeKnown: false },
+        { path: join(darwinEbWebView, 'Default', 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false },
         {
           path: join(homedir(), 'Library', 'Application Support', 'Microsoft', 'Teams', 'Cookies'),
           accountType: 'work',
+          accountTypeKnown: false,
         },
       ])
     })
@@ -51,6 +64,7 @@ describe('TeamsTokenExtractor', () => {
         {
           path: join(homedir(), '.config', 'Microsoft', 'Microsoft Teams', 'Cookies'),
           accountType: 'work',
+          accountTypeKnown: false,
         },
       ])
     })
@@ -71,13 +85,21 @@ describe('TeamsTokenExtractor', () => {
         'EBWebView',
       )
       expect(paths).toEqual([
-        { path: join(winEbWebView, 'WV2Profile_tfw', 'Cookies'), accountType: 'work' },
-        { path: join(winEbWebView, 'WV2Profile_tfw', 'Network', 'Cookies'), accountType: 'work' },
-        { path: join(winEbWebView, 'WV2Profile_tfl', 'Cookies'), accountType: 'personal' },
-        { path: join(winEbWebView, 'WV2Profile_tfl', 'Network', 'Cookies'), accountType: 'personal' },
-        { path: join(winEbWebView, 'Default', 'Cookies'), accountType: 'work' },
-        { path: join(winEbWebView, 'Default', 'Network', 'Cookies'), accountType: 'work' },
-        { path: join(appdata, 'Microsoft', 'Teams', 'Cookies'), accountType: 'work' },
+        { path: join(winEbWebView, 'WV2Profile_tfw', 'Cookies'), accountType: 'work', accountTypeKnown: true },
+        {
+          path: join(winEbWebView, 'WV2Profile_tfw', 'Network', 'Cookies'),
+          accountType: 'work',
+          accountTypeKnown: true,
+        },
+        { path: join(winEbWebView, 'WV2Profile_tfl', 'Cookies'), accountType: 'personal', accountTypeKnown: true },
+        {
+          path: join(winEbWebView, 'WV2Profile_tfl', 'Network', 'Cookies'),
+          accountType: 'personal',
+          accountTypeKnown: true,
+        },
+        { path: join(winEbWebView, 'Default', 'Cookies'), accountType: 'work', accountTypeKnown: false },
+        { path: join(winEbWebView, 'Default', 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false },
+        { path: join(appdata, 'Microsoft', 'Teams', 'Cookies'), accountType: 'work', accountTypeKnown: false },
       ])
     })
 
@@ -96,10 +118,12 @@ describe('TeamsTokenExtractor', () => {
       expect(paths).toContainEqual({
         path: join(chromeBase, 'Default', 'Cookies'),
         accountType: 'work',
+        accountTypeKnown: false,
       })
       expect(paths).toContainEqual({
         path: join(chromeBase, 'Default', 'Network', 'Cookies'),
         accountType: 'work',
+        accountTypeKnown: false,
       })
     })
 
@@ -111,6 +135,7 @@ describe('TeamsTokenExtractor', () => {
       expect(paths).toContainEqual({
         path: join(chromeBase, 'Default', 'Cookies'),
         accountType: 'work',
+        accountTypeKnown: false,
       })
     })
 
@@ -123,6 +148,7 @@ describe('TeamsTokenExtractor', () => {
       expect(paths).toContainEqual({
         path: join(chromeBase, 'Default', 'Cookies'),
         accountType: 'work',
+        accountTypeKnown: false,
       })
     })
 
@@ -131,10 +157,14 @@ describe('TeamsTokenExtractor', () => {
       expect(unsupportedExtractor.getBrowserCookiesPaths()).toEqual([])
     })
 
-    it('all browser paths have accountType work', () => {
+    // Regression for #163: browser paths must not assert accountType confidently because
+    // Chromium profile paths don't encode work vs personal. Desktop WV2Profile_tfw/_tfl
+    // paths are authoritative; browsers must be probed at validation time.
+    it('browser paths have accountTypeKnown=false so they get probed at validation', () => {
       const darwinExtractor = new TeamsTokenExtractor('darwin')
       const paths = darwinExtractor.getBrowserCookiesPaths()
-      expect(paths.every((p) => p.accountType === 'work')).toBe(true)
+      expect(paths.length).toBeGreaterThan(0)
+      expect(paths.every((p) => p.accountTypeKnown === false)).toBe(true)
     })
   })
 
@@ -166,6 +196,7 @@ describe('TeamsTokenExtractor', () => {
         {
           path: join(homedir(), '.config', 'Microsoft', 'Microsoft Teams', 'Cookies'),
           accountType: 'work',
+          accountTypeKnown: false,
         },
       ])
       expect(paths.length).toBeGreaterThan(desktopPaths.length)
@@ -338,7 +369,7 @@ describe('TeamsTokenExtractor', () => {
 
       const linuxExtractor = new TeamsTokenExtractor('linux')
       const extractFromCookiesDBSpy = spyOn(linuxExtractor as any, 'extractFromCookiesDB').mockResolvedValue([
-        { token: mockToken, accountType: 'work' },
+        { token: mockToken, accountType: 'work', accountTypeKnown: true },
       ])
 
       const result = await linuxExtractor.extract()
@@ -382,8 +413,8 @@ describe('TeamsTokenExtractor', () => {
 
       const winExtractor = new TeamsTokenExtractor('win32')
       const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
-        { path: cookiesPath, accountType: 'personal' },
-        { path: networkCookiesPath, accountType: 'personal' },
+        { path: cookiesPath, accountType: 'personal', accountTypeKnown: true },
+        { path: networkCookiesPath, accountType: 'personal', accountTypeKnown: true },
       ])
       const tried: string[] = []
       const copyAndExtractSpy = spyOn(winExtractor as any, 'copyAndExtract').mockImplementation(async (...args) => {
@@ -398,7 +429,7 @@ describe('TeamsTokenExtractor', () => {
       // then: the Cookies path was skipped (never passed to copyAndExtract),
       // the Network/Cookies sibling was tried, and the token was returned.
       expect(tried).toEqual([networkCookiesPath])
-      expect(results).toEqual([{ token: mockToken, accountType: 'personal' }])
+      expect(results).toEqual([{ token: mockToken, accountType: 'personal', accountTypeKnown: true }])
 
       getPathsSpy.mockRestore()
       copyAndExtractSpy.mockRestore()
@@ -419,8 +450,8 @@ describe('TeamsTokenExtractor', () => {
       const firstPath = join(workDir, 'WV2Profile_tfw', 'Cookies')
       const secondPath = join(workDir, 'Default', 'Network', 'Cookies')
       const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
-        { path: firstPath, accountType: 'work' },
-        { path: secondPath, accountType: 'work' },
+        { path: firstPath, accountType: 'work', accountTypeKnown: true },
+        { path: secondPath, accountType: 'work', accountTypeKnown: true },
       ])
       mkdirSync(join(workDir, 'WV2Profile_tfw'), { recursive: true })
       mkdirSync(join(workDir, 'Default', 'Network'), { recursive: true })
@@ -436,7 +467,98 @@ describe('TeamsTokenExtractor', () => {
 
       // then: garbage was rejected, loop continued to the real token
       expect(copyAndExtractSpy).toHaveBeenCalledTimes(2)
-      expect(results).toEqual([{ token: realToken, accountType: 'work' }])
+      expect(results).toEqual([{ token: realToken, accountType: 'work', accountTypeKnown: true }])
+
+      getPathsSpy.mockRestore()
+      copyAndExtractSpy.mockRestore()
+      cleanup()
+    })
+
+    // Regression for #163: browser-sourced tokens carry accountTypeKnown=false so that
+    // the auth command can probe both endpoints. The extraction loop must preserve the
+    // flag and must not dedupe an unknown-type browser token by its guessed accountType.
+    it('propagates accountTypeKnown=false for browser-sourced tokens', async () => {
+      // given: a browser Cookies path returning a valid token, guessed as work
+      const browserPath = join(workDir, 'Chrome', 'Default', 'Cookies')
+      mkdirSync(join(workDir, 'Chrome', 'Default'), { recursive: true })
+      writeFileSync(browserPath, '')
+
+      const winExtractor = new TeamsTokenExtractor('win32')
+      const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
+        { path: browserPath, accountType: 'work', accountTypeKnown: false },
+      ])
+      const copyAndExtractSpy = spyOn(winExtractor as any, 'copyAndExtract').mockResolvedValue(mockToken)
+
+      // when
+      const results = await (winExtractor as any).extractFromCookiesDB()
+
+      // then: the flag is passed through so callers can probe
+      expect(results).toEqual([{ token: mockToken, accountType: 'work', accountTypeKnown: false }])
+
+      getPathsSpy.mockRestore()
+      copyAndExtractSpy.mockRestore()
+      cleanup()
+    })
+
+    // Regression for #163: when a desktop path (known=true) for 'work' already succeeded,
+    // a subsequent browser path (known=false) guessed as 'work' must still be explored —
+    // it might be a personal account misguessed as work. The dedup only kicks in for
+    // confidently labeled paths.
+    it('does not skip unknown-type path just because a known-type same-label succeeded', async () => {
+      const desktopPath = join(workDir, 'WV2Profile_tfw', 'Network', 'Cookies')
+      const browserPath = join(workDir, 'Chrome', 'Default', 'Cookies')
+      mkdirSync(join(workDir, 'WV2Profile_tfw', 'Network'), { recursive: true })
+      mkdirSync(join(workDir, 'Chrome', 'Default'), { recursive: true })
+      writeFileSync(desktopPath, '')
+      writeFileSync(browserPath, '')
+
+      const desktopToken = mockToken
+      const browserToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJicm93c2VyIn0.different_signature_here_abc'
+
+      const winExtractor = new TeamsTokenExtractor('win32')
+      const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
+        { path: desktopPath, accountType: 'work', accountTypeKnown: true },
+        { path: browserPath, accountType: 'work', accountTypeKnown: false },
+      ])
+      const copyAndExtractSpy = spyOn(winExtractor as any, 'copyAndExtract')
+        .mockResolvedValueOnce(desktopToken)
+        .mockResolvedValueOnce(browserToken)
+
+      // when
+      const results = await (winExtractor as any).extractFromCookiesDB()
+
+      // then: both tokens returned; browser token keeps accountTypeKnown=false for probing
+      expect(results).toEqual([
+        { token: desktopToken, accountType: 'work', accountTypeKnown: true },
+        { token: browserToken, accountType: 'work', accountTypeKnown: false },
+      ])
+
+      getPathsSpy.mockRestore()
+      copyAndExtractSpy.mockRestore()
+      cleanup()
+    })
+
+    it('dedupes identical tokens extracted from multiple paths', async () => {
+      const path1 = join(workDir, 'Chrome', 'Default', 'Cookies')
+      const path2 = join(workDir, 'Edge', 'Default', 'Cookies')
+      mkdirSync(join(workDir, 'Chrome', 'Default'), { recursive: true })
+      mkdirSync(join(workDir, 'Edge', 'Default'), { recursive: true })
+      writeFileSync(path1, '')
+      writeFileSync(path2, '')
+
+      const winExtractor = new TeamsTokenExtractor('win32')
+      const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
+        { path: path1, accountType: 'work', accountTypeKnown: false },
+        { path: path2, accountType: 'work', accountTypeKnown: false },
+      ])
+      const copyAndExtractSpy = spyOn(winExtractor as any, 'copyAndExtract').mockResolvedValue(mockToken)
+
+      // when
+      const results = await (winExtractor as any).extractFromCookiesDB()
+
+      // then: only one result despite two paths returning the same token
+      expect(results).toHaveLength(1)
+      expect(results[0].token).toBe(mockToken)
 
       getPathsSpy.mockRestore()
       copyAndExtractSpy.mockRestore()
@@ -454,8 +576,8 @@ describe('TeamsTokenExtractor', () => {
 
       const winExtractor = new TeamsTokenExtractor('win32')
       const getPathsSpy = spyOn(winExtractor, 'getTeamsCookiesPaths').mockReturnValue([
-        { path: workCookies, accountType: 'work' },
-        { path: workNetworkCookies, accountType: 'work' },
+        { path: workCookies, accountType: 'work', accountTypeKnown: true },
+        { path: workNetworkCookies, accountType: 'work', accountTypeKnown: true },
       ])
       const copyAndExtractSpy = spyOn(winExtractor as any, 'copyAndExtract').mockResolvedValue(mockToken)
 

--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -20,11 +20,17 @@ import type { TeamsAccountType } from './types'
 export interface ExtractedTeamsToken {
   token: string
   accountType: TeamsAccountType
+  // False when the account type was guessed from the cookie path and needs to be
+  // confirmed against the Teams API (e.g. browser profiles, which don't encode
+  // work vs personal in the path). True for desktop paths that reliably encode
+  // the account type (WV2Profile_tfw vs WV2Profile_tfl).
+  accountTypeKnown: boolean
 }
 
 interface TeamsCookiePath {
   path: string
   accountType: TeamsAccountType
+  accountTypeKnown: boolean
 }
 
 const TEAMS_PROCESS_NAMES: Record<string, string> = {
@@ -91,15 +97,28 @@ export class TeamsTokenExtractor {
           'EBWebView',
         )
         return [
-          { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Cookies'), accountType: 'work' },
-          { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Network', 'Cookies'), accountType: 'work' },
-          { path: join(ebWebViewBase, 'WV2Profile_tfl', 'Cookies'), accountType: 'personal' },
-          { path: join(ebWebViewBase, 'WV2Profile_tfl', 'Network', 'Cookies'), accountType: 'personal' },
-          { path: join(ebWebViewBase, 'Default', 'Cookies'), accountType: 'work' },
-          { path: join(ebWebViewBase, 'Default', 'Network', 'Cookies'), accountType: 'work' },
+          { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Cookies'), accountType: 'work', accountTypeKnown: true },
+          {
+            path: join(ebWebViewBase, 'WV2Profile_tfw', 'Network', 'Cookies'),
+            accountType: 'work',
+            accountTypeKnown: true,
+          },
+          {
+            path: join(ebWebViewBase, 'WV2Profile_tfl', 'Cookies'),
+            accountType: 'personal',
+            accountTypeKnown: true,
+          },
+          {
+            path: join(ebWebViewBase, 'WV2Profile_tfl', 'Network', 'Cookies'),
+            accountType: 'personal',
+            accountTypeKnown: true,
+          },
+          { path: join(ebWebViewBase, 'Default', 'Cookies'), accountType: 'work', accountTypeKnown: false },
+          { path: join(ebWebViewBase, 'Default', 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false },
           {
             path: join(homedir(), 'Library', 'Application Support', 'Microsoft', 'Teams', 'Cookies'),
             accountType: 'work',
+            accountTypeKnown: false,
           },
         ]
       }
@@ -108,6 +127,7 @@ export class TeamsTokenExtractor {
           {
             path: join(homedir(), '.config', 'Microsoft', 'Microsoft Teams', 'Cookies'),
             accountType: 'work',
+            accountTypeKnown: false,
           },
         ]
       case 'win32': {
@@ -123,13 +143,25 @@ export class TeamsTokenExtractor {
           'EBWebView',
         )
         return [
-          { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Cookies'), accountType: 'work' },
-          { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Network', 'Cookies'), accountType: 'work' },
-          { path: join(ebWebViewBase, 'WV2Profile_tfl', 'Cookies'), accountType: 'personal' },
-          { path: join(ebWebViewBase, 'WV2Profile_tfl', 'Network', 'Cookies'), accountType: 'personal' },
-          { path: join(ebWebViewBase, 'Default', 'Cookies'), accountType: 'work' },
-          { path: join(ebWebViewBase, 'Default', 'Network', 'Cookies'), accountType: 'work' },
-          { path: join(appdata, 'Microsoft', 'Teams', 'Cookies'), accountType: 'work' },
+          { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Cookies'), accountType: 'work', accountTypeKnown: true },
+          {
+            path: join(ebWebViewBase, 'WV2Profile_tfw', 'Network', 'Cookies'),
+            accountType: 'work',
+            accountTypeKnown: true,
+          },
+          {
+            path: join(ebWebViewBase, 'WV2Profile_tfl', 'Cookies'),
+            accountType: 'personal',
+            accountTypeKnown: true,
+          },
+          {
+            path: join(ebWebViewBase, 'WV2Profile_tfl', 'Network', 'Cookies'),
+            accountType: 'personal',
+            accountTypeKnown: true,
+          },
+          { path: join(ebWebViewBase, 'Default', 'Cookies'), accountType: 'work', accountTypeKnown: false },
+          { path: join(ebWebViewBase, 'Default', 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false },
+          { path: join(appdata, 'Microsoft', 'Teams', 'Cookies'), accountType: 'work', accountTypeKnown: false },
         ]
       }
       default:
@@ -145,8 +177,8 @@ export class TeamsTokenExtractor {
       if (!browserBase) continue
 
       for (const profileDir of discoverBrowserProfileDirs(browserBase)) {
-        paths.push({ path: join(profileDir, 'Cookies'), accountType: 'work' })
-        paths.push({ path: join(profileDir, 'Network', 'Cookies'), accountType: 'work' })
+        paths.push({ path: join(profileDir, 'Cookies'), accountType: 'work', accountTypeKnown: false })
+        paths.push({ path: join(profileDir, 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false })
       }
     }
 
@@ -213,12 +245,13 @@ export class TeamsTokenExtractor {
 
   private async extractFromCookiesDB(): Promise<ExtractedTeamsToken[]> {
     const results: ExtractedTeamsToken[] = []
-    const seenAccountTypes = new Set<TeamsAccountType>()
+    const seenKnownAccountTypes = new Set<TeamsAccountType>()
+    const seenTokens = new Set<string>()
     const allPaths = this.getTeamsCookiesPaths()
 
     this.debug(`Scanning ${allPaths.length} candidate cookie path(s)`)
 
-    for (const { path: dbPath, accountType } of allPaths) {
+    for (const { path: dbPath, accountType, accountTypeKnown } of allPaths) {
       if (!dbPath) continue
 
       if (!existsSync(dbPath)) {
@@ -226,22 +259,34 @@ export class TeamsTokenExtractor {
         continue
       }
 
-      if (seenAccountTypes.has(accountType)) {
+      if (accountTypeKnown && seenKnownAccountTypes.has(accountType)) {
         this.debug(`  [skip] ${dbPath} (already have ${accountType} account)`)
         continue
       }
 
-      this.debug(`  [try]  ${dbPath} (${accountType})`)
+      const typeLabel = accountTypeKnown ? accountType : `${accountType}?`
+      this.debug(`  [try]  ${dbPath} (${typeLabel})`)
 
       const token = await this.copyAndExtract(dbPath)
-      if (token && this.isValidSkypeToken(token)) {
-        this.debug(`  [ok]   Extracted valid token (${token.length} chars)`)
-        results.push({ token, accountType })
-        seenAccountTypes.add(accountType)
-      } else if (token) {
-        this.debug(`  [fail] Token too short (${token.length} chars, need >=50)`)
-      } else {
-        this.debug(`  [fail] No token extracted`)
+      if (!token || !this.isValidSkypeToken(token)) {
+        if (token) {
+          this.debug(`  [fail] Token too short (${token.length} chars, need >=50)`)
+        } else {
+          this.debug(`  [fail] No token extracted`)
+        }
+        continue
+      }
+
+      if (seenTokens.has(token)) {
+        this.debug(`  [skip] Duplicate token (already extracted from another path)`)
+        continue
+      }
+
+      this.debug(`  [ok]   Extracted valid token (${token.length} chars)`)
+      results.push({ token, accountType, accountTypeKnown })
+      seenTokens.add(token)
+      if (accountTypeKnown) {
+        seenKnownAccountTypes.add(accountType)
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #163 — `agent-teams auth extract` was labeling every browser-sourced cookie as a `work` account, causing personal Microsoft accounts logged in through Chrome/Edge to fail validation with HTTP 403 against the work endpoint (`{region}.ng.msg.teams.microsoft.com`).

Surfaced in the closing thread of #156 ([comment](https://github.com/agent-messenger/agent-messenger/issues/156#issuecomment-4282361125)):

> I'm logged in the same way in all platforms. It is a personal account, not a work one. So, Chrome shows as a work account and the app shows as personal.

## Root cause

`TeamsTokenExtractor.getBrowserCookiesPaths()` hardcoded `accountType: 'work'` for every cookie extracted from a Chromium profile:

\`\`\`typescript
for (const profileDir of discoverBrowserProfileDirs(browserBase)) {
  paths.push({ path: join(profileDir, 'Cookies'), accountType: 'work' })         // WRONG
  paths.push({ path: join(profileDir, 'Network', 'Cookies'), accountType: 'work' }) // WRONG
}
\`\`\`

MSTeams desktop uses \`WV2Profile_tfw\` (work) vs \`WV2Profile_tfl\` (personal/\"tenant-free/life\") as an authoritative discriminator. Chromium profile paths carry no such signal — the same \`Default/Cookies\` file is used for both account types. The old code assumed \"work\" and had no way to recover.

## Fix

Since browser cookies carry no path-level signal, **don't guess at extraction time — probe at validation time.** The two account types already use different API bases, so whichever endpoint returns 2xx wins.

1. **`ExtractedTeamsToken` carries a new `accountTypeKnown: boolean` flag.**
   - `true` for MSTeams desktop `WV2Profile_tfw`/`_tfl` paths (accurate).
   - `false` for browser paths and generic `Default` cookie paths (guessed, needs confirmation).
2. **`extractAction()` and `ensureTeamsAuth()` probe both endpoints when `accountTypeKnown === false`.** On HTTP 403 (or any error) from the guessed endpoint, they retry the other one before giving up. A single `testAuth()` call per fallback — the region discovery loop already amortizes this for work tokens.
3. **Dedup logic updated**: only paths with `accountTypeKnown: true` pre-reserve their account slot. Unknown-type paths don't block each other or known-type paths of the same guessed label. Identical tokens extracted from multiple paths are deduped by token value.

Result: a personal account logged in through Chrome is now probed against `msgapi.teams.live.com`, validates, and is saved with `account_type: 'personal'` — instead of failing against `{region}.ng.msg.teams.microsoft.com` as \"work\".

## Tests

- **`src/platforms/teams/token-extractor.test.ts`**: updated path-table expectations to include `accountTypeKnown` on every candidate. Added 3 new regression cases for #163:
  - `propagates accountTypeKnown=false for browser-sourced tokens`
  - `does not skip unknown-type path just because a known-type same-label succeeded`
  - `dedupes identical tokens extracted from multiple paths`
- **`src/platforms/teams/ensure-auth.test.ts`**: 2 new regression cases:
  - `reclassifies browser-sourced token from work to personal when work probe fails` — simulates the reported bug; first `testAuth` rejects with 403, fallback succeeds, saved as `personal`.
  - `does not overwrite existing account when a later token reclassifies to same type` — desktop-first-wins semantics preserved.

\`\`\`
bun lint             →  0 warnings, 0 errors
bun run format:check →  All matched files use the correct format
bun typecheck        →  0 errors
bun test             →  exit 0
bun test src/platforms/teams →  197 pass, 0 fail, 344 expect() calls
\`\`\`

## Risk

- The extra probe only fires when \`accountTypeKnown === false\` (browser paths and generic \`Default\` cookies). Desktop \`WV2Profile_tfw\`/\`_tfl\` tokens skip the probe entirely — zero perf impact on the common case.
- Worst-case cost for a misguessed browser token is one extra HTTPS request (\`/users/ME/properties\` against the other endpoint) — no retries, no exponential backoff.
- The \`ExtractedTeamsToken\` interface gained a field; all internal call sites updated. This is an exported type from \`@/platforms/teams\` — external SDK consumers who were constructing \`ExtractedTeamsToken\` manually will need to add \`accountTypeKnown\`. In practice only the extractor produces these.

Closes #163

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassification of browser-sourced Microsoft Teams tokens by probing both work and personal endpoints when the account type is unknown, so personal accounts in Chrome/Edge validate correctly. Also refines extraction and dedup logic to prevent false negatives and duplicate saves.

- **Bug Fixes**
  - Added `accountTypeKnown` to extracted tokens; desktop `WV2Profile_tfw/_tfl` paths set `true`, browser paths set `false`.
  - When `accountTypeKnown` is `false`, validate against the guessed endpoint, then fallback to the other and reclassify on success.
  - Updated dedup to skip only known-type duplicates and dedup identical tokens by value; avoid overwriting an existing saved account.

- **Migration**
  - `ExtractedTeamsToken` now includes `accountTypeKnown: boolean`; any external constructors must set it.
  - Docs: No SKILL.md or docs changes required.

<sup>Written for commit b83f900169de0f41041366667b75bf523c39fd05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

