### PR TITLE
fix: narrow discordbot uploadFile attachment access for noUncheckedIndexedAccess

### DIFF
--- a/src/platforms/discordbot/client.test.ts
+++ b/src/platforms/discordbot/client.test.ts
@@ -290,6 +290,25 @@ describe('DiscordBotClient', () => {
       const headers = fetchCalls[0].options?.headers as Record<string, string>
       expect(headers.Authorization).toBe('Bot bot-token')
     })
+
+    it('throws when response has no attachments', async () => {
+      const { tmpdir } = await import('node:os')
+      const { join } = await import('node:path')
+      const tempFile = join(tmpdir(), 'test-discordbot-upload-empty.txt')
+      await Bun.write(tempFile, 'test content')
+
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: '',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        attachments: [],
+      })
+
+      const client = await new DiscordBotClient().login({ token: 'bot-token' })
+      await expect(client.uploadFile('ch1', tempFile)).rejects.toThrow('Upload succeeded but no attachments returned')
+    })
   })
 
   describe('listFiles', () => {

--- a/src/platforms/discordbot/client.ts
+++ b/src/platforms/discordbot/client.ts
@@ -307,11 +307,12 @@ export class DiscordBotClient {
     }
     const message = await this.requestFormData<MessageWithAttachments>(`/channels/${channelId}/messages`, formData)
 
-    if (!message.attachments || message.attachments.length === 0) {
+    const first = message.attachments?.[0]
+    if (!first) {
       throw new DiscordBotError('Upload succeeded but no attachments returned', 'no_attachments')
     }
 
-    return message.attachments[0]
+    return first
   }
 
   async listFiles(channelId: string): Promise<DiscordFile[]> {


### PR DESCRIPTION
## Summary

Fixes #176.

`src/platforms/discordbot/client.ts` accessed `message.attachments[0]` after a `length === 0` check. TypeScript's flow analysis under `noUncheckedIndexedAccess` cannot narrow indexed access through such guards, so downstream consumers with strict TS settings could not typecheck against this package (since we ship raw `.ts`, `skipLibCheck` doesn't silence it).

## Change

Extract the indexed access into a local first, then narrow on the local:

```ts
const first = message.attachments?.[0]
if (!first) {
  throw new DiscordBotError('Upload succeeded but no attachments returned', 'no_attachments')
}
return first
```

Behavior is preserved end-to-end:
- Same `DiscordBotError('Upload succeeded but no attachments returned', 'no_attachments')` thrown when the upload response has no attachments.
- Same first attachment returned on success.

## Tests

- Existing happy-path test still passes.
- Added regression test for the empty-attachments error path.
- \`bun test src/platforms/discordbot/\`: 244 pass, 0 fail.
- \`bun typecheck\`, \`bun lint\`, \`bun run format:check\`: clean.

(Pre-existing slack \`token-extractor\` test failures are environment-dependent and present on \`main\` — unrelated to this change.)

Closes #176

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeScript narrowing issue in Discord `uploadFile` so projects with `noUncheckedIndexedAccess` can typecheck this package. Behavior is unchanged: same error on no attachments; same first attachment returned on success.

- **Bug Fixes**
  - Extracted `message.attachments?.[0]` into a local before the guard to satisfy TS flow analysis.
  - Added a regression test for the empty-attachments path; existing upload test still passes.

- **Docs**
  - No updates to SKILL.md or docs.

<sup>Written for commit eaa8c74a18b4660c7f9dff3697bb912b82bffb2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

