### PR TITLE
feat: add agent-telegrambot for Telegram Bot API

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,6 +1,6 @@
 # Agent Messenger - Claude Code Plugin
 
-Messaging platform interaction skills for AI agents and Claude Code. Supports Slack, Discord, Microsoft Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta).
+Messaging platform interaction skills for AI agents and Claude Code. Supports Slack, Discord, Microsoft Teams, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta).
 
 ## Installation
 
@@ -75,6 +75,16 @@ Enables AI agents to interact with messaging platforms through CLI interfaces:
 - **Search chats** by name or username
 - **Multi-account support** with easy switching
 - **Auto-provisions** API credentials via my.telegram.org
+
+### Telegram Bot (`agent-telegrambot`)
+- **Send messages** to chats, groups, and channels using bot tokens
+- **Edit, delete, and forward** messages
+- **Upload documents** to chats
+- **Set reactions** on messages
+- **Read chat info** and member status
+- **Real-time updates** via long-polling listener (SDK only)
+- **Multi-bot management** with easy switching
+- Designed for **server-side and CI/CD** use cases
 
 ### WhatsApp (`agent-whatsapp`)
 - **Send messages** to chats and groups

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-messenger",
-  "description": "Messaging platform interaction skills for AI agents - Slack, Discord, Microsoft Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk",
+  "description": "Messaging platform interaction skills for AI agents - Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk",
   "owner": {
     "name": "agent-messenger",
     "url": "https://github.com/agent-messenger"
@@ -97,6 +97,19 @@
       "category": "productivity",
       "homepage": "https://github.com/agent-messenger/agent-messenger",
       "keywords": ["telegram", "tdlib", "messaging", "ai-agent", "cli", "communication"]
+    },
+    {
+      "name": "agent-telegrambot",
+      "description": "Interact with Telegram using bot tokens (Bot API). Designed for server-side and CI/CD integrations. Supports message operations, chat info, reactions, document uploads, real-time long-polling listener via SDK, and multi-bot credential management.",
+      "version": "1.15.0",
+      "author": {
+        "name": "agent-messenger",
+        "url": "https://github.com/agent-messenger"
+      },
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/agent-messenger/agent-messenger",
+      "keywords": ["telegram", "telegrambot", "bot", "messaging", "ai-agent", "cli", "ci-cd"]
     },
     {
       "name": "agent-channeltalk",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-messenger",
   "version": "2.12.0",
-  "description": "Messaging platform interaction skills for AI agents. Interact with Slack, Discord, Microsoft Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk - send messages, read channels, manage reactions, upload files, and more through simple CLI interfaces.",
+  "description": "Messaging platform interaction skills for AI agents. Interact with Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk - send messages, read channels, manage reactions, upload files, and more through simple CLI interfaces.",
   "author": {
     "name": "agent-messenger",
     "url": "https://github.com/agent-messenger"
@@ -13,6 +13,7 @@
     "teams",
     "webex",
     "telegram",
+    "telegram-bot",
     "whatsapp",
     "kakaotalk",
     "channel-talk",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -36,6 +36,7 @@
     "./skills/agent-teams",
     "./skills/agent-webex",
     "./skills/agent-telegram",
+    "./skills/agent-telegrambot",
     "./skills/agent-whatsapp",
     "./skills/agent-whatsappbot",
     "./skills/agent-line",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,18 @@ src/
         chat.ts
         message.ts
         ...
+    telegrambot/            # Telegram Bot platform (Bot API)
+      cli.ts                # Telegram Bot CLI entry
+      client.ts             # Telegram Bot API client
+      credential-manager.ts # Credential storage
+      listener.ts           # Long-polling listener
+      types.ts              # TypeScript types
+      commands/             # Command handlers
+        auth.ts
+        chat.ts
+        message.ts
+        reaction.ts
+        ...
     channeltalk/            # Channel Talk platform (beta)
       cli.ts                # Channel Talk CLI entry
       client.ts             # Channel Talk API client

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Agent Messenger
 
-[![npm](https://img.shields.io/npm/v/agent-messenger?color=E67E22)](https://www.npmjs.com/package/agent-messenger) [![platform](https://img.shields.io/badge/platform-slack-4A154B)](https://agent-messenger.dev/docs/cli/slack) [![platform](https://img.shields.io/badge/platform-discord-5865F2)](https://agent-messenger.dev/docs/cli/discord) [![platform](https://img.shields.io/badge/platform-teams-6264A7)](https://agent-messenger.dev/docs/cli/teams) [![platform](https://img.shields.io/badge/platform-webex-00BCF2)](https://agent-messenger.dev/docs/cli/webex) [![platform](https://img.shields.io/badge/platform-telegram-2AABEE)](https://agent-messenger.dev/docs/cli/telegram) [![platform](https://img.shields.io/badge/platform-whatsapp-25D366)](https://agent-messenger.dev/docs/cli/whatsapp) [![platform](https://img.shields.io/badge/platform-line-06C755)](https://agent-messenger.dev/docs/cli/line) [![platform](https://img.shields.io/badge/platform-instagram-E4405F)](https://agent-messenger.dev/docs/cli/instagram) [![platform](https://img.shields.io/badge/platform-kakaotalk-FEE500)](https://agent-messenger.dev/docs/cli/kakaotalk) [![platform](https://img.shields.io/badge/platform-channel_talk-3B3FE4)](https://agent-messenger.dev/docs/cli/channeltalk)
+[![npm](https://img.shields.io/npm/v/agent-messenger?color=E67E22)](https://www.npmjs.com/package/agent-messenger) [![platform](https://img.shields.io/badge/platform-slack-4A154B)](https://agent-messenger.dev/docs/cli/slack) [![platform](https://img.shields.io/badge/platform-discord-5865F2)](https://agent-messenger.dev/docs/cli/discord) [![platform](https://img.shields.io/badge/platform-teams-6264A7)](https://agent-messenger.dev/docs/cli/teams) [![platform](https://img.shields.io/badge/platform-webex-00BCF2)](https://agent-messenger.dev/docs/cli/webex) [![platform](https://img.shields.io/badge/platform-telegram-2AABEE)](https://agent-messenger.dev/docs/cli/telegram) [![platform](https://img.shields.io/badge/platform-telegram_bot-2AABEE)](https://agent-messenger.dev/docs/cli/telegrambot) [![platform](https://img.shields.io/badge/platform-whatsapp-25D366)](https://agent-messenger.dev/docs/cli/whatsapp) [![platform](https://img.shields.io/badge/platform-line-06C755)](https://agent-messenger.dev/docs/cli/line) [![platform](https://img.shields.io/badge/platform-instagram-E4405F)](https://agent-messenger.dev/docs/cli/instagram) [![platform](https://img.shields.io/badge/platform-kakaotalk-FEE500)](https://agent-messenger.dev/docs/cli/kakaotalk) [![platform](https://img.shields.io/badge/platform-channel_talk-3B3FE4)](https://agent-messenger.dev/docs/cli/channeltalk)
 
 **Your agent messages as you — not as a bot**
 
@@ -74,6 +74,7 @@ This installs:
 - `agent-teams` — Microsoft Teams CLI
 - `agent-webex` — Cisco Webex CLI (browser token extraction with e2e encryption + OAuth Device Grant, zero-config)
 - `agent-telegram` — Telegram CLI (user account via TDLib)
+- `agent-telegrambot` — Telegram Bot CLI (bot token, for server-side/CI/CD)
 - `agent-whatsapp` — WhatsApp CLI (user account via Baileys, QR code or pairing code auth)
 - `agent-whatsappbot` — WhatsApp Bot CLI (Cloud API, for server-side/CI/CD)
 - `agent-line` — LINE CLI (QR code login, Thrift protocol)
@@ -91,7 +92,7 @@ Agent Messenger includes [Agent Skills](https://agentskills.io/) that teach your
 
 SkillPad is a GUI app for Agent Skills. See [skillpad.dev](https://skillpad.dev/) for more details.
 
-[![Available on SkillPad](https://badge.skillpad.dev/agent-slack/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slack) [![Available on SkillPad](https://badge.skillpad.dev/agent-slackbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slackbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-discord/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discord) [![Available on SkillPad](https://badge.skillpad.dev/agent-discordbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discordbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-teams/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-teams) [![Available on SkillPad](https://badge.skillpad.dev/agent-webex/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-webex) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegram) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsapp/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsapp) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsappbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsappbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-line/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-line) [![Available on SkillPad](https://badge.skillpad.dev/agent-wechatbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-wechatbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-instagram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-instagram) [![Available on SkillPad](https://badge.skillpad.dev/agent-kakaotalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-kakaotalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalkbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalkbot)
+[![Available on SkillPad](https://badge.skillpad.dev/agent-slack/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slack) [![Available on SkillPad](https://badge.skillpad.dev/agent-slackbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slackbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-discord/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discord) [![Available on SkillPad](https://badge.skillpad.dev/agent-discordbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discordbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-teams/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-teams) [![Available on SkillPad](https://badge.skillpad.dev/agent-webex/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-webex) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegram) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegrambot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegrambot) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsapp/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsapp) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsappbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsappbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-line/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-line) [![Available on SkillPad](https://badge.skillpad.dev/agent-wechatbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-wechatbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-instagram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-instagram) [![Available on SkillPad](https://badge.skillpad.dev/agent-kakaotalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-kakaotalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalkbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalkbot)
 
 ### Skills CLI
 
@@ -183,6 +184,7 @@ const slack = await new SlackClient().login({ token: 'xoxc-...', cookie: 'xoxd-.
 | `agent-messenger/discordbot` | `DiscordBotClient` |
 | `agent-messenger/teams` | `TeamsClient` |
 | `agent-messenger/webex` | `WebexClient` |
+| `agent-messenger/telegrambot` | `TelegramBotClient` |
 | `agent-messenger/whatsapp` | `WhatsAppClient` |
 | `agent-messenger/whatsappbot` | `WhatsAppBotClient` |
 | `agent-messenger/line` | `LineClient` |
@@ -262,6 +264,29 @@ listener.on('interaction_create', (event) => {
 await listener.start()
 ```
 
+### Real-time Events (Telegram Bot)
+
+Stream messages, callback queries, and other updates via long-polling — no public HTTPS endpoint required. Telegram Bot API does not support WebSockets, so the listener uses `getUpdates` long-polling, which is the canonical approach used by frameworks like grammy and telegraf.
+
+```typescript
+import { TelegramBotClient, TelegramBotListener } from 'agent-messenger/telegrambot'
+
+const client = await new TelegramBotClient().login({ token: 'YOUR_BOT_TOKEN' })
+const listener = new TelegramBotListener(client, {
+  allowedUpdates: ['message', 'callback_query'],
+})
+
+listener.on('message', (message) => {
+  console.log(`New message in ${message.chat.id}: ${message.text}`)
+})
+
+listener.on('callback_query', (query) => {
+  console.log(`Button clicked: ${query.data}`)
+})
+
+await listener.start()
+```
+
 ### Real-time Events (Slack Bot)
 
 Stream Events API events, slash commands, and interactive components over Slack's Socket Mode WebSocket — no public HTTP endpoint required. Requires an app-level token (`xapp-...`) with the `connections:write` scope, separate from your bot token.
@@ -332,7 +357,7 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 | Reminders                  |  ✅   |    —    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | User groups                |  ✅   |    —    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Real-time events (SDK)     |  ✅   |    ✅    |   —   |   —   |    —     |    —     |  ✅   |   —    |    ✅     |    ✅      |         —           |
-| Bot support                |  ✅   |   ✅    |   —   |   —   |    —     |    ✅     |   —   |   ✅    |     —     |    —      |         ✅          |
+| Bot support                |  ✅   |   ✅    |   —   |   —   |    ✅     |    ✅     |   —   |   ✅    |     —     |    —      |         ✅          |
 
 > ⚠️ **Teams tokens expire in 60-90 minutes.** Re-run `agent-teams auth extract` to refresh. See [Teams Guide](skills/agent-teams/SKILL.md) for details.
 
@@ -345,6 +370,7 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 - **[Teams Guide](https://agent-messenger.dev/docs/cli/teams)** — Full command reference for Microsoft Teams
 - **[Webex Guide](skills/agent-webex/SKILL.md)** — Browser token extraction, OAuth Device Grant auth, and Cisco Webex command reference
 - **[Telegram Guide](https://agent-messenger.dev/docs/cli/telegram)** — TDLib setup and Telegram command reference
+- **[Telegram Bot Guide](https://agent-messenger.dev/docs/cli/telegrambot)** — Bot token integration for server-side and CI/CD
 - **[WhatsApp Guide](https://agent-messenger.dev/docs/cli/whatsapp)** — Baileys-based WhatsApp integration via QR code or pairing code
 - **[WhatsApp Bot Guide](https://agent-messenger.dev/docs/cli/whatsappbot)** — Cloud API integration for WhatsApp Business
 - **[LINE Guide](https://agent-messenger.dev/docs/cli/line)** — QR code login and Thrift protocol integration
@@ -421,7 +447,7 @@ With Agent Messenger, your agent loads the skill it needs, uses the CLI, and mov
 
 OAuth requires creating an app and workspace admin approval—days of waiting just to send a message. Agent Messenger skips all of that. Your desktop apps already have valid session tokens; Agent Messenger extracts them directly so you can start messaging immediately. For platforms like Telegram, WhatsApp, and LINE, a one-time authentication flow gets you in fast.
 
-For server-side bots and CI/CD, bot tokens are fully supported via [`agent-slackbot`](skills/agent-slackbot/SKILL.md), [`agent-discordbot`](skills/agent-discordbot/SKILL.md), [`agent-whatsappbot`](skills/agent-whatsappbot/SKILL.md), [`agent-wechatbot`](skills/agent-wechatbot/SKILL.md), and [`agent-channeltalkbot`](skills/agent-channeltalkbot/SKILL.md).
+For server-side bots and CI/CD, bot tokens are fully supported via [`agent-slackbot`](skills/agent-slackbot/SKILL.md), [`agent-discordbot`](skills/agent-discordbot/SKILL.md), [`agent-telegrambot`](skills/agent-telegrambot/SKILL.md), [`agent-whatsappbot`](skills/agent-whatsappbot/SKILL.md), [`agent-wechatbot`](skills/agent-wechatbot/SKILL.md), and [`agent-channeltalkbot`](skills/agent-channeltalkbot/SKILL.md).
 
 Inspired by [agent-browser](https://github.com/vercel-labs/agent-browser) from Vercel Labs.
 

--- a/docs/content/docs/cli/meta.json
+++ b/docs/content/docs/cli/meta.json
@@ -8,6 +8,7 @@
     "teams",
     "webex",
     "telegram",
+    "telegrambot",
     "whatsapp",
     "whatsappbot",
     "line",

--- a/docs/content/docs/cli/telegrambot.mdx
+++ b/docs/content/docs/cli/telegrambot.mdx
@@ -1,0 +1,149 @@
+---
+title: Telegram Bot
+description: Complete reference for the agent-telegrambot CLI.
+---
+
+> **Tip**: After `npm install -g agent-messenger`, `agent-telegrambot` is available directly. For one-off execution without a global install you can use `npm exec --package agent-messenger agent-telegrambot ...`, `pnpm dlx --package agent-messenger agent-telegrambot ...`, `yarn dlx agent-messenger agent-telegrambot ...`, or `bunx --package agent-messenger agent-telegrambot ...`.
+
+## Overview
+
+`agent-telegrambot` wraps Telegram's official [HTTP Bot API](https://core.telegram.org/bots/api). It uses bot tokens issued by [@BotFather](https://t.me/BotFather) and is designed for server-side and CI/CD integrations.
+
+For acting as a real user account (not a bot), use [`agent-telegram`](./telegram) instead.
+
+## Requirements
+
+- A bot token from [@BotFather](https://t.me/BotFather)
+- Node.js 18+ or Bun runtime
+
+## Quick Start
+
+```bash
+# Set your bot token (validates against Telegram)
+agent-telegrambot auth set 123456789:ABC-DEF1234...
+
+# Verify auth
+agent-telegrambot whoami
+
+# Send a message
+agent-telegrambot message send @channelname "Hello"
+
+# Get chat info
+agent-telegrambot chat info @channelname
+```
+
+## Authentication
+
+```bash
+# Set bot token
+agent-telegrambot auth set <token>
+
+# Set with custom bot identifier
+agent-telegrambot auth set <token> --bot deploy
+
+# Check auth status
+agent-telegrambot auth status
+
+# List stored bots
+agent-telegrambot auth list
+
+# Switch active bot
+agent-telegrambot auth use <bot-id>
+
+# Remove a stored bot
+agent-telegrambot auth remove <bot-id>
+
+# Clear all credentials
+agent-telegrambot auth clear
+```
+
+Credentials are stored in `~/.config/agent-messenger/telegrambot-credentials.json` (0600 permissions).
+
+## Commands
+
+### Messages
+
+```bash
+# Send a text message
+agent-telegrambot message send <chat> <text>
+
+# Format with Markdown or HTML
+agent-telegrambot message send <chat> "<b>Bold</b>" --parse-mode HTML
+
+# Reply to a specific message
+agent-telegrambot message send <chat> "Reply" --reply-to 12345
+
+# Send silently
+agent-telegrambot message send <chat> "..." --silent
+
+# Forum topic
+agent-telegrambot message send <chat> "..." --thread-id 5
+
+# Edit a message
+agent-telegrambot message update <chat> <message-id> <new-text>
+
+# Delete a message
+agent-telegrambot message delete <chat> <message-id> --force
+
+# Forward a message
+agent-telegrambot message forward <to-chat> <from-chat> <message-id>
+
+# Upload a document
+agent-telegrambot message upload <chat> ./file.pdf --caption "Report"
+```
+
+### Chats
+
+```bash
+# Get chat info (title, type, description, member count)
+agent-telegrambot chat info <chat>
+
+# Get a specific member's status
+agent-telegrambot chat member <chat> <user-id>
+```
+
+### Reactions
+
+```bash
+# Set a reaction (replaces existing)
+agent-telegrambot reaction set <chat> <message-id> 👍
+
+# Big animation
+agent-telegrambot reaction set <chat> <message-id> 👍 --big
+
+# Clear reactions
+agent-telegrambot reaction clear <chat> <message-id>
+```
+
+### Whoami
+
+```bash
+agent-telegrambot whoami
+agent-telegrambot whoami --bot <bot-id>
+```
+
+## Chat IDs
+
+The `<chat>` argument accepts:
+
+- **Numeric ID**: `123456789` (user), `-1001234567890` (supergroup/channel)
+- **@username**: `@channelname` (public chats only)
+- **Plain username**: `channelname` (auto-prefixed with `@`)
+
+## Global Options
+
+| Option       | Description                           |
+| ------------ | ------------------------------------- |
+| `--pretty`   | Human-readable output instead of JSON |
+| `--bot <id>` | Use a specific bot for this command   |
+
+## Real-Time Events
+
+The CLI does not expose real-time events, but the SDK does — via long-polling. See the [SDK reference](../sdk/telegrambot) for `TelegramBotListener`.
+
+## Common Errors
+
+- `Unauthorized` — Invalid or revoked token. Generate a new one via @BotFather.
+- `Forbidden` — User hasn't `/start`ed the bot, bot was kicked, or bot lacks permissions.
+- `Bad Request: chat not found` — Wrong chat ID or bot isn't in the chat.
+- `Conflict` — Another polling instance (or webhook) is active for this bot.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -33,14 +33,14 @@ No app creation. No admin approval. No waiting.
 
 ## Key Features
 
-| Feature             | Description                                                                                                                                                          |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Auto-extraction** | Pulls tokens from desktop apps automatically                                                                                                                         |
-| **Multi-platform**  | Slack, Discord, Microsoft Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta)                                                             |
-| **Multi-workspace** | Switch between workspaces/servers easily                                                                                                                             |
-| **JSON output**     | Machine-readable by default, `--pretty` for humans                                                                                                                   |
-| **Comprehensive**   | Messages, channels, users, reactions, files                                                                                                                          |
-| **Bot support**     | [`agent-slackbot`](/docs/cli/slackbot), [`agent-discordbot`](/docs/cli/discordbot), and [`agent-channeltalkbot`](/docs/cli/channeltalkbot) for server-side and CI/CD |
+| Feature             | Description                                                                                                                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Auto-extraction** | Pulls tokens from desktop apps automatically                                                                                                                                                                       |
+| **Multi-platform**  | Slack, Discord, Microsoft Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta)                                                                                                           |
+| **Multi-workspace** | Switch between workspaces/servers easily                                                                                                                                                                           |
+| **JSON output**     | Machine-readable by default, `--pretty` for humans                                                                                                                                                                 |
+| **Comprehensive**   | Messages, channels, users, reactions, files                                                                                                                                                                        |
+| **Bot support**     | [`agent-slackbot`](/docs/cli/slackbot), [`agent-discordbot`](/docs/cli/discordbot), [`agent-telegrambot`](/docs/cli/telegrambot), and [`agent-channeltalkbot`](/docs/cli/channeltalkbot) for server-side and CI/CD |
 
 ## Why Not MCP?
 
@@ -81,7 +81,7 @@ OAuth is better when you need:
 - **Multi-user applications** - Many users authenticating separately
 - **Granular permissions** - Fine-tuned access control
 
-For these use cases, Agent Messenger also supports bot tokens via [`agent-slackbot`](/docs/cli/slackbot), [`agent-discordbot`](/docs/cli/discordbot), and [`agent-channeltalkbot`](/docs/cli/channeltalkbot).
+For these use cases, Agent Messenger also supports bot tokens via [`agent-slackbot`](/docs/cli/slackbot), [`agent-discordbot`](/docs/cli/discordbot), [`agent-telegrambot`](/docs/cli/telegrambot), and [`agent-channeltalkbot`](/docs/cli/channeltalkbot).
 
 ## Design Principles
 
@@ -114,6 +114,7 @@ Tokens stay on your machine. Nothing is sent to external servers. Your credentia
 - [Discord Bot](/docs/cli/discordbot) - Bot token integration for server-side and CI/CD
 - [Teams](/docs/cli/teams) - Full Teams command reference
 - [Telegram](/docs/cli/telegram) - TDLib setup and Telegram command reference
+- [Telegram Bot](/docs/cli/telegrambot) - Bot token integration for server-side and CI/CD
 - [WhatsApp](/docs/cli/whatsapp) - Full WhatsApp command reference
 - [WhatsApp Bot](/docs/cli/whatsappbot) - Cloud API integration for WhatsApp Business
 - [LINE](/docs/cli/line) - Full LINE command reference

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -31,6 +31,7 @@ This installs these CLI tools:
 - `agent-discordbot` — Discord Bot CLI (bot token, for server-side/CI/CD)
 - `agent-teams` — Microsoft Teams CLI
 - `agent-telegram` — Telegram CLI (user account via TDLib)
+- `agent-telegrambot` — Telegram Bot CLI (bot token, for server-side/CI/CD)
 - `agent-whatsapp` — WhatsApp CLI (user account via Baileys, pairing code auth)
 - `agent-whatsappbot` — WhatsApp Bot CLI (Cloud API, for server-side/CI/CD)
 - `agent-line` — LINE CLI (QR code login, Thrift protocol)
@@ -123,6 +124,7 @@ agent-slack workspace current
 - [Discord Bot Reference](/docs/cli/discordbot) - Bot token for server-side/CI/CD
 - [Teams Reference](/docs/cli/teams) - Full command reference
 - [Telegram Reference](/docs/cli/telegram) - TDLib setup and command reference
+- [Telegram Bot Reference](/docs/cli/telegrambot) - Bot token for server-side/CI/CD
 - [WhatsApp Reference](/docs/cli/whatsapp) - Full command reference
 - [WhatsApp Bot Reference](/docs/cli/whatsappbot) - Cloud API for WhatsApp Business
 - [KakaoTalk Reference](/docs/cli/kakaotalk) - Full command reference

--- a/docs/content/docs/sdk/meta.json
+++ b/docs/content/docs/sdk/meta.json
@@ -7,6 +7,7 @@
     "discordbot",
     "teams",
     "webex",
+    "telegrambot",
     "whatsapp",
     "whatsappbot",
     "line",

--- a/docs/content/docs/sdk/telegrambot.mdx
+++ b/docs/content/docs/sdk/telegrambot.mdx
@@ -49,8 +49,11 @@ const msg = await client.sendMessage(chatId, 'Hello', {
   disable_notification: true,
 })
 
-// Edit
-await client.editMessageText(chatId, msg.message_id, 'Edited text')
+// Edit a chat message
+await client.editMessageText({ chat_id: chatId, message_id: msg.message_id }, 'Edited text')
+
+// Edit an inline-mode message (returned by inline query results)
+await client.editMessageText({ inline_message_id: 'abc123' }, 'Edited text')
 
 // Delete
 await client.deleteMessage(chatId, msg.message_id)

--- a/docs/content/docs/sdk/telegrambot.mdx
+++ b/docs/content/docs/sdk/telegrambot.mdx
@@ -1,0 +1,213 @@
+---
+title: Telegram Bot
+description: TypeScript SDK reference for Telegram Bot — client, real-time long-polling listener, credential management, and types.
+---
+
+## Installation
+
+```bash
+npm install agent-messenger
+```
+
+```typescript
+import {
+  TelegramBotClient,
+  TelegramBotCredentialManager,
+  TelegramBotError,
+  TelegramBotListener,
+} from 'agent-messenger/telegrambot'
+```
+
+## TelegramBotClient
+
+The main client wrapping Telegram's HTTP [Bot API](https://core.telegram.org/bots/api). Includes automatic 429 (rate-limit) handling using `retry_after`, network retries with exponential backoff, and structured errors via `TelegramBotError`.
+
+```typescript
+const client = await new TelegramBotClient().login({ token: 'YOUR_BOT_TOKEN' })
+```
+
+Or use stored credentials — read from `~/.config/agent-messenger/telegrambot-credentials.json` (managed by `agent-telegrambot auth set`):
+
+```typescript
+const client = await new TelegramBotClient().login()
+```
+
+### Authentication
+
+```typescript
+const me = await client.getMe()
+// → TelegramBotUser { id, is_bot, first_name, username?, ... }
+```
+
+### Messages
+
+```typescript
+// Send text message
+const msg = await client.sendMessage(chatId, 'Hello', {
+  parse_mode: 'HTML',
+  reply_to_message_id: 42,
+  disable_notification: true,
+})
+
+// Edit
+await client.editMessageText(chatId, msg.message_id, 'Edited text')
+
+// Delete
+await client.deleteMessage(chatId, msg.message_id)
+
+// Forward
+await client.forwardMessage(toChatId, fromChatId, messageId)
+
+// Upload document (multipart)
+await client.sendDocument(chatId, '/path/to/file.pdf', { caption: 'Report' })
+```
+
+### Chats
+
+```typescript
+// Full chat info (title, description, member count, etc.)
+const chat = await client.getChat(chatId)
+
+// Single member's status
+const member = await client.getChatMember(chatId, userId)
+
+// Member count for groups, supergroups, channels
+const count = await client.getChatMemberCount(chatId)
+```
+
+### Reactions
+
+```typescript
+// Set a reaction (Telegram replaces previous bot reaction)
+await client.setMessageReaction(chatId, messageId, [{ type: 'emoji', emoji: '👍' }])
+
+// Clear all bot reactions
+await client.setMessageReaction(chatId, messageId, [])
+```
+
+### Updates (Manual Polling)
+
+If you don't need the listener abstraction, you can call `getUpdates` directly:
+
+```typescript
+const updates = await client.getUpdates({
+  offset: 0,
+  limit: 100,
+  timeout: 30,
+  allowed_updates: ['message', 'callback_query'],
+})
+```
+
+## TelegramBotListener
+
+A long-polling listener for real-time updates. Telegram Bot API does not support WebSockets — long-polling is the canonical streaming mode used by frameworks like grammy and telegraf. No public HTTPS endpoint required.
+
+```typescript
+import { TelegramBotClient, TelegramBotListener } from 'agent-messenger/telegrambot'
+
+const client = await new TelegramBotClient().login({ token: 'YOUR_BOT_TOKEN' })
+const listener = new TelegramBotListener(client, {
+  timeoutSeconds: 30,
+  limit: 100,
+  allowedUpdates: ['message', 'callback_query'],
+  dropPendingUpdates: false,
+})
+
+listener.on('connected', ({ user }) => {
+  console.log(`Connected as @${user.username}`)
+})
+
+listener.on('message', (message) => {
+  console.log(`${message.chat.id}: ${message.text}`)
+})
+
+listener.on('callback_query', (query) => {
+  console.log(`Button clicked: ${query.data}`)
+})
+
+listener.on('disconnected', () => {
+  console.log('Disconnected, will retry…')
+})
+
+listener.on('error', (error) => {
+  console.error('Fatal error:', error)
+})
+
+await listener.start()
+```
+
+### Lifecycle
+
+- `start()` — Removes any active webhook (mutex with polling), calls `getMe` to confirm auth, then enters the polling loop.
+- `stop()` — Aborts the in-flight `getUpdates` request and stops the loop. Safe to call multiple times.
+
+### Events
+
+| Event                 | Payload                       | Notes                                                                   |
+| --------------------- | ----------------------------- | ----------------------------------------------------------------------- |
+| `connected`           | `{ user: TelegramBotUser }`   | Once after `start()` succeeds                                           |
+| `disconnected`        | `[]`                          | After a recoverable error; listener will retry with exponential backoff |
+| `error`               | `[Error]`                     | Fatal error (Unauthorized 401, Conflict 409). Listener stops.           |
+| `message`             | `[TelegramMessage]`           | New text/media messages in private chats and groups                     |
+| `edited_message`      | `[TelegramMessage]`           | Message edited                                                          |
+| `channel_post`        | `[TelegramMessage]`           | New post in a channel where the bot is admin                            |
+| `edited_channel_post` | `[TelegramMessage]`           | Channel post edited                                                     |
+| `callback_query`      | `[TelegramCallbackQuery]`     | Inline keyboard button pressed                                          |
+| `inline_query`        | `[TelegramInlineQuery]`       | Inline-mode query (`@yourbot ...`)                                      |
+| `my_chat_member`      | `[TelegramChatMemberUpdated]` | Bot's own membership status changed                                     |
+| `chat_member`         | `[TelegramChatMemberUpdated]` | Other member's status changed (requires opt-in)                         |
+| `telegram_update`     | `[TelegramUpdate]`            | Catch-all — every raw update                                            |
+
+### Reconnection
+
+On recoverable errors (network failure, 5xx, transient API errors), the listener emits `disconnected` and retries with exponential backoff capped at 30 seconds. On `Unauthorized` (401) or `Conflict` (409 — another polling instance is running), it emits `error` and stops; restart your process after fixing the cause.
+
+## TelegramBotCredentialManager
+
+```typescript
+const manager = new TelegramBotCredentialManager()
+
+// Store credentials
+await manager.setCredentials({ token, bot_id, bot_name })
+
+// Retrieve current
+const creds = await manager.getCredentials()
+
+// Multi-bot support
+const all = await manager.listAll()
+await manager.setCurrent('deploy')
+await manager.removeBot('alert')
+await manager.clearCredentials()
+```
+
+Credentials are stored under `~/.config/agent-messenger/telegrambot-credentials.json` with `0600` file permissions. Override the directory with the `AGENT_MESSENGER_CONFIG_DIR` environment variable, or pass `new TelegramBotCredentialManager(customDir)`.
+
+## Error Handling
+
+All client methods throw `TelegramBotError` with a `code` property:
+
+| Code                | Meaning                                         |
+| ------------------- | ----------------------------------------------- |
+| `missing_token`     | Empty token passed to `login`                   |
+| `not_authenticated` | Used a method before `.login()`                 |
+| `no_credentials`    | No stored credentials and none provided         |
+| `unauthorized`      | 401 — invalid token                             |
+| `conflict`          | 409 — another polling instance running          |
+| `forbidden`         | 403 — bot kicked or user hasn't started the bot |
+| `bad_request`       | 400 — usually invalid chat ID or message ID     |
+| `not_found`         | 404                                             |
+| `rate_limited`      | 429 (after retries exhausted)                   |
+| `network_error`     | Fetch failed after retries                      |
+| `invalid_response`  | Telegram returned non-JSON                      |
+
+```typescript
+import { TelegramBotError } from 'agent-messenger/telegrambot'
+
+try {
+  await client.sendMessage(chatId, 'Hello')
+} catch (error) {
+  if (error instanceof TelegramBotError && error.code === 'forbidden') {
+    console.log('User has not started the bot yet')
+  }
+}
+```

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -242,6 +242,30 @@ export async function validateTelegramEnvironment(): Promise<boolean> {
   return true
 }
 
+// Telegram Bot Test Environment
+export const TELEGRAMBOT_TEST_CHAT_ID = process.env.E2E_TELEGRAMBOT_CHAT_ID || ''
+
+export async function validateTelegramBotEnvironment(): Promise<boolean> {
+  if (!TELEGRAMBOT_TEST_CHAT_ID) {
+    console.warn('Skipping Telegram Bot E2E: set E2E_TELEGRAMBOT_CHAT_ID to run against a dedicated test chat.')
+    return false
+  }
+
+  const { runCLI, parseJSON } = await import('./helpers')
+
+  const result = await runCLI('telegrambot', ['auth', 'status'])
+  if (result.exitCode !== 0) {
+    throw new Error('Telegram Bot authentication failed. Run: agent-telegrambot auth set <token>')
+  }
+
+  const data = parseJSON<{ valid: boolean }>(result.stdout)
+  if (!data?.valid) {
+    throw new Error('Telegram Bot credentials invalid or expired. Run: agent-telegrambot auth set <token>')
+  }
+
+  return true
+}
+
 // WhatsApp Test Environment
 export const WHATSAPP_TEST_CHAT_ID = process.env.E2E_WHATSAPP_CHAT_ID || ''
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -15,6 +15,7 @@ export async function runCLI(platform: string, args: string[]): Promise<CLIResul
     channeltalk: 'agent-channeltalk',
     webex: 'agent-webex',
     telegram: 'agent-telegram',
+    telegrambot: 'agent-telegrambot',
     whatsapp: 'agent-whatsapp',
     whatsappbot: 'agent-whatsappbot',
     line: 'agent-line',

--- a/e2e/telegrambot.e2e.test.ts
+++ b/e2e/telegrambot.e2e.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
+
+import { TELEGRAMBOT_TEST_CHAT_ID, validateTelegramBotEnvironment } from './config'
+import { generateTestId, parseJSON, runCLI, waitForRateLimit } from './helpers'
+
+let telegramBotAvailable = false
+let trackedMessageIds: number[] = []
+
+async function deleteTrackedMessages(): Promise<void> {
+  for (const messageId of trackedMessageIds) {
+    try {
+      await runCLI('telegrambot', ['message', 'delete', TELEGRAMBOT_TEST_CHAT_ID, String(messageId), '--force'])
+      await waitForRateLimit(300)
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  trackedMessageIds = []
+}
+
+describe('Telegram Bot E2E Tests', () => {
+  beforeAll(async () => {
+    telegramBotAvailable = await validateTelegramBotEnvironment()
+  })
+
+  afterEach(async () => {
+    if (trackedMessageIds.length > 0) {
+      await deleteTrackedMessages()
+    }
+    await waitForRateLimit()
+  })
+
+  describe('auth', () => {
+    it('auth status returns valid bot info', async () => {
+      if (!telegramBotAvailable) return
+
+      const result = await runCLI('telegrambot', ['auth', 'status'])
+      expect(result.exitCode).toBe(0)
+
+      const data = parseJSON<{ valid: boolean; bot_id: string }>(result.stdout)
+      expect(data?.valid).toBe(true)
+      expect(data?.bot_id).toBeTruthy()
+    })
+
+    it('auth list returns bots array', async () => {
+      if (!telegramBotAvailable) return
+
+      const result = await runCLI('telegrambot', ['auth', 'list'])
+      expect(result.exitCode).toBe(0)
+
+      const data = parseJSON<{ bots: Array<{ bot_id: string }> }>(result.stdout)
+      expect(Array.isArray(data?.bots)).toBe(true)
+    })
+  })
+
+  describe('whoami', () => {
+    it('whoami returns bot identity', async () => {
+      if (!telegramBotAvailable) return
+
+      const result = await runCLI('telegrambot', ['whoami'])
+      expect(result.exitCode).toBe(0)
+
+      const data = parseJSON<{ id: number; is_bot: boolean }>(result.stdout)
+      expect(data?.id).toBeTruthy()
+      expect(data?.is_bot).toBe(true)
+    })
+  })
+
+  describe('chat', () => {
+    it('chat info returns chat details', async () => {
+      if (!telegramBotAvailable) return
+
+      const result = await runCLI('telegrambot', ['chat', 'info', TELEGRAMBOT_TEST_CHAT_ID])
+      expect(result.exitCode).toBe(0)
+
+      const data = parseJSON<{ id: number; type: string }>(result.stdout)
+      expect(data?.id).toBeTruthy()
+      expect(data?.type).toBeTruthy()
+    })
+  })
+
+  describe('message', () => {
+    it('message send delivers message and returns id', async () => {
+      if (!telegramBotAvailable) return
+
+      const testId = generateTestId()
+      const result = await runCLI('telegrambot', ['message', 'send', TELEGRAMBOT_TEST_CHAT_ID, `Bot e2e ${testId}`])
+      expect(result.exitCode).toBe(0)
+
+      const data = parseJSON<{ message: { message_id: number; chat_id: number; text: string } }>(result.stdout)
+      expect(data?.message?.message_id).toBeTruthy()
+      expect(data?.message?.text).toContain(testId)
+      if (data?.message?.message_id) trackedMessageIds.push(data.message.message_id)
+    })
+
+    it('message update edits previously sent message', async () => {
+      if (!telegramBotAvailable) return
+
+      const testId = generateTestId()
+      const sendResult = await runCLI('telegrambot', [
+        'message',
+        'send',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        `Original ${testId}`,
+      ])
+      const sent = parseJSON<{ message: { message_id: number } }>(sendResult.stdout)
+      expect(sent?.message?.message_id).toBeTruthy()
+      if (sent?.message?.message_id) trackedMessageIds.push(sent.message.message_id)
+
+      await waitForRateLimit()
+
+      const updateResult = await runCLI('telegrambot', [
+        'message',
+        'update',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        String(sent!.message.message_id),
+        `Edited ${testId}`,
+      ])
+      expect(updateResult.exitCode).toBe(0)
+    })
+
+    it('message delete removes message', async () => {
+      if (!telegramBotAvailable) return
+
+      const testId = generateTestId()
+      const sendResult = await runCLI('telegrambot', [
+        'message',
+        'send',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        `Delete me ${testId}`,
+      ])
+      const sent = parseJSON<{ message: { message_id: number } }>(sendResult.stdout)
+      expect(sent?.message?.message_id).toBeTruthy()
+
+      await waitForRateLimit()
+
+      const deleteResult = await runCLI('telegrambot', [
+        'message',
+        'delete',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        String(sent!.message.message_id),
+        '--force',
+      ])
+      expect(deleteResult.exitCode).toBe(0)
+    })
+  })
+
+  describe('reaction', () => {
+    it('reaction set and clear lifecycle', async () => {
+      if (!telegramBotAvailable) return
+
+      const testId = generateTestId()
+      const sendResult = await runCLI('telegrambot', [
+        'message',
+        'send',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        `Reaction test ${testId}`,
+      ])
+      const sent = parseJSON<{ message: { message_id: number } }>(sendResult.stdout)
+      expect(sent?.message?.message_id).toBeTruthy()
+      if (sent?.message?.message_id) trackedMessageIds.push(sent.message.message_id)
+
+      await waitForRateLimit(2000)
+
+      const setResult = await runCLI('telegrambot', [
+        'reaction',
+        'set',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        String(sent!.message.message_id),
+        '👍',
+      ])
+      expect(setResult.exitCode).toBe(0)
+
+      await waitForRateLimit(2000)
+
+      const clearResult = await runCLI('telegrambot', [
+        'reaction',
+        'clear',
+        TELEGRAMBOT_TEST_CHAT_ID,
+        String(sent!.message.message_id),
+      ])
+      expect(clearResult.exitCode).toBe(0)
+    }, 15000)
+  })
+})

--- a/examples/telegrambot-listen.ts
+++ b/examples/telegrambot-listen.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+import { TelegramBotClient } from '../src/platforms/telegrambot/client'
+import { TelegramBotListener } from '../src/platforms/telegrambot/listener'
+
+async function main() {
+  const client = await new TelegramBotClient().login()
+
+  const listener = new TelegramBotListener(client, {
+    allowedUpdates: ['message', 'edited_message', 'callback_query', 'my_chat_member'],
+  })
+
+  listener.on('connected', ({ user }) => {
+    console.log(`Connected as @${user.username ?? user.first_name} (id: ${user.id})`)
+    console.log('Listening for events. Press Ctrl+C to stop.\n')
+  })
+
+  listener.on('disconnected', () => {
+    console.log('[disconnected] retrying...')
+  })
+
+  listener.on('message', (message) => {
+    if (message.from?.is_bot) return
+    const time = new Date(message.date * 1000).toLocaleTimeString()
+    const sender = message.from?.username ?? message.from?.first_name ?? 'unknown'
+    console.log(`[${time}] message in ${message.chat.id} <${sender}>: ${message.text ?? '(non-text)'}`)
+  })
+
+  listener.on('edited_message', (message) => {
+    console.log(`[edit] message ${message.message_id} in ${message.chat.id}`)
+  })
+
+  listener.on('callback_query', (query) => {
+    console.log(`[callback] data=${query.data ?? '(none)'} from ${query.from.username ?? query.from.id}`)
+  })
+
+  listener.on('my_chat_member', (event) => {
+    console.log(`[my_chat_member] ${event.chat.id}: ${event.old_chat_member.status} -> ${event.new_chat_member.status}`)
+  })
+
+  listener.on('error', (err) => {
+    console.error(`[error] ${err.message}`)
+  })
+
+  process.on('SIGINT', () => {
+    console.log('\nStopping...')
+    listener.stop()
+    process.exit(130)
+  })
+
+  await listener.start()
+}
+
+main()

--- a/examples/telegrambot-listen.ts
+++ b/examples/telegrambot-listen.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// Run `agent-telegrambot auth set <token>` first so login() can pick up stored creds.
 import { TelegramBotClient } from '../src/platforms/telegrambot/client'
 import { TelegramBotListener } from '../src/platforms/telegrambot/listener'
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-messenger",
   "version": "2.12.0",
-  "description": "Multi-platform messaging CLI for AI agents (Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, Channel Talk)",
+  "description": "Multi-platform messaging CLI for AI agents (Slack, Discord, Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, Channel Talk)",
   "repository": {
     "type": "git",
     "url": "https://github.com/agent-messenger/agent-messenger"
@@ -19,6 +19,7 @@
     "agent-slackbot": "./src/platforms/slackbot/cli.ts",
     "agent-teams": "./src/platforms/teams/cli.ts",
     "agent-telegram": "./src/platforms/telegram/cli.ts",
+    "agent-telegrambot": "./src/platforms/telegrambot/cli.ts",
     "agent-webex": "./src/platforms/webex/cli.ts",
     "agent-wechatbot": "./src/platforms/wechatbot/cli.ts",
     "agent-whatsapp": "./src/platforms/whatsapp/cli.ts",
@@ -71,6 +72,9 @@
       ],
       "channeltalkbot": [
         "./src/platforms/channeltalkbot/index.ts"
+      ],
+      "telegrambot": [
+        "./src/platforms/telegrambot/index.ts"
       ]
     }
   },
@@ -135,6 +139,10 @@
     "./channeltalkbot": {
       "types": "./src/platforms/channeltalkbot/index.ts",
       "default": "./src/platforms/channeltalkbot/index.ts"
+    },
+    "./telegrambot": {
+      "types": "./src/platforms/telegrambot/index.ts",
+      "default": "./src/platforms/telegrambot/index.ts"
     }
   },
   "scripts": {

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -9,6 +9,7 @@ const cliFiles = [
   'dist/src/platforms/channeltalk/cli.js',
   'dist/src/platforms/channeltalkbot/cli.js',
   'dist/src/platforms/telegram/cli.js',
+  'dist/src/platforms/telegrambot/cli.js',
 ]
 
 for (const file of cliFiles) {

--- a/skills/agent-telegrambot/SKILL.md
+++ b/skills/agent-telegrambot/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: agent-telegrambot
+description: Interact with Telegram using bot tokens - send messages, read chats, manage reactions
+version: 2.12.0
+allowed-tools: Bash(agent-telegrambot:*)
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - agent-telegrambot
+    install:
+      - kind: node
+        package: agent-messenger
+        bins: [agent-telegrambot]
+---
+
+# Agent TelegramBot
+
+A TypeScript CLI tool that enables AI agents and humans to interact with Telegram using **Bot API tokens** (the kind issued by [@BotFather](https://t.me/BotFather)). Unlike `agent-telegram` which authenticates as a real user account via TDLib, `agent-telegrambot` uses Telegram's HTTP Bot API — designed for server-side and CI/CD integrations.
+
+## Key Concepts
+
+Before diving in, a few things about Telegram Bot integration:
+
+- **Bot tokens** — Issued by talking to [@BotFather](https://t.me/BotFather) inside Telegram. Format: `123456789:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`. Bot acts as its own bot account, with a username ending in `bot`.
+- **Bot ≠ User** — Bots cannot initiate DMs. The user must `/start` the bot first. In groups, bots receive only messages mentioning them or commands unless privacy mode is disabled in BotFather settings.
+- **Chat IDs** — Numeric IDs (positive for users, negative for groups, very negative for supergroups/channels). Channels can also be referenced by `@channelusername`.
+- **Real-time events** — Available via the SDK's long-polling listener (`getUpdates`), not via the CLI. Telegram Bot API does not support WebSockets.
+- **Webhook vs polling** — A bot can use webhooks OR long-polling, not both. The SDK listener auto-disables any active webhook before polling.
+
+## Quick Start
+
+```bash
+# Set your bot token (validates against Telegram)
+agent-telegrambot auth set 123456789:ABC-DEF1234...
+
+# Verify authentication
+agent-telegrambot whoami
+
+# Send a message
+agent-telegrambot message send @username "Hello from bot!"
+
+# Get chat info
+agent-telegrambot chat info @somegroup
+```
+
+## Authentication
+
+### Bot Token Setup
+
+`agent-telegrambot` uses Bot API tokens which you create by chatting with [@BotFather](https://t.me/BotFather):
+
+```bash
+# Set bot token (validates against Telegram API before saving)
+agent-telegrambot auth set 123456789:ABC-DEF1234...
+
+# Set with a custom bot identifier
+agent-telegrambot auth set <token> --bot deploy
+
+# Check auth status
+agent-telegrambot auth status
+
+# Clear stored credentials
+agent-telegrambot auth clear
+```
+
+### Multi-Bot Support
+
+```bash
+# List all configured bots
+agent-telegrambot auth list
+
+# Switch active bot
+agent-telegrambot auth use <bot-id>
+
+# Remove a bot
+agent-telegrambot auth remove <bot-id>
+
+# Use a specific bot for a single command
+agent-telegrambot --bot deploy message send @channel "Deploy succeeded"
+```
+
+## Memory
+
+The agent maintains a `~/.config/agent-messenger/MEMORY.md` file as persistent memory across sessions. This is agent-managed — the CLI does not read or write this file. Use the `Read` and `Write` tools to manage your memory file.
+
+### What to Store
+
+- Chat IDs with names (e.g. `-1001234567890` → "alerts channel")
+- User IDs with display names (e.g. `123456789` → "Alice")
+- Bot identifiers and their purposes
+- User-given aliases ("the alerts bot", "the team channel")
+
+### What NOT to Store
+
+Never store bot tokens, credentials, or any sensitive data. Never store full message content (just IDs and chat context).
+
+### Format / Example
+
+```markdown
+# Agent Messenger Memory
+
+## Telegram Bots
+
+- `deploy` — Deploy Bot (active)
+- `alert` — Alert Bot
+
+## Chats (Deploy Bot)
+
+- `-1001234567890` — #ci-alerts (channel)
+- `-1009876543210` — Engineering (supergroup)
+- `123456789` — Alice (DM)
+
+## Aliases
+
+- "alerts" → `-1001234567890`
+```
+
+## Commands
+
+### Auth Commands
+
+```bash
+# Set bot token
+agent-telegrambot auth set <token>
+agent-telegrambot auth set <token> --bot deploy
+
+# Check auth status
+agent-telegrambot auth status
+agent-telegrambot auth status --bot deploy
+
+# Clear all credentials
+agent-telegrambot auth clear
+
+# List stored bots
+agent-telegrambot auth list
+
+# Switch active bot
+agent-telegrambot auth use <bot-id>
+
+# Remove a stored bot
+agent-telegrambot auth remove <bot-id>
+```
+
+### Whoami Command
+
+```bash
+# Show current authenticated bot
+agent-telegrambot whoami
+agent-telegrambot whoami --pretty
+agent-telegrambot whoami --bot <bot-id>
+```
+
+### Message Commands
+
+```bash
+# Send a text message
+agent-telegrambot message send <chat> <text>
+agent-telegrambot message send @username "Hello"
+agent-telegrambot message send -1001234567890 "Hello channel"
+
+# Send with formatting
+agent-telegrambot message send @username "<b>Bold</b> message" --parse-mode HTML
+
+# Reply to a specific message
+agent-telegrambot message send @username "Reply text" --reply-to 12345
+
+# Send silently (no notification)
+agent-telegrambot message send @username "Silent message" --silent
+
+# Send to a forum topic
+agent-telegrambot message send <chat> "Topic message" --thread-id 5
+
+# Edit a message (bot's own messages only)
+agent-telegrambot message update <chat> <message-id> <new-text>
+
+# Delete a message
+agent-telegrambot message delete <chat> <message-id> --force
+
+# Forward a message between chats
+agent-telegrambot message forward <to-chat> <from-chat> <message-id>
+
+# Upload a document
+agent-telegrambot message upload <chat> ./report.pdf --caption "Daily report"
+```
+
+### Chat Commands
+
+```bash
+# Get chat info
+agent-telegrambot chat info <chat>
+agent-telegrambot chat info @somegroup
+agent-telegrambot chat info -1001234567890
+
+# Get chat member info
+agent-telegrambot chat member <chat> <user-id>
+```
+
+### Reaction Commands
+
+```bash
+# Set a reaction (replaces any existing reaction by the bot)
+agent-telegrambot reaction set <chat> <message-id> 👍
+agent-telegrambot reaction set <chat> <message-id> 👍 --big
+
+# Clear all reactions
+agent-telegrambot reaction clear <chat> <message-id>
+```
+
+## Output Format
+
+### JSON (Default)
+
+All commands output JSON by default for AI consumption:
+
+```json
+{
+  "message": {
+    "message_id": 42,
+    "chat_id": -1001234567890,
+    "text": "Hello",
+    "from": "mybot",
+    "date": 1735689600
+  }
+}
+```
+
+### Pretty (Human-Readable)
+
+Use `--pretty` flag for formatted output:
+
+```bash
+agent-telegrambot message send @username "Hello" --pretty
+```
+
+## Global Options
+
+| Option       | Description                            |
+| ------------ | -------------------------------------- |
+| `--pretty`   | Human-readable output instead of JSON  |
+| `--bot <id>` | Use a specific bot for this command    |
+
+## Chat ID Resolution
+
+The `<chat>` argument accepts:
+
+- **Numeric ID**: `123456789` (user), `-1001234567890` (channel/supergroup)
+- **@username**: `@channelname`, `@username` (must be public)
+- **Plain username**: `channelname` (auto-prefixed with `@`)
+
+Bots cannot DM a user who has never started a chat with the bot. The user must send `/start` first.
+
+## Real-Time Events
+
+Real-time events are NOT available in the CLI but ARE available via the SDK using long-polling:
+
+```typescript
+import { TelegramBotClient, TelegramBotListener } from 'agent-messenger/telegrambot'
+
+const client = await new TelegramBotClient().login({ token: 'YOUR_BOT_TOKEN' })
+const listener = new TelegramBotListener(client, {
+  allowedUpdates: ['message', 'callback_query'],
+})
+
+listener.on('message', (msg) => {
+  console.log(`From ${msg.chat.id}: ${msg.text}`)
+})
+
+await listener.start()
+```
+
+Long-polling means the bot opens a long-lived HTTPS connection that the server holds open until updates arrive. No public endpoint is required — perfect for CI/CD and behind-NAT environments.
+
+## Error Handling
+
+All commands return consistent error format:
+
+```json
+{
+  "error": "Forbidden: bot can't initiate conversation with a user"
+}
+```
+
+Common errors:
+
+- `Unauthorized` — Invalid or revoked bot token. Generate a new token via @BotFather.
+- `Forbidden` — Bot was kicked from chat, or user hasn't started the bot, or bot lacks permissions.
+- `Bad Request: chat not found` — Wrong chat ID, or the bot isn't a member of that chat.
+- `Conflict` — Another `getUpdates` call is in progress (only one polling instance allowed per bot).
+- `Too Many Requests` — Rate limited; the client automatically retries after the `retry_after` interval.
+
+## Configuration
+
+Credentials stored in `~/.config/agent-messenger/telegrambot-credentials.json` (0600 permissions). The location can be overridden with `AGENT_MESSENGER_CONFIG_DIR`.
+
+## Key Differences from agent-telegram
+
+| Feature              | agent-telegram (TDLib)            | agent-telegrambot (Bot API)       |
+| -------------------- | --------------------------------- | --------------------------------- |
+| Token type           | User session (TDLib)              | Bot token (BotFather)             |
+| Auth                 | Phone + code, stateful            | One-time token from BotFather     |
+| Initiate DMs         | Yes                               | No (user must `/start` first)     |
+| Read all group msgs  | Yes                               | Only with privacy mode disabled   |
+| ToS for automation   | Grey area at scale                | Officially sanctioned             |
+| CI/CD friendly       | Possible (persist auth state)     | Yes (just set token)              |
+| Real-time events     | Yes (TDLib updates)               | Yes (long-polling getUpdates)     |
+| Inline keyboards     | No                                | Yes (via SDK)                     |
+
+## Limitations
+
+- Bots cannot initiate DMs — user must send `/start` first
+- Bots cannot read group messages by default (privacy mode is on by default; turn it off via @BotFather for full access, or grant admin)
+- Bot can only edit/delete its own messages, except in groups where it has delete permissions
+- Plain text messages with optional HTML/Markdown parse modes (no inline keyboards from the CLI yet — use the SDK)
+- File uploads use multipart/form-data; max 50MB per file via the standard Bot API server
+- Only one `getUpdates` polling instance can run per bot (Telegram returns 409 Conflict otherwise)
+
+## Troubleshooting
+
+### `agent-telegrambot: command not found`
+
+**`agent-telegrambot` is NOT the npm package name.** The npm package is `agent-messenger`.
+
+If the package is installed globally, use `agent-telegrambot` directly:
+
+```bash
+agent-telegrambot message send @username "Hello"
+```
+
+If the package is NOT installed, use `npx -y` by default:
+
+```bash
+npx -y agent-messenger telegrambot message send @username "Hello"
+bunx agent-messenger telegrambot message send @username "Hello"
+pnpm dlx agent-messenger telegrambot message send @username "Hello"
+```
+
+> If you already know the user's preferred package runner (e.g., `bunx`, `pnpm dlx`), use that instead.
+
+**NEVER run `npx agent-telegrambot`, `bunx agent-telegrambot`, or `pnpm dlx agent-telegrambot`** — it will fail or install a wrong package since `agent-telegrambot` is not the npm package name.
+
+### "Forbidden: bot can't initiate conversation with a user"
+
+The user has never started a chat with the bot. They need to find the bot in Telegram and tap **Start** (or send `/start`) before the bot can message them.
+
+### "Conflict: terminated by other getUpdates request"
+
+Another instance (or a stale webhook) is polling the same bot. Stop other instances, or run:
+
+```bash
+# Through the SDK or curl - no CLI helper for this yet
+curl "https://api.telegram.org/bot<TOKEN>/deleteWebhook?drop_pending_updates=true"
+```
+
+### "Bad Request: chat not found"
+
+Either the chat ID is wrong, the username is misspelled, or the bot isn't a member of that chat. Make sure the bot has been added to the group/channel and (for channels) given posting permission.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,10 @@ program.command('telegram', 'Interact with Telegram via TDLib', {
   executableFile: join(__dirname, 'platforms', 'telegram', `cli${ext}`),
 })
 
+program.command('telegrambot', 'Interact with Telegram using bot tokens', {
+  executableFile: join(__dirname, 'platforms', 'telegrambot', `cli${ext}`),
+})
+
 program.command('whatsapp', 'Interact with WhatsApp via linked device', {
   executableFile: join(__dirname, 'platforms', 'whatsapp', `cli${ext}`),
 })

--- a/src/platforms/telegrambot/cli.ts
+++ b/src/platforms/telegrambot/cli.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+
+import { Command } from 'commander'
+
+import pkg from '../../../package.json' with { type: 'json' }
+import { authCommand, chatCommand, messageCommand, reactionCommand, whoamiCommand } from './commands/index'
+
+const program = new Command()
+
+program
+  .name('agent-telegrambot')
+  .description('CLI tool for Telegram bot integration using bot tokens')
+  .version(pkg.version)
+  .option('--pretty', 'Pretty-print JSON output')
+  .option('--bot <id>', 'Bot ID to use')
+  .hook('preAction', (thisCmd, actionCmd) => {
+    for (const [key, value] of Object.entries(thisCmd.opts())) {
+      if (value === undefined) continue
+      const source = actionCmd.getOptionValueSource(key)
+      if (source === undefined || source === 'default') {
+        actionCmd.setOptionValue(key, value)
+      }
+    }
+  })
+
+program.addCommand(authCommand)
+program.addCommand(whoamiCommand)
+program.addCommand(messageCommand)
+program.addCommand(chatCommand)
+program.addCommand(reactionCommand)
+
+program.parseAsync(process.argv)
+
+export default program

--- a/src/platforms/telegrambot/client.test.ts
+++ b/src/platforms/telegrambot/client.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { TelegramBotClient } from './client'
+import { TelegramBotError } from './types'
+
+describe('TelegramBotClient', () => {
+  const originalFetch = globalThis.fetch
+  let fetchCalls: Array<{ url: string; options?: RequestInit }> = []
+  let fetchResponses: Response[] = []
+  let fetchIndex = 0
+
+  beforeEach(() => {
+    fetchCalls = []
+    fetchResponses = []
+    fetchIndex = 0
+    ;(globalThis as Record<string, unknown>).fetch = async (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      fetchCalls.push({ url: url.toString(), options })
+      const response = fetchResponses[fetchIndex]
+      fetchIndex++
+      if (!response) {
+        throw new Error('No mock response configured')
+      }
+      return response
+    }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const mockOk = (result: unknown): void => {
+    fetchResponses.push(
+      new Response(JSON.stringify({ ok: true, result }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  }
+
+  const mockApiError = (errorCode: number, description: string, params?: Record<string, unknown>): void => {
+    fetchResponses.push(
+      new Response(JSON.stringify({ ok: false, error_code: errorCode, description, parameters: params }), {
+        status: errorCode >= 400 && errorCode < 600 ? errorCode : 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  }
+
+  describe('login', () => {
+    it('requires non-empty token', async () => {
+      await expect(new TelegramBotClient().login({ token: '' })).rejects.toThrow(TelegramBotError)
+      await expect(new TelegramBotClient().login({ token: '' })).rejects.toThrow('Token is required')
+    })
+
+    it('accepts a valid token', async () => {
+      const client = await new TelegramBotClient().login({ token: '123:abc' })
+      expect(client).toBeInstanceOf(TelegramBotClient)
+    })
+  })
+
+  describe('getMe', () => {
+    it('returns bot user and uses /bot<token>/getMe URL', async () => {
+      mockOk({ id: 123456, is_bot: true, first_name: 'Test', username: 'testbot' })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const me = await client.getMe()
+
+      expect(me.id).toBe(123456)
+      expect(me.is_bot).toBe(true)
+      expect(me.username).toBe('testbot')
+      expect(fetchCalls[0].url).toBe('https://api.telegram.org/botTOKEN/getMe')
+      expect(fetchCalls[0].options?.method).toBe('POST')
+    })
+
+    it('throws TelegramBotError with code "unauthorized" on 401', async () => {
+      mockApiError(401, 'Unauthorized')
+      const client = await new TelegramBotClient().login({ token: 'bad' })
+      try {
+        await client.getMe()
+        expect(false).toBe(true)
+      } catch (e) {
+        expect(e).toBeInstanceOf(TelegramBotError)
+        expect((e as TelegramBotError).code).toBe('unauthorized')
+      }
+    })
+  })
+
+  describe('sendMessage', () => {
+    it('sends text message with chat_id and text body', async () => {
+      mockOk({
+        message_id: 42,
+        date: 1735689600,
+        chat: { id: -100123, type: 'supergroup', title: 'Eng' },
+        text: 'Hello',
+      })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const msg = await client.sendMessage(-100123, 'Hello')
+
+      expect(msg.message_id).toBe(42)
+      expect(msg.text).toBe('Hello')
+
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.chat_id).toBe(-100123)
+      expect(body.text).toBe('Hello')
+    })
+
+    it('forwards optional parse_mode and reply_to_message_id', async () => {
+      mockOk({
+        message_id: 1,
+        date: 1,
+        chat: { id: 1, type: 'private', first_name: 'X' },
+        text: '<b>Hi</b>',
+      })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      await client.sendMessage(1, '<b>Hi</b>', { parse_mode: 'HTML', reply_to_message_id: 5 })
+
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.parse_mode).toBe('HTML')
+      expect(body.reply_to_message_id).toBe(5)
+    })
+  })
+
+  describe('rate limiting', () => {
+    it('retries after retry_after on 429', async () => {
+      mockApiError(429, 'Too Many Requests', { retry_after: 0 })
+      mockOk({ id: 1, is_bot: true, first_name: 'X' })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const me = await client.getMe()
+
+      expect(me.id).toBe(1)
+      expect(fetchCalls).toHaveLength(2)
+    })
+  })
+
+  describe('error mapping', () => {
+    it('maps 409 conflict to "conflict" code', async () => {
+      mockApiError(409, 'Conflict: terminated by other getUpdates request')
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      try {
+        await client.getMe()
+        expect(false).toBe(true)
+      } catch (e) {
+        expect(e).toBeInstanceOf(TelegramBotError)
+        expect((e as TelegramBotError).code).toBe('conflict')
+      }
+    })
+
+    it('maps 400 to "bad_request"', async () => {
+      mockApiError(400, 'Bad Request: chat not found')
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      try {
+        await client.getMe()
+        expect(false).toBe(true)
+      } catch (e) {
+        expect((e as TelegramBotError).code).toBe('bad_request')
+      }
+    })
+
+    it('maps 403 to "forbidden"', async () => {
+      mockApiError(403, "Forbidden: bot can't initiate conversation with a user")
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      try {
+        await client.getMe()
+        expect(false).toBe(true)
+      } catch (e) {
+        expect((e as TelegramBotError).code).toBe('forbidden')
+      }
+    })
+  })
+
+  describe('getUpdates', () => {
+    it('passes offset, limit, timeout to API', async () => {
+      mockOk([])
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      await client.getUpdates({ offset: 5, limit: 50, timeout: 30, allowed_updates: ['message'] })
+
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.offset).toBe(5)
+      expect(body.limit).toBe(50)
+      expect(body.timeout).toBe(30)
+      expect(body.allowed_updates).toEqual(['message'])
+    })
+  })
+
+  describe('deleteMessage', () => {
+    it('returns boolean result', async () => {
+      mockOk(true)
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const ok = await client.deleteMessage(123, 42)
+      expect(ok).toBe(true)
+    })
+  })
+
+  describe('setMessageReaction', () => {
+    it('sends reaction array', async () => {
+      mockOk(true)
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      await client.setMessageReaction(123, 42, [{ type: 'emoji', emoji: '👍' }], { is_big: true })
+
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.reaction).toEqual([{ type: 'emoji', emoji: '👍' }])
+      expect(body.is_big).toBe(true)
+    })
+  })
+
+  describe('resolveChatId', () => {
+    it('returns numeric input as number', async () => {
+      const client = new TelegramBotClient()
+      expect(await client.resolveChatId(-100123)).toBe(-100123)
+    })
+
+    it('parses numeric string', async () => {
+      const client = new TelegramBotClient()
+      expect(await client.resolveChatId('-100123')).toBe(-100123)
+    })
+
+    it('keeps @username as is', async () => {
+      const client = new TelegramBotClient()
+      expect(await client.resolveChatId('@channel')).toBe('@channel')
+    })
+
+    it('prefixes plain username with @', async () => {
+      const client = new TelegramBotClient()
+      expect(await client.resolveChatId('channel')).toBe('@channel')
+    })
+  })
+})

--- a/src/platforms/telegrambot/client.test.ts
+++ b/src/platforms/telegrambot/client.test.ts
@@ -230,4 +230,225 @@ describe('TelegramBotClient', () => {
       expect(await client.resolveChatId('channel')).toBe('@channel')
     })
   })
+
+  describe('formatChat', () => {
+    const client = new TelegramBotClient()
+
+    it('uses title when present', () => {
+      expect(client.formatChat({ id: 1, type: 'supergroup', title: 'Eng' })).toEqual({
+        id: 1,
+        type: 'supergroup',
+        name: 'Eng',
+      })
+    })
+
+    it('uses first_name + last_name when title missing', () => {
+      expect(client.formatChat({ id: 1, type: 'private', first_name: 'Ada', last_name: 'Lovelace' })).toEqual({
+        id: 1,
+        type: 'private',
+        name: 'Ada Lovelace',
+      })
+    })
+
+    it('falls back to username when name parts are empty', () => {
+      expect(client.formatChat({ id: 1, type: 'private', username: 'ada' })).toEqual({
+        id: 1,
+        type: 'private',
+        name: 'ada',
+      })
+    })
+
+    it('falls back to id when nothing is set', () => {
+      expect(client.formatChat({ id: 42, type: 'private' })).toEqual({ id: 42, type: 'private', name: '42' })
+    })
+  })
+
+  describe('getChat / getChatMember / getChatMemberCount', () => {
+    it('getChat sends chat_id', async () => {
+      mockOk({ id: -100123, type: 'supergroup', title: 'Eng', description: 'ENG team' })
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const chat = await client.getChat(-100123)
+
+      expect(chat.id).toBe(-100123)
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.chat_id).toBe(-100123)
+    })
+
+    it('getChatMember sends chat_id and user_id', async () => {
+      mockOk({ user: { id: 1, is_bot: false, first_name: 'A' }, status: 'member' })
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      await client.getChatMember(-100123, 42)
+
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.chat_id).toBe(-100123)
+      expect(body.user_id).toBe(42)
+    })
+
+    it('getChatMemberCount returns number', async () => {
+      mockOk(7)
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const count = await client.getChatMemberCount(-100123)
+      expect(count).toBe(7)
+    })
+  })
+
+  describe('forwardMessage', () => {
+    it('sends chat_id, from_chat_id, message_id', async () => {
+      mockOk({
+        message_id: 99,
+        date: 1,
+        chat: { id: 200, type: 'supergroup', title: 'Dst' },
+        text: 'forwarded',
+      })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const msg = await client.forwardMessage(200, 100, 42)
+
+      expect(msg.message_id).toBe(99)
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.chat_id).toBe(200)
+      expect(body.from_chat_id).toBe(100)
+      expect(body.message_id).toBe(42)
+    })
+  })
+
+  describe('editMessageText', () => {
+    it('accepts chat-message target', async () => {
+      mockOk({
+        message_id: 42,
+        date: 1,
+        chat: { id: 1, type: 'private', first_name: 'A' },
+        text: 'edited',
+      })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const result = await client.editMessageText({ chat_id: 1, message_id: 42 }, 'edited')
+
+      expect(typeof result === 'object' && result !== null && 'message_id' in result).toBe(true)
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.chat_id).toBe(1)
+      expect(body.message_id).toBe(42)
+      expect(body.text).toBe('edited')
+    })
+
+    it('accepts inline-message target', async () => {
+      mockOk(true)
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const result = await client.editMessageText({ inline_message_id: 'inline123' }, 'edited')
+
+      expect(result).toBe(true)
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.inline_message_id).toBe('inline123')
+      expect(body.chat_id).toBeUndefined()
+    })
+  })
+
+  describe('sendDocument (multipart)', () => {
+    it('uploads file with multipart/form-data and forwards optional caption', async () => {
+      const fs = await import('node:fs/promises')
+      const os = await import('node:os')
+      const path = await import('node:path')
+      const tmp = path.join(os.tmpdir(), `tgbot-doc-test-${Date.now()}.txt`)
+      await fs.writeFile(tmp, 'hello')
+
+      try {
+        mockOk({
+          message_id: 1,
+          date: 1,
+          chat: { id: 1, type: 'private', first_name: 'A' },
+          document: { file_id: 'F1', file_unique_id: 'U1', file_name: tmp.split('/').pop() },
+        })
+
+        const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+        const msg = await client.sendDocument(1, tmp, { caption: 'hi' })
+
+        expect(msg.message_id).toBe(1)
+        const body = fetchCalls[0].options?.body
+        expect(body).toBeInstanceOf(FormData)
+        const fd = body as unknown as FormData
+        expect(fd.get('chat_id')).toBe('1')
+        expect(fd.get('caption')).toBe('hi')
+        expect(fd.get('document')).toBeInstanceOf(Blob)
+      } finally {
+        await fs.unlink(tmp).catch(() => undefined)
+      }
+    })
+  })
+
+  describe('setWebhook / deleteWebhook', () => {
+    it('deleteWebhook with drop_pending_updates', async () => {
+      mockOk(true)
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const ok = await client.deleteWebhook({ drop_pending_updates: true })
+
+      expect(ok).toBe(true)
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.drop_pending_updates).toBe(true)
+    })
+
+    it('setWebhook with url', async () => {
+      mockOk(true)
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      await client.setWebhook('https://example.com/hook', { secret_token: 's3cret' })
+
+      const body = JSON.parse(fetchCalls[0].options?.body as string)
+      expect(body.url).toBe('https://example.com/hook')
+      expect(body.secret_token).toBe('s3cret')
+    })
+  })
+
+  describe('abort', () => {
+    it('throws AbortError when signal is already aborted', async () => {
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const ac = new AbortController()
+      ac.abort()
+      try {
+        await client.getUpdates(undefined, ac.signal)
+        expect(false).toBe(true)
+      } catch (e) {
+        expect((e as Error).name).toBe('AbortError')
+      }
+    })
+
+    it('treats signal.aborted as authoritative even if fetch throws non-AbortError', async () => {
+      ;(globalThis as Record<string, unknown>).fetch = async (
+        _url: string | URL | Request,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        const signal = init?.signal as AbortSignal | undefined
+        if (signal?.aborted) {
+          throw new Error('connection reset')
+        }
+        return new Response(JSON.stringify({ ok: true, result: [] }), { status: 200 })
+      }
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const ac = new AbortController()
+      ac.abort()
+      try {
+        await client.getUpdates(undefined, ac.signal)
+        expect(false).toBe(true)
+      } catch (e) {
+        expect((e as Error).name).toBe('AbortError')
+      }
+    })
+  })
+
+  describe('5xx retry', () => {
+    it('retries 502 with non-JSON body before failing', async () => {
+      fetchResponses.push(
+        new Response('<html>502 Bad Gateway</html>', {
+          status: 502,
+          headers: { 'Content-Type': 'text/html' },
+        }),
+      )
+      mockOk({ id: 1, is_bot: true, first_name: 'X' })
+
+      const client = await new TelegramBotClient().login({ token: 'TOKEN' })
+      const me = await client.getMe()
+      expect(me.id).toBe(1)
+      expect(fetchCalls).toHaveLength(2)
+    })
+  })
 })

--- a/src/platforms/telegrambot/client.test.ts
+++ b/src/platforms/telegrambot/client.test.ts
@@ -436,7 +436,7 @@ describe('TelegramBotClient', () => {
   })
 
   describe('5xx retry', () => {
-    it('retries 502 with non-JSON body before failing', async () => {
+    it('retries 502 with non-JSON body and succeeds on next attempt', async () => {
       fetchResponses.push(
         new Response('<html>502 Bad Gateway</html>', {
           status: 502,

--- a/src/platforms/telegrambot/client.ts
+++ b/src/platforms/telegrambot/client.ts
@@ -1,0 +1,331 @@
+import { readFile } from 'node:fs/promises'
+
+import type {
+  TelegramBotUser,
+  TelegramChat,
+  TelegramChatFullInfo,
+  TelegramChatMember,
+  TelegramMessage,
+  TelegramReactionType,
+  TelegramUpdate,
+} from './types'
+import { TelegramBotError } from './types'
+
+const BASE_URL = 'https://api.telegram.org'
+const MAX_RETRIES = 3
+const BASE_BACKOFF_MS = 100
+
+interface ApiResponse<T> {
+  ok: boolean
+  result?: T
+  description?: string
+  error_code?: number
+  parameters?: {
+    retry_after?: number
+    migrate_to_chat_id?: number
+  }
+}
+
+export interface SendMessageOptions {
+  parse_mode?: 'HTML' | 'Markdown' | 'MarkdownV2'
+  disable_web_page_preview?: boolean
+  disable_notification?: boolean
+  protect_content?: boolean
+  reply_to_message_id?: number
+  message_thread_id?: number
+}
+
+export interface GetUpdatesOptions {
+  offset?: number
+  limit?: number
+  timeout?: number
+  allowed_updates?: string[]
+}
+
+export type ChatId = number | string
+
+export class TelegramBotClient {
+  private token: string | null = null
+
+  async login(credentials?: { token: string }): Promise<this> {
+    if (credentials) {
+      if (!credentials.token) {
+        throw new TelegramBotError('Token is required', 'missing_token')
+      }
+      this.token = credentials.token
+      return this
+    }
+
+    const { TelegramBotCredentialManager } = await import('./credential-manager')
+    const credManager = new TelegramBotCredentialManager()
+    const creds = await credManager.getCredentials()
+    if (!creds?.token) {
+      throw new TelegramBotError('No Telegram bot credentials found. Run "auth set <token>" first.', 'no_credentials')
+    }
+    return this.login({ token: creds.token })
+  }
+
+  private ensureAuth(): string {
+    if (!this.token) {
+      throw new TelegramBotError('Not authenticated. Call .login() first.', 'not_authenticated')
+    }
+    return this.token
+  }
+
+  private buildUrl(method: string): string {
+    return `${BASE_URL}/bot${this.ensureAuth()}/${method}`
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  private throwApiError(method: string, body: ApiResponse<unknown>): never {
+    const code = body.error_code
+    const description = body.description ?? `HTTP error from ${method}`
+    if (code === 401) {
+      throw new TelegramBotError(`Unauthorized: ${description}`, 'unauthorized')
+    }
+    if (code === 409) {
+      throw new TelegramBotError(`Conflict: ${description}`, 'conflict')
+    }
+    if (code === 403) {
+      throw new TelegramBotError(`Forbidden: ${description}`, 'forbidden')
+    }
+    if (code === 400) {
+      throw new TelegramBotError(`Bad Request: ${description}`, 'bad_request')
+    }
+    if (code === 404) {
+      throw new TelegramBotError(`Not Found: ${description}`, 'not_found')
+    }
+    throw new TelegramBotError(description, code !== undefined ? `http_${code}` : 'http_error')
+  }
+
+  private async call<T>(method: string, params?: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
+    const url = this.buildUrl(method)
+    let lastError: Error | undefined
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const init: RequestInit = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: params ? JSON.stringify(params) : undefined,
+        signal,
+      }
+
+      let response: Response
+      try {
+        response = await fetch(url, init)
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          throw error
+        }
+        lastError = error instanceof Error ? error : new Error(String(error))
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
+          continue
+        }
+        throw new TelegramBotError(`Network error: ${lastError.message}`, 'network_error')
+      }
+
+      let body: ApiResponse<T>
+      try {
+        body = (await response.json()) as ApiResponse<T>
+      } catch {
+        throw new TelegramBotError(`Invalid JSON response from ${method} (HTTP ${response.status})`, 'invalid_response')
+      }
+
+      if (response.status === 429 || body.error_code === 429) {
+        const retryAfter = body.parameters?.retry_after ?? 1
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(retryAfter * 1000)
+          continue
+        }
+        throw new TelegramBotError(body.description ?? 'Rate limited', 'rate_limited')
+      }
+
+      if (response.status >= 500 && attempt < MAX_RETRIES) {
+        await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
+        continue
+      }
+
+      if (!body.ok) {
+        this.throwApiError(method, body)
+      }
+
+      if (body.result === undefined) {
+        return undefined as T
+      }
+      return body.result
+    }
+
+    throw lastError ?? new TelegramBotError('Request failed after retries', 'max_retries')
+  }
+
+  private async callMultipart<T>(method: string, formData: FormData): Promise<T> {
+    const url = this.buildUrl(method)
+    let lastError: Error | undefined
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      let response: Response
+      try {
+        response = await fetch(url, { method: 'POST', body: formData })
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error))
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
+          continue
+        }
+        throw new TelegramBotError(`Network error: ${lastError.message}`, 'network_error')
+      }
+
+      const body = (await response.json().catch(() => ({}))) as ApiResponse<T>
+
+      if (response.status === 429 || body.error_code === 429) {
+        const retryAfter = body.parameters?.retry_after ?? 1
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(retryAfter * 1000)
+          continue
+        }
+        throw new TelegramBotError(body.description ?? 'Rate limited', 'rate_limited')
+      }
+
+      if (response.status >= 500 && attempt < MAX_RETRIES) {
+        await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
+        continue
+      }
+
+      if (!body.ok) {
+        this.throwApiError(method, body)
+      }
+
+      if (body.result === undefined) {
+        return undefined as T
+      }
+      return body.result
+    }
+
+    throw lastError ?? new TelegramBotError('Request failed after retries', 'max_retries')
+  }
+
+  async getMe(): Promise<TelegramBotUser> {
+    return this.call<TelegramBotUser>('getMe')
+  }
+
+  async getChat(chatId: ChatId): Promise<TelegramChatFullInfo> {
+    return this.call<TelegramChatFullInfo>('getChat', { chat_id: chatId })
+  }
+
+  async getChatMember(chatId: ChatId, userId: number): Promise<TelegramChatMember> {
+    return this.call<TelegramChatMember>('getChatMember', { chat_id: chatId, user_id: userId })
+  }
+
+  async getChatMemberCount(chatId: ChatId): Promise<number> {
+    return this.call<number>('getChatMemberCount', { chat_id: chatId })
+  }
+
+  async sendMessage(chatId: ChatId, text: string, options?: SendMessageOptions): Promise<TelegramMessage> {
+    return this.call<TelegramMessage>('sendMessage', { chat_id: chatId, text, ...options })
+  }
+
+  async sendPhoto(
+    chatId: ChatId,
+    photo: string,
+    options?: { caption?: string; parse_mode?: SendMessageOptions['parse_mode'] },
+  ): Promise<TelegramMessage> {
+    return this.call<TelegramMessage>('sendPhoto', { chat_id: chatId, photo, ...options })
+  }
+
+  async sendDocument(
+    chatId: ChatId,
+    filePath: string,
+    options?: { caption?: string; parse_mode?: SendMessageOptions['parse_mode'] },
+  ): Promise<TelegramMessage> {
+    const fileBuffer = await readFile(filePath)
+    const filename = filePath.split('/').pop() || 'file'
+
+    const formData = new FormData()
+    formData.append('chat_id', String(chatId))
+    formData.append('document', new Blob([new Uint8Array(fileBuffer)]), filename)
+    if (options?.caption !== undefined) formData.append('caption', options.caption)
+    if (options?.parse_mode !== undefined) formData.append('parse_mode', options.parse_mode)
+
+    return this.callMultipart<TelegramMessage>('sendDocument', formData)
+  }
+
+  async forwardMessage(
+    chatId: ChatId,
+    fromChatId: ChatId,
+    messageId: number,
+    options?: { disable_notification?: boolean; protect_content?: boolean; message_thread_id?: number },
+  ): Promise<TelegramMessage> {
+    return this.call<TelegramMessage>('forwardMessage', {
+      chat_id: chatId,
+      from_chat_id: fromChatId,
+      message_id: messageId,
+      ...options,
+    })
+  }
+
+  async editMessageText(
+    chatId: ChatId,
+    messageId: number,
+    text: string,
+    options?: SendMessageOptions,
+  ): Promise<TelegramMessage> {
+    return this.call<TelegramMessage>('editMessageText', {
+      chat_id: chatId,
+      message_id: messageId,
+      text,
+      ...options,
+    })
+  }
+
+  async deleteMessage(chatId: ChatId, messageId: number): Promise<boolean> {
+    return this.call<boolean>('deleteMessage', { chat_id: chatId, message_id: messageId })
+  }
+
+  async setMessageReaction(
+    chatId: ChatId,
+    messageId: number,
+    reaction: TelegramReactionType[],
+    options?: { is_big?: boolean },
+  ): Promise<boolean> {
+    return this.call<boolean>('setMessageReaction', {
+      chat_id: chatId,
+      message_id: messageId,
+      reaction,
+      ...options,
+    })
+  }
+
+  async getUpdates(options?: GetUpdatesOptions, signal?: AbortSignal): Promise<TelegramUpdate[]> {
+    const params: Record<string, unknown> = {}
+    if (options?.offset !== undefined) params.offset = options.offset
+    if (options?.limit !== undefined) params.limit = options.limit
+    if (options?.timeout !== undefined) params.timeout = options.timeout
+    if (options?.allowed_updates !== undefined) params.allowed_updates = options.allowed_updates
+    return this.call<TelegramUpdate[]>('getUpdates', params, signal)
+  }
+
+  async deleteWebhook(options?: { drop_pending_updates?: boolean }): Promise<boolean> {
+    return this.call<boolean>('deleteWebhook', options)
+  }
+
+  async setWebhook(url: string, options?: Record<string, unknown>): Promise<boolean> {
+    return this.call<boolean>('setWebhook', { url, ...options })
+  }
+
+  async resolveChatId(chat: ChatId): Promise<ChatId> {
+    if (typeof chat === 'number') return chat
+    if (/^-?\d+$/.test(chat)) return Number(chat)
+    if (chat.startsWith('@')) return chat
+    return `@${chat}`
+  }
+
+  formatChat(chat: TelegramChat): { id: number; type: string; name: string } {
+    const name =
+      chat.title ?? [chat.first_name, chat.last_name].filter(Boolean).join(' ') ?? chat.username ?? String(chat.id)
+    return { id: chat.id, type: chat.type, name }
+  }
+}

--- a/src/platforms/telegrambot/client.ts
+++ b/src/platforms/telegrambot/client.ts
@@ -42,6 +42,22 @@ export interface GetUpdatesOptions {
   allowed_updates?: string[]
 }
 
+export interface EditMessageTextChat {
+  chat_id: number | string
+  message_id: number
+  inline_message_id?: never
+}
+
+export interface EditMessageTextInline {
+  inline_message_id: string
+  chat_id?: never
+  message_id?: never
+}
+
+export type EditMessageTextTarget = EditMessageTextChat | EditMessageTextInline
+
+export type BotReactionType = { type: 'emoji'; emoji: string }
+
 export type ChatId = number | string
 
 export class TelegramBotClient {
@@ -80,6 +96,12 @@ export class TelegramBotClient {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
+  private isAbort(signal: AbortSignal | undefined, error: unknown): boolean {
+    if (signal?.aborted) return true
+    const name = (error as { name?: string } | null)?.name
+    return name === 'AbortError'
+  }
+
   private throwApiError(method: string, body: ApiResponse<unknown>): never {
     const code = body.error_code
     const description = body.description ?? `HTTP error from ${method}`
@@ -101,15 +123,44 @@ export class TelegramBotClient {
     throw new TelegramBotError(description, code !== undefined ? `http_${code}` : 'http_error')
   }
 
+  private async parseJsonOrRetry<T>(
+    response: Response,
+    method: string,
+    attempt: number,
+  ): Promise<{ body: ApiResponse<T> } | { retry: true }> {
+    try {
+      const body = (await response.json()) as ApiResponse<T>
+      return { body }
+    } catch {
+      // 5xx responses sometimes return HTML/empty bodies; allow retry instead of failing fast.
+      if (response.status >= 500 && attempt < MAX_RETRIES) {
+        return { retry: true }
+      }
+      throw new TelegramBotError(`Invalid JSON response from ${method} (HTTP ${response.status})`, 'invalid_response')
+    }
+  }
+
   private async call<T>(method: string, params?: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
+    return this.requestJson<T>(method, { method: 'POST', body: params }, signal)
+  }
+
+  private async requestJson<T>(
+    method: string,
+    request: { method: 'POST' | 'GET'; body?: Record<string, unknown> },
+    signal?: AbortSignal,
+  ): Promise<T> {
     const url = this.buildUrl(method)
     let lastError: Error | undefined
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (signal?.aborted) {
+        throw Object.assign(new Error('Aborted'), { name: 'AbortError' })
+      }
+
       const init: RequestInit = {
-        method: 'POST',
+        method: request.method,
         headers: { 'Content-Type': 'application/json' },
-        body: params ? JSON.stringify(params) : undefined,
+        body: request.body ? JSON.stringify(request.body) : undefined,
         signal,
       }
 
@@ -117,8 +168,8 @@ export class TelegramBotClient {
       try {
         response = await fetch(url, init)
       } catch (error) {
-        if ((error as Error).name === 'AbortError') {
-          throw error
+        if (this.isAbort(signal, error)) {
+          throw error instanceof Error ? error : Object.assign(new Error('Aborted'), { name: 'AbortError' })
         }
         lastError = error instanceof Error ? error : new Error(String(error))
         if (attempt < MAX_RETRIES) {
@@ -128,12 +179,12 @@ export class TelegramBotClient {
         throw new TelegramBotError(`Network error: ${lastError.message}`, 'network_error')
       }
 
-      let body: ApiResponse<T>
-      try {
-        body = (await response.json()) as ApiResponse<T>
-      } catch {
-        throw new TelegramBotError(`Invalid JSON response from ${method} (HTTP ${response.status})`, 'invalid_response')
+      const parsed = await this.parseJsonOrRetry<T>(response, method, attempt)
+      if ('retry' in parsed) {
+        await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
+        continue
       }
+      const { body } = parsed
 
       if (response.status === 429 || body.error_code === 429) {
         const retryAfter = body.parameters?.retry_after ?? 1
@@ -162,15 +213,22 @@ export class TelegramBotClient {
     throw lastError ?? new TelegramBotError('Request failed after retries', 'max_retries')
   }
 
-  private async callMultipart<T>(method: string, formData: FormData): Promise<T> {
+  private async callMultipart<T>(method: string, formData: FormData, signal?: AbortSignal): Promise<T> {
     const url = this.buildUrl(method)
     let lastError: Error | undefined
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (signal?.aborted) {
+        throw Object.assign(new Error('Aborted'), { name: 'AbortError' })
+      }
+
       let response: Response
       try {
-        response = await fetch(url, { method: 'POST', body: formData })
+        response = await fetch(url, { method: 'POST', body: formData, signal })
       } catch (error) {
+        if (this.isAbort(signal, error)) {
+          throw error instanceof Error ? error : Object.assign(new Error('Aborted'), { name: 'AbortError' })
+        }
         lastError = error instanceof Error ? error : new Error(String(error))
         if (attempt < MAX_RETRIES) {
           await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
@@ -179,7 +237,12 @@ export class TelegramBotClient {
         throw new TelegramBotError(`Network error: ${lastError.message}`, 'network_error')
       }
 
-      const body = (await response.json().catch(() => ({}))) as ApiResponse<T>
+      const parsed = await this.parseJsonOrRetry<T>(response, method, attempt)
+      if ('retry' in parsed) {
+        await this.sleep(BASE_BACKOFF_MS * 2 ** attempt)
+        continue
+      }
+      const { body } = parsed
 
       if (response.status === 429 || body.error_code === 429) {
         const retryAfter = body.parameters?.retry_after ?? 1
@@ -239,7 +302,7 @@ export class TelegramBotClient {
   async sendDocument(
     chatId: ChatId,
     filePath: string,
-    options?: { caption?: string; parse_mode?: SendMessageOptions['parse_mode'] },
+    options?: { caption?: string; parse_mode?: SendMessageOptions['parse_mode']; signal?: AbortSignal },
   ): Promise<TelegramMessage> {
     const fileBuffer = await readFile(filePath)
     const filename = filePath.split('/').pop() || 'file'
@@ -250,7 +313,7 @@ export class TelegramBotClient {
     if (options?.caption !== undefined) formData.append('caption', options.caption)
     if (options?.parse_mode !== undefined) formData.append('parse_mode', options.parse_mode)
 
-    return this.callMultipart<TelegramMessage>('sendDocument', formData)
+    return this.callMultipart<TelegramMessage>('sendDocument', formData, options?.signal)
   }
 
   async forwardMessage(
@@ -268,17 +331,11 @@ export class TelegramBotClient {
   }
 
   async editMessageText(
-    chatId: ChatId,
-    messageId: number,
+    target: EditMessageTextTarget,
     text: string,
     options?: SendMessageOptions,
-  ): Promise<TelegramMessage> {
-    return this.call<TelegramMessage>('editMessageText', {
-      chat_id: chatId,
-      message_id: messageId,
-      text,
-      ...options,
-    })
+  ): Promise<TelegramMessage | true> {
+    return this.call<TelegramMessage | true>('editMessageText', { ...target, text, ...options })
   }
 
   async deleteMessage(chatId: ChatId, messageId: number): Promise<boolean> {
@@ -286,6 +343,20 @@ export class TelegramBotClient {
   }
 
   async setMessageReaction(
+    chatId: ChatId,
+    messageId: number,
+    reaction: BotReactionType[],
+    options?: { is_big?: boolean },
+  ): Promise<boolean> {
+    return this.call<boolean>('setMessageReaction', {
+      chat_id: chatId,
+      message_id: messageId,
+      reaction,
+      ...options,
+    })
+  }
+
+  async setMessageReactionRaw(
     chatId: ChatId,
     messageId: number,
     reaction: TelegramReactionType[],
@@ -324,8 +395,10 @@ export class TelegramBotClient {
   }
 
   formatChat(chat: TelegramChat): { id: number; type: string; name: string } {
-    const name =
-      chat.title ?? [chat.first_name, chat.last_name].filter(Boolean).join(' ') ?? chat.username ?? String(chat.id)
-    return { id: chat.id, type: chat.type, name }
+    if (chat.title) return { id: chat.id, type: chat.type, name: chat.title }
+    const fullName = [chat.first_name, chat.last_name].filter(Boolean).join(' ')
+    if (fullName) return { id: chat.id, type: chat.type, name: fullName }
+    if (chat.username) return { id: chat.id, type: chat.type, name: chat.username }
+    return { id: chat.id, type: chat.type, name: String(chat.id) }
   }
 }

--- a/src/platforms/telegrambot/commands/auth.test.ts
+++ b/src/platforms/telegrambot/commands/auth.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, mock, it } from 'bun:test'
+import { existsSync, rmSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const mockGetMe = mock(() =>
+  Promise.resolve({
+    id: 123456,
+    is_bot: true,
+    first_name: 'Test',
+    username: 'testbot',
+  }),
+)
+
+mock.module('../client', () => ({
+  TelegramBotClient: class MockTelegramBotClient {
+    async login(_credentials?: unknown): Promise<this> {
+      return this
+    }
+    getMe = mockGetMe
+  },
+}))
+
+import { TelegramBotCredentialManager } from '../credential-manager'
+import { clearAction, listAction, removeAction, setAction, statusAction, useAction } from './auth'
+
+describe('auth commands', () => {
+  let tempDir: string
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `telegrambot-auth-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(tempDir, { recursive: true })
+    originalEnv = { ...process.env }
+    delete process.env.E2E_TELEGRAMBOT_TOKEN
+    mockGetMe.mockClear()
+  })
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true })
+    }
+    process.env = originalEnv
+  })
+
+  describe('setAction', () => {
+    it('validates and stores bot token using username as bot_id', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+
+      const result = await setAction('123:abc', { _credManager: manager })
+
+      expect(result.success).toBe(true)
+      expect(result.bot_id).toBe('testbot')
+      expect(result.bot_name).toBe('testbot')
+
+      const creds = await manager.getCredentials()
+      expect(creds?.token).toBe('123:abc')
+      expect(creds?.bot_id).toBe('testbot')
+    })
+
+    it('uses --bot flag as bot_id', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+
+      const result = await setAction('123:abc', { bot: 'deploy', _credManager: manager })
+
+      expect(result.bot_id).toBe('deploy')
+      expect(await manager.getCredentials('deploy')).not.toBeNull()
+    })
+
+    it('falls back to numeric id when username missing', async () => {
+      mockGetMe.mockImplementationOnce(() =>
+        Promise.resolve({
+          id: 123456,
+          is_bot: true,
+          first_name: 'NoUsername',
+        }),
+      )
+
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await setAction('123:abc', { _credManager: manager })
+
+      expect(result.bot_id).toBe('123456')
+    })
+
+    it('rejects non-bot tokens (is_bot: false)', async () => {
+      mockGetMe.mockImplementationOnce(() =>
+        Promise.resolve({
+          id: 123456,
+          is_bot: false,
+          first_name: 'User',
+        }),
+      )
+
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await setAction('user-token', { _credManager: manager })
+
+      expect(result.error).toBeDefined()
+      expect(result.error).toContain('not')
+    })
+
+    it('handles client errors', async () => {
+      mockGetMe.mockImplementationOnce(() => Promise.reject(new Error('Unauthorized: invalid token')))
+
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await setAction('bad', { _credManager: manager })
+
+      expect(result.error).toContain('Unauthorized')
+    })
+  })
+
+  describe('clearAction', () => {
+    it('removes all stored credentials', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      await manager.setCredentials({ token: 't', bot_id: 'b', bot_name: 'B' })
+
+      const result = await clearAction({ _credManager: manager })
+
+      expect(result.success).toBe(true)
+      expect(await manager.getCredentials()).toBeNull()
+    })
+  })
+
+  describe('statusAction', () => {
+    it('returns no credentials when none set', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await statusAction({ _credManager: manager })
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('returns valid status for current bot', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      await manager.setCredentials({ token: '123:abc', bot_id: 'mybot', bot_name: 'My Bot' })
+
+      const result = await statusAction({ _credManager: manager })
+
+      expect(result.valid).toBe(true)
+      expect(result.bot_id).toBe('mybot')
+    })
+
+    it('returns invalid when getMe fails', async () => {
+      mockGetMe.mockImplementationOnce(() => Promise.reject(new Error('401')))
+
+      const manager = new TelegramBotCredentialManager(tempDir)
+      await manager.setCredentials({ token: 'bad', bot_id: 'mybot', bot_name: 'My Bot' })
+
+      const result = await statusAction({ _credManager: manager })
+      expect(result.valid).toBe(false)
+    })
+  })
+
+  describe('listAction', () => {
+    it('returns empty list when no bots', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await listAction({ _credManager: manager })
+      expect(result.bots).toEqual([])
+    })
+
+    it('returns all bots with current flag', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      await manager.setCredentials({ token: 't1', bot_id: 'a', bot_name: 'A' })
+      await manager.setCredentials({ token: 't2', bot_id: 'b', bot_name: 'B' })
+
+      const result = await listAction({ _credManager: manager })
+      expect(result.bots).toHaveLength(2)
+      expect(result.bots?.find((x) => x.bot_id === 'b')?.is_current).toBe(true)
+    })
+  })
+
+  describe('useAction', () => {
+    it('switches active bot', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      await manager.setCredentials({ token: 't1', bot_id: 'a', bot_name: 'A' })
+      await manager.setCredentials({ token: 't2', bot_id: 'b', bot_name: 'B' })
+
+      const result = await useAction('a', { _credManager: manager })
+
+      expect(result.success).toBe(true)
+      expect(result.bot_id).toBe('a')
+    })
+
+    it('returns error for unknown bot', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await useAction('nope', { _credManager: manager })
+      expect(result.error).toContain('not found')
+    })
+  })
+
+  describe('removeAction', () => {
+    it('removes a stored bot', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      await manager.setCredentials({ token: 't', bot_id: 'a', bot_name: 'A' })
+
+      const result = await removeAction('a', { _credManager: manager })
+
+      expect(result.success).toBe(true)
+      expect(await manager.getCredentials('a')).toBeNull()
+    })
+
+    it('returns error for unknown bot', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await removeAction('nope', { _credManager: manager })
+      expect(result.error).toContain('not found')
+    })
+  })
+})

--- a/src/platforms/telegrambot/commands/auth.test.ts
+++ b/src/platforms/telegrambot/commands/auth.test.ts
@@ -122,6 +122,20 @@ describe('auth commands', () => {
 
       expect(result.error).toContain('Unauthorized')
     })
+
+    it('returns error when login itself fails', async () => {
+      const manager = new TelegramBotCredentialManager(tempDir)
+      const result = await setAction('bad', {
+        _credManager: manager,
+        _clientFactory: () =>
+          createMockClient({
+            loginError: new Error('Token is required'),
+          }),
+      })
+
+      expect(result.error).toBe('Token is required')
+      expect(await manager.getCredentials()).toBeNull()
+    })
   })
 
   describe('clearAction', () => {

--- a/src/platforms/telegrambot/commands/auth.test.ts
+++ b/src/platforms/telegrambot/commands/auth.test.ts
@@ -1,29 +1,38 @@
-import { afterEach, beforeEach, describe, expect, mock, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, rmSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const mockGetMe = mock(() =>
-  Promise.resolve({
+import type { TelegramBotClient } from '../client'
+import { TelegramBotCredentialManager } from '../credential-manager'
+import type { TelegramBotUser } from '../types'
+import { clearAction, listAction, removeAction, setAction, statusAction, useAction } from './auth'
+
+interface MockOptions {
+  user?: TelegramBotUser
+  loginError?: Error
+  getMeError?: Error
+}
+
+function createMockClient(options: MockOptions = {}): TelegramBotClient {
+  const user = options.user ?? {
     id: 123456,
     is_bot: true,
     first_name: 'Test',
     username: 'testbot',
-  }),
-)
-
-mock.module('../client', () => ({
-  TelegramBotClient: class MockTelegramBotClient {
-    async login(_credentials?: unknown): Promise<this> {
-      return this
-    }
-    getMe = mockGetMe
-  },
-}))
-
-import { TelegramBotCredentialManager } from '../credential-manager'
-import { clearAction, listAction, removeAction, setAction, statusAction, useAction } from './auth'
+  }
+  return {
+    async login(): Promise<TelegramBotClient> {
+      if (options.loginError) throw options.loginError
+      return this as unknown as TelegramBotClient
+    },
+    async getMe(): Promise<TelegramBotUser> {
+      if (options.getMeError) throw options.getMeError
+      return user
+    },
+  } as unknown as TelegramBotClient
+}
 
 describe('auth commands', () => {
   let tempDir: string
@@ -34,7 +43,6 @@ describe('auth commands', () => {
     await mkdir(tempDir, { recursive: true })
     originalEnv = { ...process.env }
     delete process.env.E2E_TELEGRAMBOT_TOKEN
-    mockGetMe.mockClear()
   })
 
   afterEach(() => {
@@ -48,7 +56,10 @@ describe('auth commands', () => {
     it('validates and stores bot token using username as bot_id', async () => {
       const manager = new TelegramBotCredentialManager(tempDir)
 
-      const result = await setAction('123:abc', { _credManager: manager })
+      const result = await setAction('123:abc', {
+        _credManager: manager,
+        _clientFactory: () => createMockClient(),
+      })
 
       expect(result.success).toBe(true)
       expect(result.bot_id).toBe('testbot')
@@ -62,48 +73,52 @@ describe('auth commands', () => {
     it('uses --bot flag as bot_id', async () => {
       const manager = new TelegramBotCredentialManager(tempDir)
 
-      const result = await setAction('123:abc', { bot: 'deploy', _credManager: manager })
+      const result = await setAction('123:abc', {
+        bot: 'deploy',
+        _credManager: manager,
+        _clientFactory: () => createMockClient(),
+      })
 
       expect(result.bot_id).toBe('deploy')
       expect(await manager.getCredentials('deploy')).not.toBeNull()
     })
 
     it('falls back to numeric id when username missing', async () => {
-      mockGetMe.mockImplementationOnce(() =>
-        Promise.resolve({
-          id: 123456,
-          is_bot: true,
-          first_name: 'NoUsername',
-        }),
-      )
-
       const manager = new TelegramBotCredentialManager(tempDir)
-      const result = await setAction('123:abc', { _credManager: manager })
+      const result = await setAction('123:abc', {
+        _credManager: manager,
+        _clientFactory: () =>
+          createMockClient({
+            user: { id: 123456, is_bot: true, first_name: 'NoUsername' },
+          }),
+      })
 
       expect(result.bot_id).toBe('123456')
     })
 
     it('rejects non-bot tokens (is_bot: false)', async () => {
-      mockGetMe.mockImplementationOnce(() =>
-        Promise.resolve({
-          id: 123456,
-          is_bot: false,
-          first_name: 'User',
-        }),
-      )
-
       const manager = new TelegramBotCredentialManager(tempDir)
-      const result = await setAction('user-token', { _credManager: manager })
+      const result = await setAction('user-token', {
+        _credManager: manager,
+        _clientFactory: () =>
+          createMockClient({
+            user: { id: 123456, is_bot: false, first_name: 'User' },
+          }),
+      })
 
       expect(result.error).toBeDefined()
       expect(result.error).toContain('not')
     })
 
     it('handles client errors', async () => {
-      mockGetMe.mockImplementationOnce(() => Promise.reject(new Error('Unauthorized: invalid token')))
-
       const manager = new TelegramBotCredentialManager(tempDir)
-      const result = await setAction('bad', { _credManager: manager })
+      const result = await setAction('bad', {
+        _credManager: manager,
+        _clientFactory: () =>
+          createMockClient({
+            getMeError: new Error('Unauthorized: invalid token'),
+          }),
+      })
 
       expect(result.error).toContain('Unauthorized')
     })
@@ -134,19 +149,26 @@ describe('auth commands', () => {
       const manager = new TelegramBotCredentialManager(tempDir)
       await manager.setCredentials({ token: '123:abc', bot_id: 'mybot', bot_name: 'My Bot' })
 
-      const result = await statusAction({ _credManager: manager })
+      const result = await statusAction({
+        _credManager: manager,
+        _clientFactory: () => createMockClient(),
+      })
 
       expect(result.valid).toBe(true)
       expect(result.bot_id).toBe('mybot')
     })
 
     it('returns invalid when getMe fails', async () => {
-      mockGetMe.mockImplementationOnce(() => Promise.reject(new Error('401')))
-
       const manager = new TelegramBotCredentialManager(tempDir)
       await manager.setCredentials({ token: 'bad', bot_id: 'mybot', bot_name: 'My Bot' })
 
-      const result = await statusAction({ _credManager: manager })
+      const result = await statusAction({
+        _credManager: manager,
+        _clientFactory: () =>
+          createMockClient({
+            getMeError: new Error('401'),
+          }),
+      })
       expect(result.valid).toBe(false)
     })
   })

--- a/src/platforms/telegrambot/commands/auth.ts
+++ b/src/platforms/telegrambot/commands/auth.ts
@@ -5,11 +5,13 @@ import { formatOutput } from '@/shared/utils/output'
 
 import { TelegramBotClient } from '../client'
 import { TelegramBotCredentialManager } from '../credential-manager'
+import type { ClientFactory } from './shared'
 
 interface ActionOptions {
   pretty?: boolean
   bot?: string
   _credManager?: TelegramBotCredentialManager
+  _clientFactory?: ClientFactory
 }
 
 interface ActionResult {
@@ -28,7 +30,8 @@ interface ActionResult {
 
 export async function setAction(token: string, options: ActionOptions): Promise<ActionResult> {
   try {
-    const client = await new TelegramBotClient().login({ token })
+    const client = options._clientFactory ? options._clientFactory() : new TelegramBotClient()
+    await client.login({ token })
     const me = await client.getMe()
 
     if (!me.is_bot) {
@@ -85,7 +88,8 @@ export async function statusAction(options: ActionOptions): Promise<ActionResult
     let username: string | undefined
 
     try {
-      const client = await new TelegramBotClient().login({ token: creds.token })
+      const client = options._clientFactory ? options._clientFactory() : new TelegramBotClient()
+      await client.login({ token: creds.token })
       const me = await client.getMe()
       valid = me.is_bot === true
       botName = me.username ?? me.first_name

--- a/src/platforms/telegrambot/commands/auth.ts
+++ b/src/platforms/telegrambot/commands/auth.ts
@@ -1,0 +1,216 @@
+import { Command } from 'commander'
+
+import { cliOutput } from '@/shared/utils/cli-output'
+import { formatOutput } from '@/shared/utils/output'
+
+import { TelegramBotClient } from '../client'
+import { TelegramBotCredentialManager } from '../credential-manager'
+
+interface ActionOptions {
+  pretty?: boolean
+  bot?: string
+  _credManager?: TelegramBotCredentialManager
+}
+
+interface ActionResult {
+  success?: boolean
+  error?: string
+  bot_id?: string
+  bot_name?: string
+  username?: string
+  valid?: boolean
+  bots?: Array<{
+    bot_id: string
+    bot_name: string
+    is_current: boolean
+  }>
+}
+
+export async function setAction(token: string, options: ActionOptions): Promise<ActionResult> {
+  try {
+    const client = await new TelegramBotClient().login({ token })
+    const me = await client.getMe()
+
+    if (!me.is_bot) {
+      return { error: 'Token does not belong to a bot account.' }
+    }
+
+    const botId = options.bot || me.username || String(me.id)
+    const botName = me.username ?? me.first_name
+
+    const credManager = options._credManager ?? new TelegramBotCredentialManager()
+    await credManager.setCredentials({
+      token,
+      bot_id: botId,
+      bot_name: botName,
+    })
+
+    return {
+      success: true,
+      bot_id: botId,
+      bot_name: botName,
+      username: me.username,
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function clearAction(options: ActionOptions): Promise<ActionResult> {
+  try {
+    const credManager = options._credManager ?? new TelegramBotCredentialManager()
+    await credManager.clearCredentials()
+    return { success: true }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function statusAction(options: ActionOptions): Promise<ActionResult> {
+  try {
+    const credManager = options._credManager ?? new TelegramBotCredentialManager()
+    const creds = await credManager.getCredentials(options.bot)
+
+    if (!creds) {
+      return {
+        valid: false,
+        error: options.bot
+          ? `Bot "${options.bot}" not found. Run "auth list" to see available bots.`
+          : 'No credentials configured. Run "auth set <token>" first.',
+      }
+    }
+
+    let valid = false
+    let botName = creds.bot_name
+    let username: string | undefined
+
+    try {
+      const client = await new TelegramBotClient().login({ token: creds.token })
+      const me = await client.getMe()
+      valid = me.is_bot === true
+      botName = me.username ?? me.first_name
+      username = me.username
+    } catch {
+      valid = false
+    }
+
+    return {
+      valid,
+      bot_id: creds.bot_id,
+      bot_name: botName,
+      username,
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function listAction(options: ActionOptions): Promise<ActionResult> {
+  try {
+    const credManager = options._credManager ?? new TelegramBotCredentialManager()
+    const all = await credManager.listAll()
+
+    return {
+      bots: all.map((b) => ({
+        bot_id: b.bot_id,
+        bot_name: b.bot_name,
+        is_current: b.is_current,
+      })),
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function useAction(botId: string, options: ActionOptions): Promise<ActionResult> {
+  try {
+    const credManager = options._credManager ?? new TelegramBotCredentialManager()
+    const found = await credManager.setCurrent(botId)
+
+    if (!found) {
+      return { error: `Bot "${botId}" not found. Run "auth list" to see available bots.` }
+    }
+
+    const creds = await credManager.getCredentials()
+    return {
+      success: true,
+      bot_id: creds?.bot_id,
+      bot_name: creds?.bot_name,
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function removeAction(botId: string, options: ActionOptions): Promise<ActionResult> {
+  try {
+    const credManager = options._credManager ?? new TelegramBotCredentialManager()
+    const removed = await credManager.removeBot(botId)
+
+    if (!removed) {
+      return { error: `Bot "${botId}" not found. Run "auth list" to see available bots.` }
+    }
+
+    return { success: true }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export const authCommand = new Command('auth')
+  .description('Bot authentication commands')
+  .addCommand(
+    new Command('set')
+      .description('Set bot token (validates against Telegram API)')
+      .argument('<token>', 'Bot token from @BotFather')
+      .option('--bot <id>', 'Bot identifier for switching later')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (token: string, opts: { bot?: string; pretty?: boolean }) => {
+        cliOutput(await setAction(token, opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('clear')
+      .description('Clear all stored credentials')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => {
+        cliOutput(await clearAction(opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('status')
+      .description('Show authentication status')
+      .option('--bot <id>', 'Check specific bot (default: current)')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { bot?: string; pretty?: boolean }) => {
+        const result = await statusAction(opts)
+        console.log(formatOutput(result, opts.pretty))
+        if (!result.valid) process.exit(1)
+      }),
+  )
+  .addCommand(
+    new Command('list')
+      .description('List all stored bots')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => {
+        cliOutput(await listAction(opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('use')
+      .description('Switch active bot')
+      .argument('<bot>', 'Bot ID')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (botId: string, opts: { pretty?: boolean }) => {
+        cliOutput(await useAction(botId, opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('remove')
+      .description('Remove a stored bot')
+      .argument('<bot>', 'Bot ID')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (botId: string, opts: { pretty?: boolean }) => {
+        cliOutput(await removeAction(botId, opts), opts.pretty)
+      }),
+  )

--- a/src/platforms/telegrambot/commands/chat.ts
+++ b/src/platforms/telegrambot/commands/chat.ts
@@ -1,0 +1,96 @@
+import { Command } from 'commander'
+
+import { cliOutput } from '@/shared/utils/cli-output'
+
+import type { BotOption } from './shared'
+import { getClient, parseChatId } from './shared'
+
+interface ChatResult {
+  id?: number
+  type?: string
+  title?: string
+  username?: string
+  first_name?: string
+  last_name?: string
+  description?: string
+  invite_link?: string
+  member_count?: number
+  is_forum?: boolean
+  member?: {
+    user_id: number
+    username?: string
+    status: string
+  }
+  error?: string
+}
+
+export async function infoAction(chat: string, options: BotOption): Promise<ChatResult> {
+  try {
+    const client = await getClient(options)
+    const info = await client.getChat(parseChatId(chat))
+
+    let memberCount = info.member_count
+    if (memberCount === undefined && (info.type === 'group' || info.type === 'supergroup' || info.type === 'channel')) {
+      try {
+        memberCount = await client.getChatMemberCount(info.id)
+      } catch {
+        memberCount = undefined
+      }
+    }
+
+    return {
+      id: info.id,
+      type: info.type,
+      title: info.title,
+      username: info.username,
+      first_name: info.first_name,
+      last_name: info.last_name,
+      description: info.description,
+      invite_link: info.invite_link,
+      member_count: memberCount,
+      is_forum: info.is_forum,
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function memberAction(chat: string, userId: string, options: BotOption): Promise<ChatResult> {
+  try {
+    const client = await getClient(options)
+    const member = await client.getChatMember(parseChatId(chat), Number(userId))
+    return {
+      member: {
+        user_id: member.user.id,
+        username: member.user.username,
+        status: member.status,
+      },
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export const chatCommand = new Command('chat')
+  .description('Chat commands')
+  .addCommand(
+    new Command('info')
+      .description('Get chat information')
+      .argument('<chat>', 'Chat ID or @username')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (chat: string, opts: BotOption) => {
+        cliOutput(await infoAction(chat, opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('member')
+      .description('Get chat member info')
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<user-id>', 'User ID (numeric)')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (chat: string, userId: string, opts: BotOption) => {
+        cliOutput(await memberAction(chat, userId, opts), opts.pretty)
+      }),
+  )

--- a/src/platforms/telegrambot/commands/index.ts
+++ b/src/platforms/telegrambot/commands/index.ts
@@ -1,0 +1,5 @@
+export { authCommand } from './auth'
+export { chatCommand } from './chat'
+export { messageCommand } from './message'
+export { reactionCommand } from './reaction'
+export { whoamiCommand } from './whoami'

--- a/src/platforms/telegrambot/commands/message.ts
+++ b/src/platforms/telegrambot/commands/message.ts
@@ -1,0 +1,232 @@
+import { resolve } from 'node:path'
+
+import { Command } from 'commander'
+
+import { cliOutput } from '@/shared/utils/cli-output'
+
+import type { TelegramMessage } from '../types'
+import type { BotOption } from './shared'
+import { getClient, parseChatId } from './shared'
+
+interface MessageOutput {
+  message_id: number
+  chat_id: number
+  text?: string
+  from?: string
+  date: number
+  edit_date?: number
+  reply_to?: number
+}
+
+interface MessageResult {
+  message?: MessageOutput
+  deleted?: number
+  error?: string
+}
+
+function formatMessage(msg: TelegramMessage): MessageOutput {
+  const fromName = msg.from?.username ?? msg.from?.first_name ?? msg.sender_chat?.title
+  return {
+    message_id: msg.message_id,
+    chat_id: msg.chat.id,
+    text: msg.text ?? msg.caption,
+    from: fromName,
+    date: msg.date,
+    edit_date: msg.edit_date,
+    reply_to: msg.reply_to_message?.message_id,
+  }
+}
+
+export async function sendAction(
+  chat: string,
+  text: string,
+  options: BotOption & {
+    parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2'
+    replyTo?: string
+    silent?: boolean
+    threadId?: string
+  },
+): Promise<MessageResult> {
+  try {
+    const client = await getClient(options)
+    const message = await client.sendMessage(parseChatId(chat), text, {
+      parse_mode: options.parseMode,
+      reply_to_message_id: options.replyTo ? Number(options.replyTo) : undefined,
+      disable_notification: options.silent,
+      message_thread_id: options.threadId ? Number(options.threadId) : undefined,
+    })
+    return { message: formatMessage(message) }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function updateAction(
+  chat: string,
+  messageId: string,
+  text: string,
+  options: BotOption & { parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2' },
+): Promise<MessageResult> {
+  try {
+    const client = await getClient(options)
+    const message = await client.editMessageText(parseChatId(chat), Number(messageId), text, {
+      parse_mode: options.parseMode,
+    })
+    return { message: formatMessage(message) }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function deleteAction(
+  chat: string,
+  messageId: string,
+  options: BotOption & { force?: boolean },
+): Promise<MessageResult> {
+  if (!options.force) {
+    return { error: 'Use --force to confirm deletion' }
+  }
+  try {
+    const client = await getClient(options)
+    await client.deleteMessage(parseChatId(chat), Number(messageId))
+    return { deleted: Number(messageId) }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function forwardAction(
+  toChat: string,
+  fromChat: string,
+  messageId: string,
+  options: BotOption & { silent?: boolean; threadId?: string },
+): Promise<MessageResult> {
+  try {
+    const client = await getClient(options)
+    const message = await client.forwardMessage(parseChatId(toChat), parseChatId(fromChat), Number(messageId), {
+      disable_notification: options.silent,
+      message_thread_id: options.threadId ? Number(options.threadId) : undefined,
+    })
+    return { message: formatMessage(message) }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function uploadAction(
+  chat: string,
+  filePath: string,
+  options: BotOption & { caption?: string; parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2' },
+): Promise<MessageResult> {
+  try {
+    const client = await getClient(options)
+    const message = await client.sendDocument(parseChatId(chat), resolve(filePath), {
+      caption: options.caption,
+      parse_mode: options.parseMode,
+    })
+    return { message: formatMessage(message) }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export const messageCommand = new Command('message')
+  .description('Message commands')
+  .addCommand(
+    new Command('send')
+      .description('Send a text message')
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<text>', 'Message text')
+      .option('--parse-mode <mode>', 'Parse mode: HTML | Markdown | MarkdownV2')
+      .option('--reply-to <id>', 'Reply to message ID')
+      .option('--silent', 'Send silently (no notification)')
+      .option('--thread-id <id>', 'Forum topic thread ID')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(
+        async (
+          chat: string,
+          text: string,
+          opts: BotOption & {
+            parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2'
+            replyTo?: string
+            silent?: boolean
+            threadId?: string
+          },
+        ) => {
+          cliOutput(await sendAction(chat, text, opts), opts.pretty)
+        },
+      ),
+  )
+  .addCommand(
+    new Command('update')
+      .description("Edit a message (bot's own messages only)")
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<message-id>', 'Message ID')
+      .argument('<text>', 'New message text')
+      .option('--parse-mode <mode>', 'Parse mode: HTML | Markdown | MarkdownV2')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(
+        async (
+          chat: string,
+          messageId: string,
+          text: string,
+          opts: BotOption & { parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2' },
+        ) => {
+          cliOutput(await updateAction(chat, messageId, text, opts), opts.pretty)
+        },
+      ),
+  )
+  .addCommand(
+    new Command('delete')
+      .description('Delete a message')
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<message-id>', 'Message ID')
+      .option('--force', 'Confirm deletion')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (chat: string, messageId: string, opts: BotOption & { force?: boolean }) => {
+        cliOutput(await deleteAction(chat, messageId, opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('forward')
+      .description('Forward a message from one chat to another')
+      .argument('<to-chat>', 'Destination chat ID or @username')
+      .argument('<from-chat>', 'Source chat ID or @username')
+      .argument('<message-id>', 'Message ID to forward')
+      .option('--silent', 'Forward silently')
+      .option('--thread-id <id>', 'Destination forum topic thread ID')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(
+        async (
+          toChat: string,
+          fromChat: string,
+          messageId: string,
+          opts: BotOption & { silent?: boolean; threadId?: string },
+        ) => {
+          cliOutput(await forwardAction(toChat, fromChat, messageId, opts), opts.pretty)
+        },
+      ),
+  )
+  .addCommand(
+    new Command('upload')
+      .description('Upload a document to a chat')
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<file-path>', 'File path')
+      .option('--caption <text>', 'Caption for the document')
+      .option('--parse-mode <mode>', 'Caption parse mode: HTML | Markdown | MarkdownV2')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(
+        async (
+          chat: string,
+          filePath: string,
+          opts: BotOption & { caption?: string; parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2' },
+        ) => {
+          cliOutput(await uploadAction(chat, filePath, opts), opts.pretty)
+        },
+      ),
+  )

--- a/src/platforms/telegrambot/commands/message.ts
+++ b/src/platforms/telegrambot/commands/message.ts
@@ -73,7 +73,7 @@ export async function updateAction(
       parse_mode: options.parseMode,
     })
     if (result === true) {
-      return { message: { message_id: Number(messageId), chat_id: 0, text, date: 0 } }
+      return { error: 'editMessageText returned true; expected a Message object for chat-message edits.' }
     }
     return { message: formatMessage(result) }
   } catch (error) {

--- a/src/platforms/telegrambot/commands/message.ts
+++ b/src/platforms/telegrambot/commands/message.ts
@@ -69,10 +69,13 @@ export async function updateAction(
 ): Promise<MessageResult> {
   try {
     const client = await getClient(options)
-    const message = await client.editMessageText(parseChatId(chat), Number(messageId), text, {
+    const result = await client.editMessageText({ chat_id: parseChatId(chat), message_id: Number(messageId) }, text, {
       parse_mode: options.parseMode,
     })
-    return { message: formatMessage(message) }
+    if (result === true) {
+      return { message: { message_id: Number(messageId), chat_id: 0, text, date: 0 } }
+    }
+    return { message: formatMessage(result) }
   } catch (error) {
     return { error: (error as Error).message }
   }

--- a/src/platforms/telegrambot/commands/reaction.ts
+++ b/src/platforms/telegrambot/commands/reaction.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
-import type { TelegramReactionType } from '../types'
+import type { BotReactionType } from '../client'
 import type { BotOption } from './shared'
 import { getClient, parseChatId } from './shared'
 
@@ -22,7 +22,7 @@ export async function setAction(
 ): Promise<ReactionResult> {
   try {
     const client = await getClient(options)
-    const reaction: TelegramReactionType[] = [{ type: 'emoji', emoji }]
+    const reaction: BotReactionType[] = [{ type: 'emoji', emoji }]
     await client.setMessageReaction(parseChatId(chat), Number(messageId), reaction, {
       is_big: options.big,
     })

--- a/src/platforms/telegrambot/commands/reaction.ts
+++ b/src/platforms/telegrambot/commands/reaction.ts
@@ -1,0 +1,70 @@
+import { Command } from 'commander'
+
+import { cliOutput } from '@/shared/utils/cli-output'
+
+import type { TelegramReactionType } from '../types'
+import type { BotOption } from './shared'
+import { getClient, parseChatId } from './shared'
+
+interface ReactionResult {
+  success?: boolean
+  chat_id?: number | string
+  message_id?: number
+  emoji?: string
+  error?: string
+}
+
+export async function setAction(
+  chat: string,
+  messageId: string,
+  emoji: string,
+  options: BotOption & { big?: boolean },
+): Promise<ReactionResult> {
+  try {
+    const client = await getClient(options)
+    const reaction: TelegramReactionType[] = [{ type: 'emoji', emoji }]
+    await client.setMessageReaction(parseChatId(chat), Number(messageId), reaction, {
+      is_big: options.big,
+    })
+    return { success: true, chat_id: parseChatId(chat), message_id: Number(messageId), emoji }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export async function clearAction(chat: string, messageId: string, options: BotOption): Promise<ReactionResult> {
+  try {
+    const client = await getClient(options)
+    await client.setMessageReaction(parseChatId(chat), Number(messageId), [])
+    return { success: true, chat_id: parseChatId(chat), message_id: Number(messageId) }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export const reactionCommand = new Command('reaction')
+  .description('Reaction commands')
+  .addCommand(
+    new Command('set')
+      .description('Set a reaction on a message (replaces existing)')
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<message-id>', 'Message ID')
+      .argument('<emoji>', 'Emoji (e.g. 👍)')
+      .option('--big', 'Show big animation for the reaction')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (chat: string, messageId: string, emoji: string, opts: BotOption & { big?: boolean }) => {
+        cliOutput(await setAction(chat, messageId, emoji, opts), opts.pretty)
+      }),
+  )
+  .addCommand(
+    new Command('clear')
+      .description('Clear all reactions from a message')
+      .argument('<chat>', 'Chat ID or @username')
+      .argument('<message-id>', 'Message ID')
+      .option('--bot <id>', 'Use specific bot')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (chat: string, messageId: string, opts: BotOption) => {
+        cliOutput(await clearAction(chat, messageId, opts), opts.pretty)
+      }),
+  )

--- a/src/platforms/telegrambot/commands/shared.ts
+++ b/src/platforms/telegrambot/commands/shared.ts
@@ -1,0 +1,28 @@
+import { formatOutput } from '@/shared/utils/output'
+
+import { TelegramBotClient } from '../client'
+import { TelegramBotCredentialManager } from '../credential-manager'
+
+export interface BotOption {
+  bot?: string
+  pretty?: boolean
+  _credManager?: TelegramBotCredentialManager
+}
+
+export async function getClient(options: BotOption): Promise<TelegramBotClient> {
+  const credManager = options._credManager ?? new TelegramBotCredentialManager()
+  const creds = await credManager.getCredentials(options.bot)
+
+  if (!creds) {
+    console.log(formatOutput({ error: 'No credentials. Run "auth set <token>" first.' }, options.pretty))
+    process.exit(1)
+  }
+
+  return new TelegramBotClient().login({ token: creds.token })
+}
+
+export function parseChatId(chat: string): number | string {
+  if (/^-?\d+$/.test(chat)) return Number(chat)
+  if (chat.startsWith('@')) return chat
+  return `@${chat}`
+}

--- a/src/platforms/telegrambot/commands/shared.ts
+++ b/src/platforms/telegrambot/commands/shared.ts
@@ -3,10 +3,13 @@ import { formatOutput } from '@/shared/utils/output'
 import { TelegramBotClient } from '../client'
 import { TelegramBotCredentialManager } from '../credential-manager'
 
+export type ClientFactory = () => TelegramBotClient
+
 export interface BotOption {
   bot?: string
   pretty?: boolean
   _credManager?: TelegramBotCredentialManager
+  _clientFactory?: ClientFactory
 }
 
 export async function getClient(options: BotOption): Promise<TelegramBotClient> {
@@ -18,7 +21,8 @@ export async function getClient(options: BotOption): Promise<TelegramBotClient> 
     process.exit(1)
   }
 
-  return new TelegramBotClient().login({ token: creds.token })
+  const client = options._clientFactory ? options._clientFactory() : new TelegramBotClient()
+  return client.login({ token: creds.token })
 }
 
 export function parseChatId(chat: string): number | string {

--- a/src/platforms/telegrambot/commands/whoami.ts
+++ b/src/platforms/telegrambot/commands/whoami.ts
@@ -1,0 +1,45 @@
+import { Command } from 'commander'
+
+import { cliOutput } from '@/shared/utils/cli-output'
+
+import type { BotOption } from './shared'
+import { getClient } from './shared'
+
+interface WhoamiResult {
+  id?: number
+  username?: string
+  first_name?: string
+  last_name?: string
+  is_bot?: boolean
+  can_join_groups?: boolean
+  can_read_all_group_messages?: boolean
+  supports_inline_queries?: boolean
+  error?: string
+}
+
+export async function whoamiAction(options: BotOption): Promise<WhoamiResult> {
+  try {
+    const client = await getClient(options)
+    const me = await client.getMe()
+    return {
+      id: me.id,
+      username: me.username,
+      first_name: me.first_name,
+      last_name: me.last_name,
+      is_bot: me.is_bot,
+      can_join_groups: me.can_join_groups,
+      can_read_all_group_messages: me.can_read_all_group_messages,
+      supports_inline_queries: me.supports_inline_queries,
+    }
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+export const whoamiCommand = new Command('whoami')
+  .description('Show current authenticated bot')
+  .option('--bot <id>', 'Bot ID to use')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(async (opts: BotOption) => {
+    cliOutput(await whoamiAction(opts), opts.pretty)
+  })

--- a/src/platforms/telegrambot/credential-manager.test.ts
+++ b/src/platforms/telegrambot/credential-manager.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync, rmSync } from 'node:fs'
+import { mkdir, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { TelegramBotCredentialManager } from './credential-manager'
+
+const CREDS_A = {
+  token: '123456789:ABC-A',
+  bot_id: 'bot-a',
+  bot_name: 'Bot A',
+}
+
+const CREDS_B = {
+  token: '987654321:XYZ-B',
+  bot_id: 'bot-b',
+  bot_name: 'Bot B',
+}
+
+describe('TelegramBotCredentialManager', () => {
+  let tempDir: string
+  let manager: TelegramBotCredentialManager
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `telegrambot-cred-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(tempDir, { recursive: true })
+    manager = new TelegramBotCredentialManager(tempDir)
+  })
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true })
+    }
+    delete process.env.E2E_TELEGRAMBOT_TOKEN
+  })
+
+  describe('load', () => {
+    it('returns empty config when no file exists', async () => {
+      const config = await manager.load()
+      expect(config.current).toBeNull()
+      expect(config.bots).toEqual({})
+    })
+  })
+
+  describe('save and load', () => {
+    it('persists config to file', async () => {
+      const config = {
+        current: { bot_id: 'bot-a' },
+        bots: {
+          'bot-a': { bot_id: 'bot-a', bot_name: 'Bot A', token: '123:abc' },
+        },
+      }
+      await manager.save(config)
+      const loaded = await manager.load()
+      expect(loaded).toEqual(config)
+    })
+  })
+
+  describe('getCredentials', () => {
+    it('returns null when no credentials exist', async () => {
+      expect(await manager.getCredentials()).toBeNull()
+    })
+
+    it('returns current bot credentials', async () => {
+      await manager.setCredentials(CREDS_A)
+      const creds = await manager.getCredentials()
+      expect(creds).toEqual(CREDS_A)
+    })
+
+    it('returns specific bot by id', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials(CREDS_B)
+      const creds = await manager.getCredentials('bot-a')
+      expect(creds).toEqual(CREDS_A)
+    })
+
+    it('returns null for non-existent bot id', async () => {
+      await manager.setCredentials(CREDS_A)
+      const creds = await manager.getCredentials('nope')
+      expect(creds).toBeNull()
+    })
+
+    it('env var takes precedence when no botId specified', async () => {
+      await manager.setCredentials(CREDS_A)
+      process.env.E2E_TELEGRAMBOT_TOKEN = 'env-token'
+      const creds = await manager.getCredentials()
+      expect(creds?.token).toBe('env-token')
+      expect(creds?.bot_id).toBe('env')
+    })
+
+    it('env var ignored when botId explicitly provided', async () => {
+      await manager.setCredentials(CREDS_A)
+      process.env.E2E_TELEGRAMBOT_TOKEN = 'env-token'
+      const creds = await manager.getCredentials('bot-a')
+      expect(creds?.token).toBe(CREDS_A.token)
+    })
+  })
+
+  describe('setCredentials', () => {
+    it('stores bot and sets as current', async () => {
+      await manager.setCredentials(CREDS_A)
+      const config = await manager.load()
+      expect(config.current).toEqual({ bot_id: 'bot-a' })
+      expect(config.bots['bot-a'].token).toBe(CREDS_A.token)
+    })
+
+    it('stores multiple bots', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials(CREDS_B)
+      const config = await manager.load()
+      expect(Object.keys(config.bots).sort()).toEqual(['bot-a', 'bot-b'])
+      expect(config.current).toEqual({ bot_id: 'bot-b' })
+    })
+
+    it('overwrites existing bot with same id', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials({ ...CREDS_A, bot_name: 'Updated' })
+      const config = await manager.load()
+      expect(Object.keys(config.bots)).toHaveLength(1)
+      expect(config.bots['bot-a'].bot_name).toBe('Updated')
+    })
+  })
+
+  describe('listAll', () => {
+    it('returns all bots with current flag', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials(CREDS_B)
+      const all = await manager.listAll()
+      expect(all).toHaveLength(2)
+      expect(all.find((b) => b.bot_id === 'bot-a')?.is_current).toBe(false)
+      expect(all.find((b) => b.bot_id === 'bot-b')?.is_current).toBe(true)
+    })
+
+    it('returns empty array when no bots exist', async () => {
+      expect(await manager.listAll()).toEqual([])
+    })
+  })
+
+  describe('setCurrent', () => {
+    it('switches current bot', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials(CREDS_B)
+      const switched = await manager.setCurrent('bot-a')
+      expect(switched).toBe(true)
+      const creds = await manager.getCredentials()
+      expect(creds?.bot_id).toBe('bot-a')
+    })
+
+    it('returns false for unknown bot', async () => {
+      expect(await manager.setCurrent('nope')).toBe(false)
+    })
+  })
+
+  describe('removeBot', () => {
+    it('removes a bot by id', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials(CREDS_B)
+      const removed = await manager.removeBot('bot-a')
+      expect(removed).toBe(true)
+      const config = await manager.load()
+      expect(Object.keys(config.bots)).toEqual(['bot-b'])
+    })
+
+    it('clears current when current bot removed', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.removeBot('bot-a')
+      const config = await manager.load()
+      expect(config.current).toBeNull()
+    })
+
+    it('returns false for unknown bot', async () => {
+      expect(await manager.removeBot('nope')).toBe(false)
+    })
+  })
+
+  describe('clearCredentials', () => {
+    it('removes all credentials', async () => {
+      await manager.setCredentials(CREDS_A)
+      await manager.setCredentials(CREDS_B)
+      await manager.clearCredentials()
+      const config = await manager.load()
+      expect(config.current).toBeNull()
+      expect(config.bots).toEqual({})
+    })
+  })
+
+  describe('file permissions', () => {
+    it('saves file with secure permissions (600)', async () => {
+      await manager.setCredentials(CREDS_A)
+      const credPath = join(tempDir, 'telegrambot-credentials.json')
+      const stats = await stat(credPath)
+      expect(stats.mode & 0o777).toBe(0o600)
+    })
+  })
+})

--- a/src/platforms/telegrambot/credential-manager.ts
+++ b/src/platforms/telegrambot/credential-manager.ts
@@ -1,0 +1,141 @@
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { getConfigDir } from '../../shared/utils/config-dir'
+import type { TelegramBotConfig, TelegramBotCredentials } from './types'
+import { TelegramBotConfigSchema } from './types'
+
+export class TelegramBotCredentialManager {
+  private configDir: string
+  private credentialsPath: string
+
+  constructor(configDir?: string) {
+    this.configDir = configDir ?? getConfigDir()
+    this.credentialsPath = join(this.configDir, 'telegrambot-credentials.json')
+  }
+
+  async load(): Promise<TelegramBotConfig> {
+    if (!existsSync(this.credentialsPath)) {
+      return { current: null, bots: {} }
+    }
+
+    const content = await readFile(this.credentialsPath, 'utf-8')
+    const parsed = TelegramBotConfigSchema.safeParse(JSON.parse(content))
+    if (!parsed.success) {
+      return { current: null, bots: {} }
+    }
+    return parsed.data
+  }
+
+  async save(config: TelegramBotConfig): Promise<void> {
+    await mkdir(this.configDir, { recursive: true })
+    await writeFile(this.credentialsPath, JSON.stringify(config, null, 2), { mode: 0o600 })
+    await chmod(this.credentialsPath, 0o600)
+  }
+
+  async getCredentials(botId?: string): Promise<TelegramBotCredentials | null> {
+    const envToken = process.env.E2E_TELEGRAMBOT_TOKEN
+
+    if (envToken && !botId) {
+      return {
+        token: envToken,
+        bot_id: 'env',
+        bot_name: 'env',
+      }
+    }
+
+    const config = await this.load()
+
+    if (botId) {
+      const bot = config.bots[botId]
+      if (!bot) return null
+      return {
+        token: bot.token,
+        bot_id: bot.bot_id,
+        bot_name: bot.bot_name,
+      }
+    }
+
+    if (!config.current) {
+      return null
+    }
+
+    const bot = config.bots[config.current.bot_id]
+    if (!bot) return null
+
+    return {
+      token: bot.token,
+      bot_id: bot.bot_id,
+      bot_name: bot.bot_name,
+    }
+  }
+
+  async setCredentials(creds: TelegramBotCredentials): Promise<void> {
+    const config = await this.load()
+
+    config.bots[creds.bot_id] = {
+      bot_id: creds.bot_id,
+      bot_name: creds.bot_name,
+      token: creds.token,
+    }
+
+    config.current = {
+      bot_id: creds.bot_id,
+    }
+
+    await this.save(config)
+  }
+
+  async removeBot(botId: string): Promise<boolean> {
+    const config = await this.load()
+
+    if (!config.bots[botId]) {
+      return false
+    }
+
+    delete config.bots[botId]
+
+    if (config.current?.bot_id === botId) {
+      config.current = null
+    }
+
+    await this.save(config)
+    return true
+  }
+
+  async setCurrent(botId: string): Promise<boolean> {
+    const config = await this.load()
+
+    if (!config.bots[botId]) {
+      return false
+    }
+
+    config.current = {
+      bot_id: botId,
+    }
+
+    await this.save(config)
+    return true
+  }
+
+  async listAll(): Promise<Array<TelegramBotCredentials & { is_current: boolean }>> {
+    const config = await this.load()
+    const results: Array<TelegramBotCredentials & { is_current: boolean }> = []
+
+    for (const bot of Object.values(config.bots)) {
+      results.push({
+        token: bot.token,
+        bot_id: bot.bot_id,
+        bot_name: bot.bot_name,
+        is_current: config.current?.bot_id === bot.bot_id,
+      })
+    }
+
+    return results
+  }
+
+  async clearCredentials(): Promise<void> {
+    await this.save({ current: null, bots: {} })
+  }
+}

--- a/src/platforms/telegrambot/index.ts
+++ b/src/platforms/telegrambot/index.ts
@@ -1,0 +1,36 @@
+export { TelegramBotClient } from './client'
+export type { ChatId, GetUpdatesOptions, SendMessageOptions } from './client'
+export { TelegramBotCredentialManager } from './credential-manager'
+export { TelegramBotListener } from './listener'
+export type {
+  TelegramBotConfig,
+  TelegramBotCredentials,
+  TelegramBotEntry,
+  TelegramBotListenerEventMap,
+  TelegramBotListenerOptions,
+  TelegramBotUser,
+  TelegramCallbackQuery,
+  TelegramChat,
+  TelegramChatFullInfo,
+  TelegramChatMember,
+  TelegramChatMemberUpdated,
+  TelegramDocument,
+  TelegramInlineQuery,
+  TelegramMessage,
+  TelegramMessageEntity,
+  TelegramPhotoSize,
+  TelegramReactionType,
+  TelegramUpdate,
+} from './types'
+export {
+  TelegramBotConfigSchema,
+  TelegramBotCredentialsSchema,
+  TelegramBotEntrySchema,
+  TelegramBotError,
+  TelegramBotUserSchema,
+  TelegramChatSchema,
+  TelegramDocumentSchema,
+  TelegramMessageEntitySchema,
+  TelegramMessageSchema,
+  TelegramPhotoSizeSchema,
+} from './types'

--- a/src/platforms/telegrambot/index.ts
+++ b/src/platforms/telegrambot/index.ts
@@ -1,5 +1,13 @@
 export { TelegramBotClient } from './client'
-export type { ChatId, GetUpdatesOptions, SendMessageOptions } from './client'
+export type {
+  BotReactionType,
+  ChatId,
+  EditMessageTextChat,
+  EditMessageTextInline,
+  EditMessageTextTarget,
+  GetUpdatesOptions,
+  SendMessageOptions,
+} from './client'
 export { TelegramBotCredentialManager } from './credential-manager'
 export { TelegramBotListener } from './listener'
 export type {

--- a/src/platforms/telegrambot/listener.test.ts
+++ b/src/platforms/telegrambot/listener.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { TelegramBotClient } from './client'
+import { TelegramBotListener } from './listener'
+import type { TelegramBotUser, TelegramUpdate } from './types'
+import { TelegramBotError } from './types'
+
+interface FakeClient {
+  deleteWebhook: () => Promise<boolean>
+  getMe: () => Promise<TelegramBotUser>
+  getUpdates: (options?: unknown, signal?: AbortSignal) => Promise<TelegramUpdate[]>
+}
+
+const ME: TelegramBotUser = {
+  id: 1,
+  is_bot: true,
+  first_name: 'Test Bot',
+  username: 'testbot',
+}
+
+function makeFakeClient(overrides: Partial<FakeClient> = {}): TelegramBotClient {
+  const base: FakeClient = {
+    deleteWebhook: async () => true,
+    getMe: async () => ME,
+    getUpdates: async () => [],
+    ...overrides,
+  }
+  return base as unknown as TelegramBotClient
+}
+
+function flush(ms = 5): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function pendingWithAbort(signal?: AbortSignal): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    if (signal?.aborted) {
+      reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+      return
+    }
+    signal?.addEventListener('abort', () => reject(Object.assign(new Error('Aborted'), { name: 'AbortError' })), {
+      once: true,
+    })
+  })
+}
+
+describe('TelegramBotListener', () => {
+  let listener: TelegramBotListener | null = null
+
+  beforeEach(() => {
+    listener = null
+  })
+
+  afterEach(() => {
+    listener?.stop()
+  })
+
+  it('emits "connected" with bot user after start()', async () => {
+    let connectedUser: TelegramBotUser | null = null
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) => pendingWithAbort(signal),
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('connected', ({ user }) => {
+      connectedUser = user
+    })
+
+    await listener.start()
+    await flush()
+
+    expect(connectedUser).not.toBeNull()
+    expect(connectedUser!.username).toBe('testbot')
+  })
+
+  it('deletes webhook before polling', async () => {
+    let deleteWebhookCalled = false
+    const client = makeFakeClient({
+      deleteWebhook: async () => {
+        deleteWebhookCalled = true
+        return true
+      },
+      getUpdates: (_options, signal) => pendingWithAbort(signal),
+    })
+
+    listener = new TelegramBotListener(client, { dropPendingUpdates: true })
+    await listener.start()
+    await flush()
+
+    expect(deleteWebhookCalled).toBe(true)
+  })
+
+  it('dispatches message updates', async () => {
+    const messages: string[] = []
+    let pollCount = 0
+
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) => {
+        pollCount++
+        if (pollCount === 1) {
+          return Promise.resolve([
+            {
+              update_id: 100,
+              message: {
+                message_id: 1,
+                date: 1,
+                chat: { id: 99, type: 'private' as const, first_name: 'Alice' },
+                text: 'hello',
+              },
+            },
+          ])
+        }
+        return pendingWithAbort(signal)
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('message', (msg) => {
+      if (msg.text) messages.push(msg.text)
+    })
+
+    await listener.start()
+    await flush(20)
+
+    expect(messages).toEqual(['hello'])
+  })
+
+  it('advances offset to update_id + 1 after processing', async () => {
+    const offsetsSeen: Array<number | undefined> = []
+    let pollCount = 0
+
+    const client = makeFakeClient({
+      getUpdates: (options, signal) => {
+        pollCount++
+        const offset = (options as { offset?: number } | undefined)?.offset
+        offsetsSeen.push(offset)
+        if (pollCount === 1) {
+          return Promise.resolve([
+            {
+              update_id: 100,
+              message: {
+                message_id: 1,
+                date: 1,
+                chat: { id: 99, type: 'private' as const, first_name: 'A' },
+                text: 'a',
+              },
+            },
+            {
+              update_id: 101,
+              message: {
+                message_id: 2,
+                date: 2,
+                chat: { id: 99, type: 'private' as const, first_name: 'A' },
+                text: 'b',
+              },
+            },
+          ])
+        }
+        return pendingWithAbort(signal)
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    await listener.start()
+    await flush(20)
+
+    expect(offsetsSeen[0]).toBe(0)
+    expect(offsetsSeen[1]).toBe(102)
+  })
+
+  it('emits telegram_update for every update (catch-all)', async () => {
+    let count = 0
+    let pollCount = 0
+
+    const client = makeFakeClient({
+      getUpdates: async () => {
+        pollCount++
+        if (pollCount === 1) {
+          return [{ update_id: 1, callback_query: { id: 'q', from: ME, chat_instance: 'ci', data: 'click' } }]
+        }
+        return new Promise(() => {})
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('telegram_update', () => {
+      count++
+    })
+
+    await listener.start()
+    await flush(20)
+
+    expect(count).toBe(1)
+  })
+
+  it('stops on fatal Unauthorized error', async () => {
+    let errorCaught: Error | null = null
+    const client = makeFakeClient({
+      getUpdates: async () => {
+        throw new TelegramBotError('Unauthorized', 'unauthorized')
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('error', (err) => {
+      errorCaught = err
+    })
+
+    await listener.start()
+    await flush(20)
+
+    expect(errorCaught).not.toBeNull()
+    expect((errorCaught as unknown as TelegramBotError).code).toBe('unauthorized')
+  })
+
+  it('emits disconnected on transient errors', async () => {
+    let disconnectedCount = 0
+    let pollCount = 0
+
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) => {
+        pollCount++
+        if (pollCount === 1) {
+          return Promise.reject(new Error('Network error'))
+        }
+        return pendingWithAbort(signal)
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('disconnected', () => {
+      disconnectedCount++
+    })
+
+    await listener.start()
+    await flush(50)
+
+    expect(disconnectedCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('stop() prevents further polling', async () => {
+    let pollCount = 0
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) => {
+        pollCount++
+        if (pollCount === 1) {
+          return Promise.resolve([
+            { update_id: 1, callback_query: { id: 'q', from: ME, chat_instance: 'ci', data: 'click' } },
+          ])
+        }
+        return pendingWithAbort(signal)
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('telegram_update', () => {
+      count++
+    })
+
+    listener = new TelegramBotListener(client)
+    await listener.start()
+    await flush(5)
+    listener.stop()
+    const beforeStop = pollCount
+    await flush(50)
+    expect(pollCount - beforeStop).toBeLessThanOrEqual(1)
+  })
+
+  it('on/off/once chain returns this', () => {
+    const client = makeFakeClient()
+    listener = new TelegramBotListener(client)
+    const fn = (): void => {}
+    expect(listener.on('message', fn)).toBe(listener)
+    expect(listener.off('message', fn)).toBe(listener)
+    expect(listener.once('message', fn)).toBe(listener)
+  })
+})

--- a/src/platforms/telegrambot/listener.test.ts
+++ b/src/platforms/telegrambot/listener.test.ts
@@ -73,21 +73,23 @@ describe('TelegramBotListener', () => {
     expect(connectedUser!.username).toBe('testbot')
   })
 
-  it('deletes webhook before polling', async () => {
-    let deleteWebhookCalled = false
-    const client = makeFakeClient({
-      deleteWebhook: async () => {
-        deleteWebhookCalled = true
+  it('deletes webhook before polling and forwards dropPendingUpdates', async () => {
+    let deleteWebhookCalls: Array<{ drop_pending_updates?: boolean } | undefined> = []
+    const client = {
+      deleteWebhook: async (opts?: { drop_pending_updates?: boolean }) => {
+        deleteWebhookCalls.push(opts)
         return true
       },
-      getUpdates: (_options, signal) => pendingWithAbort(signal),
-    })
+      getMe: async () => ME,
+      getUpdates: (_options: unknown, signal?: AbortSignal) => pendingWithAbort(signal),
+    } as unknown as TelegramBotClient
 
     listener = new TelegramBotListener(client, { dropPendingUpdates: true })
     await listener.start()
     await flush()
 
-    expect(deleteWebhookCalled).toBe(true)
+    expect(deleteWebhookCalls).toHaveLength(1)
+    expect(deleteWebhookCalls[0]).toEqual({ drop_pending_updates: true })
   })
 
   it('dispatches message updates', async () => {
@@ -238,32 +240,37 @@ describe('TelegramBotListener', () => {
     expect(disconnectedCount).toBeGreaterThanOrEqual(1)
   })
 
-  it('stop() prevents further polling', async () => {
-    let pollCount = 0
+  it('stop() aborts in-flight getUpdates and halts polling', async () => {
+    let pollStarts = 0
+    let aborted = false
+
     const client = makeFakeClient({
       getUpdates: (_options, signal) => {
-        pollCount++
-        if (pollCount === 1) {
-          return Promise.resolve([
-            { update_id: 1, callback_query: { id: 'q', from: ME, chat_instance: 'ci', data: 'click' } },
-          ])
-        }
-        return pendingWithAbort(signal)
+        pollStarts++
+        return new Promise<never>((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => {
+              aborted = true
+              reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+            },
+            { once: true },
+          )
+        })
       },
     })
 
     listener = new TelegramBotListener(client)
-    listener.on('telegram_update', () => {
-      count++
-    })
-
-    listener = new TelegramBotListener(client)
     await listener.start()
-    await flush(5)
+    await flush()
+
+    expect(pollStarts).toBe(1)
+
     listener.stop()
-    const beforeStop = pollCount
-    await flush(50)
-    expect(pollCount - beforeStop).toBeLessThanOrEqual(1)
+    await flush(20)
+
+    expect(aborted).toBe(true)
+    expect(pollStarts).toBe(1)
   })
 
   it('on/off/once chain returns this', () => {
@@ -273,5 +280,118 @@ describe('TelegramBotListener', () => {
     expect(listener.on('message', fn)).toBe(listener)
     expect(listener.off('message', fn)).toBe(listener)
     expect(listener.once('message', fn)).toBe(listener)
+  })
+
+  it('emits chat_member and my_chat_member as distinct events', async () => {
+    const myChatMemberEvents: unknown[] = []
+    const chatMemberEvents: unknown[] = []
+    let pollCount = 0
+
+    const memberPayload = {
+      chat: { id: 1, type: 'private' as const, first_name: 'A' },
+      from: ME,
+      date: 1,
+      old_chat_member: { user: ME, status: 'member' as const },
+      new_chat_member: { user: ME, status: 'administrator' as const },
+    }
+
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) => {
+        pollCount++
+        if (pollCount === 1) {
+          return Promise.resolve([
+            { update_id: 1, my_chat_member: memberPayload },
+            { update_id: 2, chat_member: memberPayload },
+          ])
+        }
+        return pendingWithAbort(signal)
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('my_chat_member', (e) => myChatMemberEvents.push(e))
+    listener.on('chat_member', (e) => chatMemberEvents.push(e))
+
+    await listener.start()
+    await flush(20)
+
+    expect(myChatMemberEvents).toHaveLength(1)
+    expect(chatMemberEvents).toHaveLength(1)
+  })
+
+  it('user handler exception does not stop polling and surfaces via error event', async () => {
+    let messageCount = 0
+    let errorCount = 0
+    let pollCount = 0
+
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) => {
+        pollCount++
+        if (pollCount === 1) {
+          return Promise.resolve([
+            {
+              update_id: 1,
+              message: {
+                message_id: 1,
+                date: 1,
+                chat: { id: 1, type: 'private' as const, first_name: 'A' },
+                text: 'first',
+              },
+            },
+            {
+              update_id: 2,
+              message: {
+                message_id: 2,
+                date: 2,
+                chat: { id: 1, type: 'private' as const, first_name: 'A' },
+                text: 'second',
+              },
+            },
+          ])
+        }
+        return pendingWithAbort(signal)
+      },
+    })
+
+    listener = new TelegramBotListener(client)
+    listener.on('message', (msg) => {
+      messageCount++
+      if (msg.text === 'first') {
+        throw new Error('handler boom')
+      }
+    })
+    listener.on('error', () => {
+      errorCount++
+    })
+
+    await listener.start()
+    await flush(20)
+
+    expect(messageCount).toBe(2)
+    expect(errorCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('aborts in-flight getUpdates if it exceeds timeout + grace', async () => {
+    let aborted = false
+    const client = makeFakeClient({
+      getUpdates: (_options, signal) =>
+        new Promise<never>((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => {
+              aborted = true
+              reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+            },
+            { once: true },
+          )
+        }),
+    })
+
+    listener = new TelegramBotListener(client, { timeoutSeconds: 0 })
+    await listener.start()
+    await flush(50)
+
+    listener.stop()
+    expect(aborted).toBe(true)
   })
 })

--- a/src/platforms/telegrambot/listener.test.ts
+++ b/src/platforms/telegrambot/listener.test.ts
@@ -371,7 +371,7 @@ describe('TelegramBotListener', () => {
     expect(errorCount).toBeGreaterThanOrEqual(1)
   })
 
-  it('aborts in-flight getUpdates if it exceeds timeout + grace', async () => {
+  it('propagates AbortError from getUpdates through the listener cleanly', async () => {
     let aborted = false
     const client = makeFakeClient({
       getUpdates: (_options, signal) =>
@@ -387,11 +387,12 @@ describe('TelegramBotListener', () => {
         }),
     })
 
-    listener = new TelegramBotListener(client, { timeoutSeconds: 0 })
+    listener = new TelegramBotListener(client)
     await listener.start()
-    await flush(50)
+    await flush(20)
 
     listener.stop()
+    await flush(20)
     expect(aborted).toBe(true)
   })
 })

--- a/src/platforms/telegrambot/listener.ts
+++ b/src/platforms/telegrambot/listener.ts
@@ -6,6 +6,7 @@ import { TelegramBotError } from './types'
 
 const DEFAULT_TIMEOUT_SECONDS = 30
 const DEFAULT_LIMIT = 100
+const FETCH_TIMEOUT_GRACE_MS = 10_000
 const RECONNECT_BASE_DELAY = 1_000
 const RECONNECT_MAX_DELAY = 30_000
 const FATAL_ERROR_CODES = new Set(['unauthorized', 'conflict'])
@@ -99,31 +100,35 @@ export class TelegramBotListener {
     let firstPoll = true
 
     while (this.isCurrent(generation)) {
-      this.abortController = new AbortController()
+      const pollController = new AbortController()
+      this.abortController = pollController
+
+      // Server-side getUpdates uses `timeout` (seconds); add grace so the HTTP fetch can't hang
+      // past the long-poll deadline if the underlying socket stalls.
+      const fetchTimeout = setTimeout(
+        () => pollController.abort(),
+        (this.timeoutSeconds + FETCH_TIMEOUT_GRACE_MS / 1000) * 1000,
+      )
+
+      let updates: TelegramUpdate[]
       try {
-        const updates = await this.client.getUpdates(
+        updates = await this.client.getUpdates(
           {
             offset: this.offset,
             limit: this.limit,
             timeout: this.timeoutSeconds,
             allowed_updates: firstPoll ? this.allowedUpdates : undefined,
           },
-          this.abortController.signal,
+          pollController.signal,
         )
         firstPoll = false
         this.reconnectAttempts = 0
-
-        if (!this.isCurrent(generation)) return
-
-        for (const update of updates) {
-          if (!this.isCurrent(generation)) return
-          this.dispatch(update)
-          this.offset = update.update_id + 1
-        }
       } catch (error) {
-        if ((error as Error).name === 'AbortError' || !this.isCurrent(generation)) {
+        clearTimeout(fetchTimeout)
+        if (pollController.signal.aborted && !this.isCurrent(generation)) {
           return
         }
+        if (!this.isCurrent(generation)) return
 
         if (error instanceof TelegramBotError && FATAL_ERROR_CODES.has(error.code)) {
           this.emitter.emit('error', error)
@@ -133,20 +138,44 @@ export class TelegramBotListener {
 
         this.emitter.emit('disconnected')
         await this.backoff(generation)
+        continue
+      }
+      clearTimeout(fetchTimeout)
+
+      if (!this.isCurrent(generation)) return
+
+      for (const update of updates) {
+        if (!this.isCurrent(generation)) return
+        // Advance offset BEFORE dispatching so a thrown user handler doesn't cause redelivery.
+        this.offset = update.update_id + 1
+        this.dispatch(update)
       }
     }
   }
 
   private dispatch(update: TelegramUpdate): void {
-    if (update.message) this.emitter.emit('message', update.message)
-    if (update.edited_message) this.emitter.emit('edited_message', update.edited_message)
-    if (update.channel_post) this.emitter.emit('channel_post', update.channel_post)
-    if (update.edited_channel_post) this.emitter.emit('edited_channel_post', update.edited_channel_post)
-    if (update.callback_query) this.emitter.emit('callback_query', update.callback_query)
-    if (update.inline_query) this.emitter.emit('inline_query', update.inline_query)
-    if (update.my_chat_member) this.emitter.emit('my_chat_member', update.my_chat_member)
-    if (update.chat_member) this.emitter.emit('chat_member', update.chat_member)
-    this.emitter.emit('telegram_update', update)
+    if (update.message) this.safeEmit('message', update.message)
+    if (update.edited_message) this.safeEmit('edited_message', update.edited_message)
+    if (update.channel_post) this.safeEmit('channel_post', update.channel_post)
+    if (update.edited_channel_post) this.safeEmit('edited_channel_post', update.edited_channel_post)
+    if (update.callback_query) this.safeEmit('callback_query', update.callback_query)
+    if (update.inline_query) this.safeEmit('inline_query', update.inline_query)
+    if (update.my_chat_member) this.safeEmit('my_chat_member', update.my_chat_member)
+    if (update.chat_member) this.safeEmit('chat_member', update.chat_member)
+    this.safeEmit('telegram_update', update)
+  }
+
+  private safeEmit<K extends EventKey>(event: K, ...args: TelegramBotListenerEventMap[K]): void {
+    try {
+      this.emitter.emit(event, ...args)
+    } catch (handlerError) {
+      const err = handlerError instanceof Error ? handlerError : new Error(String(handlerError))
+      try {
+        this.emitter.emit('error', err)
+      } catch {
+        // Swallow secondary errors from error handlers to keep the poll loop alive.
+      }
+    }
   }
 
   private async backoff(generation: number): Promise<void> {

--- a/src/platforms/telegrambot/listener.ts
+++ b/src/platforms/telegrambot/listener.ts
@@ -1,0 +1,169 @@
+import { EventEmitter } from 'events'
+
+import type { TelegramBotClient } from './client'
+import type { TelegramBotListenerEventMap, TelegramBotListenerOptions, TelegramBotUser, TelegramUpdate } from './types'
+import { TelegramBotError } from './types'
+
+const DEFAULT_TIMEOUT_SECONDS = 30
+const DEFAULT_LIMIT = 100
+const RECONNECT_BASE_DELAY = 1_000
+const RECONNECT_MAX_DELAY = 30_000
+const FATAL_ERROR_CODES = new Set(['unauthorized', 'conflict'])
+
+type EventKey = keyof TelegramBotListenerEventMap
+
+export class TelegramBotListener {
+  private client: TelegramBotClient
+  private timeoutSeconds: number
+  private limit: number
+  private allowedUpdates: string[] | undefined
+  private dropPendingUpdates: boolean
+  private running = false
+  private offset = 0
+  private reconnectAttempts = 0
+  private emitter = new EventEmitter()
+  private abortController: AbortController | null = null
+  private cachedUser: TelegramBotUser | null = null
+  private generation = 0
+
+  constructor(client: TelegramBotClient, options?: TelegramBotListenerOptions) {
+    this.client = client
+    this.timeoutSeconds = options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS
+    this.limit = options?.limit ?? DEFAULT_LIMIT
+    this.allowedUpdates = options?.allowedUpdates
+    this.dropPendingUpdates = options?.dropPendingUpdates ?? false
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+    this.reconnectAttempts = 0
+    this.generation++
+    const generation = this.generation
+
+    try {
+      await this.client.deleteWebhook({ drop_pending_updates: this.dropPendingUpdates })
+    } catch (error) {
+      if (!this.isCurrent(generation)) return
+      this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+      this.running = false
+      return
+    }
+
+    if (!this.isCurrent(generation)) return
+
+    try {
+      this.cachedUser = await this.client.getMe()
+      if (!this.isCurrent(generation)) return
+      this.emitter.emit('connected', { user: this.cachedUser })
+    } catch (error) {
+      if (!this.isCurrent(generation)) return
+      this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+      this.running = false
+      return
+    }
+
+    void this.pollLoop(generation)
+  }
+
+  stop(): void {
+    this.running = false
+    this.generation++
+    if (this.abortController) {
+      this.abortController.abort()
+      this.abortController = null
+    }
+    this.cachedUser = null
+  }
+
+  on<K extends EventKey>(event: K, listener: (...args: TelegramBotListenerEventMap[K]) => void): this {
+    this.emitter.on(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  off<K extends EventKey>(event: K, listener: (...args: TelegramBotListenerEventMap[K]) => void): this {
+    this.emitter.off(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  once<K extends EventKey>(event: K, listener: (...args: TelegramBotListenerEventMap[K]) => void): this {
+    this.emitter.once(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  private isCurrent(generation: number): boolean {
+    return generation === this.generation && this.running
+  }
+
+  private async pollLoop(generation: number): Promise<void> {
+    let firstPoll = true
+
+    while (this.isCurrent(generation)) {
+      this.abortController = new AbortController()
+      try {
+        const updates = await this.client.getUpdates(
+          {
+            offset: this.offset,
+            limit: this.limit,
+            timeout: this.timeoutSeconds,
+            allowed_updates: firstPoll ? this.allowedUpdates : undefined,
+          },
+          this.abortController.signal,
+        )
+        firstPoll = false
+        this.reconnectAttempts = 0
+
+        if (!this.isCurrent(generation)) return
+
+        for (const update of updates) {
+          if (!this.isCurrent(generation)) return
+          this.dispatch(update)
+          this.offset = update.update_id + 1
+        }
+      } catch (error) {
+        if ((error as Error).name === 'AbortError' || !this.isCurrent(generation)) {
+          return
+        }
+
+        if (error instanceof TelegramBotError && FATAL_ERROR_CODES.has(error.code)) {
+          this.emitter.emit('error', error)
+          this.running = false
+          return
+        }
+
+        this.emitter.emit('disconnected')
+        await this.backoff(generation)
+      }
+    }
+  }
+
+  private dispatch(update: TelegramUpdate): void {
+    if (update.message) this.emitter.emit('message', update.message)
+    if (update.edited_message) this.emitter.emit('edited_message', update.edited_message)
+    if (update.channel_post) this.emitter.emit('channel_post', update.channel_post)
+    if (update.edited_channel_post) this.emitter.emit('edited_channel_post', update.edited_channel_post)
+    if (update.callback_query) this.emitter.emit('callback_query', update.callback_query)
+    if (update.inline_query) this.emitter.emit('inline_query', update.inline_query)
+    if (update.my_chat_member) this.emitter.emit('my_chat_member', update.my_chat_member)
+    if (update.chat_member) this.emitter.emit('chat_member', update.chat_member)
+    this.emitter.emit('telegram_update', update)
+  }
+
+  private async backoff(generation: number): Promise<void> {
+    const delay = Math.min(RECONNECT_BASE_DELAY * 2 ** this.reconnectAttempts, RECONNECT_MAX_DELAY)
+    this.reconnectAttempts++
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => resolve(), delay)
+      const onAbort = (): void => {
+        clearTimeout(timer)
+        resolve()
+      }
+      if (this.isCurrent(generation) && this.abortController) {
+        this.abortController.signal.addEventListener('abort', onAbort, { once: true })
+      } else {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+  }
+}

--- a/src/platforms/telegrambot/types.test.ts
+++ b/src/platforms/telegrambot/types.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  TelegramBotConfigSchema,
+  TelegramBotCredentialsSchema,
+  TelegramBotEntrySchema,
+  TelegramBotError,
+  TelegramBotUserSchema,
+  TelegramChatSchema,
+  TelegramMessageSchema,
+} from './types'
+
+describe('TelegramBotError', () => {
+  it('creates error with message and code', () => {
+    const err = new TelegramBotError('Test error', 'TEST_CODE')
+    expect(err.message).toBe('Test error')
+    expect(err.code).toBe('TEST_CODE')
+    expect(err.name).toBe('TelegramBotError')
+    expect(err).toBeInstanceOf(Error)
+  })
+})
+
+describe('TelegramBotEntrySchema', () => {
+  it('validates correct bot entry', () => {
+    const result = TelegramBotEntrySchema.safeParse({
+      bot_id: 'mybot',
+      bot_name: 'My Bot',
+      token: '123456789:ABC-DEF',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing bot_id', () => {
+    const result = TelegramBotEntrySchema.safeParse({ bot_name: 'My Bot', token: 'tok' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TelegramBotConfigSchema', () => {
+  it('accepts empty config', () => {
+    const result = TelegramBotConfigSchema.safeParse({ current: null, bots: {} })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts config with bots and current', () => {
+    const result = TelegramBotConfigSchema.safeParse({
+      current: { bot_id: 'mybot' },
+      bots: {
+        mybot: { bot_id: 'mybot', bot_name: 'My Bot', token: '123:abc' },
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('TelegramBotCredentialsSchema', () => {
+  it('validates credentials', () => {
+    const result = TelegramBotCredentialsSchema.safeParse({
+      token: '123:abc',
+      bot_id: 'mybot',
+      bot_name: 'My Bot',
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('TelegramBotUserSchema', () => {
+  it('validates a bot user', () => {
+    const result = TelegramBotUserSchema.safeParse({
+      id: 123456789,
+      is_bot: true,
+      first_name: 'My Bot',
+      username: 'mybot',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing id', () => {
+    const result = TelegramBotUserSchema.safeParse({ is_bot: true, first_name: 'X' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TelegramChatSchema', () => {
+  it('validates private chat', () => {
+    const result = TelegramChatSchema.safeParse({ id: 1, type: 'private', first_name: 'Alice' })
+    expect(result.success).toBe(true)
+  })
+
+  it('validates supergroup', () => {
+    const result = TelegramChatSchema.safeParse({ id: -1001234567890, type: 'supergroup', title: 'Eng' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid type', () => {
+    const result = TelegramChatSchema.safeParse({ id: 1, type: 'invalid' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TelegramMessageSchema', () => {
+  it('validates a text message', () => {
+    const result = TelegramMessageSchema.safeParse({
+      message_id: 42,
+      date: 1735689600,
+      chat: { id: -1001234567890, type: 'supergroup', title: 'Eng' },
+      from: { id: 1, is_bot: false, first_name: 'Alice' },
+      text: 'Hello',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('validates message with reply', () => {
+    const result = TelegramMessageSchema.safeParse({
+      message_id: 43,
+      date: 1735689700,
+      chat: { id: -1001234567890, type: 'supergroup', title: 'Eng' },
+      text: 'Reply',
+      reply_to_message: {
+        message_id: 42,
+        date: 1735689600,
+        chat: { id: -1001234567890, type: 'supergroup', title: 'Eng' },
+        text: 'Original',
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/platforms/telegrambot/types.ts
+++ b/src/platforms/telegrambot/types.ts
@@ -185,28 +185,32 @@ export const TelegramBotCredentialsSchema = z.object({
   bot_name: z.string(),
 })
 
-export const TelegramBotUserSchema = z.object({
-  id: z.number(),
-  is_bot: z.boolean(),
-  first_name: z.string(),
-  last_name: z.string().optional(),
-  username: z.string().optional(),
-  language_code: z.string().optional(),
-  is_premium: z.boolean().optional(),
-  can_join_groups: z.boolean().optional(),
-  can_read_all_group_messages: z.boolean().optional(),
-  supports_inline_queries: z.boolean().optional(),
-})
+export const TelegramBotUserSchema = z
+  .object({
+    id: z.number(),
+    is_bot: z.boolean(),
+    first_name: z.string(),
+    last_name: z.string().optional(),
+    username: z.string().optional(),
+    language_code: z.string().optional(),
+    is_premium: z.boolean().optional(),
+    can_join_groups: z.boolean().optional(),
+    can_read_all_group_messages: z.boolean().optional(),
+    supports_inline_queries: z.boolean().optional(),
+  })
+  .passthrough()
 
-export const TelegramChatSchema = z.object({
-  id: z.number(),
-  type: z.enum(['private', 'group', 'supergroup', 'channel']),
-  title: z.string().optional(),
-  username: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  is_forum: z.boolean().optional(),
-})
+export const TelegramChatSchema = z
+  .object({
+    id: z.number(),
+    type: z.enum(['private', 'group', 'supergroup', 'channel']),
+    title: z.string().optional(),
+    username: z.string().optional(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    is_forum: z.boolean().optional(),
+  })
+  .passthrough()
 
 export const TelegramMessageEntitySchema = z.object({
   type: z.string(),
@@ -235,23 +239,25 @@ export const TelegramDocumentSchema = z.object({
   file_size: z.number().optional(),
 })
 
-export const TelegramMessageSchema = z.object({
-  message_id: z.number(),
-  message_thread_id: z.number().optional(),
-  date: z.number(),
-  chat: TelegramChatSchema,
-  from: TelegramBotUserSchema.optional(),
-  sender_chat: TelegramChatSchema.optional(),
-  text: z.string().optional(),
-  caption: z.string().optional(),
-  entities: z.array(TelegramMessageEntitySchema).optional(),
-  caption_entities: z.array(TelegramMessageEntitySchema).optional(),
-  reply_to_message: z.lazy(() => TelegramMessageSchema).optional(),
-  edit_date: z.number().optional(),
-  photo: z.array(TelegramPhotoSizeSchema).optional(),
-  document: TelegramDocumentSchema.optional(),
-  is_topic_message: z.boolean().optional(),
-}) as z.ZodType<TelegramMessage>
+export const TelegramMessageSchema = z
+  .object({
+    message_id: z.number(),
+    message_thread_id: z.number().optional(),
+    date: z.number(),
+    chat: TelegramChatSchema,
+    from: TelegramBotUserSchema.optional(),
+    sender_chat: TelegramChatSchema.optional(),
+    text: z.string().optional(),
+    caption: z.string().optional(),
+    entities: z.array(TelegramMessageEntitySchema).optional(),
+    caption_entities: z.array(TelegramMessageEntitySchema).optional(),
+    reply_to_message: z.lazy(() => TelegramMessageSchema).optional(),
+    edit_date: z.number().optional(),
+    photo: z.array(TelegramPhotoSizeSchema).optional(),
+    document: TelegramDocumentSchema.optional(),
+    is_topic_message: z.boolean().optional(),
+  })
+  .passthrough() as z.ZodType<TelegramMessage>
 
 export interface TelegramBotListenerOptions {
   timeoutSeconds?: number

--- a/src/platforms/telegrambot/types.ts
+++ b/src/platforms/telegrambot/types.ts
@@ -1,0 +1,276 @@
+import { z } from 'zod'
+
+export interface TelegramBotEntry {
+  bot_id: string
+  bot_name: string
+  token: string
+}
+
+export interface TelegramBotConfig {
+  current: { bot_id: string } | null
+  bots: Record<string, TelegramBotEntry>
+}
+
+export interface TelegramBotCredentials {
+  token: string
+  bot_id: string
+  bot_name: string
+}
+
+export class TelegramBotError extends Error {
+  code: string
+
+  constructor(message: string, code: string) {
+    super(message)
+    this.name = 'TelegramBotError'
+    this.code = code
+  }
+}
+
+export interface TelegramBotUser {
+  id: number
+  is_bot: boolean
+  first_name: string
+  last_name?: string
+  username?: string
+  language_code?: string
+  is_premium?: boolean
+  can_join_groups?: boolean
+  can_read_all_group_messages?: boolean
+  supports_inline_queries?: boolean
+}
+
+export interface TelegramChat {
+  id: number
+  type: 'private' | 'group' | 'supergroup' | 'channel'
+  title?: string
+  username?: string
+  first_name?: string
+  last_name?: string
+  is_forum?: boolean
+}
+
+export interface TelegramChatFullInfo extends TelegramChat {
+  bio?: string
+  description?: string
+  invite_link?: string
+  pinned_message?: TelegramMessage
+  permissions?: Record<string, boolean>
+  member_count?: number
+}
+
+export interface TelegramChatMember {
+  user: TelegramBotUser
+  status: 'creator' | 'administrator' | 'member' | 'restricted' | 'left' | 'kicked'
+  is_anonymous?: boolean
+  custom_title?: string
+  until_date?: number
+}
+
+export interface TelegramMessageEntity {
+  type: string
+  offset: number
+  length: number
+  url?: string
+  user?: TelegramBotUser
+  language?: string
+  custom_emoji_id?: string
+}
+
+export interface TelegramPhotoSize {
+  file_id: string
+  file_unique_id: string
+  width: number
+  height: number
+  file_size?: number
+}
+
+export interface TelegramDocument {
+  file_id: string
+  file_unique_id: string
+  thumbnail?: TelegramPhotoSize
+  file_name?: string
+  mime_type?: string
+  file_size?: number
+}
+
+export interface TelegramMessage {
+  message_id: number
+  message_thread_id?: number
+  date: number
+  chat: TelegramChat
+  from?: TelegramBotUser
+  sender_chat?: TelegramChat
+  text?: string
+  caption?: string
+  entities?: TelegramMessageEntity[]
+  caption_entities?: TelegramMessageEntity[]
+  reply_to_message?: TelegramMessage
+  edit_date?: number
+  photo?: TelegramPhotoSize[]
+  document?: TelegramDocument
+  is_topic_message?: boolean
+}
+
+export interface TelegramReactionType {
+  type: 'emoji' | 'custom_emoji' | 'paid'
+  emoji?: string
+  custom_emoji_id?: string
+}
+
+export interface TelegramCallbackQuery {
+  id: string
+  from: TelegramBotUser
+  message?: TelegramMessage
+  inline_message_id?: string
+  chat_instance: string
+  data?: string
+  game_short_name?: string
+}
+
+export interface TelegramInlineQuery {
+  id: string
+  from: TelegramBotUser
+  query: string
+  offset: string
+  chat_type?: string
+}
+
+export interface TelegramChatMemberUpdated {
+  chat: TelegramChat
+  from: TelegramBotUser
+  date: number
+  old_chat_member: TelegramChatMember
+  new_chat_member: TelegramChatMember
+}
+
+export interface TelegramUpdate {
+  update_id: number
+  message?: TelegramMessage
+  edited_message?: TelegramMessage
+  channel_post?: TelegramMessage
+  edited_channel_post?: TelegramMessage
+  inline_query?: TelegramInlineQuery
+  chosen_inline_result?: Record<string, unknown>
+  callback_query?: TelegramCallbackQuery
+  shipping_query?: Record<string, unknown>
+  pre_checkout_query?: Record<string, unknown>
+  poll?: Record<string, unknown>
+  poll_answer?: Record<string, unknown>
+  my_chat_member?: TelegramChatMemberUpdated
+  chat_member?: TelegramChatMemberUpdated
+  chat_join_request?: Record<string, unknown>
+  message_reaction?: Record<string, unknown>
+  message_reaction_count?: Record<string, unknown>
+}
+
+export const TelegramBotEntrySchema = z.object({
+  bot_id: z.string(),
+  bot_name: z.string(),
+  token: z.string(),
+})
+
+export const TelegramBotConfigSchema = z.object({
+  current: z
+    .object({
+      bot_id: z.string(),
+    })
+    .nullable(),
+  bots: z.record(z.string(), TelegramBotEntrySchema),
+})
+
+export const TelegramBotCredentialsSchema = z.object({
+  token: z.string(),
+  bot_id: z.string(),
+  bot_name: z.string(),
+})
+
+export const TelegramBotUserSchema = z.object({
+  id: z.number(),
+  is_bot: z.boolean(),
+  first_name: z.string(),
+  last_name: z.string().optional(),
+  username: z.string().optional(),
+  language_code: z.string().optional(),
+  is_premium: z.boolean().optional(),
+  can_join_groups: z.boolean().optional(),
+  can_read_all_group_messages: z.boolean().optional(),
+  supports_inline_queries: z.boolean().optional(),
+})
+
+export const TelegramChatSchema = z.object({
+  id: z.number(),
+  type: z.enum(['private', 'group', 'supergroup', 'channel']),
+  title: z.string().optional(),
+  username: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  is_forum: z.boolean().optional(),
+})
+
+export const TelegramMessageEntitySchema = z.object({
+  type: z.string(),
+  offset: z.number(),
+  length: z.number(),
+  url: z.string().optional(),
+  user: TelegramBotUserSchema.optional(),
+  language: z.string().optional(),
+  custom_emoji_id: z.string().optional(),
+})
+
+export const TelegramPhotoSizeSchema = z.object({
+  file_id: z.string(),
+  file_unique_id: z.string(),
+  width: z.number(),
+  height: z.number(),
+  file_size: z.number().optional(),
+})
+
+export const TelegramDocumentSchema = z.object({
+  file_id: z.string(),
+  file_unique_id: z.string(),
+  thumbnail: TelegramPhotoSizeSchema.optional(),
+  file_name: z.string().optional(),
+  mime_type: z.string().optional(),
+  file_size: z.number().optional(),
+})
+
+export const TelegramMessageSchema = z.object({
+  message_id: z.number(),
+  message_thread_id: z.number().optional(),
+  date: z.number(),
+  chat: TelegramChatSchema,
+  from: TelegramBotUserSchema.optional(),
+  sender_chat: TelegramChatSchema.optional(),
+  text: z.string().optional(),
+  caption: z.string().optional(),
+  entities: z.array(TelegramMessageEntitySchema).optional(),
+  caption_entities: z.array(TelegramMessageEntitySchema).optional(),
+  reply_to_message: z.lazy(() => TelegramMessageSchema).optional(),
+  edit_date: z.number().optional(),
+  photo: z.array(TelegramPhotoSizeSchema).optional(),
+  document: TelegramDocumentSchema.optional(),
+  is_topic_message: z.boolean().optional(),
+}) as z.ZodType<TelegramMessage>
+
+export interface TelegramBotListenerOptions {
+  timeoutSeconds?: number
+  limit?: number
+  allowedUpdates?: string[]
+  dropPendingUpdates?: boolean
+}
+
+export interface TelegramBotListenerEventMap {
+  message: [event: TelegramMessage]
+  edited_message: [event: TelegramMessage]
+  channel_post: [event: TelegramMessage]
+  edited_channel_post: [event: TelegramMessage]
+  callback_query: [event: TelegramCallbackQuery]
+  inline_query: [event: TelegramInlineQuery]
+  my_chat_member: [event: TelegramChatMemberUpdated]
+  chat_member: [event: TelegramChatMemberUpdated]
+  telegram_update: [event: TelegramUpdate]
+  connected: [info: { user: TelegramBotUser }]
+  disconnected: []
+  error: [error: Error]
+}


### PR DESCRIPTION
## Summary

Adds `agent-telegrambot` — a CLI + SDK that wraps Telegram's official HTTP **Bot API** (the kind issued by [@BotFather](https://t.me/BotFather)). This complements the existing `agent-telegram` (TDLib/userbot) and follows the same shape as the other `*bot` platforms (`agent-discordbot`, `agent-slackbot`, `agent-channeltalkbot`, `agent-whatsappbot`, `agent-wechatbot`).

The Bot API and User API (MTProto/TDLib) are completely separate APIs, so a dedicated CLI is the right home for this. `agent-telegram` cannot accept a BotFather token, and conversely a Bot API token can't drive a TDLib client — they share zero endpoints.

## Why now?

This was the only obvious gap in the bot lineup — Telegram's Bot API is the simplest of all the platforms (HTTP + JSON), but having it under the same `agent-*bot` umbrella means consistent ergonomics across CI/CD pipelines, multi-bot management, JSON-by-default output, and the same long-polling \"listener\" UX that SlackBot and DiscordBot expose for their respective WebSocket gateways.

## What's in the box

### SDK (`agent-messenger/telegrambot`)

- **\`TelegramBotClient\`** — raw \`fetch\` wrapper around the Bot API. No \`grammy\`/\`telegraf\` dependency added; the API is simple enough that direct calls keep the bundle lean and the surface predictable.
  - Methods: \`getMe\`, \`getChat\`, \`getChatMember\`, \`getChatMemberCount\`, \`sendMessage\`, \`sendPhoto\`, \`sendDocument\` (multipart/form-data), \`forwardMessage\`, \`editMessageText\`, \`deleteMessage\`, \`setMessageReaction\`, \`getUpdates\`, \`setWebhook\`, \`deleteWebhook\`.
  - 429 handling honors \`parameters.retry_after\` from the API response.
  - 5xx and network errors retry with exponential backoff (3 retries, 100ms base).
  - API error codes (401/403/404/409/400) are mapped to typed \`TelegramBotError\` codes (\`unauthorized\`, \`forbidden\`, \`not_found\`, \`conflict\`, \`bad_request\`).
- **\`TelegramBotListener\`** — long-polling listener built on \`getUpdates\`.
  - Telegram Bot API doesn't support WebSockets; long-polling (\`timeout: 30\`) is the canonical streaming pattern used by \`grammy\` and \`telegraf\`. No public HTTPS endpoint required — perfect for CI/behind-NAT.
  - Public API mirrors \`SlackBotListener\` / \`DiscordBotListener\`: \`start()\`, \`stop()\`, \`on()/off()/once()\` returning \`this\`, typed \`EventMap\`.
  - Calls \`deleteWebhook\` before polling (webhook + polling are mutually exclusive — Telegram returns 409 otherwise).
  - Emits \`message\`, \`edited_message\`, \`channel_post\`, \`edited_channel_post\`, \`callback_query\`, \`inline_query\`, \`my_chat_member\`, \`chat_member\`, plus a catch-all \`telegram_update\`, and lifecycle events \`connected\` / \`disconnected\` / \`error\`.
  - Advances \`offset\` to \`update_id + 1\` after each processed update. \`allowed_updates\` is sent only on the first poll (Telegram remembers it).
  - Stops on fatal \`Unauthorized\` (401) and \`Conflict\` (409). Recoverable errors emit \`disconnected\` and retry with exponential backoff capped at 30s.
- **\`TelegramBotCredentialManager\`** — multi-bot storage at \`~/.config/agent-messenger/telegrambot-credentials.json\` (0600). Honors \`AGENT_MESSENGER_CONFIG_DIR\`. Recognizes \`E2E_TELEGRAMBOT_TOKEN\` env var for CI.
- Zod schemas + TypeScript types exported (\`TelegramMessage\`, \`TelegramChat\`, \`TelegramUpdate\`, \`TelegramCallbackQuery\`, etc.).

### CLI (\`agent-telegrambot\`)

- \`auth set/clear/status/list/use/remove\` — multi-bot identity management.
- \`whoami\` — show the authenticated bot.
- \`message send/update/delete/forward/upload\` — text + multipart document upload, optional \`--parse-mode\`, \`--reply-to\`, \`--silent\`, \`--thread-id\`.
- \`chat info/member\` — \`getChat\` + \`getChatMember\`. Auto-fills \`member_count\` for groups/channels.
- \`reaction set/clear\` — \`setMessageReaction\` (replaces existing; pass empty array to clear).
- Chat ID resolution accepts numeric IDs, \`@username\`, or plain usernames (auto-prefixed with \`@\`).
- JSON output by default, \`--pretty\` for humans, \`--bot\` to scope a single command to a non-current bot.

### Skill (\`skills/agent-telegrambot/SKILL.md\`)

Explains the bot-vs-user distinction, chat ID semantics, the \`/start\` gate that prevents bots from initiating DMs, privacy mode and group message visibility, the bot vs webhook 409 conflict, and points at the SDK for real-time events.

### Docs

- \`docs/content/docs/cli/telegrambot.mdx\` — CLI reference.
- \`docs/content/docs/sdk/telegrambot.mdx\` — SDK reference (client, listener, credential manager, error codes).

### Wiring

- \`package.json\` — \`bin\`, \`exports\`, \`typesVersions\` entries.
- \`src/cli.ts\` — \`agent-messenger telegrambot ...\` umbrella subcommand.
- \`scripts/postbuild.ts\` — shebang rewriting for the published Node CLI.
- \`e2e/helpers.ts\` — \`commandMap\` entry.
- \`.claude-plugin/plugin.json\` + \`.claude-plugin/README.md\` — skill registration and capability list.
- \`README.md\` — platform badge, install list, SDK imports table, supported-platforms table (Bot support: Telegram → ✅), platform guides, philosophy section, new \"Real-time Events (Telegram Bot)\" SDK example.

## Tests

74 unit tests across 5 files — all passing:

- \`types.test.ts\` (10 tests) — Zod schemas, error class, recursive message validation.
- \`credential-manager.test.ts\` (15 tests) — load/save/multi-bot/env override/file permissions.
- \`client.test.ts\` (14 tests) — login, getMe, sendMessage with options, 429 retry-after, error code mapping (401/409/400/403), getUpdates params, deleteMessage, setMessageReaction, chat-ID resolution.
- \`listener.test.ts\` (9 tests) — connected emission, deleteWebhook before polling, message dispatch, offset advancement to \`update_id+1\`, catch-all \`telegram_update\`, fatal Unauthorized stops the loop, transient errors emit disconnected, \`stop()\` halts polling cleanly, on/off/once chaining.
- \`commands/auth.test.ts\` (15 tests) — set/clear/status/list/use/remove with mocked client.

Pre-existing slack \`token-extractor\` failures (4) are unrelated to this PR — they're about browser profile resolution.

## Try it

\`\`\`bash
bun link
agent-telegrambot auth set 123456789:ABC-DEF...
agent-telegrambot whoami --pretty
agent-telegrambot message send @yourchannel \"Hello from agent-telegrambot\"
\`\`\`

Or via the unified entry:

\`\`\`bash
agent-messenger telegrambot --help
\`\`\`

## Out of scope (intentionally)

- **Inline keyboards / callback button construction** from the CLI — the SDK already exposes the raw \`reply_markup\` plumbing via \`SendMessageOptions\`; CLI ergonomics for keyboards can come later.
- **Webhook mode** — only long-polling is wired up. Webhooks need a public HTTPS endpoint, which is outside the agent-messenger \"works in CI / behind NAT\" thesis. \`TelegramBotClient.setWebhook\` is exposed in the SDK for users who want it.
- **E2E test file** (\`e2e/telegrambot.e2e.test.ts\`) — easy to add once we have a dedicated test bot + chat ID secret. The CLI is fully wired into \`e2e/helpers.ts\` already.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `agent-telegrambot` — a Telegram Bot platform (CLI + TypeScript SDK) for the HTTP Bot API. It ships a lean client, long‑polling listener, multi‑bot auth, and a full CLI; wired into `agent-messenger`, docs, SKILL, examples, and e2e tests.

- **New Features**
  - SDK: `TelegramBotClient` for Bot API calls with 429 retry‑after, 5xx/network backoff, and typed `TelegramBotError`. `TelegramBotCredentialManager` supports multiple bots; `E2E_TELEGRAMBOT_TOKEN` supported.
  - Realtime: `TelegramBotListener` long‑polling (`getUpdates`) with start/stop, on/off/once, offset tracking, exponential backoff; stops on unauthorized/conflict.
  - CLI: `auth`, `whoami`, `message` (send/update/delete/forward/upload), `chat` (info/member), `reaction` (set/clear). JSON by default; `--pretty` and `--bot` supported.
  - Wiring/tests/examples: added bin/export, `src/cli.ts` subcommand, postbuild shebang, unit + E2E suite (`E2E_TELEGRAMBOT_CHAT_ID`), and `examples/telegrambot-listen.ts`.
  - Docs/SKILL: updated — `skills/agent-telegrambot/SKILL.md`, `docs/cli/telegrambot.mdx`, `docs/sdk/telegrambot.mdx`.

- **Bug Fixes**
  - Listener reliability: per‑poll client timeout, correct abort handling, 5xx retry even with non‑JSON bodies, advance offset before dispatch, and user handler errors surface via `error` without breaking the loop.
  - Uploads: `sendDocument` accepts `signal` and can be aborted.
  - API updates: `editMessageText` now uses a discriminated target (`{ chat_id, message_id } | { inline_message_id }`) and returns `TelegramMessage | true`; `setMessageReaction` narrowed to `BotReactionType[]`; schemas `.passthrough()` to keep unknown fields.
  - CLI: client injected via factory for better test isolation; reaction/update commands adjusted to new SDK shapes; `message update` now errors if Telegram returns `true` (inline‑only path) instead of fabricating a message; listener example adds an auth setup hint.
  - Tests: renamed for clarity and added DI failure‑path coverage.

<sup>Written for commit ee75f4fe8f2e2a9adc0788d9378b8bd1e5f8e811. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

