### PR TITLE
feat: support AGENT_MESSENGER_CONFIG_DIR env var for custom config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ agent-slack message send general "Hello from the CLI!"
 
 That's it. Credentials are extracted automatically from your Slack desktop app on first run. No OAuth flows. No API tokens. No configuration files.
 
+### Custom config directory
+
+By default, Agent Messenger stores credentials, sync state, and derived-key caches under `~/.config/agent-messenger`. To relocate everything (e.g. for CI sandboxes, multi-tenant setups, or non-default home directories), set the `AGENT_MESSENGER_CONFIG_DIR` environment variable:
+
+```bash
+export AGENT_MESSENGER_CONFIG_DIR="$HOME/.local/share/agent-messenger"
+agent-slack auth extract
+```
+
+The variable is read on every CLI/SDK invocation and applies to all platforms (Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, WeChat, Instagram, KakaoTalk, Channel Talk, and their bot variants). Explicit `configDir` arguments to credential managers still take precedence.
+
 ## Telegram Quick Start
 
 Get up and running with Telegram in a minute:

--- a/src/platforms/channeltalk/credential-manager.ts
+++ b/src/platforms/channeltalk/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { ChannelConfig, ChannelCredentials, ChannelWorkspaceEntry } from './types'
 import { ChannelConfigSchema } from './types'
 
@@ -11,7 +11,7 @@ export class ChannelCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'channel-credentials.json')
   }
 

--- a/src/platforms/channeltalkbot/credential-manager.ts
+++ b/src/platforms/channeltalkbot/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { ChannelBotConfig, ChannelBotCredentials, ChannelBotWorkspaceEntry } from './types'
 import { ChannelBotConfigSchema } from './types'
 
@@ -17,7 +17,7 @@ export class ChannelBotCredentialManager {
   protected renameFile: typeof rename = rename
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, CREDENTIALS_FILENAME)
     this.legacyPath = join(this.configDir, LEGACY_FILENAME)
   }

--- a/src/platforms/discord/credential-manager.ts
+++ b/src/platforms/discord/credential-manager.ts
@@ -1,7 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
+
+import { getConfigDir } from '../../shared/utils/config-dir'
 
 export interface DiscordConfig {
   token: string | null
@@ -14,7 +15,7 @@ export class DiscordCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'discord-credentials.json')
   }
 

--- a/src/platforms/discordbot/credential-manager.ts
+++ b/src/platforms/discordbot/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { DiscordBotConfig, DiscordBotCredentials } from './types'
 import { DiscordBotConfigSchema } from './types'
 
@@ -11,7 +11,7 @@ export class DiscordBotCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'discordbot-credentials.json')
   }
 

--- a/src/platforms/instagram/credential-manager.ts
+++ b/src/platforms/instagram/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import { createAccountId, type InstagramAccount, type InstagramAccountPaths, type InstagramConfig } from './types'
 
 export class InstagramCredentialManager {
@@ -11,7 +11,7 @@ export class InstagramCredentialManager {
   private instagramRootDir: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'instagram-credentials.json')
     this.instagramRootDir = join(this.configDir, 'instagram')
   }

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -1,10 +1,10 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
 import { Long } from 'bson'
 
+import { getConfigDir } from '@/shared/utils/config-dir'
 import { warn } from '@/shared/utils/stderr'
 
 import { LANG, PC_OS_NAME, getLocoDeviceConfig } from './protocol/config'
@@ -105,10 +105,8 @@ function wrapError(error: unknown, code: string): KakaoTalkError {
 
 const MAX_PAGES = 50
 
-const CONFIG_DIR = join(homedir(), '.config', 'agent-messenger')
-
 function syncStatePath(deviceUuid: string): string {
-  return join(CONFIG_DIR, `kakaotalk-sync-state-${deviceUuid}.json`)
+  return join(getConfigDir(), `kakaotalk-sync-state-${deviceUuid}.json`)
 }
 
 async function loadSyncState(deviceUuid: string): Promise<SyncState | undefined> {
@@ -133,7 +131,7 @@ async function loadSyncState(deviceUuid: string): Promise<SyncState | undefined>
 }
 
 async function saveSyncState(deviceUuid: string, state: SyncState): Promise<void> {
-  await mkdir(CONFIG_DIR, { recursive: true })
+  await mkdir(getConfigDir(), { recursive: true })
   const path = syncStatePath(deviceUuid)
   await writeFile(path, JSON.stringify(state, null, 2))
   await chmod(path, 0o600)

--- a/src/platforms/kakaotalk/credential-manager.ts
+++ b/src/platforms/kakaotalk/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { KakaoAccountCredentials, KakaoConfig, KakaoDeviceType } from './types'
 
 export interface PendingLoginState {
@@ -18,7 +18,7 @@ export class KakaoCredentialManager {
   private pendingLoginPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'kakaotalk-credentials.json')
     this.pendingLoginPath = join(this.configDir, 'kakaotalk-pending-login.json')
   }

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '@/shared/utils/config-dir'
 import { FileStorage } from '@/vendor/linejs/base/storage/mod.js'
 import {
   loginWithQR as linejsLoginWithQR,
@@ -41,7 +41,7 @@ function getDefaultDevice(): LineDevice {
 }
 
 function createStorage(accountId?: string): FileStorage {
-  const dir = join(homedir(), '.config', 'agent-messenger', 'line-storage')
+  const dir = join(getConfigDir(), 'line-storage')
   mkdirSync(dir, { recursive: true })
   return new FileStorage(join(dir, `${accountId ?? 'default'}.json`))
 }

--- a/src/platforms/line/credential-manager.ts
+++ b/src/platforms/line/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, rm, writeFile, readFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { LineAccountCredentials, LineConfig } from './types'
 
 export class LineCredentialManager {
@@ -10,7 +10,7 @@ export class LineCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'line-credentials.json')
   }
 

--- a/src/platforms/slack/credential-manager.ts
+++ b/src/platforms/slack/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { Config, WorkspaceCredentials } from './types'
 
 export class SlackCredentialManager {
@@ -10,7 +10,7 @@ export class SlackCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'slack-credentials.json')
   }
 

--- a/src/platforms/slackbot/credential-manager.ts
+++ b/src/platforms/slackbot/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { SlackBotConfig, SlackBotCredentials, SlackBotWorkspace } from './types'
 import { SlackBotConfigSchema } from './types'
 
@@ -11,7 +11,7 @@ export class SlackBotCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'slackbot-credentials.json')
   }
 

--- a/src/platforms/teams/credential-manager.ts
+++ b/src/platforms/teams/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig, TeamsConfigLegacy, TeamsRegion } from './types'
 
 export class TeamsCredentialManager {
@@ -12,7 +12,7 @@ export class TeamsCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'teams-credentials.json')
   }
 

--- a/src/platforms/telegram/credential-manager.ts
+++ b/src/platforms/telegram/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import {
   createAccountId,
   type TelegramAccount,
@@ -21,7 +21,7 @@ export class TelegramCredentialManager {
   private tdlibRootDir: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'telegram-credentials.json')
     this.provisioningStatePath = join(this.configDir, 'telegram-provisioning-state.json')
     this.tdlibRootDir = join(this.configDir, 'telegram')

--- a/src/platforms/webex/credential-manager.ts
+++ b/src/platforms/webex/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import { getWebexAppCredentials } from './app-config'
 import type { WebexConfig } from './types'
 import { WebexConfigSchema } from './types'
@@ -19,7 +19,7 @@ export class WebexCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'webex-credentials.json')
   }
 

--- a/src/platforms/wechatbot/credential-manager.ts
+++ b/src/platforms/wechatbot/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { WeChatBotAccountEntry, WeChatBotConfig, WeChatBotCredentials } from './types'
 import { WeChatBotConfigSchema } from './types'
 
@@ -11,7 +11,7 @@ export class WeChatBotCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'wechatbot-credentials.json')
   }
 

--- a/src/platforms/whatsapp/credential-manager.ts
+++ b/src/platforms/whatsapp/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import { createAccountId, type WhatsAppAccount, type WhatsAppAccountPaths, type WhatsAppConfig } from './types'
 
 export class WhatsAppCredentialManager {
@@ -11,7 +11,7 @@ export class WhatsAppCredentialManager {
   private baileysRootDir: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'whatsapp-credentials.json')
     this.baileysRootDir = join(this.configDir, 'whatsapp')
   }

--- a/src/platforms/whatsappbot/credential-manager.ts
+++ b/src/platforms/whatsappbot/credential-manager.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { getConfigDir } from '../../shared/utils/config-dir'
 import type { WhatsAppBotAccountEntry, WhatsAppBotConfig, WhatsAppBotCredentials } from './types'
 import { WhatsAppBotConfigSchema } from './types'
 
@@ -11,7 +11,7 @@ export class WhatsAppBotCredentialManager {
   private credentialsPath: string
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'agent-messenger')
+    this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'whatsappbot-credentials.json')
   }
 

--- a/src/shared/utils/config-dir.test.ts
+++ b/src/shared/utils/config-dir.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { CONFIG_DIR_ENV_VAR, getConfigDir } from './config-dir'
+
+describe('getConfigDir', () => {
+  let original: string | undefined
+
+  beforeEach(() => {
+    original = process.env[CONFIG_DIR_ENV_VAR]
+    delete process.env[CONFIG_DIR_ENV_VAR]
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[CONFIG_DIR_ENV_VAR]
+    } else {
+      process.env[CONFIG_DIR_ENV_VAR] = original
+    }
+  })
+
+  it('returns the default path when the env var is unset', () => {
+    expect(getConfigDir()).toBe(join(homedir(), '.config', 'agent-messenger'))
+  })
+
+  it('returns the env var value when set', () => {
+    process.env[CONFIG_DIR_ENV_VAR] = '/tmp/custom-config-dir'
+    expect(getConfigDir()).toBe('/tmp/custom-config-dir')
+  })
+
+  it('falls back to the default when the env var is empty', () => {
+    process.env[CONFIG_DIR_ENV_VAR] = ''
+    expect(getConfigDir()).toBe(join(homedir(), '.config', 'agent-messenger'))
+  })
+
+  it('does not append agent-messenger to the override path', () => {
+    process.env[CONFIG_DIR_ENV_VAR] = '/var/lib/messenger'
+    expect(getConfigDir()).toBe('/var/lib/messenger')
+  })
+})

--- a/src/shared/utils/config-dir.ts
+++ b/src/shared/utils/config-dir.ts
@@ -1,0 +1,23 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export const CONFIG_DIR_ENV_VAR = 'AGENT_MESSENGER_CONFIG_DIR'
+
+/**
+ * Resolves the directory used to persist agent-messenger configuration and
+ * credentials.
+ *
+ * Resolution order:
+ * 1. `AGENT_MESSENGER_CONFIG_DIR` environment variable (if set and non-empty)
+ * 2. Default: `~/.config/agent-messenger`
+ *
+ * Used by every platform credential manager so that a single env var override
+ * relocates all stored credentials, sync state, and derived-key caches.
+ */
+export function getConfigDir(): string {
+  const override = process.env[CONFIG_DIR_ENV_VAR]
+  if (override && override.length > 0) {
+    return override
+  }
+  return join(homedir(), '.config', 'agent-messenger')
+}

--- a/src/shared/utils/derived-key-cache.ts
+++ b/src/shared/utils/derived-key-cache.ts
@@ -1,7 +1,8 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
+
+import { getConfigDir } from './config-dir'
 
 export type Platform = 'slack' | 'discord' | 'teams' | 'instagram' | 'channeltalk'
 
@@ -18,7 +19,7 @@ export class DerivedKeyCache {
   private cacheDir: string
 
   constructor(cacheDir?: string) {
-    this.cacheDir = cacheDir ?? join(homedir(), '.config', 'agent-messenger', '.derived-keys')
+    this.cacheDir = cacheDir ?? join(getConfigDir(), '.derived-keys')
   }
 
   private getKeyPath(platform: Platform): string {


### PR DESCRIPTION
## Summary

Adds env var support for relocating agent-messenger's config directory away from the default `~/.config/agent-messenger`.

- New shared helper `getConfigDir()` in `src/shared/utils/config-dir.ts` reads `AGENT_MESSENGER_CONFIG_DIR` (falls back to `~/.config/agent-messenger`).
- Refactors all 15 platform credential managers + `derived-key-cache` + `kakaotalk/client` + `line/client` to use the helper instead of inlining `join(homedir(), '.config', 'agent-messenger')`.
- Explicit `configDir` constructor arguments still take precedence — SDK consumers and existing tests are unaffected.
- Documents the variable in README under Quick Start.

## Why

Useful for CI sandboxes, multi-tenant setups, ephemeral test environments, and non-default home directory layouts. One variable relocates everything (credentials, sync state, derived-key caches) across all 15 platforms and bot variants.

## Resolution order

1. Explicit `configDir` argument to a credential manager
2. `AGENT_MESSENGER_CONFIG_DIR` env var (if set and non-empty)
3. Default: `~/.config/agent-messenger`

The naming follows the existing `AGENT_MESSENGER_*` legacy env var convention (e.g. `AGENT_MESSENGER_TELEGRAM_API_ID`, `AGENT_MESSENGER_DISABLE_AGENT_BROWSER_PROFILE_DISCOVERY`).

## Verification

- \`bun typecheck\` — clean
- \`bun lint\` — clean
- \`bun test\` — only 4 pre-existing failures in \`slack/token-extractor.test.ts\` (unrelated; reproduce on \`main\` without these changes — they pick up real Slack credentials from the dev environment)
- New \`config-dir.test.ts\` covers default path, env override, empty-string fallback, and no double-appending of \`agent-messenger\`

## Out of scope

Token extractor paths (Slack/Discord/Teams/etc. desktop app locations, Chromium profile dirs) intentionally still resolve from the OS — they read third-party app data, not agent-messenger config. SKILL.md docs still mention `~/.config/agent-messenger`; can update those in a follow-up if desired (didn't touch them since the README is the canonical user-facing reference and the path is still correct as the default).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the `AGENT_MESSENGER_CONFIG_DIR` env var to set a custom config directory across all platforms via a shared `getConfigDir()` helper. This lets CI and multi-tenant setups relocate credentials, sync state, and key caches with one setting.

- New Features
  - Added `getConfigDir()` that reads `AGENT_MESSENGER_CONFIG_DIR`, falling back to `~/.config/agent-messenger`.
  - Refactored all platform credential managers, `derived-key-cache`, and KakaoTalk/LINE clients to use it.
  - Precedence: explicit `configDir` arg > `AGENT_MESSENGER_CONFIG_DIR` > default.
  - Added tests for default, override, empty string, and no double-append cases.

- Migration
  - No breaking changes; existing constructor args and tests keep working.
  - Docs: `README.md` updated; `SKILL.md` not updated.

<sup>Written for commit 9d42c6909952c369dc40568bc4f76d5e4d57baea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

