### PR TITLE
feat: add Slack Bot Socket Mode listener for real-time events

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,30 @@ listener.on('interaction_create', (event) => {
 await listener.start()
 ```
 
+### Real-time Events (Slack Bot)
+
+Stream Events API events, slash commands, and interactive components over Slack's Socket Mode WebSocket — no public HTTP endpoint required. Requires an app-level token (`xapp-...`) with the `connections:write` scope, separate from your bot token.
+
+```typescript
+import { SlackBotClient, SlackBotListener } from 'agent-messenger/slackbot'
+
+const client = await new SlackBotClient().login({ token: 'xoxb-...' })
+const listener = new SlackBotListener(client, {
+  appToken: process.env.SLACK_APP_TOKEN!, // xapp-...
+})
+
+listener.on('message', ({ ack, event }) => {
+  ack()
+  console.log(`New message in ${event.channel}: ${event.text}`)
+})
+
+listener.on('slash_commands', ({ ack, body }) => {
+  ack({ text: `Got \`${body.command} ${body.text}\`` })
+})
+
+await listener.start()
+```
+
 ## TUI (Experimental)
 
 A unified terminal interface for all your messaging platforms in one screen. Navigate between Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk — all from your terminal.

--- a/examples/slackbot-listen.ts
+++ b/examples/slackbot-listen.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+import { SlackBotClient } from '../src/platforms/slackbot/client'
+import { SlackBotListener } from '../src/platforms/slackbot/listener'
+
+async function main() {
+  const appToken = process.env.SLACK_APP_TOKEN
+  if (!appToken) {
+    console.error('Set SLACK_APP_TOKEN to an xapp-... token with connections:write scope.')
+    console.error('Create one in your Slack app: Settings → Basic Information → App-Level Tokens.')
+    process.exit(1)
+  }
+
+  const client = await new SlackBotClient().login()
+  const listener = new SlackBotListener(client, { appToken })
+
+  listener.on('connected', (info) => {
+    console.log(`Connected (app: ${info.app_id}, connections: ${info.num_connections})`)
+    console.log('Listening for events. Press Ctrl+C to stop.\n')
+  })
+
+  listener.on('disconnected', () => {
+    console.log('[disconnected] reconnecting...')
+  })
+
+  listener.on('message', ({ ack, event }) => {
+    ack()
+    if (event.subtype || event.bot_id) return
+    const time = new Date(Number(event.ts) * 1000).toLocaleTimeString()
+    console.log(`[${time}] message #${event.channel} <${event.user ?? 'system'}>: ${event.text}`)
+  })
+
+  listener.on('app_mention', ({ ack, event }) => {
+    ack()
+    console.log(`[mention] ${event.user} in #${event.channel}: ${event.text}`)
+  })
+
+  listener.on('reaction_added', ({ ack, event }) => {
+    ack()
+    console.log(`[reaction] :${event.reaction}: by ${event.user} on ${event.item.channel}/${event.item.ts}`)
+  })
+
+  listener.on('slash_commands', ({ ack, body }) => {
+    console.log(`[slash] ${body.command} ${body.text} from ${body.user_id}`)
+    ack({ text: `Got \`${body.command} ${body.text}\`` })
+  })
+
+  listener.on('interactive', ({ ack, body }) => {
+    console.log(`[interactive] ${body.type} from ${body.user?.id}`)
+    ack()
+  })
+
+  listener.on('error', (err) => {
+    console.error(`[error] ${err.message}`)
+  })
+
+  process.on('SIGINT', () => {
+    console.log('\nStopping...')
+    listener.stop()
+    process.exit(130)
+  })
+
+  await listener.start()
+}
+
+main()

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -306,7 +306,7 @@ Credentials stored in `~/.config/agent-messenger/slackbot-credentials.json` (060
 
 ## Limitations
 
-- No real-time events / Socket Mode
+- No real-time events in the CLI (real-time Socket Mode events are available via the SDK — see the README's "Real-time Events (Slack Bot)" section)
 - No message search (requires user token scope)
 - No file upload/download
 - No workspace snapshot

--- a/src/platforms/slackbot/client.ts
+++ b/src/platforms/slackbot/client.ts
@@ -52,7 +52,9 @@ export class SlackBotClient {
         break
       }
     }
-    throw new SlackBotError(lastError?.message || 'Unknown error', (lastError as any)?.code || 'unknown_error')
+    const code = (lastError as any)?.code || 'unknown_error'
+    const retryAfter = code === RATE_LIMIT_ERROR_CODE ? (lastError as any)?.retryAfter : undefined
+    throw new SlackBotError(lastError?.message || 'Unknown error', code, retryAfter)
   }
 
   private sleep(ms: number): Promise<void> {

--- a/src/platforms/slackbot/client.ts
+++ b/src/platforms/slackbot/client.ts
@@ -464,4 +464,22 @@ export class SlackBotClient {
       this.checkResponse(response)
     })
   }
+
+  async appsConnectionsOpen(appToken: string): Promise<{ url: string }> {
+    if (!appToken) {
+      throw new SlackBotError('App-level token is required for Socket Mode', 'missing_app_token')
+    }
+    if (!appToken.startsWith('xapp-')) {
+      throw new SlackBotError(
+        'Token must be an app-level token (xapp-) with connections:write scope',
+        'invalid_app_token_type',
+      )
+    }
+
+    return this.withRetry(async () => {
+      const response = await new WebClient(appToken).apps.connections.open()
+      this.checkResponse(response)
+      return { url: (response as { url: string }).url }
+    })
+  }
 }

--- a/src/platforms/slackbot/index.test.ts
+++ b/src/platforms/slackbot/index.test.ts
@@ -1,0 +1,59 @@
+import { expect, it } from 'bun:test'
+
+import {
+  SlackBotClient,
+  SlackBotConfigSchema,
+  SlackBotCredentialManager,
+  SlackBotCredentialsSchema,
+  SlackBotError,
+  SlackBotListener,
+  SlackChannelSchema,
+  SlackFileSchema,
+  SlackMessageSchema,
+  SlackReactionSchema,
+  SlackUserSchema,
+} from '@/platforms/slackbot/index'
+
+it('SlackBotClient is exported from barrel', () => {
+  expect(typeof SlackBotClient).toBe('function')
+})
+
+it('SlackBotError is exported from barrel', () => {
+  expect(typeof SlackBotError).toBe('function')
+})
+
+it('SlackBotCredentialManager is exported from barrel', () => {
+  expect(typeof SlackBotCredentialManager).toBe('function')
+})
+
+it('SlackBotListener is exported from barrel', () => {
+  expect(typeof SlackBotListener).toBe('function')
+})
+
+it('SlackBotConfigSchema is exported from barrel', () => {
+  expect(typeof SlackBotConfigSchema.parse).toBe('function')
+})
+
+it('SlackBotCredentialsSchema is exported from barrel', () => {
+  expect(typeof SlackBotCredentialsSchema.parse).toBe('function')
+})
+
+it('SlackChannelSchema is exported from barrel', () => {
+  expect(typeof SlackChannelSchema.parse).toBe('function')
+})
+
+it('SlackMessageSchema is exported from barrel', () => {
+  expect(typeof SlackMessageSchema.parse).toBe('function')
+})
+
+it('SlackUserSchema is exported from barrel', () => {
+  expect(typeof SlackUserSchema.parse).toBe('function')
+})
+
+it('SlackReactionSchema is exported from barrel', () => {
+  expect(typeof SlackReactionSchema.parse).toBe('function')
+})
+
+it('SlackFileSchema is exported from barrel', () => {
+  expect(typeof SlackFileSchema.parse).toBe('function')
+})

--- a/src/platforms/slackbot/index.ts
+++ b/src/platforms/slackbot/index.ts
@@ -1,19 +1,43 @@
 export { SlackBotClient } from './client'
 export { SlackBotCredentialManager } from './credential-manager'
-export {
+export { SlackBotListener } from './listener'
+export type { SlackBotListenerOptions } from './listener'
+export type {
   SlackBotConfig,
-  SlackBotConfigSchema,
   SlackBotCredentials,
+  SlackBotListenerEventMap,
+  SlackChannel,
+  SlackFile,
+  SlackMessage,
+  SlackReaction,
+  SlackSocketModeAck,
+  SlackSocketModeAppMentionEvent,
+  SlackSocketModeChannelEvent,
+  SlackSocketModeDisconnectEnvelope,
+  SlackSocketModeDisconnectReason,
+  SlackSocketModeEnvelope,
+  SlackSocketModeEvent,
+  SlackSocketModeEventsApiArgs,
+  SlackSocketModeEventsApiEnvelope,
+  SlackSocketModeGenericEnvelope,
+  SlackSocketModeGenericEvent,
+  SlackSocketModeHelloEnvelope,
+  SlackSocketModeInteractiveArgs,
+  SlackSocketModeInteractiveEnvelope,
+  SlackSocketModeMemberChannelEvent,
+  SlackSocketModeMessageEvent,
+  SlackSocketModeReactionEvent,
+  SlackSocketModeSlashCommandArgs,
+  SlackSocketModeSlashCommandEnvelope,
+  SlackUser,
+} from './types'
+export {
+  SlackBotConfigSchema,
   SlackBotCredentialsSchema,
   SlackBotError,
-  SlackChannel,
   SlackChannelSchema,
-  SlackFile,
   SlackFileSchema,
-  SlackMessage,
   SlackMessageSchema,
-  SlackReaction,
   SlackReactionSchema,
-  SlackUser,
   SlackUserSchema,
 } from './types'

--- a/src/platforms/slackbot/listener.test.ts
+++ b/src/platforms/slackbot/listener.test.ts
@@ -1,0 +1,752 @@
+import { afterEach, describe, expect, mock, it } from 'bun:test'
+
+import { SlackBotListener } from '@/platforms/slackbot/listener'
+import type {
+  SlackSocketModeEventsApiArgs,
+  SlackSocketModeInteractiveArgs,
+  SlackSocketModeMessageEvent,
+  SlackSocketModeReactionEvent,
+  SlackSocketModeSlashCommandArgs,
+} from '@/platforms/slackbot/types'
+
+type WsHandler = (...args: any[]) => void
+
+let mockWsInstance: MockWs
+
+class MockWs {
+  static OPEN = 1
+  static CLOSED = 3
+  static lastUrl: string | null = null
+  readyState = MockWs.OPEN
+  url: string
+
+  private handlers = new Map<string, WsHandler[]>()
+  sent: string[] = []
+  pings: number = 0
+
+  constructor(url: string, _options?: any) {
+    this.url = url
+    MockWs.lastUrl = url
+    // oxlint-disable-next-line typescript-eslint/no-this-alias
+    mockWsInstance = this
+  }
+
+  on(event: string, handler: WsHandler) {
+    const list = this.handlers.get(event) ?? []
+    list.push(handler)
+    this.handlers.set(event, list)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  ping() {
+    this.pings++
+  }
+
+  close() {
+    this.readyState = MockWs.CLOSED
+    setTimeout(() => this.emit('close'), 0)
+  }
+
+  emit(event: string, ...args: any[]) {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler(...args)
+    }
+  }
+
+  simulateOpen() {
+    this.emit('open')
+  }
+
+  simulateMessage(data: Record<string, unknown>) {
+    this.emit('message', Buffer.from(JSON.stringify(data)))
+  }
+
+  simulateRawMessage(raw: string) {
+    this.emit('message', Buffer.from(raw))
+  }
+
+  simulateClose() {
+    this.readyState = MockWs.CLOSED
+    this.emit('close')
+  }
+
+  simulatePong() {
+    this.emit('pong')
+  }
+
+  simulateHello(extra: Record<string, unknown> = {}) {
+    this.simulateMessage({
+      type: 'hello',
+      connection_info: { app_id: 'A_APP' },
+      num_connections: 1,
+      ...extra,
+    })
+  }
+
+  simulateEventsApi(envelopeId: string, event: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+    this.simulateMessage({
+      type: 'events_api',
+      envelope_id: envelopeId,
+      payload: {
+        team_id: 'T_TEAM',
+        api_app_id: 'A_APP',
+        event,
+        type: 'event_callback',
+        event_id: 'Ev123',
+        event_time: 1700000000,
+      },
+      accepts_response_payload: false,
+      ...extra,
+    })
+  }
+
+  simulateSlashCommand(envelopeId: string, payload: Record<string, unknown>) {
+    this.simulateMessage({
+      type: 'slash_commands',
+      envelope_id: envelopeId,
+      payload,
+      accepts_response_payload: true,
+    })
+  }
+
+  simulateInteractive(envelopeId: string, payload: Record<string, unknown>) {
+    this.simulateMessage({
+      type: 'interactive',
+      envelope_id: envelopeId,
+      payload,
+      accepts_response_payload: true,
+    })
+  }
+
+  simulateDisconnect(reason = 'warning') {
+    this.simulateMessage({ type: 'disconnect', reason, debug_info: { host: 'h' } })
+  }
+}
+
+mock.module('ws', () => ({ default: MockWs, __esModule: true }))
+
+function createMockClient(overrides: Record<string, any> = {}) {
+  return {
+    appsConnectionsOpen: mock(() => Promise.resolve({ url: 'wss://wss.slack.com/?ticket=abc' })),
+    ...overrides,
+  } as any
+}
+
+const APP_TOKEN = 'xapp-1-A123-456-deadbeef'
+
+describe('SlackBotListener', () => {
+  let listener: SlackBotListener
+
+  afterEach(() => {
+    listener?.stop()
+  })
+
+  describe('constructor', () => {
+    it('throws without app token', () => {
+      const client = createMockClient()
+      expect(() => new SlackBotListener(client, { appToken: '' })).toThrow(/app-level token/i)
+    })
+
+    it('accepts a valid xapp- token', () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+      expect(listener).toBeInstanceOf(SlackBotListener)
+    })
+  })
+
+  describe('start', () => {
+    it('calls appsConnectionsOpen with the app token and opens WebSocket', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+
+      expect(client.appsConnectionsOpen).toHaveBeenCalledTimes(1)
+      expect(client.appsConnectionsOpen).toHaveBeenCalledWith(APP_TOKEN)
+      expect(MockWs.lastUrl).toBe('wss://wss.slack.com/?ticket=abc')
+    })
+
+    it('is idempotent', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      await listener.start()
+
+      expect(client.appsConnectionsOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('appends debug_reconnects=true when option is set', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN, debugReconnects: true })
+
+      await listener.start()
+
+      expect(MockWs.lastUrl).toContain('debug_reconnects=true')
+    })
+
+    it('preserves existing query params when appending debug_reconnects', async () => {
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => Promise.resolve({ url: 'wss://wss.slack.com/?ticket=abc' })),
+      })
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN, debugReconnects: true })
+
+      await listener.start()
+
+      expect(MockWs.lastUrl).toBe('wss://wss.slack.com/?ticket=abc&debug_reconnects=true')
+    })
+
+    it('uses ? when URL has no existing query string', async () => {
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => Promise.resolve({ url: 'wss://wss.slack.com/' })),
+      })
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN, debugReconnects: true })
+
+      await listener.start()
+
+      expect(MockWs.lastUrl).toBe('wss://wss.slack.com/?debug_reconnects=true')
+    })
+  })
+
+  describe('hello envelope', () => {
+    it('emits connected with app_id and num_connections', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const connected: any[] = []
+      listener.on('connected', (info) => connected.push(info))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      expect(connected.length).toBe(1)
+      expect(connected[0].app_id).toBe('A_APP')
+      expect(connected[0].num_connections).toBe(1)
+    })
+
+    it('resets reconnect attempts on hello', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      ;(listener as any).reconnectAttempts = 5
+
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      expect((listener as any).reconnectAttempts).toBe(0)
+    })
+  })
+
+  describe('events_api envelope', () => {
+    it('emits inner event type with ack and event payload', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const args: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent>[] = []
+      listener.on('message', (a) => args.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_001', {
+        type: 'message',
+        channel: 'C123',
+        user: 'U456',
+        text: 'hello',
+        ts: '111.222',
+      })
+
+      expect(args.length).toBe(1)
+      expect(args[0].envelope_id).toBe('env_001')
+      expect(args[0].event.type).toBe('message')
+      expect(args[0].event.channel).toBe('C123')
+      expect(args[0].event.text).toBe('hello')
+      expect(args[0].body.team_id).toBe('T_TEAM')
+    })
+
+    it('ack() sends envelope_id back over the WebSocket', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      let captured: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent> | null = null
+      listener.on('message', (a) => {
+        captured = a
+      })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_002', { type: 'message', channel: 'C', ts: '1' })
+
+      expect(captured).not.toBeNull()
+      captured!.ack()
+
+      expect(mockWsInstance.sent.length).toBe(1)
+      expect(JSON.parse(mockWsInstance.sent[0])).toEqual({ envelope_id: 'env_002' })
+    })
+
+    it('ack(payload) sends envelope_id with response payload', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      let captured: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent> | null = null
+      listener.on('message', (a) => {
+        captured = a
+      })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_003', { type: 'message', channel: 'C', ts: '1' })
+
+      captured!.ack({ text: 'ok' })
+
+      expect(mockWsInstance.sent.length).toBe(1)
+      expect(JSON.parse(mockWsInstance.sent[0])).toEqual({
+        envelope_id: 'env_003',
+        payload: { text: 'ok' },
+      })
+    })
+
+    it('ack is idempotent — only the first call hits the wire', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      let captured: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent> | null = null
+      listener.on('message', (a) => {
+        captured = a
+      })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_004', { type: 'message', channel: 'C', ts: '1' })
+
+      captured!.ack()
+      captured!.ack({ retry: true })
+      captured!.ack()
+
+      expect(mockWsInstance.sent.length).toBe(1)
+    })
+
+    it('exposes retry_attempt and retry_reason', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const args: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent>[] = []
+      listener.on('message', (a) => args.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi(
+        'env_005',
+        { type: 'message', channel: 'C', ts: '1' },
+        { retry_attempt: 2, retry_reason: 'timeout' },
+      )
+
+      expect(args[0].retry_num).toBe(2)
+      expect(args[0].retry_reason).toBe('timeout')
+    })
+
+    it('routes reaction_added to its own listener', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const reactions: SlackSocketModeEventsApiArgs<SlackSocketModeReactionEvent>[] = []
+      listener.on('reaction_added', (a) => reactions.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_r1', {
+        type: 'reaction_added',
+        user: 'U1',
+        reaction: 'thumbsup',
+        item: { type: 'message', channel: 'C', ts: '1' },
+        event_ts: '2',
+      })
+
+      expect(reactions.length).toBe(1)
+      expect(reactions[0].event.reaction).toBe('thumbsup')
+    })
+
+    it('also emits slack_event for every events_api dispatch', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const generic: any[] = []
+      listener.on('slack_event', (a) => generic.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_g1', { type: 'message', channel: 'C', ts: '1' })
+      mockWsInstance.simulateEventsApi('env_g2', { type: 'app_mention', channel: 'C', user: 'U', text: 'hi', ts: '2' })
+
+      expect(generic.length).toBe(2)
+    })
+
+    it('ignores events_api envelope with no inner event.type', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const events: any[] = []
+      listener.on('slack_event', (a) => events.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateMessage({
+        type: 'events_api',
+        envelope_id: 'env_bad',
+        payload: { event: {} },
+      })
+
+      expect(events.length).toBe(0)
+    })
+  })
+
+  describe('slash_commands envelope', () => {
+    it('emits slash_commands with ack and command payload', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const commands: SlackSocketModeSlashCommandArgs[] = []
+      listener.on('slash_commands', (a) => commands.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateSlashCommand('env_sc1', {
+        command: '/deploy',
+        text: 'production',
+        user_id: 'U1',
+        channel_id: 'C1',
+        team_id: 'T1',
+      })
+
+      expect(commands.length).toBe(1)
+      expect(commands[0].body.command).toBe('/deploy')
+      expect(commands[0].body.text).toBe('production')
+      expect(commands[0].accepts_response_payload).toBe(true)
+
+      commands[0].ack({ text: 'Deploying...' })
+
+      expect(mockWsInstance.sent.length).toBe(1)
+      expect(JSON.parse(mockWsInstance.sent[0])).toEqual({
+        envelope_id: 'env_sc1',
+        payload: { text: 'Deploying...' },
+      })
+    })
+  })
+
+  describe('interactive envelope', () => {
+    it('emits interactive with ack and action payload', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const interactions: SlackSocketModeInteractiveArgs[] = []
+      listener.on('interactive', (a) => interactions.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateInteractive('env_i1', {
+        type: 'block_actions',
+        user: { id: 'U1' },
+        actions: [{ action_id: 'approve', value: 'PR-123' }],
+      })
+
+      expect(interactions.length).toBe(1)
+      expect(interactions[0].body.type).toBe('block_actions')
+
+      interactions[0].ack()
+
+      expect(JSON.parse(mockWsInstance.sent[0])).toEqual({ envelope_id: 'env_i1' })
+    })
+  })
+
+  describe('disconnect envelope', () => {
+    it('closes the WebSocket on disconnect message (triggering reconnect)', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      const ws = mockWsInstance
+      mockWsInstance.simulateDisconnect('refresh_requested')
+
+      expect(ws.readyState).toBe(MockWs.CLOSED)
+    })
+
+    it('does not emit slack_event for disconnect envelopes', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const events: any[] = []
+      listener.on('slack_event', (a) => events.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateDisconnect('warning')
+
+      expect(events.length).toBe(0)
+    })
+  })
+
+  describe('unknown envelope', () => {
+    it('emits slack_event for envelopes the listener does not specifically handle', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const events: any[] = []
+      listener.on('slack_event', (a) => events.push(a))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateMessage({ type: 'something_new', envelope_id: 'env_x', payload: { foo: 'bar' } })
+
+      expect(events.length).toBe(1)
+      expect(events[0].type).toBe('something_new')
+    })
+  })
+
+  describe('malformed frames', () => {
+    it('does not emit error or crash on invalid JSON', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const errors: Error[] = []
+      listener.on('error', (e) => errors.push(e))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateRawMessage('not json')
+
+      expect(errors.length).toBe(0)
+    })
+  })
+
+  describe('ping/pong', () => {
+    it('clears the pong timeout when a pong is received', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      ;(listener as any).pongTimer = setTimeout(() => {}, 60_000)
+
+      mockWsInstance.simulatePong()
+
+      expect((listener as any).pongTimer).toBeNull()
+    })
+  })
+
+  describe('stop', () => {
+    it('closes the WebSocket and prevents reconnection', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      listener.stop()
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(client.appsConnectionsOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('ack after stop is a no-op', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      let captured: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent> | null = null
+      listener.on('message', (a) => {
+        captured = a
+      })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('env_stop', { type: 'message', channel: 'C', ts: '1' })
+
+      const ws = mockWsInstance
+      listener.stop()
+      ws.sent = []
+
+      captured!.ack()
+
+      expect(ws.sent.length).toBe(0)
+    })
+  })
+
+  describe('reconnection', () => {
+    it('reconnects after WebSocket close while running', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const disconnected: boolean[] = []
+      listener.on('disconnected', () => disconnected.push(true))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateClose()
+
+      expect(disconnected.length).toBe(1)
+
+      await new Promise((r) => setTimeout(r, 1500))
+      expect(client.appsConnectionsOpen.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('emits error and reconnects on appsConnectionsOpen network failure', async () => {
+      let callCount = 0
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => {
+          callCount++
+          if (callCount === 1) return Promise.reject(new Error('network_error'))
+          return Promise.resolve({ url: 'wss://wss.slack.com/?ticket=2' })
+        }),
+      })
+
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const errors: Error[] = []
+      listener.on('error', (e) => errors.push(e))
+
+      await listener.start()
+      await new Promise((r) => setTimeout(r, 1500))
+
+      expect(errors.length).toBe(1)
+      expect(errors[0].message).toBe('network_error')
+      expect(client.appsConnectionsOpen.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('does not reconnect on fatal Slack errors', async () => {
+      const fatal: any = new Error('invalid auth')
+      fatal.code = 'invalid_auth'
+
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => Promise.reject(fatal)),
+      })
+
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const errors: Error[] = []
+      listener.on('error', (e) => errors.push(e))
+
+      await listener.start()
+      await new Promise((r) => setTimeout(r, 1500))
+
+      expect(errors.length).toBe(1)
+      expect(client.appsConnectionsOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reconnect on missing_app_token', async () => {
+      const fatal: any = new Error('missing app token')
+      fatal.code = 'missing_app_token'
+
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => Promise.reject(fatal)),
+      })
+
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const errors: Error[] = []
+      listener.on('error', (e) => errors.push(e))
+
+      await listener.start()
+      await new Promise((r) => setTimeout(r, 1500))
+
+      expect(client.appsConnectionsOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('resets reconnectAttempts to 0 on hello after reconnect', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      ;(listener as any).reconnectAttempts = 3
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      expect((listener as any).reconnectAttempts).toBe(0)
+    })
+  })
+
+  describe('on/off/once', () => {
+    it('off removes a listener', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const messages: any[] = []
+      const handler = (a: any) => messages.push(a.event)
+      listener.on('message', handler)
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('e1', { type: 'message', channel: 'C', text: 'a', ts: '1' })
+
+      listener.off('message', handler)
+      mockWsInstance.simulateEventsApi('e2', { type: 'message', channel: 'C', text: 'b', ts: '2' })
+
+      expect(messages.length).toBe(1)
+      expect(messages[0].text).toBe('a')
+    })
+
+    it('once fires only once', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const messages: any[] = []
+      listener.once('message', (a) => messages.push(a.event))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+      mockWsInstance.simulateEventsApi('e1', { type: 'message', channel: 'C', text: 'first', ts: '1' })
+      mockWsInstance.simulateEventsApi('e2', { type: 'message', channel: 'C', text: 'second', ts: '2' })
+
+      expect(messages.length).toBe(1)
+      expect(messages[0].text).toBe('first')
+    })
+  })
+
+  describe('generation guard', () => {
+    it('ignores frames from a stale socket after stop/start', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const messages: any[] = []
+      listener.on('message', (a) => messages.push(a.event))
+
+      await listener.start()
+      const staleWs = mockWsInstance
+      staleWs.simulateOpen()
+
+      listener.stop()
+      await listener.start()
+
+      staleWs.simulateMessage({
+        type: 'events_api',
+        envelope_id: 'stale',
+        payload: { event: { type: 'message', channel: 'C', text: 'old', ts: '1' } },
+      })
+
+      expect(messages.length).toBe(0)
+    })
+  })
+})

--- a/src/platforms/slackbot/listener.test.ts
+++ b/src/platforms/slackbot/listener.test.ts
@@ -748,5 +748,265 @@ describe('SlackBotListener', () => {
 
       expect(messages.length).toBe(0)
     })
+
+    it('ignores stale close events after stop+start (does not double-schedule reconnect)', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      const staleWs = mockWsInstance
+      staleWs.simulateOpen()
+
+      listener.stop()
+      await listener.start()
+      const callsAfterRestart = client.appsConnectionsOpen.mock.calls.length
+
+      staleWs.simulateClose()
+      await new Promise((r) => setTimeout(r, 1500))
+
+      expect(client.appsConnectionsOpen.mock.calls.length).toBe(callsAfterRestart)
+    })
+
+    it('stale ack after reconnect targets the new socket guard, not the old socket', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      let captured: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent> | null = null
+      listener.on('message', (a) => {
+        captured = a
+      })
+
+      await listener.start()
+      const staleWs = mockWsInstance
+      staleWs.simulateOpen()
+      staleWs.simulateHello()
+      staleWs.simulateEventsApi('env_stale', { type: 'message', channel: 'C', ts: '1' })
+
+      listener.stop()
+      await listener.start()
+
+      const newWs = mockWsInstance
+      expect(newWs).not.toBe(staleWs)
+
+      captured!.ack()
+
+      expect(newWs.sent.length).toBe(0)
+      expect(staleWs.sent.length).toBe(0)
+    })
+  })
+
+  describe('start after stop', () => {
+    it('resets reconnect attempts on fresh start', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      ;(listener as any).reconnectAttempts = 5
+      listener.stop()
+
+      await listener.start()
+      expect((listener as any).reconnectAttempts).toBe(0)
+    })
+
+    it('clears retryAfter floor on fresh start', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      ;(listener as any).nextReconnectFloorMs = 5000
+      listener.stop()
+
+      await listener.start()
+      expect((listener as any).nextReconnectFloorMs).toBe(0)
+    })
+  })
+
+  describe('zombie connection', () => {
+    it('closes the WebSocket when no pong arrives within the timeout', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      const ws = mockWsInstance
+
+      const pingTimer = (listener as any).pingTimer
+      if (pingTimer) clearInterval(pingTimer)
+      ws.ping()
+      ;(listener as any).pongTimer = setTimeout(() => {
+        if (!(listener as any).isCurrent((listener as any).generation, ws)) return
+        ws.close()
+      }, 5)
+
+      await new Promise((r) => setTimeout(r, 30))
+
+      expect(ws.readyState).toBe(MockWs.CLOSED)
+    })
+  })
+
+  describe('disconnect envelope reason handling', () => {
+    it('resets reconnectAttempts on non-terminal disconnect (refresh_requested)', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      ;(listener as any).reconnectAttempts = 5
+      mockWsInstance.simulateDisconnect('refresh_requested')
+
+      expect((listener as any).reconnectAttempts).toBe(0)
+    })
+
+    it('resets reconnectAttempts on warning disconnect', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      ;(listener as any).reconnectAttempts = 3
+      mockWsInstance.simulateDisconnect('warning')
+
+      expect((listener as any).reconnectAttempts).toBe(0)
+    })
+
+    it('treats link_disabled as terminal: emits error, stops, no reconnect', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      const errors: Error[] = []
+      listener.on('error', (e) => errors.push(e))
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      mockWsInstance.simulateHello()
+
+      const callsBeforeDisconnect = client.appsConnectionsOpen.mock.calls.length
+      mockWsInstance.simulateDisconnect('link_disabled')
+      await new Promise((r) => setTimeout(r, 1500))
+
+      expect(errors.length).toBe(1)
+      expect(errors[0].message).toMatch(/link_disabled/)
+      expect(client.appsConnectionsOpen.mock.calls.length).toBe(callsBeforeDisconnect)
+    })
+  })
+
+  describe('hello timeout', () => {
+    it('closes the socket if hello does not arrive within HELLO_TIMEOUT', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      const ws = mockWsInstance
+
+      const helloTimer = (listener as any).helloTimer
+      expect(helloTimer).not.toBeNull()
+
+      ;(listener as any).clearHelloTimer()
+      ;(listener as any).helloTimer = setTimeout(() => {
+        if (!(listener as any).isCurrent((listener as any).generation, ws)) return
+        ws.close()
+      }, 5)
+
+      await new Promise((r) => setTimeout(r, 30))
+
+      expect(ws.readyState).toBe(MockWs.CLOSED)
+    })
+
+    it('clears the hello timer once hello arrives', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      await listener.start()
+      mockWsInstance.simulateOpen()
+      expect((listener as any).helloTimer).not.toBeNull()
+
+      mockWsInstance.simulateHello()
+      expect((listener as any).helloTimer).toBeNull()
+    })
+  })
+
+  describe('retryAfter floor', () => {
+    it('uses retryAfter as a floor on the next reconnect delay', async () => {
+      const rateLimited: any = new Error('rate limited')
+      rateLimited.code = 'slack_webapi_rate_limited_error'
+      rateLimited.retryAfter = 5
+
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => Promise.reject(rateLimited)),
+      })
+
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+      listener.on('error', () => {})
+
+      const setTimeoutSpy = mock<typeof setTimeout>()
+      const realSetTimeout = globalThis.setTimeout
+      globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+        setTimeoutSpy(fn, ms)
+        return realSetTimeout(() => {}, 1_000_000) as any
+      }) as any
+
+      try {
+        await listener.start()
+      } finally {
+        globalThis.setTimeout = realSetTimeout
+      }
+
+      const reconnectCalls = setTimeoutSpy.mock.calls.filter((call) => {
+        const ms = call[1] as number | undefined
+        return typeof ms === 'number' && ms >= 1000
+      })
+      expect(reconnectCalls.length).toBeGreaterThanOrEqual(1)
+      expect(reconnectCalls[0][1]).toBe(5000)
+    })
+
+    it('does not set floor when retryAfter is absent (uses base exponential delay)', async () => {
+      const networkErr: any = new Error('boom')
+      const client = createMockClient({
+        appsConnectionsOpen: mock(() => Promise.reject(networkErr)),
+      })
+
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+      listener.on('error', () => {})
+
+      const setTimeoutSpy = mock<typeof setTimeout>()
+      const realSetTimeout = globalThis.setTimeout
+      globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+        setTimeoutSpy(fn, ms)
+        return realSetTimeout(() => {}, 1_000_000) as any
+      }) as any
+
+      try {
+        await listener.start()
+      } finally {
+        globalThis.setTimeout = realSetTimeout
+      }
+
+      const reconnectCalls = setTimeoutSpy.mock.calls.filter((call) => {
+        const ms = call[1] as number | undefined
+        return typeof ms === 'number' && ms >= 1000
+      })
+      expect(reconnectCalls.length).toBeGreaterThanOrEqual(1)
+      expect(reconnectCalls[0][1]).toBe(1000)
+    })
+
+    it('clears floor after applying it once', async () => {
+      const client = createMockClient()
+      listener = new SlackBotListener(client, { appToken: APP_TOKEN })
+
+      ;(listener as any).running = true
+      ;(listener as any).generation = 1
+      ;(listener as any).nextReconnectFloorMs = 7000
+      ;(listener as any).scheduleReconnect()
+
+      expect((listener as any).nextReconnectFloorMs).toBe(0)
+      clearTimeout((listener as any).reconnectTimer)
+    })
   })
 })

--- a/src/platforms/slackbot/listener.ts
+++ b/src/platforms/slackbot/listener.ts
@@ -21,6 +21,7 @@ const RECONNECT_BASE_DELAY = 1_000
 const RECONNECT_MAX_DELAY = 30_000
 const PING_INTERVAL = 30_000
 const PONG_TIMEOUT = 10_000
+const HELLO_TIMEOUT = 10_000
 
 const FATAL_ERROR_CODES = new Set([
   'not_authed',
@@ -32,6 +33,8 @@ const FATAL_ERROR_CODES = new Set([
   'missing_app_token',
   'invalid_app_token_type',
 ])
+
+const TERMINAL_DISCONNECT_REASONS = new Set(['link_disabled'])
 
 type EventKey = keyof SlackBotListenerEventMap
 
@@ -49,8 +52,10 @@ export class SlackBotListener {
   private emitter = new EventEmitter()
   private pingTimer: ReturnType<typeof setInterval> | null = null
   private pongTimer: ReturnType<typeof setTimeout> | null = null
+  private helloTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
+  private nextReconnectFloorMs = 0
   private generation = 0
 
   constructor(client: SlackBotClient, options: SlackBotListenerOptions) {
@@ -66,6 +71,7 @@ export class SlackBotListener {
     if (this.running) return
     this.running = true
     this.reconnectAttempts = 0
+    this.nextReconnectFloorMs = 0
     this.generation++
     await this.connect(this.generation)
   }
@@ -118,6 +124,7 @@ export class SlackBotListener {
           return
         }
         this.startPing(generation, ws)
+        this.armHelloTimeout(generation, ws)
       })
 
       ws.on('message', (raw) => {
@@ -160,6 +167,11 @@ export class SlackBotListener {
         return
       }
 
+      const retryAfter = (error as { retryAfter?: number })?.retryAfter
+      if (typeof retryAfter === 'number' && retryAfter > 0) {
+        this.nextReconnectFloorMs = retryAfter * 1000
+      }
+
       if (this.running) {
         this.scheduleReconnect()
       }
@@ -172,6 +184,7 @@ export class SlackBotListener {
     switch (envelope.type) {
       case 'hello': {
         const hello = envelope as { connection_info?: { app_id?: string }; num_connections?: number }
+        this.clearHelloTimer()
         this.reconnectAttempts = 0
         this.emitter.emit('connected', {
           app_id: hello.connection_info?.app_id,
@@ -181,8 +194,20 @@ export class SlackBotListener {
       }
 
       case 'disconnect': {
-        // Slack tells us to reconnect (warning, refresh_requested, link_disabled).
-        // Closing the socket triggers our `close` handler which schedules a reconnect.
+        // Server-requested reconnect (warning, refresh_requested) — analogous to
+        // Discord opcode 7, so reset backoff. `link_disabled` is terminal: the app
+        // was disabled, reconnecting would loop forever.
+        const reason = (envelope as { reason?: string }).reason
+        if (reason && TERMINAL_DISCONNECT_REASONS.has(reason)) {
+          this.emitter.emit(
+            'error',
+            new SlackBotError(`Slack closed the Socket Mode session: ${reason}`, 'disconnect_terminal'),
+          )
+          this.running = false
+          ws.close()
+          return
+        }
+        this.reconnectAttempts = 0
         ws.close()
         return
       }
@@ -264,6 +289,22 @@ export class SlackBotListener {
     }
   }
 
+  private armHelloTimeout(generation: number, ws: WebSocket): void {
+    this.clearHelloTimer()
+    this.helloTimer = setTimeout(() => {
+      this.helloTimer = null
+      if (!this.isCurrent(generation, ws)) return
+      ws.close()
+    }, HELLO_TIMEOUT)
+  }
+
+  private clearHelloTimer(): void {
+    if (this.helloTimer) {
+      clearTimeout(this.helloTimer)
+      this.helloTimer = null
+    }
+  }
+
   private startPing(generation: number, ws: WebSocket): void {
     this.clearPingTimers()
     this.pingTimer = setInterval(() => {
@@ -284,7 +325,9 @@ export class SlackBotListener {
   }
 
   private scheduleReconnect(): void {
-    const delay = Math.min(RECONNECT_BASE_DELAY * 2 ** this.reconnectAttempts, RECONNECT_MAX_DELAY)
+    const exponential = Math.min(RECONNECT_BASE_DELAY * 2 ** this.reconnectAttempts, RECONNECT_MAX_DELAY)
+    const delay = Math.max(exponential, this.nextReconnectFloorMs)
+    this.nextReconnectFloorMs = 0
     this.reconnectAttempts++
     const generation = this.generation
     this.reconnectTimer = setTimeout(() => {
@@ -310,6 +353,7 @@ export class SlackBotListener {
 
   private clearTimers(): void {
     this.clearPingTimers()
+    this.clearHelloTimer()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null

--- a/src/platforms/slackbot/listener.ts
+++ b/src/platforms/slackbot/listener.ts
@@ -1,0 +1,318 @@
+import { EventEmitter } from 'events'
+
+import WebSocket from 'ws'
+
+import type { SlackBotClient } from './client'
+import { SlackBotError } from './types'
+import type {
+  SlackBotListenerEventMap,
+  SlackSocketModeAck,
+  SlackSocketModeEnvelope,
+  SlackSocketModeEventsApiArgs,
+  SlackSocketModeEventsApiEnvelope,
+  SlackSocketModeGenericEvent,
+  SlackSocketModeInteractiveArgs,
+  SlackSocketModeInteractiveEnvelope,
+  SlackSocketModeSlashCommandArgs,
+  SlackSocketModeSlashCommandEnvelope,
+} from './types'
+
+const RECONNECT_BASE_DELAY = 1_000
+const RECONNECT_MAX_DELAY = 30_000
+const PING_INTERVAL = 30_000
+const PONG_TIMEOUT = 10_000
+
+const FATAL_ERROR_CODES = new Set([
+  'not_authed',
+  'invalid_auth',
+  'account_inactive',
+  'user_removed_from_team',
+  'team_disabled',
+  'not_allowed_token_type',
+  'missing_app_token',
+  'invalid_app_token_type',
+])
+
+type EventKey = keyof SlackBotListenerEventMap
+
+export interface SlackBotListenerOptions {
+  appToken: string
+  debugReconnects?: boolean
+}
+
+export class SlackBotListener {
+  private client: SlackBotClient
+  private appToken: string
+  private debugReconnects: boolean
+  private running = false
+  private ws: WebSocket | null = null
+  private emitter = new EventEmitter()
+  private pingTimer: ReturnType<typeof setInterval> | null = null
+  private pongTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private generation = 0
+
+  constructor(client: SlackBotClient, options: SlackBotListenerOptions) {
+    if (!options?.appToken) {
+      throw new SlackBotError('App-level token (xapp-) is required for Socket Mode', 'missing_app_token')
+    }
+    this.client = client
+    this.appToken = options.appToken
+    this.debugReconnects = options.debugReconnects ?? false
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+    this.reconnectAttempts = 0
+    this.generation++
+    await this.connect(this.generation)
+  }
+
+  stop(): void {
+    this.running = false
+    this.generation++
+    this.clearTimers()
+    if (this.ws) {
+      this.ws.close()
+      this.ws = null
+    }
+  }
+
+  on<K extends EventKey>(event: K, listener: (...args: SlackBotListenerEventMap[K]) => void): this {
+    this.emitter.on(event, listener as (...args: any[]) => void)
+    return this
+  }
+
+  off<K extends EventKey>(event: K, listener: (...args: SlackBotListenerEventMap[K]) => void): this {
+    this.emitter.off(event, listener as (...args: any[]) => void)
+    return this
+  }
+
+  once<K extends EventKey>(event: K, listener: (...args: SlackBotListenerEventMap[K]) => void): this {
+    this.emitter.once(event, listener as (...args: any[]) => void)
+    return this
+  }
+
+  private isCurrent(generation: number, ws?: WebSocket): boolean {
+    if (generation !== this.generation || !this.running) return false
+    if (ws !== undefined && this.ws !== ws) return false
+    return true
+  }
+
+  private async connect(generation: number): Promise<void> {
+    if (!this.isCurrent(generation)) return
+
+    try {
+      const { url } = await this.client.appsConnectionsOpen(this.appToken)
+      if (!this.isCurrent(generation)) return
+
+      const wsUrl = this.debugReconnects ? `${url}${url.includes('?') ? '&' : '?'}debug_reconnects=true` : url
+      const ws = new WebSocket(wsUrl)
+      this.ws = ws
+
+      ws.on('open', () => {
+        if (!this.isCurrent(generation, ws)) {
+          ws.close()
+          return
+        }
+        this.startPing(generation, ws)
+      })
+
+      ws.on('message', (raw) => {
+        if (!this.isCurrent(generation, ws)) return
+        try {
+          const data = JSON.parse(raw.toString()) as SlackSocketModeEnvelope
+          this.handleEnvelope(data, generation, ws)
+        } catch {
+          // Malformed frame; ignore — ping/pong handles liveness.
+        }
+      })
+
+      ws.on('pong', () => {
+        if (!this.isCurrent(generation, ws)) return
+        this.clearPongTimer()
+      })
+
+      ws.on('close', () => {
+        if (!this.isCurrent(generation, ws)) return
+        this.clearTimers()
+        this.ws = null
+        if (this.running) {
+          this.emitter.emit('disconnected')
+          this.scheduleReconnect()
+        }
+      })
+
+      ws.on('error', (err) => {
+        if (!this.isCurrent(generation, ws)) return
+        this.emitter.emit('error', err instanceof Error ? err : new Error(String(err)))
+      })
+    } catch (error) {
+      if (!this.isCurrent(generation)) return
+      const wrapped = error instanceof Error ? error : new Error(String(error))
+      this.emitter.emit('error', wrapped)
+
+      const code = (error as { code?: string })?.code
+      if (code && FATAL_ERROR_CODES.has(code)) {
+        this.running = false
+        return
+      }
+
+      if (this.running) {
+        this.scheduleReconnect()
+      }
+    }
+  }
+
+  private handleEnvelope(envelope: SlackSocketModeEnvelope, generation: number, ws: WebSocket): void {
+    if (!this.isCurrent(generation, ws)) return
+
+    switch (envelope.type) {
+      case 'hello': {
+        const hello = envelope as { connection_info?: { app_id?: string }; num_connections?: number }
+        this.reconnectAttempts = 0
+        this.emitter.emit('connected', {
+          app_id: hello.connection_info?.app_id,
+          num_connections: hello.num_connections,
+        })
+        return
+      }
+
+      case 'disconnect': {
+        // Slack tells us to reconnect (warning, refresh_requested, link_disabled).
+        // Closing the socket triggers our `close` handler which schedules a reconnect.
+        ws.close()
+        return
+      }
+
+      case 'events_api': {
+        this.dispatchEventsApi(envelope as SlackSocketModeEventsApiEnvelope, generation, ws)
+        return
+      }
+
+      case 'slash_commands': {
+        this.dispatchSlashCommand(envelope as SlackSocketModeSlashCommandEnvelope, generation, ws)
+        return
+      }
+
+      case 'interactive': {
+        this.dispatchInteractive(envelope as SlackSocketModeInteractiveEnvelope, generation, ws)
+        return
+      }
+
+      default: {
+        this.emitter.emit('slack_event', envelope)
+      }
+    }
+  }
+
+  private dispatchEventsApi(envelope: SlackSocketModeEventsApiEnvelope, generation: number, ws: WebSocket): void {
+    const event = envelope.payload?.event as SlackSocketModeGenericEvent | undefined
+    if (!event?.type) return
+
+    const ack = this.makeAck(envelope.envelope_id, generation, ws)
+    const args: SlackSocketModeEventsApiArgs = {
+      ack,
+      envelope_id: envelope.envelope_id,
+      body: envelope.payload,
+      event,
+      retry_num: envelope.retry_attempt,
+      retry_reason: envelope.retry_reason,
+      accepts_response_payload: envelope.accepts_response_payload,
+    }
+
+    this.emitter.emit(event.type, args)
+    this.emitter.emit('slack_event', args)
+  }
+
+  private dispatchSlashCommand(envelope: SlackSocketModeSlashCommandEnvelope, generation: number, ws: WebSocket): void {
+    const ack = this.makeAck(envelope.envelope_id, generation, ws)
+    const args: SlackSocketModeSlashCommandArgs = {
+      ack,
+      envelope_id: envelope.envelope_id,
+      body: envelope.payload,
+      accepts_response_payload: envelope.accepts_response_payload,
+    }
+    this.emitter.emit('slash_commands', args)
+  }
+
+  private dispatchInteractive(envelope: SlackSocketModeInteractiveEnvelope, generation: number, ws: WebSocket): void {
+    const ack = this.makeAck(envelope.envelope_id, generation, ws)
+    const args: SlackSocketModeInteractiveArgs = {
+      ack,
+      envelope_id: envelope.envelope_id,
+      body: envelope.payload,
+      accepts_response_payload: envelope.accepts_response_payload,
+    }
+    this.emitter.emit('interactive', args)
+  }
+
+  private makeAck(envelopeId: string, generation: number, ws: WebSocket): SlackSocketModeAck {
+    let acked = false
+    return (responsePayload?: Record<string, unknown>) => {
+      if (acked) return
+      acked = true
+      if (!this.isCurrent(generation, ws)) return
+      if (ws.readyState !== WebSocket.OPEN) return
+      const message =
+        responsePayload === undefined
+          ? { envelope_id: envelopeId }
+          : { envelope_id: envelopeId, payload: responsePayload }
+      ws.send(JSON.stringify(message))
+    }
+  }
+
+  private startPing(generation: number, ws: WebSocket): void {
+    this.clearPingTimers()
+    this.pingTimer = setInterval(() => {
+      if (!this.isCurrent(generation, ws)) {
+        this.clearPingTimers()
+        return
+      }
+      if (ws.readyState !== WebSocket.OPEN) return
+
+      ws.ping()
+
+      this.clearPongTimer()
+      this.pongTimer = setTimeout(() => {
+        if (!this.isCurrent(generation, ws)) return
+        ws.close()
+      }, PONG_TIMEOUT)
+    }, PING_INTERVAL)
+  }
+
+  private scheduleReconnect(): void {
+    const delay = Math.min(RECONNECT_BASE_DELAY * 2 ** this.reconnectAttempts, RECONNECT_MAX_DELAY)
+    this.reconnectAttempts++
+    const generation = this.generation
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.connect(generation)
+    }, delay)
+  }
+
+  private clearPongTimer(): void {
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer)
+      this.pongTimer = null
+    }
+  }
+
+  private clearPingTimers(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer)
+      this.pingTimer = null
+    }
+    this.clearPongTimer()
+  }
+
+  private clearTimers(): void {
+    this.clearPingTimers()
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+}

--- a/src/platforms/slackbot/types.ts
+++ b/src/platforms/slackbot/types.ts
@@ -221,3 +221,224 @@ export const SlackFileSchema = z.object({
   user: z.string(),
   channels: z.array(z.string()).optional(),
 })
+
+// Socket Mode envelope types — see https://api.slack.com/apis/socket-mode
+
+export interface SlackSocketModeHelloEnvelope {
+  type: 'hello'
+  connection_info?: { app_id: string }
+  num_connections?: number
+  debug_info?: {
+    host?: string
+    started?: string
+    build_number?: number
+    approximate_connection_time?: number
+  }
+}
+
+export type SlackSocketModeDisconnectReason = 'warning' | 'refresh_requested' | 'link_disabled' | string
+
+export interface SlackSocketModeDisconnectEnvelope {
+  type: 'disconnect'
+  reason: SlackSocketModeDisconnectReason
+  debug_info?: {
+    host?: string
+  }
+}
+
+export interface SlackSocketModeEventsApiEnvelope {
+  type: 'events_api'
+  envelope_id: string
+  payload: {
+    token?: string
+    team_id?: string
+    api_app_id?: string
+    event: SlackSocketModeEvent
+    type?: 'event_callback' | string
+    event_id?: string
+    event_time?: number
+    [key: string]: unknown
+  }
+  accepts_response_payload?: boolean
+  retry_attempt?: number
+  retry_reason?: string
+}
+
+export interface SlackSocketModeSlashCommandEnvelope {
+  type: 'slash_commands'
+  envelope_id: string
+  payload: {
+    command: string
+    text: string
+    user_id: string
+    user_name?: string
+    channel_id: string
+    channel_name?: string
+    team_id: string
+    team_domain?: string
+    api_app_id?: string
+    response_url?: string
+    trigger_id?: string
+    [key: string]: unknown
+  }
+  accepts_response_payload?: boolean
+}
+
+export interface SlackSocketModeInteractiveEnvelope {
+  type: 'interactive'
+  envelope_id: string
+  payload: {
+    type: string
+    user?: { id: string; username?: string; name?: string; team_id?: string }
+    api_app_id?: string
+    token?: string
+    trigger_id?: string
+    response_url?: string
+    actions?: Array<Record<string, unknown>>
+    view?: Record<string, unknown>
+    [key: string]: unknown
+  }
+  accepts_response_payload?: boolean
+}
+
+export interface SlackSocketModeGenericEnvelope {
+  type: string
+  envelope_id?: string
+  payload?: Record<string, unknown>
+  accepts_response_payload?: boolean
+  [key: string]: unknown
+}
+
+export type SlackSocketModeEnvelope =
+  | SlackSocketModeHelloEnvelope
+  | SlackSocketModeDisconnectEnvelope
+  | SlackSocketModeEventsApiEnvelope
+  | SlackSocketModeSlashCommandEnvelope
+  | SlackSocketModeInteractiveEnvelope
+  | SlackSocketModeGenericEnvelope
+
+// Inner Events API event lives at `payload.event` — see SlackSocketModeEventsApiEnvelope.
+
+export interface SlackSocketModeMessageEvent {
+  type: 'message'
+  subtype?: string
+  channel: string
+  channel_type?: string
+  user?: string
+  bot_id?: string
+  text?: string
+  ts: string
+  thread_ts?: string
+  event_ts?: string
+  edited?: { user: string; ts: string }
+  hidden?: boolean
+  [key: string]: unknown
+}
+
+export interface SlackSocketModeAppMentionEvent {
+  type: 'app_mention'
+  channel: string
+  user: string
+  text: string
+  ts: string
+  thread_ts?: string
+  event_ts?: string
+  [key: string]: unknown
+}
+
+export interface SlackSocketModeReactionEvent {
+  type: 'reaction_added' | 'reaction_removed'
+  user: string
+  reaction: string
+  item: { type: string; channel: string; ts: string }
+  item_user?: string
+  event_ts: string
+  [key: string]: unknown
+}
+
+export interface SlackSocketModeMemberChannelEvent {
+  type: 'member_joined_channel' | 'member_left_channel'
+  user: string
+  channel: string
+  channel_type?: string
+  team?: string
+  event_ts?: string
+  [key: string]: unknown
+}
+
+export interface SlackSocketModeChannelEvent {
+  type:
+    | 'channel_created'
+    | 'channel_deleted'
+    | 'channel_rename'
+    | 'channel_archive'
+    | 'channel_unarchive'
+    | 'channel_left'
+  channel: { id: string; name?: string } | string
+  event_ts?: string
+  [key: string]: unknown
+}
+
+export interface SlackSocketModeGenericEvent {
+  type: string
+  [key: string]: unknown
+}
+
+export type SlackSocketModeEvent =
+  | SlackSocketModeMessageEvent
+  | SlackSocketModeAppMentionEvent
+  | SlackSocketModeReactionEvent
+  | SlackSocketModeMemberChannelEvent
+  | SlackSocketModeChannelEvent
+  | SlackSocketModeGenericEvent
+
+// Acknowledgment callback. Without args sends `{ envelope_id }`; with args sends
+// `{ envelope_id, payload }` (for `accepts_response_payload: true` envelopes).
+export type SlackSocketModeAck = (responsePayload?: Record<string, unknown>) => void
+
+export interface SlackSocketModeEventsApiArgs<E extends SlackSocketModeEvent = SlackSocketModeEvent> {
+  ack: SlackSocketModeAck
+  envelope_id: string
+  body: SlackSocketModeEventsApiEnvelope['payload']
+  event: E
+  retry_num?: number
+  retry_reason?: string
+  accepts_response_payload?: boolean
+}
+
+export interface SlackSocketModeSlashCommandArgs {
+  ack: SlackSocketModeAck
+  envelope_id: string
+  body: SlackSocketModeSlashCommandEnvelope['payload']
+  accepts_response_payload?: boolean
+}
+
+export interface SlackSocketModeInteractiveArgs {
+  ack: SlackSocketModeAck
+  envelope_id: string
+  body: SlackSocketModeInteractiveEnvelope['payload']
+  accepts_response_payload?: boolean
+}
+
+export interface SlackBotListenerEventMap {
+  connected: [info: { app_id?: string; num_connections?: number }]
+  disconnected: []
+  error: [error: Error]
+
+  message: [args: SlackSocketModeEventsApiArgs<SlackSocketModeMessageEvent>]
+  app_mention: [args: SlackSocketModeEventsApiArgs<SlackSocketModeAppMentionEvent>]
+  reaction_added: [args: SlackSocketModeEventsApiArgs<SlackSocketModeReactionEvent>]
+  reaction_removed: [args: SlackSocketModeEventsApiArgs<SlackSocketModeReactionEvent>]
+  member_joined_channel: [args: SlackSocketModeEventsApiArgs<SlackSocketModeMemberChannelEvent>]
+  member_left_channel: [args: SlackSocketModeEventsApiArgs<SlackSocketModeMemberChannelEvent>]
+  channel_created: [args: SlackSocketModeEventsApiArgs<SlackSocketModeChannelEvent>]
+  channel_deleted: [args: SlackSocketModeEventsApiArgs<SlackSocketModeChannelEvent>]
+  channel_rename: [args: SlackSocketModeEventsApiArgs<SlackSocketModeChannelEvent>]
+  channel_archive: [args: SlackSocketModeEventsApiArgs<SlackSocketModeChannelEvent>]
+  channel_unarchive: [args: SlackSocketModeEventsApiArgs<SlackSocketModeChannelEvent>]
+
+  slash_commands: [args: SlackSocketModeSlashCommandArgs]
+  interactive: [args: SlackSocketModeInteractiveArgs]
+
+  slack_event: [args: SlackSocketModeEventsApiArgs<SlackSocketModeGenericEvent> | SlackSocketModeGenericEnvelope]
+}

--- a/src/platforms/slackbot/types.ts
+++ b/src/platforms/slackbot/types.ts
@@ -30,11 +30,13 @@ export interface SlackBotConfig {
 // Error class for SlackBot operations
 export class SlackBotError extends Error {
   code: string
+  retryAfter?: number
 
-  constructor(message: string, code: string) {
+  constructor(message: string, code: string, retryAfter?: number) {
     super(message)
     this.name = 'SlackBotError'
     this.code = code
+    if (retryAfter !== undefined) this.retryAfter = retryAfter
   }
 }
 


### PR DESCRIPTION
## Summary

Adds `SlackBotListener` — a WebSocket Socket Mode client that streams Events API events, slash commands, and interactive components for bot SDK consumers. This fills the gap documented in the `agent-slackbot` skill as "No real-time events / Socket Mode".

The implementation mirrors the `DiscordBotListener` pattern from #167 but adapts to Slack's Socket Mode protocol: envelope-based delivery with explicit `envelope_id` acks, and a separate `xapp-` app-level token distinct from the `xoxb-` bot token.

## Changes

### New files
- `src/platforms/slackbot/listener.ts` — `SlackBotListener` class. Lifecycle: `apps.connections.open` → WebSocket → `hello` → dispatch → `ack` → reconnect on disconnect/close. Exponential backoff (1 s → 30 s cap), generation guard against stale-socket races, WebSocket-level ping/pong (RFC 6455) for liveness — Socket Mode does **not** use application-level pings like RTM. Fatal-error short-circuit on `apps.connections.open` error codes: `not_authed`, `invalid_auth`, `account_inactive`, `user_removed_from_team`, `team_disabled`, `not_allowed_token_type`. Transient errors get exponential backoff reconnect.
- `src/platforms/slackbot/listener.test.ts` — 34 new test cases covering `hello`, `events_api` dispatch and acknowledgment, `slash_commands`, interactive components, disconnect-triggered reconnect, malformed frames, fatal-error short-circuit, generation guard, `debug_reconnects` URL composition, and `on`/`off`/`once`.
- `src/platforms/slackbot/index.test.ts` — barrel export tests for the new SDK surface.
- `examples/slackbot-listen.ts` — runnable example showing message, reaction, slash command, and interactive event handling.

### Modified files
- `src/platforms/slackbot/types.ts` — adds `SlackSocketMode*` envelope types (`hello`, `disconnect`, `events_api`, `slash_commands`, `interactive`, `generic`), inner Events API event shapes, the `SlackSocketModeAck` callback type, handler argument shapes (`SlackSocketModeEventsApiArgs`, `SlashCommandArgs`, `InteractiveArgs`), and `SlackBotListenerEventMap` for typed `.on()` listeners.
- `src/platforms/slackbot/client.ts` — adds `appsConnectionsOpen(appToken)` returning `{ url }` so the listener can fetch the WebSocket URL. Uses a fresh `WebClient` bound to the `xapp-` token rather than the client's `xoxb-` token (Socket Mode requires the app-level token type). Validates the `xapp-` prefix.
- `src/platforms/slackbot/index.ts` — re-exports `SlackBotListener`, the Socket Mode types, and `SlackBotListenerOptions`. Splits `export type` from `export` to fix Bun's runtime resolution of interface-only exports (same fix discordbot did in #167).
- `README.md` — adds a "Real-time Events (Slack Bot)" SDK example block after the Discord Bot example, including the `xapp-` token requirement and the `ack` contract.
- `skills/agent-slackbot/SKILL.md` — flips the limitation "No real-time events / Socket Mode" to point users at the SDK.

## Context

Bot tokens (`xoxb-`) cannot use the legacy RTM API — that path is user-token only (via `SlackListener`). Socket Mode is the official Slack-supported path for real-time bot events without a public HTTP endpoint.

**Two-token design**: the listener takes an explicit `{ appToken }` option rather than reusing `SlackBotClient`'s bot token. Slack requires two distinct tokens for bots: `xoxb-` for Web API calls (`chat.postMessage`, etc.) and `xapp-` for Socket Mode. Conflating them at the type level would invite runtime 401s from Slack.

**`ack` semantics**: the `ack` callback handed to listeners is idempotent (only the first call hits the wire) and a no-op if the socket has been torn down. Calling with no args sends `{ envelope_id }`; calling with a payload sends `{ envelope_id, payload }` (for `accepts_response_payload: true` envelopes like slash commands).

**No CLI command is added** — per design, this PR is SDK-only, matching #167.

## Verification

- `bun typecheck` — clean.
- `bun lint` (oxlint) — 0 warnings, 0 errors.
- `oxfmt --check` on changed files — clean.
- `bun test src/platforms/slackbot/` — 138 pass, 0 fail (+45 new test cases; was 99 before this branch).
- The 3 pre-existing `src/platforms/slack/token-extractor.test.ts` failures reproduce on `origin/main` and are unrelated environment-dependent flakes (they read the developer's local Slack tokens), same as documented in #167.

## Review Notes

- The reconnect/lifecycle logic in `listener.ts` intentionally mirrors the `DiscordBotListener` from #167, diverging only on Socket Mode protocol specifics (envelope acks, `xapp-` token, `apps.connections.open` URL fetch). Any unexplained divergence from that pattern should be treated as a bug.
- Socket Mode uses WebSocket-level ping/pong (RFC 6455) for liveness — **not** application-level pings. Do not conflate with RTM's `ping` message type.
- The generation guard (`this.#generation`) prevents stale-socket callbacks from firing after a rapid `stop()`/`start()` cycle — same guard used in #167.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Slack Bot Socket Mode listener to stream real-time Slack events, slash commands, and interactive components over WebSocket. Improves reliability with better reconnects, hello timeout, and rate-limit backoff.

- **New Features**
  - Introduced `SlackBotListener` (Socket Mode): dispatches Events API, slash commands, and interactive payloads with explicit `ack()` (idempotent; supports response payloads).
  - Added `SlackBotClient.appsConnectionsOpen(appToken)` using an `xapp-` app-level token (validated) to fetch the WebSocket URL.
  - Reliable lifecycle: WebSocket ping/pong, 10s hello timeout, disconnect handling, exponential backoff (1s–30s), generation guard, optional `debugReconnects`.
  - New Socket Mode types and `SlackBotListenerEventMap`; barrel exports updated. Example added at `examples/slackbot-listen.ts`.
  - Docs updated: README adds “Real-time Events (Slack Bot)” and `ack` notes. `skills/agent-slackbot/SKILL.md` updated to reflect SDK real-time support.

- **Bug Fixes**
  - Reset reconnect backoff on non-terminal `disconnect` reasons (`warning`, `refresh_requested`).
  - Treat `link_disabled` as terminal: emit error, stop, and do not reconnect.
  - Close and reconnect if `hello` doesn’t arrive within 10s after socket open.
  - Preserve Slack rate-limit `retryAfter` and use it as a floor for the next reconnect delay (`SlackBotError` now carries `retryAfter`).

<sup>Written for commit 2f2a81a18df5dcda3858f4c7d394f68cfa67dc43. Summary will update on new commits. <a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/168?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

