### PR TITLE
Scan agent-browser profiles for auth extraction

### DIFF
--- a/src/platforms/channeltalk/token-extractor.ts
+++ b/src/platforms/channeltalk/token-extractor.ts
@@ -12,6 +12,7 @@ import {
   discoverBrowserProfileDirs,
   findLocalStatePath,
   getBrowserBasePath,
+  getAgentBrowserProfileDirs,
 } from '@/shared/chromium'
 import type { KeychainVariant } from '@/shared/chromium'
 
@@ -92,6 +93,11 @@ export class ChannelTokenExtractor {
         paths.push(join(profileDir, 'Cookies'))
         paths.push(join(profileDir, 'Network', 'Cookies'))
       }
+    }
+
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      paths.push(join(profileDir, 'Cookies'))
+      paths.push(join(profileDir, 'Network', 'Cookies'))
     }
 
     return paths

--- a/src/platforms/discord/token-extractor.ts
+++ b/src/platforms/discord/token-extractor.ts
@@ -10,6 +10,7 @@ import {
   ChromiumCookieDecryptor,
   discoverBrowserProfileDirs,
   getBrowserBasePath,
+  getAgentBrowserProfileDirs,
 } from '@/shared/chromium'
 import type { KeychainVariant } from '@/shared/chromium'
 import { DerivedKeyCache } from '@/shared/utils/derived-key-cache'
@@ -123,6 +124,10 @@ export class DiscordTokenExtractor {
       for (const profileDir of profileDirs) {
         dirs.push(join(profileDir, 'Local Storage', 'leveldb'))
       }
+    }
+
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      dirs.push(join(profileDir, 'Local Storage', 'leveldb'))
     }
 
     return dirs

--- a/src/platforms/instagram/token-extractor.ts
+++ b/src/platforms/instagram/token-extractor.ts
@@ -10,6 +10,7 @@ import {
   discoverBrowserProfileDirs,
   findLocalStatePath,
   getBrowserBasePath,
+  getAgentBrowserProfileDirs,
 } from '@/shared/chromium'
 import type { KeychainVariant } from '@/shared/chromium'
 
@@ -52,6 +53,11 @@ export class InstagramTokenExtractor {
       }
     }
 
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      paths.push(join(profileDir, 'Cookies'))
+      paths.push(join(profileDir, 'Network', 'Cookies'))
+    }
+
     return paths
   }
 
@@ -63,6 +69,10 @@ export class InstagramTokenExtractor {
       if (!browserBase) continue
 
       paths.push(join(browserBase, 'Local State'))
+    }
+
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      paths.push(join(profileDir, 'Local State'))
     }
 
     return paths

--- a/src/platforms/slack/token-extractor.test.ts
+++ b/src/platforms/slack/token-extractor.test.ts
@@ -6,11 +6,20 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { ChromiumCookieDecryptor } from '@/shared/chromium'
+
 import { ExtractedWorkspace, TokenExtractor } from './token-extractor'
 
 const tempDirs: string[] = []
+const originalAgentBrowserProfile = process.env.AGENT_BROWSER_PROFILE
 
 afterEach(() => {
+  if (originalAgentBrowserProfile) {
+    process.env.AGENT_BROWSER_PROFILE = originalAgentBrowserProfile
+  } else {
+    delete process.env.AGENT_BROWSER_PROFILE
+  }
+
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -800,6 +809,52 @@ describe('TokenExtractor browser fallback', () => {
     const extractor = new TokenExtractor('darwin', slackDir)
     const result = await extractor.extractFromBrowsers()
     expect(result).toEqual([])
+  })
+
+  it('resolves Local State from agent-browser profile root for encrypted cookies', async () => {
+    // given
+    const agentBrowserProfile = mkdtempSync(join(tmpdir(), 'agent-browser-slack-profile-'))
+    tempDirs.push(agentBrowserProfile)
+    process.env.AGENT_BROWSER_PROFILE = agentBrowserProfile
+
+    const hex64 = 'c'.repeat(64)
+    const token = `xoxc-1111111111-2222222222-3333333333-${hex64}`
+    const profileDir = join(agentBrowserProfile, 'Default')
+    const leveldbDir = join(profileDir, 'Local Storage', 'leveldb')
+    const networkDir = join(profileDir, 'Network')
+    mkdirSync(leveldbDir, { recursive: true })
+    mkdirSync(networkDir, { recursive: true })
+    writeFileSync(join(leveldbDir, '000001.log'), `"${token}"T12345678"name":"agent-browser-workspace"`)
+    writeFileSync(join(agentBrowserProfile, 'Local State'), '{}')
+    createCookiesDb(join(networkDir, 'Cookies'), [
+      {
+        name: 'd',
+        value: '',
+        encrypted_value: new Uint8Array([1, 2, 3]),
+        host_key: '.slack.com',
+        last_access_utc: 1,
+      },
+    ])
+    const decryptSpy = spyOn(ChromiumCookieDecryptor.prototype, 'decryptCookie').mockReturnValue('xoxd-AgentBrowser')
+
+    try {
+      // when
+      const extractor = new TokenExtractor('darwin', join(agentBrowserProfile, 'missing-desktop'))
+      const result = await extractor.extractFromBrowsers()
+
+      // then
+      expect(result).toEqual([
+        {
+          workspace_id: 'T12345678',
+          workspace_name: 'agent-browser-workspace',
+          token,
+          cookie: 'xoxd-AgentBrowser',
+        },
+      ])
+      expect(decryptSpy).toHaveBeenCalledWith(Buffer.from([1, 2, 3]), join(agentBrowserProfile, 'Local State'))
+    } finally {
+      decryptSpy.mockRestore()
+    }
   })
 
   it('extract tries desktop before browser profiles', async () => {

--- a/src/platforms/slack/token-extractor.ts
+++ b/src/platforms/slack/token-extractor.ts
@@ -12,7 +12,9 @@ import {
   ChromiumCookieDecryptor,
   ChromiumCookieReader,
   discoverBrowserProfileDirs,
+  findLocalStatePath,
   getBrowserBasePath,
+  getAgentBrowserProfileDirs,
 } from '@/shared/chromium'
 import { DerivedKeyCache } from '@/shared/utils/derived-key-cache'
 import { lookupLinuxKeyringPassword } from '@/shared/utils/linux-keyring'
@@ -259,6 +261,33 @@ export class TokenExtractor {
       }
     }
 
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      const leveldbDir = join(profileDir, 'Local Storage', 'leveldb')
+      if (!existsSync(leveldbDir)) continue
+
+      let tokenInfos: TokenInfo[]
+      try {
+        tokenInfos = await this.extractFromLevelDB(leveldbDir, 'local-storage')
+      } catch {
+        continue
+      }
+
+      if (tokenInfos.length === 0) continue
+
+      const cookie = await this.extractCookieFromBrowserProfile(profileDir, profileDir)
+
+      for (const t of tokenInfos) {
+        if (seenTokens.has(t.token)) continue
+        seenTokens.add(t.token)
+        results.push({
+          workspace_id: t.teamId,
+          workspace_name: t.teamName,
+          token: t.token,
+          cookie,
+        })
+      }
+    }
+
     return results
   }
 
@@ -293,7 +322,7 @@ export class TokenExtractor {
     if (row.value?.startsWith('xoxd-')) return row.value
 
     if (row.encrypted_value && row.encrypted_value.length > 0) {
-      const localStatePath = join(browserBase, 'Local State')
+      const localStatePath = findLocalStatePath(cookiesPath) ?? join(browserBase, 'Local State')
       const decrypted = this.browserDecryptor.decryptCookie(
         Buffer.from(row.encrypted_value),
         existsSync(localStatePath) ? localStatePath : undefined,

--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -11,6 +11,7 @@ import {
   discoverBrowserProfileDirs,
   findLocalStatePath,
   getBrowserBasePath,
+  getAgentBrowserProfileDirs,
 } from '@/shared/chromium'
 import type { KeychainVariant } from '@/shared/chromium'
 import { DerivedKeyCache } from '@/shared/utils/derived-key-cache'
@@ -180,6 +181,11 @@ export class TeamsTokenExtractor {
         paths.push({ path: join(profileDir, 'Cookies'), accountType: 'work', accountTypeKnown: false })
         paths.push({ path: join(profileDir, 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false })
       }
+    }
+
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      paths.push({ path: join(profileDir, 'Cookies'), accountType: 'work', accountTypeKnown: false })
+      paths.push({ path: join(profileDir, 'Network', 'Cookies'), accountType: 'work', accountTypeKnown: false })
     }
 
     return paths

--- a/src/platforms/webex/token-extractor.ts
+++ b/src/platforms/webex/token-extractor.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 
 import { ClassicLevel } from 'classic-level'
 
+import { getAgentBrowserProfileDirs } from '@/shared/chromium'
+
 export interface ExtractedWebexToken {
   accessToken: string
   refreshToken?: string
@@ -98,6 +100,13 @@ export class WebexTokenExtractor {
 
       const profileDirs = this.discoverProfileDirs(browserBase)
       dirs.push(...profileDirs)
+    }
+
+    for (const profileDir of getAgentBrowserProfileDirs()) {
+      const leveldb = join(profileDir, 'Local Storage', 'leveldb')
+      if (existsSync(leveldb)) {
+        dirs.push(leveldb)
+      }
     }
 
     return dirs

--- a/src/shared/chromium/browsers.test.ts
+++ b/src/shared/chromium/browsers.test.ts
@@ -8,6 +8,7 @@ import {
   CHROMIUM_BROWSERS,
   discoverBrowserProfileDirs,
   findLocalStatePath,
+  getAgentBrowserProfileDirs,
   getBrowserBasePath,
 } from './browsers'
 
@@ -192,6 +193,80 @@ describe('browsers', () => {
 
       // then
       expect(dirs).toEqual([join(browserBase, 'Default')])
+    })
+  })
+
+  describe('getAgentBrowserProfileDirs', () => {
+    it('includes profile dirs from env and config files', () => {
+      // given
+      const homeDir = mkdtempSync(join(tmpdir(), 'agent-browser-home-'))
+      const projectDir = mkdtempSync(join(tmpdir(), 'agent-browser-project-'))
+      const customConfigDir = mkdtempSync(join(tmpdir(), 'agent-browser-custom-'))
+      tempDirs.push(homeDir, projectDir, customConfigDir)
+
+      mkdirSync(join(homeDir, '.agent-browser'))
+      writeFileSync(join(homeDir, '.agent-browser', 'config.json'), JSON.stringify({ profile: './global-profile' }))
+      writeFileSync(join(projectDir, 'agent-browser.json'), JSON.stringify({ profile: './project-profile' }))
+      const customConfigPath = join(customConfigDir, 'custom-agent-browser.json')
+      writeFileSync(customConfigPath, JSON.stringify({ profile: './custom-profile' }))
+
+      // when
+      const dirs = getAgentBrowserProfileDirs({
+        cwd: projectDir,
+        env: {
+          AGENT_BROWSER_CONFIG: customConfigPath,
+          AGENT_BROWSER_PROFILE: join(projectDir, 'env-profile'),
+        },
+        homeDir,
+      })
+
+      // then
+      expect(dirs).toEqual([
+        join(projectDir, 'env-profile'),
+        join(projectDir, 'env-profile', 'Default'),
+        join(homeDir, '.agent-browser', 'global-profile'),
+        join(homeDir, '.agent-browser', 'global-profile', 'Default'),
+        join(projectDir, 'project-profile'),
+        join(projectDir, 'project-profile', 'Default'),
+        join(customConfigDir, 'custom-profile'),
+        join(customConfigDir, 'custom-profile', 'Default'),
+      ])
+    })
+
+    it('expands existing agent-browser profile bases with numbered Chromium profiles', () => {
+      // given
+      const homeDir = mkdtempSync(join(tmpdir(), 'agent-browser-expand-home-'))
+      const projectDir = mkdtempSync(join(tmpdir(), 'agent-browser-expand-project-'))
+      const profileBase = join(projectDir, 'browser-data')
+      tempDirs.push(homeDir, projectDir)
+      mkdirSync(join(profileBase, 'Profile 1'), { recursive: true })
+      mkdirSync(join(profileBase, 'Profile 2'))
+      writeFileSync(join(projectDir, 'agent-browser.json'), JSON.stringify({ profile: './browser-data' }))
+
+      // when
+      const dirs = getAgentBrowserProfileDirs({ cwd: projectDir, env: {}, homeDir })
+
+      // then
+      expect(dirs).toEqual([
+        profileBase,
+        join(profileBase, 'Default'),
+        join(profileBase, 'Profile 1'),
+        join(profileBase, 'Profile 2'),
+      ])
+    })
+
+    it('ignores malformed agent-browser configs', () => {
+      // given
+      const homeDir = mkdtempSync(join(tmpdir(), 'agent-browser-malformed-home-'))
+      const projectDir = mkdtempSync(join(tmpdir(), 'agent-browser-malformed-project-'))
+      tempDirs.push(homeDir, projectDir)
+      writeFileSync(join(projectDir, 'agent-browser.json'), '{')
+
+      // when
+      const dirs = getAgentBrowserProfileDirs({ cwd: projectDir, env: {}, homeDir })
+
+      // then
+      expect(dirs).toEqual([])
     })
   })
 

--- a/src/shared/chromium/browsers.ts
+++ b/src/shared/chromium/browsers.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 
 import type { BrowserConfig, KeychainVariant } from './types'
 
@@ -39,6 +39,16 @@ export const BROWSER_KEYCHAIN_VARIANTS: KeychainVariant[] = [
   { service: 'Chromium Safe Storage', account: 'Chromium' },
 ]
 
+interface AgentBrowserProfileDiscoveryOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+}
+
+type AgentBrowserConfig = {
+  profile?: unknown
+}
+
 export function getBrowserBasePath(browser: BrowserConfig, platform: NodeJS.Platform): string | null {
   let relative: string
   switch (platform) {
@@ -70,8 +80,35 @@ export function discoverBrowserProfileDirs(browserBase: string): string[] {
       if (!/^Profile \d+$/i.test(entry.name)) continue
       dirs.push(join(browserBase, entry.name))
     }
-  } catch {}
+  } catch {
+    return dirs
+  }
   return dirs
+}
+
+export function getAgentBrowserProfileDirs(options: AgentBrowserProfileDiscoveryOptions = {}): string[] {
+  const cwd = options.cwd ?? process.cwd()
+  const env = options.env ?? process.env
+  const homeDir = options.homeDir ?? homedir()
+  if (env.AGENT_MESSENGER_DISABLE_AGENT_BROWSER_PROFILE_DISCOVERY === '1') return []
+
+  const profileDirs: string[] = []
+
+  addAgentBrowserProfileDir(profileDirs, env.AGENT_BROWSER_PROFILE, cwd)
+
+  const configPaths = [
+    join(homeDir, '.agent-browser', 'config.json'),
+    join(cwd, 'agent-browser.json'),
+    env.AGENT_BROWSER_CONFIG,
+  ]
+
+  for (const configPath of configPaths) {
+    if (!configPath) continue
+    const config = readAgentBrowserConfig(configPath)
+    addAgentBrowserProfileDir(profileDirs, config?.profile, dirname(configPath))
+  }
+
+  return dedupePaths(profileDirs.flatMap((profileDir) => [profileDir, ...discoverBrowserProfileDirs(profileDir)]))
 }
 
 export function findLocalStatePath(cookieOrProfilePath: string): string | null {
@@ -83,4 +120,31 @@ export function findLocalStatePath(cookieOrProfilePath: string): string | null {
     if (existsSync(candidate)) return candidate
   }
   return null
+}
+
+function readAgentBrowserConfig(configPath: string): AgentBrowserConfig | null {
+  if (!existsSync(configPath)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    return parsed as AgentBrowserConfig
+  } catch {
+    return null
+  }
+}
+
+function addAgentBrowserProfileDir(dirs: string[], profile: unknown, baseDir: string): void {
+  if (typeof profile !== 'string' || profile.length === 0) return
+  dirs.push(isAbsolute(profile) ? profile : resolve(baseDir, profile))
+}
+
+function dedupePaths(paths: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const path of paths) {
+    if (seen.has(path)) continue
+    seen.add(path)
+    result.push(path)
+  }
+  return result
 }

--- a/src/shared/chromium/index.ts
+++ b/src/shared/chromium/index.ts
@@ -4,6 +4,7 @@ export {
   CHROMIUM_BROWSERS,
   discoverBrowserProfileDirs,
   findLocalStatePath,
+  getAgentBrowserProfileDirs,
   getBrowserBasePath,
 } from './browsers'
 export { ChromiumCookieDecryptor } from './decryptor'


### PR DESCRIPTION
## Summary
- Discover agent-browser Chromium profile directories from env, global config, project config, and custom config files.
- Scan discovered agent-browser profiles in browser-based cookie and LevelDB token extractors.
- Resolve Slack cookie decryption Local State from the cookie path so agent-browser profile layouts work.

## Verification
- bun run lint
- bun run format:check
- bun typecheck
- HOME=\"$(mktemp -d)\" bun run test (EXIT_STATUS=0)
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discover and scan agent-browser Chromium profiles to extract auth from cookies and LevelDB across Slack, Discord, Instagram, Teams, ChannelTalk, and Webex. Also fixes Slack cookie decryption by resolving Local State from the cookie path.

- **New Features**
  - Added `getAgentBrowserProfileDirs` that reads `AGENT_BROWSER_PROFILE`, `agent-browser.json`, and `~/.agent-browser/config.json`, expands to `Default` and numbered profiles, and can be disabled with `AGENT_MESSENGER_DISABLE_AGENT_BROWSER_PROFILE_DISCOVERY=1`.
  - Updated token extractors to scan these profiles:
    - Cookies: Slack, Instagram, Teams, ChannelTalk
    - LevelDB: Slack, Discord, Webex
  - Slack: `findLocalStatePath` resolves `Local State` from cookie paths so agent-browser profile layouts decrypt correctly.
  - Docs/SKILL.md: not updated.

<sup>Written for commit 41959b00348a6279ac82ba13dcfe5b9ff1e66495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

