### PR TITLE
docs: correct Linux support in agent-kakaotalk skill

### DIFF
--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -56,7 +56,7 @@ Registers the CLI as a sub-device (tablet slot by default). Your desktop app kee
 agent-kakaotalk auth login
 ```
 
-In interactive mode, this prompts for email and password. The CLI first tries to extract cached credentials from the desktop app so you may not need to type anything.
+In interactive mode, this prompts for email and password. On macOS and Windows, the CLI first tries to extract cached credentials from the desktop app so you may not need to type anything. On Linux there is no desktop app, so always pass credentials explicitly via `--email` and `--password` (or `--password-file`).
 
 For AI agents (non-interactive), provide credentials via flags:
 
@@ -488,8 +488,7 @@ See the [KakaoTalk SDK documentation](https://agent-messenger.dev/docs/sdk/kakao
 
 ## Limitations
 
-- macOS and Windows only (desktop app needed for auto-extracting email/password during login)
-- No Linux support (KakaoTalk desktop not available on Linux)
+- Auto-extraction of email/password from the desktop app is **macOS and Windows only** (KakaoTalk desktop is not available on Linux). Linux users must pass `--email` and `--password` (or `--password-file`) explicitly — the LOCO protocol, login flow, and all messaging features work on Linux.
 - No file upload or download
 - No channel/chat room creation or management
 - No friend list management
@@ -526,7 +525,15 @@ pnpm dlx --package agent-messenger agent-kakaotalk chat list --pretty
 
 ### Password prompt on fresh install
 
-On fresh installs, the desktop app (macOS or Windows) may hash or omit the password from its cache, so the CLI cannot extract it automatically. The CLI will prompt for the password once to register the device — via a native dialog on macOS (AppKit) and Windows (PowerShell WinForms), or via a TTY prompt if a terminal is available. After registration, the password is never needed again.
+On fresh installs, the desktop app (macOS or Windows) may hash or omit the password from its cache, so the CLI cannot extract it automatically. The CLI will prompt for the password once to register the device — via a native dialog on macOS (AppKit), Windows (PowerShell WinForms), or Linux (`zenity` / `kdialog`), or via a TTY prompt if a terminal is available. After registration, the password is never needed again.
+
+On Linux there is no desktop app to extract from, so always provide credentials explicitly:
+
+```bash
+agent-kakaotalk auth login --email user@example.com --password-file /tmp/.kakao-pw
+```
+
+`--password-file` reads the file then immediately deletes it, so the password never appears in shell history or process listings.
 
 When the CLI returns `{"next_action": "run_interactive", ...}`, use a tmux session to let the user type their password securely. See "Handling `run_interactive`" above for the exact steps.
 


### PR DESCRIPTION
## Summary

The `agent-kakaotalk` skill doc previously claimed "macOS and Windows only / No Linux support" in the Limitations section. Verification against the source code revealed this was inaccurate — the restriction applies only to desktop-app credential auto-extraction, not to the platform as a whole.

## Changes

### `skills/agent-kakaotalk/SKILL.md` (docs only, no source changes)

**Authentication section**
- Clarify that auto-extraction of cached credentials from the desktop app happens on macOS and Windows only.
- Direct Linux users to always pass credentials explicitly via `--email`/`--password`/`--password-file`.

**Limitations section**
- Replace the two-bullet "macOS and Windows only / No Linux support" block with a single accurate bullet: auto-extraction is mac/win only, but the LOCO protocol, login flow, and all messaging features work on Linux.

**Troubleshooting → Password prompt on fresh install**
- Add Linux GUI fallbacks (`zenity` / `kdialog`) alongside the existing macOS (AppKit) and Windows (PowerShell WinForms) entries.
- Add a Linux-specific `--password-file` example to show how to pass credentials without exposing them in shell history.

## Context

Four findings from reading the source code drove this correction:

1. **No hard platform gate.** `token-extractor.ts` returns `null` gracefully on Linux rather than throwing, so the CLI does not abort on Linux.
2. **`--email` + `--password` bypasses extraction entirely.** `auth.ts` only calls the extractor when at least one credential flag is absent; when both are supplied the auto-extraction path is never reached.
3. **Native GUI fallbacks already support Linux.** `auth.ts` already branches on `zenity`/`kdialog` for Linux password prompts, in the same block that handles macOS AppKit and Windows PowerShell WinForms.
4. **The LOCO protocol is platform-agnostic.** `protocol/config.ts` sends `'mac'` as the device identity string on Linux — a cosmetic quirk, not a blocker.

The docs were stricter than the code. The skill ships with the npm package, so this is user-facing documentation.

## Testing

Docs-only change. Verified:
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun typecheck` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected Linux support in `agent-kakaotalk` docs: Linux is supported; only desktop credential auto-extraction is macOS/Windows-only. Updated `skills/agent-kakaotalk/SKILL.md` to clarify Linux auth via `--email`/`--password`/`--password-file`, fix the Limitations text, and add Linux GUI prompt details (`zenity`/`kdialog`).

<sup>Written for commit cfaec79d8f509f0fe7e9ef8517b38460ec9719d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

