### PR TITLE
fix: clear console.log spy in telegram whoami test to avoid stale call count

### DIFF
--- a/src/platforms/telegram/commands/whoami.test.ts
+++ b/src/platforms/telegram/commands/whoami.test.ts
@@ -33,6 +33,7 @@ describe('whoami command', () => {
       return fn(fakeClient, {} as TelegramAccount, new TelegramCredentialManager())
     })
     consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+    consoleLogSpy.mockClear()
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes a long-standing test isolation flake in \`src/platforms/telegram/commands/whoami.test.ts\` that has been surfacing a \`failure\` annotation on every CI run on \`main\` (the underlying \`bun test\` step still exits 0, so the job has been showing \"green\" while emitting the failure annotation).

The first test \`outputs account info with user when authenticated\` intermittently asserts \`Received number of calls: 2\` instead of 1. The second test in the same file passes.

## Root cause

When \`bun:test\`'s \`spyOn\` is invoked on \`console.log\` and another test file's spy on the same property is still installed (e.g. \`afterEach\` cleanup didn't reach the mockRestore for some reason during the previous file), the returned spy can carry over stale call entries from the prior file. The first \`beforeEach\` in this suite therefore sees a non-empty \`mock.calls\` array before \`whoamiAction\` runs even once.

## Fix

Call \`consoleLogSpy.mockClear()\` right after creating the spy in \`beforeEach\`. This resets the call history deterministically and matches the defensive pattern already used by sibling test files (e.g. \`telegram/commands/chat.test.ts\` calls \`mockReset()\` on its mocks).

Behavior under test is unchanged.

## Verification

- The failure has been observed on multiple recent CI runs of \`main\` (workflow runs \`25419881409\`, \`25419674347\`, \`25418968730\`, \`25330793296\`, etc.) — same line, same expected/received counts, always the first test of the file.
- After this fix the test runs deterministically locally on bun \`1.3.13\` (the version CI uses).
- \`bun typecheck\` and \`bun lint\` clean. The 4 pre-existing failures in \`slack/token-extractor.test.ts\` are unrelated and reproduce on \`main\`.

## Out of scope

The same \`spyOn(console, 'log').mockImplementation(...)\` pattern (without an explicit clear) appears in other whoami-style tests (slack, discord, teams, instagram, whatsapp, webex). They have not surfaced this flake yet because their position in the test order does not coincide with a leaky neighbor. If they regress, the same one-line fix applies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky test in `src/platforms/telegram/commands/whoami.test.ts` that intermittently reported “Received number of calls: 2” in the first test, causing CI failure annotations.

- **Bug Fixes**
  - Clear the `console.log` spy by calling `consoleLogSpy.mockClear()` in `beforeEach` to prevent stale call counts from other files.
  - No platform source changes; tests only. SKILL.md/docs not updated.

<sup>Written for commit 1d5beb334ed2e33433b7beae8ee2c7dc7538c6dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

