### PR TITLE
feat(slackbot): add `message typing` for AI Assistant thread status

### DIFF
--- a/docs/content/docs/cli/slackbot.mdx
+++ b/docs/content/docs/cli/slackbot.mdx
@@ -166,7 +166,14 @@ agent-slackbot message update <channel> <ts> <new-text>
 
 # Delete a message (bot's own messages only)
 agent-slackbot message delete <channel> <ts> --force
+
+# Show typing/status indicator in an AI Assistant thread
+agent-slackbot message typing <channel> <thread_ts>
+agent-slackbot message typing C0ACZKTDDC0 1234567890.123456 "is analyzing..."
+agent-slackbot message typing C0ACZKTDDC0 1234567890.123456 ""   # clear status
 ```
+
+`message typing` calls Slack's `assistant.threads.setStatus` API. It only works inside **AI Assistant threads** (not regular channels/DMs) and requires the `chat:write` bot scope. The status auto-clears when your bot posts the next message, or after 2 minutes if no message is sent. Pass an empty string `""` to clear the status manually.
 
 ### Channel Commands
 

--- a/docs/content/docs/sdk/slackbot.mdx
+++ b/docs/content/docs/sdk/slackbot.mdx
@@ -79,6 +79,14 @@ const edited = await client.updateMessage('C0ACZKTDDC0', '1234567890.123456', 'U
 
 // Delete a message (bot can only delete its own messages)
 await client.deleteMessage('C0ACZKTDDC0', '1234567890.123456')
+
+// Show a typing/status indicator in an AI Assistant thread (e.g. "Bot is typing...")
+await client.setAssistantStatus('C0ACZKTDDC0', '1234567890.123456', 'is typing...')
+await client.setAssistantStatus('C0ACZKTDDC0', '1234567890.123456', 'is analyzing your code...')
+
+// Clear the status manually (status also auto-clears when the bot posts a message,
+// or after a 2-minute timeout). Only works inside AI Assistant threads — requires `chat:write`.
+await client.setAssistantStatus('C0ACZKTDDC0', '1234567890.123456', '')
 ```
 
 ### Reactions
@@ -460,6 +468,38 @@ listener.on('interactive', async ({ ack, body }) => {
     (body as { channel?: { id: string } }).channel!.id,
     `<@${body.user!.id}> approved PR ${action.value}`,
   )
+})
+
+await listener.start()
+```
+
+### AI Assistant Thread with Typing Indicator
+
+Show a "Bot is typing..." status while your agent is processing, then reply. Slack auto-clears the status when the bot posts its message. Requires the app to be configured as an AI Assistant (`assistant` scope, `assistant_thread_started` event) and a `chat:write` bot scope.
+
+```typescript
+import { SlackBotClient, SlackBotListener } from 'agent-messenger/slackbot'
+
+const client = await new SlackBotClient().login()
+const listener = new SlackBotListener(client, { appToken: process.env.SLACK_APP_TOKEN! })
+
+listener.on('message', async ({ ack, event }) => {
+  ack()
+  // Only handle messages inside an AI Assistant thread (skip top-level posts and bot echoes).
+  if (!event.thread_ts || event.subtype === 'bot_message') return
+
+  // Show "Bot is typing..." while the agent thinks.
+  await client.setAssistantStatus(event.channel, event.thread_ts, 'is typing...')
+
+  try {
+    const reply = await runAgent(event.text ?? '')
+    // Posting a reply auto-clears the status indicator.
+    await client.postMessage(event.channel, reply, { thread_ts: event.thread_ts })
+  } catch (err) {
+    // Clear the status on failure so it doesn't linger until the 2-minute timeout.
+    await client.setAssistantStatus(event.channel, event.thread_ts, '')
+    throw err
+  }
 })
 
 await listener.start()

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -211,7 +211,14 @@ agent-slackbot message update <channel> <ts> <new-text>
 
 # Delete a message (bot's own messages only)
 agent-slackbot message delete <channel> <ts> --force
+
+# Show typing/status indicator in an AI Assistant thread
+agent-slackbot message typing <channel> <thread_ts>
+agent-slackbot message typing <channel> <thread_ts> "is analyzing..."
+agent-slackbot message typing <channel> <thread_ts> ""   # clear status
 ```
+
+> **Typing indicators**: `message typing` calls Slack's `assistant.threads.setStatus` API. It only works inside **AI Assistant threads** (not regular channels/DMs) and requires the `chat:write` bot scope. The status auto-clears when your bot posts the next message, or after 2 minutes if no message is sent. Pass an empty string `""` to clear the status manually.
 
 ### Channel Commands
 

--- a/src/platforms/slackbot/client.test.ts
+++ b/src/platforms/slackbot/client.test.ts
@@ -65,6 +65,11 @@ const mockReactions = {
   add: mock(() => Promise.resolve({ ok: true })),
   remove: mock(() => Promise.resolve({ ok: true })),
 }
+const mockAssistant = {
+  threads: {
+    setStatus: mock(() => Promise.resolve({ ok: true })),
+  },
+}
 const mockUsers = {
   list: mock(() =>
     Promise.resolve({
@@ -105,6 +110,7 @@ mock.module('@slack/web-api', () => ({
     chat = mockChat
     reactions = mockReactions
     users = mockUsers
+    assistant = mockAssistant
   },
 }))
 
@@ -120,6 +126,7 @@ describe('SlackBotClient', () => {
     mockReactions.remove.mockClear()
     mockUsers.list.mockClear()
     mockUsers.info.mockClear()
+    mockAssistant.threads.setStatus.mockClear()
   })
 
   describe('login', () => {
@@ -221,6 +228,38 @@ describe('SlackBotClient', () => {
       // when/then: should not throw
       await client.removeReaction('C123', '1234567890.123456', 'thumbsup')
       expect(mockReactions.remove).toHaveBeenCalled()
+    })
+  })
+
+  describe('setAssistantStatus', () => {
+    it('sets assistant typing status with channel_id and thread_ts', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.setAssistantStatus('C123', '1234567890.123456', 'is typing...')
+
+      // then
+      expect(mockAssistant.threads.setStatus).toHaveBeenCalledWith({
+        channel_id: 'C123',
+        thread_ts: '1234567890.123456',
+        status: 'is typing...',
+      })
+    })
+
+    it('clears status when given empty string', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.setAssistantStatus('C123', '1234567890.123456', '')
+
+      // then
+      expect(mockAssistant.threads.setStatus).toHaveBeenCalledWith({
+        channel_id: 'C123',
+        thread_ts: '1234567890.123456',
+        status: '',
+      })
     })
   })
 

--- a/src/platforms/slackbot/client.ts
+++ b/src/platforms/slackbot/client.ts
@@ -453,6 +453,17 @@ export class SlackBotClient {
     })
   }
 
+  async setAssistantStatus(channel: string, threadTs: string, status: string): Promise<void> {
+    return this.withRetry(async () => {
+      const response = await this.ensureAuth().assistant.threads.setStatus({
+        channel_id: channel,
+        thread_ts: threadTs,
+        status,
+      })
+      this.checkResponse(response)
+    })
+  }
+
   async joinChannel(channel: string): Promise<void> {
     return this.withRetry(async () => {
       const response = await this.ensureAuth().conversations.join({ channel })

--- a/src/platforms/slackbot/commands/message.ts
+++ b/src/platforms/slackbot/commands/message.ts
@@ -98,6 +98,18 @@ async function deleteAction(channelInput: string, ts: string, options: BotOption
   }
 }
 
+async function typingAction(channelInput: string, threadTs: string, status: string, options: BotOption): Promise<void> {
+  try {
+    const client = await getClient(options)
+    const channel = await client.resolveChannel(channelInput)
+    await client.setAssistantStatus(channel, threadTs, status)
+
+    console.log(formatOutput({ channel, thread_ts: threadTs, status }, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 async function repliesAction(
   channelInput: string,
   threadTs: string,
@@ -164,6 +176,16 @@ export const messageCommand = new Command('message')
       .option('--bot <id>', 'Use specific bot')
       .option('--pretty', 'Pretty print JSON output')
       .action(deleteAction),
+  )
+  .addCommand(
+    new Command('typing')
+      .description('Set typing status in an AI Assistant thread (e.g. "is typing...")')
+      .argument('<channel>', 'Channel ID or name')
+      .argument('<thread_ts>', 'Thread timestamp')
+      .argument('[status]', 'Status text (pass empty string to clear)', 'is typing...')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(typingAction),
   )
   .addCommand(
     new Command('replies')


### PR DESCRIPTION
## Summary

Adds a typing indicator for `agent-slackbot` so bots can show "Bot is typing…" (or any custom status) while an agent is processing a request inside a Slack **AI Assistant thread**.

- New `SlackBotClient.setAssistantStatus(channel, threadTs, status)` SDK method, wrapping Slack's [`assistant.threads.setStatus`](https://docs.slack.dev/reference/methods/assistant.threads.setStatus) Web API.
- New `agent-slackbot message typing <channel> <thread_ts> [status]` CLI subcommand. Status defaults to `"is typing..."`; pass `""` to clear.
- Slack auto-clears the status when the bot posts the next message, or after a 2-minute timeout.

## Why this scope (and not regular `user_typing`)

The classic `user_typing` indicator visible in regular DMs/channels is **only** sendable over Slack's RTM/WebSocket API with a **user token** (`xoxc-`). Bot tokens (`xoxb-`) cannot send `user_typing` — that path is fully closed off by Slack. The only typing-style signal a bot can send is `assistant.threads.setStatus`, which is scoped to AI Assistant threads. This PR implements that path and documents the constraint clearly.

## Constraints documented

- Only works inside **AI Assistant threads** — calling it in regular channels/DMs returns an error from Slack.
- Requires the `chat:write` bot scope (Slack is deprecating `assistant:write` for this method as of March 2026 — see [changelog](https://docs.slack.dev/changelog/2026/03/05/set-status-scope-update); `chat:write` is the forward-compatible scope).

## Usage

CLI:
```bash
agent-slackbot message typing C0ACZKTDDC0 1234567890.123456
agent-slackbot message typing C0ACZKTDDC0 1234567890.123456 "is analyzing..."
agent-slackbot message typing C0ACZKTDDC0 1234567890.123456 ""   # clear
```

SDK:
```typescript
await client.setAssistantStatus('C0ACZKTDDC0', '1234567890.123456', 'is typing...')
// posting a reply auto-clears the status
await client.postMessage('C0ACZKTDDC0', reply, { thread_ts: '1234567890.123456' })
```

## Test plan

- `bun test src/platforms/slackbot/` — 156 pass / 0 fail (2 new tests added: sets status with correct params; clears with empty string).
- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- Verified `agent-slackbot message typing --help` renders the new command with the default status value.

## Files changed

| File | Change |
|---|---|
| `src/platforms/slackbot/client.ts` | New `setAssistantStatus` method following the existing `withRetry` + `ensureAuth` + `checkResponse` pattern. |
| `src/platforms/slackbot/commands/message.ts` | New `typing` subcommand under `message`. |
| `src/platforms/slackbot/client.test.ts` | Added `mockAssistant.threads.setStatus` to the WebClient mock and 2 unit tests. |
| `skills/agent-slackbot/SKILL.md` | Documented the `typing` command + constraint callout. |
| `docs/content/docs/cli/slackbot.mdx` | Same docs in the public CLI reference. |
| `docs/content/docs/sdk/slackbot.mdx` | SDK reference for `setAssistantStatus` + a real-world "AI Assistant Thread with Typing Indicator" example using `SlackBotListener`. |