### PR TITLE
fix: narrow noUncheckedIndexedAccess violations in slackbot credential-manager

### DIFF
--- a/src/platforms/slackbot/credential-manager.ts
+++ b/src/platforms/slackbot/credential-manager.ts
@@ -103,6 +103,7 @@ export class SlackBotCredentialManager {
     // Try "workspace_id/bot_id" format first
     if (botId.includes('/')) {
       const [workspaceId, id] = botId.split('/')
+      if (!workspaceId || !id) return null
       const workspace = config.workspaces[workspaceId]
       if (!workspace) return null
       const bot = workspace.bots[id]
@@ -131,22 +132,24 @@ export class SlackBotCredentialManager {
       }
     }
 
-    if (matches.length === 1) return matches[0]
+    const [onlyMatch, ...rest] = matches
+    if (onlyMatch && rest.length === 0) return onlyMatch
     return null
   }
 
   async setCredentials(creds: SlackBotCredentials): Promise<void> {
     const config = await this.load()
 
-    if (!config.workspaces[creds.workspace_id]) {
-      config.workspaces[creds.workspace_id] = {
-        workspace_id: creds.workspace_id,
-        workspace_name: creds.workspace_name,
-        bots: {},
-      }
+    const existing = config.workspaces[creds.workspace_id]
+    const workspace: SlackBotWorkspace = existing ?? {
+      workspace_id: creds.workspace_id,
+      workspace_name: creds.workspace_name,
+      bots: {},
+    }
+    if (!existing) {
+      config.workspaces[creds.workspace_id] = workspace
     }
 
-    const workspace = config.workspaces[creds.workspace_id]
     workspace.workspace_name = creds.workspace_name
     workspace.bots[creds.bot_id] = {
       bot_id: creds.bot_id,
@@ -167,6 +170,7 @@ export class SlackBotCredentialManager {
 
     if (botId.includes('/')) {
       const [workspaceId, id] = botId.split('/')
+      if (!workspaceId || !id) return false
       const workspace = config.workspaces[workspaceId]
       if (!workspace || !workspace.bots[id]) return false
 
@@ -183,16 +187,16 @@ export class SlackBotCredentialManager {
       return true
     }
 
-    const matches: { workspace: SlackBotWorkspace }[] = []
+    const matches: SlackBotWorkspace[] = []
     for (const workspace of Object.values(config.workspaces)) {
       if (workspace.bots[botId]) {
-        matches.push({ workspace })
+        matches.push(workspace)
       }
     }
 
-    if (matches.length !== 1) return false
+    const [workspace, ...rest] = matches
+    if (!workspace || rest.length > 0) return false
 
-    const { workspace } = matches[0]
     delete workspace.bots[botId]
     if (Object.keys(workspace.bots).length === 0) {
       delete config.workspaces[workspace.workspace_id]


### PR DESCRIPTION
## Summary

Fixes #177.

`src/platforms/slackbot/credential-manager.ts` had 7 TypeScript `noUncheckedIndexedAccess` violations. Because agent-messenger ships raw `.ts` sources, `skipLibCheck` does not silence them — downstream consumers with strict TS settings could not typecheck the package. All 7 violations are resolved using real narrowing only: no `as` casts, no `!` non-null assertions, no `@ts-ignore`/`@ts-nocheck`.

## Changes

### `src/platforms/slackbot/credential-manager.ts`

- **Guard split-result destructuring before indexing `config.workspaces`** — add an early `if (!workspaceId || !id) return null/false` guard in both `getCredentials` and `deleteCredentials` so the subsequent `config.workspaces[workspaceId]` lookup only happens when both keys are non-undefined.
- **Replace `matches[0]` indexed access with destructured first element** — `if (matches.length === 1) return matches[0]` rewritten as `const [onlyMatch, ...rest] = matches; if (onlyMatch && rest.length === 0) return onlyMatch`. Same semantic: return the sole match or `null`; flow-type now non-undefined within the branch.
- **Cache `config.workspaces[id]` lookup in `setCredentials`** — extract `const existing = config.workspaces[creds.workspace_id]` once and use an `existing ?? { … }` initializer so the `workspace` local is typed `SlackBotWorkspace` (not `SlackBotWorkspace | undefined`) for the subsequent property writes.
- **Refactor `matches` in `deleteCredentialsByBotId`** — change `matches` from `{ workspace: SlackBotWorkspace }[]` to `SlackBotWorkspace[]`, push `workspace` directly, and destructure with `const [workspace, ...rest] = matches` before the `!== 1` guard. Eliminates the `matches[0].workspace` indexed access that previously produced an `undefined`-wide type.

## Context

The package ships `.ts` source files (not compiled `.d.ts`), so consumers that enable `noUncheckedIndexedAccess` in their own `tsconfig.json` hit these violations at typecheck time. The prior PR that fixed the same class of error in `discordbot/client.ts` (#176) established the pattern used here.

## Tests

- `bun test src/platforms/slackbot/` — **175 pass, 0 fail**.
- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- Behavior is preserved end-to-end: no logic changes, only type narrowing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all TypeScript `noUncheckedIndexedAccess` errors in `src/platforms/slackbot/credential-manager.ts` so strict consumers can typecheck without failures; no runtime changes. Fixes #177.

- **Bug Fixes**
  - Guard split `botId` parts before indexing `config.workspaces` in `getCredentials` and `deleteCredentials`.
  - Use array destructuring to return the single match instead of `matches[0]`.
  - In `setCredentials`, cache `config.workspaces[creds.workspace_id]` and initialize once to ensure a defined `workspace`.
  - In `deleteCredentialsByBotId`, store `workspace` directly in `matches` and destructure the first item to avoid `matches[0].workspace`.

- **Docs**
  - No updates to SKILL.md or docs.

<sup>Written for commit aab7c6c0b796afcadd124420f85ef0825f594a6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

