### PR TITLE
fix: add missing ./slackbot subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
       "slack": [
         "./src/platforms/slack/index.ts"
       ],
+      "slackbot": [
+        "./src/platforms/slackbot/index.ts"
+      ],
       "discord": [
         "./src/platforms/discord/index.ts"
       ],
@@ -80,6 +83,10 @@
     "./slack": {
       "types": "./src/platforms/slack/index.ts",
       "default": "./src/platforms/slack/index.ts"
+    },
+    "./slackbot": {
+      "types": "./src/platforms/slackbot/index.ts",
+      "default": "./src/platforms/slackbot/index.ts"
     },
     "./discord": {
       "types": "./src/platforms/discord/index.ts",


### PR DESCRIPTION
## Summary

`agent-messenger/slackbot` was missing from `package.json` `exports` and `typesVersions`, making the documented SDK import path unresolvable for consumers. This adds the two missing entries so `import { SlackBotClient } from 'agent-messenger/slackbot'` works correctly.

## Changes

### `package.json`
- Add `slackbot` entry to `typesVersions["*"]` pointing to `./src/platforms/slackbot/index.ts`.
- Add `./slackbot` subpath to `exports` with `types` + `default` both pointing to `./src/platforms/slackbot/index.ts`.
- Both entries placed adjacent to the existing `slack` / `./slack` entries to match the conventional ordering used throughout the file.

## Context

Every other bot platform — `discordbot`, `whatsappbot`, `wechatbot`, `channeltalkbot` — already has both a `typesVersions` entry and a named `exports` subpath. The `slackbot` platform was fully implemented (`src/platforms/slackbot/` with `cli.ts`, `client.ts`, `index.ts`, `listener.ts`, etc.) and had its `agent-slackbot` bin entry registered, but the `./slackbot` export map entry was simply never added. The README documents `agent-messenger/slackbot` as a valid SDK import path, so this was a silent breakage for any SDK consumer.

## Verification

- `bun run lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun typecheck` — clean.
- `bun test` — 4 pre-existing failures in `src/platforms/slack/token-extractor.test.ts` only; these are environmental (they read the local Slack desktop app credentials) and are unrelated to this change. They also fail on `main` unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed the missing `./slackbot` subpath so `import { SlackBotClient } from 'agent-messenger/slackbot'` works. Adds the required `typesVersions` and `exports` entries in `package.json`.

- **Bug Fixes**
  - Added `slackbot` to `typesVersions["*"]` pointing to `./src/platforms/slackbot/index.ts`.
  - Added `./slackbot` to `exports` with `types` and `default` pointing to `./src/platforms/slackbot/index.ts`.
  - No SKILL.md or docs changes (no platform source code changed).

<sup>Written for commit e5085dbede94f9460e17219a21f28277aace426f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

