### PR TITLE
feat(slackbot): add file upload, list, info, download, delete commands

### DIFF
--- a/docs/content/docs/cli/slackbot.mdx
+++ b/docs/content/docs/cli/slackbot.mdx
@@ -54,6 +54,8 @@ oauth_config:
       - users:read.email
       - reactions:write
       - reactions:read
+      - files:read
+      - files:write
 
 settings:
   org_deploy_enabled: false
@@ -108,18 +110,20 @@ agent-slackbot auth remove deploy
 
 ### Scopes Reference
 
-| Scope              | Used For                         |
-| ------------------ | -------------------------------- |
-| `chat:write`       | Sending and updating messages    |
-| `channels:history` | Reading public channel messages  |
-| `channels:read`    | Listing public channels          |
-| `channels:join`    | Joining public channels          |
-| `groups:history`   | Reading private channel messages |
-| `groups:read`      | Listing private channels         |
-| `users:read`       | Listing users                    |
-| `users:read.email` | Reading user emails              |
-| `reactions:write`  | Adding/removing reactions        |
-| `reactions:read`   | Listing reactions                |
+| Scope              | Used For                             |
+| ------------------ | ------------------------------------ |
+| `chat:write`       | Sending and updating messages        |
+| `channels:history` | Reading public channel messages      |
+| `channels:read`    | Listing public channels              |
+| `channels:join`    | Joining public channels              |
+| `groups:history`   | Reading private channel messages     |
+| `groups:read`      | Listing private channels             |
+| `users:read`       | Listing users                        |
+| `users:read.email` | Reading user emails                  |
+| `reactions:write`  | Adding/removing reactions            |
+| `reactions:read`   | Listing reactions                    |
+| `files:read`       | Listing/inspecting/downloading files |
+| `files:write`      | Uploading and deleting files         |
 
 ### Environment Variables (CI/CD)
 
@@ -209,18 +213,45 @@ agent-slackbot reaction add C0ACZKTDDC0 1234567890.123456 thumbsup
 agent-slackbot reaction remove <channel> <ts> <emoji>
 ```
 
+### File Commands
+
+```bash
+# Upload a file to a channel
+agent-slackbot file upload <channel> <path>
+agent-slackbot file upload C0ACZKTDDC0 ./report.pdf
+agent-slackbot file upload C0ACZKTDDC0 ./log.txt --filename build-log.txt
+agent-slackbot file upload C0ACZKTDDC0 ./screenshot.png --thread 1234567890.123456 --comment "FYI"
+
+# List files visible to the bot
+agent-slackbot file list
+agent-slackbot file list --channel C0ACZKTDDC0
+agent-slackbot file list --user U123 --limit 50
+
+# Show file details
+agent-slackbot file info <file-id>
+
+# Download a file by ID
+agent-slackbot file download <file-id>
+agent-slackbot file download F0123ABC ./downloads/
+
+# Delete a file (bot's own files only)
+agent-slackbot file delete <file-id> --force
+```
+
+`file upload` requires the `files:write` scope; the read commands (`list`, `info`, `download`) require `files:read`. The bot can only delete files it uploaded.
+
 ## Key Differences from agent-slack
 
-| Feature              | agent-slack                     | agent-slackbot               |
-| -------------------- | ------------------------------- | ---------------------------- |
-| Token type           | User token (xoxc-)              | Bot token (xoxb-)            |
-| Token source         | Auto-extracted from desktop app | Manual from Slack App config |
-| Message search       | Yes                             | No                           |
-| File operations      | Yes                             | No                           |
-| Snapshot             | Yes                             | No                           |
-| Edit/delete messages | Any message                     | Bot's own only               |
-| Multi-bot support    | N/A                             | Yes (`--bot` flag)           |
-| CI/CD friendly       | Requires desktop app            | Yes                          |
+| Feature              | agent-slack                     | agent-slackbot                                 |
+| -------------------- | ------------------------------- | ---------------------------------------------- |
+| Token type           | User token (xoxc-)              | Bot token (xoxb-)                              |
+| Token source         | Auto-extracted from desktop app | Manual from Slack App config                   |
+| Message search       | Yes                             | No                                             |
+| File operations      | Yes                             | Upload/list/info/download/delete (with scopes) |
+| Snapshot             | Yes                             | No                                             |
+| Edit/delete messages | Any message                     | Bot's own only                                 |
+| Multi-bot support    | N/A                             | Yes (`--bot` flag)                             |
+| CI/CD friendly       | Requires desktop app            | Yes                                            |
 
 ## AI Agent Integration
 

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -254,6 +254,33 @@ agent-slackbot reaction add C0ACZKTDDC0 1234567890.123456 thumbsup
 agent-slackbot reaction remove <channel> <ts> <emoji>
 ```
 
+### File Commands
+
+```bash
+# Upload a file to a channel (requires files:write scope)
+agent-slackbot file upload <channel> <path>
+agent-slackbot file upload C0ACZKTDDC0 ./report.pdf
+agent-slackbot file upload C0ACZKTDDC0 ./log.txt --filename build-log.txt
+agent-slackbot file upload C0ACZKTDDC0 ./screenshot.png --thread 1234567890.123456 --comment "FYI"
+
+# List files visible to the bot (requires files:read scope)
+agent-slackbot file list
+agent-slackbot file list --channel C0ACZKTDDC0
+agent-slackbot file list --user U123 --limit 50
+
+# Show file details
+agent-slackbot file info <file-id>
+
+# Download a file by ID (saves to current dir or given path)
+agent-slackbot file download <file-id>
+agent-slackbot file download F0123ABC ./downloads/
+
+# Delete a file (bot's own files only)
+agent-slackbot file delete <file-id> --force
+```
+
+> **File scopes**: `file upload` requires `files:write`; `file list`, `file info`, and `file download` require `files:read`. Add these to your Slack App's bot token scopes and reinstall the app. The bot can only delete files it uploaded.
+
 ## Output Format
 
 ### JSON (Default)
@@ -323,7 +350,7 @@ Credentials stored in `~/.config/agent-messenger/slackbot-credentials.json` (060
 | Token type           | User token (xoxc-)              | Bot token (xoxb-)            |
 | Token source         | Auto-extracted from desktop app | Manual from Slack App config |
 | Message search       | Yes                             | No (requires user token)     |
-| File operations      | Yes                             | No                           |
+| File operations      | Yes                             | Upload/list/info/download/delete (with scopes) |
 | Snapshot             | Yes                             | No                           |
 | Edit/delete messages | Any message                     | Bot's own messages only      |
 | Workspace management | Multi-workspace                 | Multi-bot, multi-workspace   |
@@ -333,7 +360,7 @@ Credentials stored in `~/.config/agent-messenger/slackbot-credentials.json` (060
 
 - No real-time events in the CLI (real-time Socket Mode events are available via the SDK — see the README's "Real-time Events (Slack Bot)" section)
 - No message search (requires user token scope)
-- No file upload/download
+- File operations require `files:read` / `files:write` scopes; bot can only delete files it uploaded
 - No workspace snapshot
 - Bot can only edit/delete its own messages
 - Bot must be invited to private channels

--- a/skills/agent-slackbot/references/authentication.md
+++ b/skills/agent-slackbot/references/authentication.md
@@ -29,6 +29,8 @@ Add these **Bot Token Scopes**:
 | `users:read.email` | Access user email addresses            |
 | `reactions:write`  | Add and remove emoji reactions         |
 | `reactions:read`   | List reactions on messages             |
+| `files:read`       | List, inspect, and download files      |
+| `files:write`      | Upload and delete files                |
 
 ### Installing the App
 
@@ -246,6 +248,8 @@ oauth_config:
       - users:read.email
       - reactions:write
       - reactions:read
+      - files:read
+      - files:write
 
 settings:
   org_deploy_enabled: false

--- a/src/platforms/slackbot/cli.ts
+++ b/src/platforms/slackbot/cli.ts
@@ -6,6 +6,7 @@ import pkg from '../../../package.json' with { type: 'json' }
 import {
   authCommand,
   channelCommand,
+  fileCommand,
   messageCommand,
   reactionCommand,
   userCommand,
@@ -36,6 +37,7 @@ program.addCommand(messageCommand)
 program.addCommand(channelCommand)
 program.addCommand(userCommand)
 program.addCommand(reactionCommand)
+program.addCommand(fileCommand)
 
 program.parseAsync(process.argv)
 

--- a/src/platforms/slackbot/client.test.ts
+++ b/src/platforms/slackbot/client.test.ts
@@ -70,6 +70,65 @@ const mockAssistant = {
     setStatus: mock(() => Promise.resolve({ ok: true })),
   },
 }
+const mockFiles = {
+  uploadV2: mock(() =>
+    Promise.resolve({
+      ok: true,
+      files: [
+        {
+          ok: true,
+          files: [
+            {
+              id: 'F123',
+              name: 'test.txt',
+              title: 'test.txt',
+              mimetype: 'text/plain',
+              size: 12,
+              url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+              created: 1234567890,
+              user: 'U123',
+              channels: ['C123'],
+            },
+          ],
+        },
+      ],
+    }),
+  ),
+  list: mock(() =>
+    Promise.resolve({
+      ok: true,
+      files: [
+        {
+          id: 'F123',
+          name: 'test.txt',
+          title: 'test.txt',
+          mimetype: 'text/plain',
+          size: 1024,
+          url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+          created: 1234567890,
+          user: 'U123',
+        },
+      ],
+    }),
+  ),
+  info: mock(() =>
+    Promise.resolve({
+      ok: true,
+      file: {
+        id: 'F123',
+        name: 'test.txt',
+        title: 'test.txt',
+        mimetype: 'text/plain',
+        size: 1024,
+        url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+        created: 1234567890,
+        user: 'U123',
+        channels: ['C123'],
+      },
+    }),
+  ),
+  delete: mock(() => Promise.resolve({ ok: true })),
+}
 const mockUsers = {
   list: mock(() =>
     Promise.resolve({
@@ -110,6 +169,7 @@ mock.module('@slack/web-api', () => ({
     chat = mockChat
     reactions = mockReactions
     users = mockUsers
+    files = mockFiles
     assistant = mockAssistant
   },
 }))
@@ -126,6 +186,10 @@ describe('SlackBotClient', () => {
     mockReactions.remove.mockClear()
     mockUsers.list.mockClear()
     mockUsers.info.mockClear()
+    mockFiles.uploadV2.mockClear()
+    mockFiles.list.mockClear()
+    mockFiles.info.mockClear()
+    mockFiles.delete.mockClear()
     mockAssistant.threads.setStatus.mockClear()
   })
 
@@ -404,6 +468,177 @@ describe('SlackBotClient', () => {
       // then
       expect(user.id).toBe('U123')
       expect(user.name).toBe('testuser')
+    })
+  })
+
+  describe('uploadFile', () => {
+    it('uploads file via files.uploadV2 and returns mapped file', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const file = await client.uploadFile('C123', Buffer.from('test content'), 'test.txt')
+
+      // then
+      expect(file.id).toBe('F123')
+      expect(file.name).toBe('test.txt')
+      expect(file.size).toBe(12)
+      expect(mockFiles.uploadV2).toHaveBeenCalledWith(
+        expect.objectContaining({ channel_id: 'C123', filename: 'test.txt' }),
+      )
+    })
+
+    it('forwards thread_ts, title, initial_comment to the SDK', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.uploadFile('C123', Buffer.from('x'), 'test.txt', {
+        thread_ts: '1234567890.123456',
+        title: 'My Title',
+        initial_comment: 'Here you go',
+      })
+
+      // then
+      expect(mockFiles.uploadV2).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel_id: 'C123',
+          filename: 'test.txt',
+          thread_ts: '1234567890.123456',
+          title: 'My Title',
+          initial_comment: 'Here you go',
+        }),
+      )
+    })
+
+    it('throws SlackBotError when API responds not ok', async () => {
+      // given
+      mockFiles.uploadV2.mockResolvedValueOnce({ ok: false, error: 'file_upload_failed' } as any)
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when/then
+      await expect(client.uploadFile('C123', Buffer.from('x'), 'test.txt')).rejects.toThrow(SlackBotError)
+    })
+
+    it('throws SlackBotError when completion has no inner files', async () => {
+      // given
+      mockFiles.uploadV2.mockResolvedValueOnce({ ok: true, files: [{ ok: true, files: [] }] } as any)
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when/then
+      await expect(client.uploadFile('C123', Buffer.from('x'), 'test.txt')).rejects.toThrow(SlackBotError)
+    })
+  })
+
+  describe('listFiles', () => {
+    it('returns mapped files', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const files = await client.listFiles()
+
+      // then
+      expect(files).toHaveLength(1)
+      expect(files[0].id).toBe('F123')
+      expect(files[0].mimetype).toBe('text/plain')
+    })
+
+    it('forwards channel/user/limit to the SDK', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.listFiles({ channel: 'C123', user: 'U123', limit: 50 })
+
+      // then
+      expect(mockFiles.list).toHaveBeenCalledWith({ channel: 'C123', user: 'U123', count: 50 })
+    })
+  })
+
+  describe('getFileInfo', () => {
+    it('returns file metadata', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const file = await client.getFileInfo('F123')
+
+      // then
+      expect(file.id).toBe('F123')
+      expect(file.url_private).toBe('https://files.slack.com/files-pri/T123-F123/test.txt')
+    })
+
+    it('throws on API failure', async () => {
+      // given
+      mockFiles.info.mockResolvedValueOnce({ ok: false, error: 'file_not_found' } as any)
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when/then
+      await expect(client.getFileInfo('F999')).rejects.toThrow(SlackBotError)
+    })
+  })
+
+  describe('downloadFile', () => {
+    it('downloads file content using the bot token', async () => {
+      // given
+      const originalFetch = globalThis.fetch
+      let capturedAuthHeader: string | null = null
+      globalThis.fetch = async (_url: any, init: any = {}) => {
+        capturedAuthHeader = init?.headers?.Authorization ?? null
+        return new Response(Buffer.from('downloaded content'), { status: 200 })
+      }
+
+      try {
+        const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+        // when
+        const result = await client.downloadFile('F123')
+
+        // then
+        expect(capturedAuthHeader).toBe('Bearer xoxb-test-token')
+        expect(result.file.id).toBe('F123')
+        expect(result.buffer.toString()).toBe('downloaded content')
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    it('throws SlackBotError when download HTTP response is not ok', async () => {
+      // given
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = async () => new Response('forbidden', { status: 403, statusText: 'Forbidden' })
+
+      try {
+        const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+        // when/then
+        await expect(client.downloadFile('F123')).rejects.toThrow(SlackBotError)
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+  })
+
+  describe('deleteFile', () => {
+    it('calls files.delete with the given file ID', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.deleteFile('F123')
+
+      // then
+      expect(mockFiles.delete).toHaveBeenCalledWith({ file: 'F123' })
+    })
+
+    it('throws on API failure', async () => {
+      // given
+      mockFiles.delete.mockResolvedValueOnce({ ok: false, error: 'cant_delete_file' } as any)
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when/then
+      await expect(client.deleteFile('F123')).rejects.toThrow(SlackBotError)
     })
   })
 })

--- a/src/platforms/slackbot/client.ts
+++ b/src/platforms/slackbot/client.ts
@@ -1,13 +1,28 @@
 import { WebClient } from '@slack/web-api'
 
 import { SlackBotCredentialManager } from './credential-manager'
-import { SlackBotError, type SlackChannel, type SlackMessage, type SlackUser } from './types'
+import { SlackBotError, type SlackChannel, type SlackFile, type SlackMessage, type SlackUser } from './types'
 
 const MAX_RETRIES = 3
 const RATE_LIMIT_ERROR_CODE = 'slack_webapi_rate_limited_error'
 
+function mapSlackFile(f: any): SlackFile {
+  return {
+    id: f?.id || '',
+    name: f?.name || '',
+    title: f?.title || f?.name || '',
+    mimetype: f?.mimetype || 'application/octet-stream',
+    size: f?.size || 0,
+    url_private: f?.url_private || '',
+    created: f?.created || 0,
+    user: f?.user || '',
+    channels: f?.channels,
+  }
+}
+
 export class SlackBotClient {
   private client: WebClient | null = null
+  private token: string | null = null
 
   async login(credentials?: { token: string }): Promise<this> {
     if (credentials) {
@@ -18,6 +33,7 @@ export class SlackBotClient {
       if (!token.startsWith('xoxb-')) {
         throw new SlackBotError('Token must be a bot token (xoxb-)', 'invalid_token_type')
       }
+      this.token = token
       this.client = new WebClient(token)
     } else {
       const credManager = new SlackBotCredentialManager()
@@ -474,6 +490,87 @@ export class SlackBotClient {
   async deleteMessage(channel: string, ts: string): Promise<void> {
     return this.withRetry(async () => {
       const response = await this.ensureAuth().chat.delete({ channel, ts })
+      this.checkResponse(response)
+    })
+  }
+
+  async uploadFile(
+    channel: string,
+    file: Buffer,
+    filename: string,
+    options?: { thread_ts?: string; title?: string; initial_comment?: string },
+  ): Promise<SlackFile> {
+    return this.withRetry(async () => {
+      const response = await this.ensureAuth().files.uploadV2({
+        channel_id: channel,
+        file,
+        filename,
+        thread_ts: options?.thread_ts,
+        title: options?.title,
+        initial_comment: options?.initial_comment,
+      })
+      this.checkResponse(response)
+
+      const completionFiles = (response as any).files?.[0]?.files
+      const f = completionFiles?.[0]
+      if (!f) {
+        throw new SlackBotError('No file returned in upload response', 'file_not_found')
+      }
+      return mapSlackFile(f)
+    })
+  }
+
+  async listFiles(options?: { channel?: string; user?: string; limit?: number }): Promise<SlackFile[]> {
+    return this.withRetry(async () => {
+      const response = await this.ensureAuth().files.list({
+        channel: options?.channel,
+        user: options?.user,
+        count: options?.limit,
+      })
+      this.checkResponse(response)
+
+      return (response.files || []).map((f) => mapSlackFile(f))
+    })
+  }
+
+  async getFileInfo(fileId: string): Promise<SlackFile> {
+    return this.withRetry(async () => {
+      const response = await this.ensureAuth().files.info({ file: fileId })
+      this.checkResponse(response)
+
+      return mapSlackFile(response.file)
+    })
+  }
+
+  async downloadFile(fileId: string): Promise<{ buffer: Buffer; file: SlackFile }> {
+    const file = await this.getFileInfo(fileId)
+
+    if (!file.url_private) {
+      throw new SlackBotError('File has no download URL', 'no_download_url')
+    }
+
+    if (!this.token) {
+      throw new SlackBotError('Not authenticated. Call .login() first.', 'not_authenticated')
+    }
+
+    const response = await fetch(file.url_private, {
+      headers: { Authorization: `Bearer ${this.token}` },
+    })
+
+    if (!response.ok) {
+      throw new SlackBotError(`Failed to download file: ${response.statusText}`, 'download_failed')
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      file,
+    }
+  }
+
+  async deleteFile(fileId: string): Promise<void> {
+    return this.withRetry(async () => {
+      const response = await this.ensureAuth().files.delete({ file: fileId })
       this.checkResponse(response)
     })
   }

--- a/src/platforms/slackbot/commands/file.test.ts
+++ b/src/platforms/slackbot/commands/file.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, mock, it } from 'bun:test'
+
+const mockResolveChannel = mock((_channel: string) => Promise.resolve('C123456'))
+const mockUploadFile = mock(() =>
+  Promise.resolve({
+    id: 'F123',
+    name: 'test.txt',
+    title: 'test.txt',
+    mimetype: 'text/plain',
+    size: 12,
+    url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+    created: 1234567890,
+    user: 'U123',
+    channels: ['C123456'],
+  }),
+)
+const mockListFiles = mock(() =>
+  Promise.resolve([
+    {
+      id: 'F123',
+      name: 'test.txt',
+      title: 'test.txt',
+      mimetype: 'text/plain',
+      size: 1024,
+      url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+      created: 1234567890,
+      user: 'U123',
+      channels: ['C123456'],
+    },
+    {
+      id: 'F456',
+      name: 'document.pdf',
+      title: 'document.pdf',
+      mimetype: 'application/pdf',
+      size: 2048,
+      url_private: 'https://files.slack.com/files-pri/T123-F456/document.pdf',
+      created: 1234567891,
+      user: 'U456',
+      channels: ['C123456'],
+    },
+  ]),
+)
+const mockGetFileInfo = mock(() =>
+  Promise.resolve({
+    id: 'F123',
+    name: 'test.txt',
+    title: 'test.txt',
+    mimetype: 'text/plain',
+    size: 1024,
+    url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+    created: 1234567890,
+    user: 'U123',
+    channels: ['C123456'],
+  }),
+)
+const mockDownloadFile = mock(() =>
+  Promise.resolve({
+    buffer: Buffer.from('downloaded content'),
+    file: {
+      id: 'F123',
+      name: 'test.txt',
+      title: 'test.txt',
+      mimetype: 'text/plain',
+      size: 18,
+      url_private: 'https://files.slack.com/files-pri/T123-F123/test.txt',
+      created: 1234567890,
+      user: 'U123',
+      channels: ['C123456'],
+    },
+  }),
+)
+const mockDeleteFile = mock(() => Promise.resolve())
+
+mock.module('../client', () => ({
+  SlackBotClient: class MockSlackBotClient {
+    async login(_credentials?: { token: string }) {
+      return this
+    }
+    resolveChannel = mockResolveChannel
+    uploadFile = mockUploadFile
+    listFiles = mockListFiles
+    getFileInfo = mockGetFileInfo
+    downloadFile = mockDownloadFile
+    deleteFile = mockDeleteFile
+  },
+}))
+
+import { SlackBotClient } from '../client'
+
+describe('file commands', () => {
+  beforeEach(() => {
+    mockResolveChannel.mockClear()
+    mockUploadFile.mockClear()
+    mockListFiles.mockClear()
+    mockGetFileInfo.mockClear()
+    mockDownloadFile.mockClear()
+    mockDeleteFile.mockClear()
+  })
+
+  describe('uploadFile', () => {
+    it('uploads a file to a channel', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const file = await client.uploadFile('C123456', Buffer.from('test content'), 'test.txt')
+
+      // then
+      expect(file.id).toBe('F123')
+      expect(file.name).toBe('test.txt')
+      expect(file.channels).toContain('C123456')
+    })
+
+    it('forwards thread, title, and initial_comment options', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.uploadFile('C123456', Buffer.from('x'), 'test.txt', {
+        thread_ts: '1234567890.000100',
+        title: 'My Title',
+        initial_comment: 'Here you go',
+      })
+
+      // then
+      expect(mockUploadFile).toHaveBeenCalledWith('C123456', Buffer.from('x'), 'test.txt', {
+        thread_ts: '1234567890.000100',
+        title: 'My Title',
+        initial_comment: 'Here you go',
+      })
+    })
+  })
+
+  describe('listFiles', () => {
+    it('returns all files visible to the bot', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const files = await client.listFiles()
+
+      // then
+      expect(files).toHaveLength(2)
+      expect(files[0].name).toBe('test.txt')
+      expect(files[1].name).toBe('document.pdf')
+    })
+
+    it('forwards channel/user/limit filters', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.listFiles({ channel: 'C123456', user: 'U123', limit: 50 })
+
+      // then
+      expect(mockListFiles).toHaveBeenCalledWith({ channel: 'C123456', user: 'U123', limit: 50 })
+    })
+  })
+
+  describe('getFileInfo', () => {
+    it('returns file metadata', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const file = await client.getFileInfo('F123')
+
+      // then
+      expect(file.id).toBe('F123')
+      expect(file.name).toBe('test.txt')
+      expect(file.url_private).toBe('https://files.slack.com/files-pri/T123-F123/test.txt')
+    })
+  })
+
+  describe('downloadFile', () => {
+    it('returns buffer and file metadata', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      const result = await client.downloadFile('F123')
+
+      // then
+      expect(result.file.id).toBe('F123')
+      expect(result.buffer.toString()).toBe('downloaded content')
+    })
+  })
+
+  describe('deleteFile', () => {
+    it("deletes the bot's file", async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.deleteFile('F123')
+
+      // then
+      expect(mockDeleteFile).toHaveBeenCalledWith('F123')
+    })
+  })
+})

--- a/src/platforms/slackbot/commands/file.ts
+++ b/src/platforms/slackbot/commands/file.ts
@@ -1,0 +1,212 @@
+import { readFileSync, statSync, writeFileSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
+
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { type BotOption, getClient } from './shared'
+
+async function uploadAction(
+  channelInput: string,
+  path: string,
+  options: BotOption & { filename?: string; thread?: string; title?: string; comment?: string },
+): Promise<void> {
+  try {
+    const client = await getClient(options)
+    const channel = await client.resolveChannel(channelInput)
+
+    const filePath = resolve(path)
+    const fileBuffer = readFileSync(filePath)
+    const filename = options.filename || basename(filePath) || 'file'
+
+    const file = await client.uploadFile(channel, fileBuffer, filename, {
+      thread_ts: options.thread,
+      title: options.title,
+      initial_comment: options.comment,
+    })
+
+    console.log(
+      formatOutput(
+        {
+          id: file.id,
+          name: file.name,
+          title: file.title,
+          mimetype: file.mimetype,
+          size: file.size,
+          url_private: file.url_private,
+          created: file.created,
+          user: file.user,
+          channels: file.channels,
+        },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function listAction(options: BotOption & { channel?: string; user?: string; limit?: string }): Promise<void> {
+  try {
+    const client = await getClient(options)
+    const channel = options.channel ? await client.resolveChannel(options.channel) : undefined
+    const limit = options.limit ? parseInt(options.limit, 10) : undefined
+
+    const files = await client.listFiles({ channel, user: options.user, limit })
+
+    console.log(
+      formatOutput(
+        files.map((file) => ({
+          id: file.id,
+          name: file.name,
+          title: file.title,
+          mimetype: file.mimetype,
+          size: file.size,
+          url_private: file.url_private,
+          created: file.created,
+          user: file.user,
+          channels: file.channels,
+        })),
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function infoAction(fileId: string, options: BotOption): Promise<void> {
+  try {
+    const client = await getClient(options)
+    const file = await client.getFileInfo(fileId)
+
+    console.log(
+      formatOutput(
+        {
+          id: file.id,
+          name: file.name,
+          title: file.title,
+          mimetype: file.mimetype,
+          size: file.size,
+          url_private: file.url_private,
+          created: file.created,
+          user: file.user,
+          channels: file.channels,
+        },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function downloadAction(fileId: string, outputPath: string | undefined, options: BotOption): Promise<void> {
+  try {
+    const client = await getClient(options)
+    const { buffer, file } = await client.downloadFile(fileId)
+
+    const safeName = basename(file.name.replace(/\\/g, '/'))
+    let destPath = outputPath ? resolve(outputPath) : resolve(safeName)
+    let isDirectory = false
+    try {
+      isDirectory = statSync(destPath).isDirectory()
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code !== 'ENOENT') {
+        throw error
+      }
+    }
+
+    if (isDirectory) {
+      destPath = join(destPath, safeName)
+    }
+
+    writeFileSync(destPath, buffer)
+
+    console.log(
+      formatOutput(
+        {
+          id: file.id,
+          name: file.name,
+          mimetype: file.mimetype,
+          size: file.size,
+          path: destPath,
+        },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function deleteAction(fileId: string, options: BotOption & { force?: boolean }): Promise<void> {
+  try {
+    if (!options.force) {
+      console.log(formatOutput({ warning: 'Use --force to confirm deletion', file_id: fileId }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await getClient(options)
+    await client.deleteFile(fileId)
+
+    console.log(formatOutput({ deleted: fileId }, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const fileCommand = new Command('file')
+  .description('File commands')
+  .addCommand(
+    new Command('upload')
+      .description('Upload file to a channel')
+      .argument('<channel>', 'Channel ID or name')
+      .argument('<path>', 'File path')
+      .option('--filename <name>', 'Override filename')
+      .option('--thread <ts>', 'Upload as a reply to a thread')
+      .option('--title <title>', 'File title')
+      .option('--comment <text>', 'Initial comment posted with the file')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(uploadAction),
+  )
+  .addCommand(
+    new Command('list')
+      .description('List files visible to the bot')
+      .option('--channel <id>', 'Filter by channel ID or name')
+      .option('--user <id>', 'Filter by user ID')
+      .option('--limit <n>', 'Number of files to fetch')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(listAction),
+  )
+  .addCommand(
+    new Command('info')
+      .description('Show file details')
+      .argument('<file>', 'File ID')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(infoAction),
+  )
+  .addCommand(
+    new Command('download')
+      .description('Download a file by ID')
+      .argument('<file>', 'File ID')
+      .argument('[output-path]', 'Output file path or directory')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(downloadAction),
+  )
+  .addCommand(
+    new Command('delete')
+      .description("Delete a file (bot's own files only)")
+      .argument('<file>', 'File ID')
+      .option('--force', 'Skip confirmation')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(deleteAction),
+  )

--- a/src/platforms/slackbot/commands/index.ts
+++ b/src/platforms/slackbot/commands/index.ts
@@ -1,5 +1,6 @@
 export { authCommand } from './auth'
 export { channelCommand } from './channel'
+export { fileCommand } from './file'
 export { messageCommand } from './message'
 export { reactionCommand } from './reaction'
 export { userCommand } from './user'


### PR DESCRIPTION
## Summary

Closes the slackbot file-operations gap. Until now \`agent-slackbot\` exposed
zero file commands and the docs explicitly listed \"No file upload/download\"
as a limitation, forcing AI agents to fall back to the user-token \`agent-slack\`
CLI just to share, fetch, or clean up a file. This PR brings slackbot to
parity with the discordbot/slack file UX.

## What's new

\`\`\`bash
agent-slackbot file upload <channel> <path> [--filename] [--thread <ts>] [--title <t>] [--comment <c>]
agent-slackbot file list   [--channel <id>] [--user <id>] [--limit <n>]
agent-slackbot file info   <file-id>
agent-slackbot file download <file-id> [output-path]
agent-slackbot file delete <file-id> --force
\`\`\`

SDK additions on \`SlackBotClient\`:

- \`uploadFile(channel, buffer, filename, { thread_ts?, title?, initial_comment? })\` via \`files.uploadV2\`
- \`listFiles({ channel?, user?, limit? })\` via \`files.list\`
- \`getFileInfo(fileId)\` via \`files.info\`
- \`downloadFile(fileId)\` — fetches \`url_private\` with \`Authorization: Bearer xoxb-...\` and returns \`{ buffer, file }\`
- \`deleteFile(fileId)\` via \`files.delete\` (bot can only delete files it uploaded)

## Implementation notes

- Mirrors the structure of \`src/platforms/slack/commands/file.ts\` and \`src/platforms/discordbot/commands/file.ts\` so the agent-facing UX is consistent across platforms.
- Reuses the existing \`BotOption\` / \`getClient\` plumbing in \`commands/shared.ts\`; adds \`fileCommand\` to \`commands/index.ts\` and registers it in \`cli.ts\`.
- \`SlackBotClient\` now retains the bot token on \`login\` so authenticated downloads of \`url_private\` work without re-deriving it.
- \`download\` resolves the destination like the slack platform does: explicit path → that path; existing directory → \`<dir>/<sanitized-filename>\`; nothing → \`./<sanitized-filename>\`. Filenames are run through \`basename\` to prevent path traversal.

## Scopes / docs

The two new bot scopes (\`files:read\`, \`files:write\`) are added to:

- \`docs/content/docs/cli/slackbot.mdx\` — manifest, scopes table, new \"File Commands\" section, and the agent-slack vs agent-slackbot feature matrix
- \`skills/agent-slackbot/SKILL.md\` — \"File Commands\" section, updated feature matrix, updated limitations
- \`skills/agent-slackbot/references/authentication.md\` — scopes table and the runnable manifest YAML

## Tests

- \`src/platforms/slackbot/client.test.ts\` — \`uploadFile\` (happy path + forwarded options + \`ok: false\` + missing inner files), \`listFiles\` (mapping + filter forwarding), \`getFileInfo\` (success + API failure), \`downloadFile\` (Bearer header captured from real \`fetch\` mock + non-2xx error), \`deleteFile\` (success + API failure).
- \`src/platforms/slackbot/commands/file.test.ts\` — command-level mocks following the existing slackbot test pattern (\`mock.module('../client', ...)\`).
- \`bun test src/platforms/slackbot/\` → **175 pass / 0 fail**.

## Verification

\`\`\`
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun test src/platforms/slackbot/   # 175 pass, 0 fail
\`\`\`

The pre-existing \`docs/src/app/globals.css\` fumadocs format error and \`src/platforms/slack/token-extractor.test.ts\` host-environment failures already exist on \`main\` and are unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds file upload, list, info, download, and delete to `agent-slackbot`, so bots no longer need `agent-slack` for file operations. Includes new CLI commands, SDK methods, and docs updates.

- New Features
  - CLI: `agent-slackbot file {upload,list,info,download,delete}` with `--filename`, `--thread`, `--title`, `--comment`, `--channel`, `--user`, `--limit`, and `--force`.
  - SDK (`SlackBotClient`): `uploadFile`, `listFiles`, `getFileInfo`, `downloadFile`, `deleteFile`. Downloads authenticate against `url_private` using the stored bot token; delete works only for bot-owned files.
  - Download path resolution: explicit path, or directory + sanitized filename, or `./<sanitized-filename>`.

- Migration
  - Add bot scopes `files:read` and `files:write` to your Slack app and reinstall it.
  - Docs updated: `skills/agent-slackbot/SKILL.md`, CLI docs, and authentication reference now list the new scopes and commands.

<sup>Written for commit 4992977bc1d1bd1ff04bfe323159980496f1adb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

