### PR TITLE
Share LOCO session between KakaoTalk client and listener

### DIFF
--- a/src/platforms/kakaotalk/client-listener-integration.test.ts
+++ b/src/platforms/kakaotalk/client-listener-integration.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, mock, it } from 'bun:test'
+
+import { KakaoTalkClient } from './client'
+import { KakaoTalkListener } from './listener'
+import type { LocoPacket } from './protocol/types'
+import type { KakaoTalkPushMessageEvent } from './types'
+
+const sessions: MockLocoSession[] = []
+const loginCalls: Array<{
+  oauthToken: string
+  userId: string
+  deviceUuid: string
+  syncState: unknown
+  deviceType: string
+}> = []
+
+class MockLocoSession {
+  pushHandler: ((packet: LocoPacket) => void) | null = null
+  closeHandler: (() => void) | null = null
+  closed = false
+  loginResult: Record<string, unknown> = {
+    chatDatas: [],
+    lastTokenId: { low: 0, high: 0 },
+    lastChatId: { low: 0, high: 0 },
+    eof: true,
+  }
+
+  loginImpl: (
+    oauthToken: string,
+    userId: string,
+    deviceUuid: string,
+    syncState: unknown,
+    deviceType: string,
+  ) => Promise<unknown> = async (oauthToken, userId, deviceUuid, syncState, deviceType) => {
+    loginCalls.push({ oauthToken, userId, deviceUuid, syncState, deviceType })
+    return this.loginResult
+  }
+
+  sendMessageImpl: (chatId: unknown, text: string) => Promise<unknown> = async () => ({
+    statusCode: 0,
+    body: { logId: { low: 1, high: 0 }, sendAt: 1 },
+  })
+
+  getChatLogsImpl: () => Promise<unknown> = async () => ({
+    body: { status: 0, chatLogs: [], eof: true },
+  })
+
+  constructor() {
+    sessions.push(this)
+  }
+
+  login(
+    oauthToken: string,
+    userId: string,
+    deviceUuid: string,
+    syncState: unknown,
+    deviceType: string,
+  ): Promise<unknown> {
+    return this.loginImpl(oauthToken, userId, deviceUuid, syncState, deviceType)
+  }
+
+  sendMessage(chatId: unknown, text: string): Promise<unknown> {
+    return this.sendMessageImpl(chatId, text)
+  }
+
+  getChatLogs(): Promise<unknown> {
+    return this.getChatLogsImpl()
+  }
+
+  getChatList(): Promise<unknown> {
+    return Promise.resolve({ body: { chatDatas: [], lastTokenId: { low: 0, high: 0 }, eof: true } })
+  }
+
+  getChatInfo(): Promise<unknown> {
+    return Promise.resolve({ body: { l: { low: 0, high: 0 } } })
+  }
+
+  syncMessages(): Promise<unknown> {
+    return Promise.resolve({ body: { chatLogs: [], isOK: true } })
+  }
+
+  onPush(handler: (packet: LocoPacket) => void): void {
+    this.pushHandler = handler
+  }
+
+  onClose(handler: () => void): void {
+    this.closeHandler = handler
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    this.closeHandler?.()
+  }
+
+  simulatePush(method: string, body: Record<string, unknown> = {}): void {
+    this.pushHandler?.({ packetId: 0, statusCode: 0, method, bodyType: 0, body })
+  }
+
+  simulateRemoteClose(): void {
+    if (this.closed) return
+    this.closed = true
+    this.closeHandler?.()
+  }
+}
+
+mock.module('./protocol/session', () => ({ LocoSession: MockLocoSession }))
+
+const CREDS = {
+  oauthToken: 'tok',
+  userId: 'user1',
+  deviceUuid: 'device-uuid-1',
+  deviceType: 'tablet' as const,
+}
+
+function currentSession(): MockLocoSession {
+  return sessions[sessions.length - 1]!
+}
+
+describe('KakaoTalkClient + KakaoTalkListener integration (shared LOCO session)', () => {
+  beforeEach(() => {
+    sessions.length = 0
+    loginCalls.length = 0
+  })
+
+  afterEach(() => {
+    sessions.length = 0
+    loginCalls.length = 0
+  })
+
+  it('opens exactly ONE LocoSession when a client and listener are used together', async () => {
+    // given — a client logged in and a listener attached
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+
+    // when — listener starts AND client makes API calls
+    await listener.start()
+    await client.sendMessage('100', 'hi')
+    await client.getChats()
+
+    // then — only one LocoSession was constructed; only one LOGINLIST sent
+    expect(sessions.length).toBe(1)
+    expect(loginCalls.length).toBe(1)
+    expect(loginCalls[0].deviceUuid).toBe(CREDS.deviceUuid)
+
+    listener.stop()
+    client.close()
+  })
+
+  it('never sends a duplicate LOGINLIST with the same duuid while a session is alive', async () => {
+    // given — a strict guard: any second login while the first session is still open is a self-KICKOUT.
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+    await listener.start()
+
+    // when — heavy interleaving of outbound calls and inbound pushes
+    for (let i = 0; i < 10; i++) {
+      await client.sendMessage(String(100 + i), `msg-${i}`)
+      currentSession().simulatePush('MSG', {
+        chatId: { low: 100 + i, high: 0 },
+        chatLog: { logId: { low: i, high: 0 }, authorId: 1, message: `pushed-${i}`, type: 1, sendAt: i },
+      })
+    }
+
+    // then — still exactly one LOGINLIST, never a second one against the live session
+    const liveSessions = sessions.filter((s) => !s.closed)
+    expect(liveSessions.length).toBe(1)
+    expect(loginCalls.length).toBe(1)
+
+    listener.stop()
+    client.close()
+  })
+
+  it('listener still receives push events when only the listener is used (no API calls)', async () => {
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+
+    const messages: KakaoTalkPushMessageEvent[] = []
+    listener.on('message', (event) => messages.push(event))
+
+    await listener.start()
+    expect(sessions.length).toBe(1)
+
+    currentSession().simulatePush('MSG', {
+      chatId: { low: 100, high: 0 },
+      chatLog: {
+        logId: { low: 1, high: 0 },
+        authorId: 42,
+        message: 'hello',
+        type: 1,
+        sendAt: 1700000000,
+      },
+    })
+
+    expect(messages.length).toBe(1)
+    expect(messages[0].chat_id).toBe('100')
+    expect(messages[0].message).toBe('hello')
+
+    listener.stop()
+    client.close()
+  })
+
+  it('client-only usage still works (no listener)', async () => {
+    const client = await new KakaoTalkClient().login(CREDS)
+    const result = await client.sendMessage('100', 'hi')
+
+    expect(result.success).toBe(true)
+    expect(sessions.length).toBe(1)
+
+    client.close()
+  })
+
+  it('real KICKOUT propagates to listener and closes the session', async () => {
+    // given — client + listener sharing a session
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+
+    const errors: Error[] = []
+    listener.on('error', (err) => errors.push(err))
+
+    await listener.start()
+    expect(sessions.length).toBe(1)
+    const sharedSession = currentSession()
+
+    // when — server pushes a KICKOUT (a different real device logged in)
+    sharedSession.simulatePush('KICKOUT', {})
+
+    // then — listener emits the canonical error and stops itself
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toContain('kicked')
+    expect((listener as unknown as { running: boolean }).running).toBe(false)
+
+    listener.stop()
+    client.close()
+  })
+
+  it('reconnect after a TCP-level disconnect produces ONE replacement session shared by both halves', async () => {
+    // given — listener + client on a shared session
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+
+    const disconnects: number[] = []
+    const connects: Array<{ userId: string }> = []
+    listener.on('disconnected', () => disconnects.push(Date.now()))
+    listener.on('connected', (info) => connects.push(info))
+
+    await listener.start()
+    expect(sessions.length).toBe(1)
+    expect(connects.length).toBe(1)
+
+    // when — the underlying socket dies (not a KICKOUT)
+    currentSession().simulateRemoteClose()
+
+    // then — listener observed the disconnect
+    expect(disconnects.length).toBe(1)
+
+    // and — the next API call transparently opens exactly ONE replacement session
+    await client.sendMessage('100', 'after-reconnect')
+
+    expect(sessions.length).toBe(2)
+    // and — the listener was re-attached to that replacement session (i.e. push fan-out works again)
+    const messages: KakaoTalkPushMessageEvent[] = []
+    listener.on('message', (event) => messages.push(event))
+    currentSession().simulatePush('MSG', {
+      chatId: { low: 100, high: 0 },
+      chatLog: { logId: { low: 9, high: 0 }, authorId: 1, message: 'after-reconnect-push', type: 1, sendAt: 1 },
+    })
+    expect(messages.length).toBe(1)
+    expect(connects.length).toBe(2)
+
+    listener.stop()
+    client.close()
+  })
+})

--- a/src/platforms/kakaotalk/client-listener-integration.test.ts
+++ b/src/platforms/kakaotalk/client-listener-integration.test.ts
@@ -363,4 +363,49 @@ describe('KakaoTalkClient + KakaoTalkListener integration (shared LOCO session)'
       MockLocoSession.prototype.login = originalLogin
     }
   })
+
+  it('drops pushes from a session that has not been adopted as the active state', async () => {
+    // given — a listener subscribed to push events, before any session is opened
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+    const messages: KakaoTalkPushMessageEvent[] = []
+    listener.on('message', (event) => messages.push(event))
+
+    // Slow down login so we can fire a push DURING the connect()/login window,
+    // when LocoSession has been constructed but this.state is still null.
+    let preAdoptionPushFired = false
+    const originalLogin = MockLocoSession.prototype.login
+    MockLocoSession.prototype.login = async function (oauthToken, userId, deviceUuid, syncState, deviceType) {
+      if (!preAdoptionPushFired) {
+        preAdoptionPushFired = true
+        this.simulatePush('MSG', {
+          chatId: { low: 1, high: 0 },
+          chatLog: { logId: { low: 1, high: 0 }, authorId: 1, message: 'too-early', type: 1, sendAt: 1 },
+        })
+      }
+      return originalLogin.call(this, oauthToken, userId, deviceUuid, syncState, deviceType)
+    }
+
+    try {
+      // when — start the listener, which triggers connect() and a pre-adoption push
+      await listener.start()
+      expect(preAdoptionPushFired).toBe(true)
+
+      // then — the pre-adoption push must NOT have leaked to subscribers
+      expect(messages.length).toBe(0)
+
+      // and — once the session is adopted, fresh pushes flow normally
+      sessions[0]!.simulatePush('MSG', {
+        chatId: { low: 1, high: 0 },
+        chatLog: { logId: { low: 2, high: 0 }, authorId: 1, message: 'fresh', type: 1, sendAt: 2 },
+      })
+      expect(messages.length).toBe(1)
+      expect(messages[0].message).toBe('fresh')
+
+      listener.stop()
+      client.close()
+    } finally {
+      MockLocoSession.prototype.login = originalLogin
+    }
+  })
 })

--- a/src/platforms/kakaotalk/client-listener-integration.test.ts
+++ b/src/platforms/kakaotalk/client-listener-integration.test.ts
@@ -271,4 +271,96 @@ describe('KakaoTalkClient + KakaoTalkListener integration (shared LOCO session)'
     listener.stop()
     client.close()
   })
+
+  it('CHANGESVR triggers an active session migration', async () => {
+    // given — a listener attached to a shared session
+    const client = await new KakaoTalkClient().login(CREDS)
+    const listener = new KakaoTalkListener(client)
+
+    const disconnects: number[] = []
+    const connects: Array<{ userId: string }> = []
+    const generic: Array<{ type: string }> = []
+    listener.on('disconnected', () => disconnects.push(1))
+    listener.on('connected', (info) => connects.push(info))
+    listener.on('kakaotalk_event', (event) => generic.push(event))
+
+    await listener.start()
+    expect(sessions.length).toBe(1)
+    expect(connects.length).toBe(1)
+
+    // when — the server pushes CHANGESVR (asking us to migrate to a new gateway)
+    sessions[0]!.simulatePush('CHANGESVR', {})
+
+    // then — the client actively migrates: old session closed, new one opened
+    await new Promise((r) => setTimeout(r, 0))
+    expect(sessions.length).toBe(2)
+    expect(sessions[0]!.closed).toBe(true)
+    expect(disconnects.length).toBe(1)
+    expect(connects.length).toBe(2)
+
+    // and — the listener re-attached to the replacement session for push events
+    const messages: KakaoTalkPushMessageEvent[] = []
+    listener.on('message', (event) => messages.push(event))
+    sessions[1]!.simulatePush('MSG', {
+      chatId: { low: 100, high: 0 },
+      chatLog: { logId: { low: 7, high: 0 }, authorId: 1, message: 'after-changesvr', type: 1, sendAt: 1 },
+    })
+    expect(messages.length).toBe(1)
+
+    // and — CHANGESVR was still surfaced as a generic event for observers that care
+    expect(generic.some((e) => e.type === 'CHANGESVR')).toBe(true)
+
+    listener.stop()
+    client.close()
+  })
+
+  it('does not open duplicate LOGINLIST when concurrent calls trigger executeWithReconnect retry', async () => {
+    // given — a client+listener with a slow LOGINLIST so concurrent reconnects can collide
+    let inflight = 0
+    let peakInflight = 0
+    const originalLogin = MockLocoSession.prototype.login
+    MockLocoSession.prototype.login = async function (oauthToken, userId, deviceUuid, syncState, deviceType) {
+      inflight++
+      peakInflight = Math.max(peakInflight, inflight)
+      try {
+        await new Promise((r) => setTimeout(r, 20))
+        return await originalLogin.call(this, oauthToken, userId, deviceUuid, syncState, deviceType)
+      } finally {
+        inflight--
+      }
+    }
+
+    try {
+      const client = await new KakaoTalkClient().login(CREDS)
+      await client.sendMessage('100', 'prime')
+      expect(sessions.length).toBe(1)
+      expect(loginCalls.length).toBe(1)
+
+      // Make the live session's sendMessage drop the socket and then throw — modeling a
+      // mid-flight TCP reset where the remote-close handler nulls this.state synchronously
+      // before the operation rejection bubbles up to executeWithReconnect's catch block.
+      // This is the precise window the executeWithReconnect retry path was designed for.
+      const dead = sessions[0]!
+      dead.sendMessageImpl = async function () {
+        dead.simulateRemoteClose()
+        throw new Error('socket closed')
+      }
+
+      // when — three concurrent sendMessage calls all hit the dead session and retry
+      await Promise.all([
+        client.sendMessage('100', 'a'),
+        client.sendMessage('100', 'b'),
+        client.sendMessage('100', 'c'),
+      ])
+
+      // then — exactly ONE replacement LOGINLIST regardless of retry collisions
+      expect(peakInflight).toBe(1)
+      expect(loginCalls.length).toBe(2)
+      expect(sessions.length).toBe(2)
+
+      client.close()
+    } finally {
+      MockLocoSession.prototype.login = originalLogin
+    }
+  })
 })

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -11,6 +11,7 @@ const mockSyncMessages = mock(() => Promise.resolve({}))
 const mockSendMessage = mock(() => Promise.resolve({}))
 const mockClose = mock(() => {})
 const mockOnClose = mock((_handler: () => void) => {})
+const mockOnPush = mock((_handler: (packet: unknown) => void) => {})
 
 mock.module('./protocol/session', () => ({
   LocoSession: class MockLocoSession {
@@ -22,6 +23,7 @@ mock.module('./protocol/session', () => ({
     sendMessage = mockSendMessage
     close = mockClose
     onClose = mockOnClose
+    onPush = mockOnPush
   },
 }))
 
@@ -38,6 +40,7 @@ function resetAllMocks() {
   mockSendMessage.mockReset()
   mockClose.mockReset()
   mockOnClose.mockReset()
+  mockOnPush.mockReset()
 }
 
 // LOCO protocol uses plain numbers for chat.c, but Long-like objects for logIds/cursors

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -9,8 +9,16 @@ import { warn } from '@/shared/utils/stderr'
 
 import { LANG, PC_OS_NAME, getLocoDeviceConfig } from './protocol/config'
 import { LocoSession } from './protocol/session'
-import type { ChatListResponse, LoginListResponse, SyncState } from './protocol/types'
+import type { ChatListResponse, LocoPacket, LoginListResponse, SyncState } from './protocol/types'
 import type { KakaoChat, KakaoDeviceType, KakaoMessage, KakaoProfile, KakaoSendResult } from './types'
+
+export type KakaoSessionEvent =
+  | { type: 'connected'; userId: string }
+  | { type: 'disconnected' }
+  | { type: 'kicked'; reason: string }
+
+export type KakaoPushHandler = (packet: LocoPacket) => void
+export type KakaoSessionEventHandler = (event: KakaoSessionEvent) => void
 
 export class KakaoTalkError extends Error {
   code: string
@@ -234,6 +242,8 @@ export class KakaoTalkClient {
   private state: SessionState | null = null
   private initPromise: Promise<SessionState> | null = null
   private closed = false
+  private pushHandlers = new Set<KakaoPushHandler>()
+  private sessionEventHandlers = new Set<KakaoSessionEventHandler>()
 
   async login(
     credentials?: { oauthToken: string; userId: string; deviceUuid?: string; deviceType?: KakaoDeviceType },
@@ -280,6 +290,7 @@ export class KakaoTalkClient {
     if (this.state) return this.state
 
     // Guard against concurrent init — reuse the in-flight promise
+    const isOwner = !this.initPromise
     if (!this.initPromise) {
       this.initPromise = this.connect()
     }
@@ -291,7 +302,11 @@ export class KakaoTalkClient {
         state.session.close()
         throw new KakaoTalkError('Client is closed', 'client_closed')
       }
+      const wasNew = this.state !== state
       this.state = state
+      if (isOwner && wasNew) {
+        this.emitSessionEvent({ type: 'connected', userId: this.userId! })
+      }
       return state
     } catch (error) {
       // Reset so next call retries cleanly; connect() already wraps in KakaoTalkError
@@ -299,6 +314,29 @@ export class KakaoTalkClient {
       this.initPromise = null
       throw error
     }
+  }
+
+  async acquireSession(): Promise<LocoSession> {
+    const state = await this.ensureSession()
+    return state.session
+  }
+
+  onPush(handler: KakaoPushHandler): () => void {
+    this.pushHandlers.add(handler)
+    return () => {
+      this.pushHandlers.delete(handler)
+    }
+  }
+
+  onSessionEvent(handler: KakaoSessionEventHandler): () => void {
+    this.sessionEventHandlers.add(handler)
+    return () => {
+      this.sessionEventHandlers.delete(handler)
+    }
+  }
+
+  isConnected(): boolean {
+    return this.state !== null && !this.closed
   }
 
   private async executeWithReconnect<T>(operation: (state: SessionState) => Promise<T>): Promise<T> {
@@ -322,6 +360,15 @@ export class KakaoTalkClient {
 
   private async connect(): Promise<SessionState> {
     const session = new LocoSession()
+    session.onPush((packet) => this.dispatchPush(session, packet))
+    session.onClose(() => {
+      if (this.state?.session === session) {
+        this.state = null
+        this.initPromise = null
+        this.emitSessionEvent({ type: 'disconnected' })
+      }
+    })
+
     try {
       const syncState = await loadSyncState(this.deviceUuid!)
       const loginResult = await session.login(
@@ -335,17 +382,36 @@ export class KakaoTalkClient {
       const newSyncState = mergeSyncState(syncState, loginResult)
       await saveSyncState(this.deviceUuid!, newSyncState)
 
-      session.onClose(() => {
-        if (this.state?.session === session) {
-          this.state = null
-          this.initPromise = null
-        }
-      })
-
       return { session, loginResult }
     } catch (error) {
       session.close()
       throw new KakaoTalkError(error instanceof Error ? error.message : String(error), 'login_failed', { cause: error })
+    }
+  }
+
+  private dispatchPush(session: LocoSession, packet: LocoPacket): void {
+    if (this.state && this.state.session !== session) return
+
+    if (packet.method === 'KICKOUT') {
+      this.emitSessionEvent({ type: 'kicked', reason: 'Session kicked — another device logged in' })
+      try {
+        session.close()
+      } catch {}
+      return
+    }
+
+    for (const handler of this.pushHandlers) {
+      try {
+        handler(packet)
+      } catch {}
+    }
+  }
+
+  private emitSessionEvent(event: KakaoSessionEvent): void {
+    for (const handler of this.sessionEventHandlers) {
+      try {
+        handler(event)
+      } catch {}
     }
   }
 
@@ -584,5 +650,7 @@ export class KakaoTalkClient {
     }
     this.state = null
     this.initPromise = null
+    this.pushHandlers.clear()
+    this.sessionEventHandlers.clear()
   }
 }

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -393,7 +393,11 @@ export class KakaoTalkClient {
   }
 
   private dispatchPush(session: LocoSession, packet: LocoPacket): void {
-    if (this.state && this.state.session !== session) return
+    // Only fan out pushes from the currently adopted session. While state is null
+    // (pre-adoption during connect, or post-invalidation during reconnect) the
+    // packet is discarded — we never want a not-yet-adopted or already-dead session
+    // to reach subscribers and look "live".
+    if (this.state?.session !== session) return
 
     if (packet.method === 'KICKOUT') {
       this.emitSessionEvent({ type: 'kicked', reason: 'Session kicked — another device logged in' })

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -352,7 +352,10 @@ export class KakaoTalkClient {
       try {
         state.session.close()
       } catch {}
-      this.initPromise = null
+      // initPromise is intentionally NOT cleared here: a concurrent caller may already
+      // be awaiting an in-flight replacement, and starting a parallel one would send a
+      // second LOGINLIST with the same duuid — re-introducing the very self-eviction
+      // this layer prevents. Lifecycle paths (onClose / invalidateSession) own that field.
       state = await this.ensureSession()
       return operation(state)
     }
@@ -394,9 +397,23 @@ export class KakaoTalkClient {
 
     if (packet.method === 'KICKOUT') {
       this.emitSessionEvent({ type: 'kicked', reason: 'Session kicked — another device logged in' })
-      try {
-        session.close()
-      } catch {}
+      this.invalidateSession(session)
+      return
+    }
+
+    if (packet.method === 'CHANGESVR') {
+      for (const handler of this.pushHandlers) {
+        try {
+          handler(packet)
+        } catch {}
+      }
+      this.invalidateSession(session)
+      this.emitSessionEvent({ type: 'disconnected' })
+      this.ensureSession().catch(() => {
+        // ensureSession already cleared state on failure; subsequent API calls will retry
+        // and surface the error. Listeners do not receive 'connected' until a reconnect
+        // succeeds, which is the correct outcome.
+      })
       return
     }
 
@@ -405,6 +422,16 @@ export class KakaoTalkClient {
         handler(packet)
       } catch {}
     }
+  }
+
+  private invalidateSession(session: LocoSession): void {
+    if (this.state?.session === session) {
+      this.state = null
+      this.initPromise = null
+    }
+    try {
+      session.close()
+    } catch {}
   }
 
   private emitSessionEvent(event: KakaoSessionEvent): void {

--- a/src/platforms/kakaotalk/listener.test.ts
+++ b/src/platforms/kakaotalk/listener.test.ts
@@ -1,59 +1,61 @@
-import { afterEach, describe, expect, mock, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 
-import { KakaoTalkListener } from '@/platforms/kakaotalk/listener'
-import type { LocoPacket } from '@/platforms/kakaotalk/protocol/types'
+import type { KakaoSessionEvent, KakaoSessionEventHandler, KakaoPushHandler, KakaoTalkClient } from './client'
+import { KakaoTalkListener } from './listener'
+import type { LocoPacket } from './protocol/types'
 import type {
   KakaoTalkPushGenericEvent,
   KakaoTalkPushMemberEvent,
   KakaoTalkPushMessageEvent,
   KakaoTalkPushReadEvent,
-} from '@/platforms/kakaotalk/types'
+} from './types'
 
-const mockLogin = mock(() => Promise.resolve({}))
-const mockSessionClose = mock(() => {})
+class FakeClient {
+  acquireCalls = 0
+  pushHandlers = new Set<KakaoPushHandler>()
+  sessionHandlers = new Set<KakaoSessionEventHandler>()
+  acquireImpl: () => Promise<void> = async () => {}
+  connected = false
 
-let mockSessionInstance: MockLocoSession
-
-class MockLocoSession {
-  pushHandler: ((packet: LocoPacket) => void) | null = null
-  closeHandler: (() => void) | null = null
-  login = mockLogin
-  close = mockSessionClose
-
-  constructor() {
-    // oxlint-disable-next-line typescript-eslint/no-this-alias
-    mockSessionInstance = this
+  async acquireSession(): Promise<unknown> {
+    this.acquireCalls++
+    await this.acquireImpl()
+    this.connected = true
+    return {}
   }
 
-  onPush(handler: (packet: LocoPacket) => void): void {
-    this.pushHandler = handler
+  isConnected(): boolean {
+    return this.connected
   }
 
-  onClose(handler: () => void): void {
-    this.closeHandler = handler
+  getCredentials(): { oauthToken: string; userId: string; deviceUuid: string; deviceType: 'tablet' } {
+    return { oauthToken: 'token', userId: 'user1', deviceUuid: 'device1', deviceType: 'tablet' }
   }
 
-  simulatePush(method: string, body: Record<string, unknown>): void {
-    this.pushHandler?.({ packetId: 0, statusCode: 0, method, bodyType: 0, body })
+  onPush(handler: KakaoPushHandler): () => void {
+    this.pushHandlers.add(handler)
+    return () => this.pushHandlers.delete(handler)
   }
 
-  simulateClose(): void {
-    this.closeHandler?.()
+  onSessionEvent(handler: KakaoSessionEventHandler): () => void {
+    this.sessionHandlers.add(handler)
+    return () => this.sessionHandlers.delete(handler)
+  }
+
+  emitPush(method: string, body: Record<string, unknown>): void {
+    const packet: LocoPacket = { packetId: 0, statusCode: 0, method, bodyType: 0, body }
+    for (const handler of this.pushHandlers) handler(packet)
+  }
+
+  emitSessionEvent(event: KakaoSessionEvent): void {
+    for (const handler of this.sessionHandlers) handler(event)
   }
 }
 
-mock.module('./protocol/session', () => ({ LocoSession: MockLocoSession }))
-
-function createMockClient(overrides: Record<string, unknown> = {}) {
-  return {
-    getCredentials: mock(() => ({
-      oauthToken: 'token',
-      userId: 'user1',
-      deviceUuid: 'device1',
-      deviceType: 'tablet' as const,
-    })),
-    ...overrides,
-  } as any
+function createListener(overrides: Partial<FakeClient> = {}): { listener: KakaoTalkListener; client: FakeClient } {
+  const client = Object.assign(new FakeClient(), overrides)
+  const listener = new KakaoTalkListener(client as unknown as KakaoTalkClient)
+  return { listener, client }
 }
 
 describe('KakaoTalkListener', () => {
@@ -61,58 +63,69 @@ describe('KakaoTalkListener', () => {
 
   afterEach(() => {
     listener?.stop()
-    mockLogin.mockReset()
-    mockLogin.mockResolvedValue({})
-    mockSessionClose.mockReset()
   })
 
   describe('start', () => {
-    it('calls login on LocoSession', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+    it('acquires the shared session from the client', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
 
       await listener.start()
 
-      expect(mockLogin).toHaveBeenCalledTimes(1)
-      expect(mockLogin).toHaveBeenCalledWith('token', 'user1', 'device1', undefined, 'tablet')
+      expect(client.acquireCalls).toBe(1)
     })
 
     it('is idempotent', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       await listener.start()
       await listener.start()
 
-      expect(mockLogin).toHaveBeenCalledTimes(1)
+      expect(client.acquireCalls).toBe(1)
     })
   })
 
   describe('connected event', () => {
-    it('emits connected with userId after successful login', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+    it('emits connected after acquiring an already-active session', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+      client.connected = true
 
-      const connected: Array<{ userId: string }> = []
-      listener.on('connected', (info) => connected.push(info))
+      const events: Array<{ userId: string }> = []
+      listener.on('connected', (info) => events.push(info))
 
       await listener.start()
 
-      expect(connected.length).toBe(1)
-      expect(connected[0].userId).toBe('user1')
+      expect(events.length).toBe(1)
+      expect(events[0].userId).toBe('user1')
+    })
+
+    it('emits connected from session-event when client connects after listener starts', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const events: Array<{ userId: string }> = []
+      listener.on('connected', (info) => events.push(info))
+
+      await listener.start()
+      client.emitSessionEvent({ type: 'connected', userId: 'user1' })
+
+      expect(events.length).toBe(1)
+      expect(events[0].userId).toBe('user1')
     })
   })
 
   describe('message events', () => {
     it('emits message on MSG push with parsed fields', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const messages: KakaoTalkPushMessageEvent[] = []
       listener.on('message', (event) => messages.push(event))
 
       await listener.start()
-      mockSessionInstance.simulatePush('MSG', {
+      client.emitPush('MSG', {
         chatId: { high: 0, low: 100 },
         chatLog: {
           logId: { high: 0, low: 200 },
@@ -136,14 +149,14 @@ describe('KakaoTalkListener', () => {
 
   describe('member events', () => {
     it('emits member_joined on NEWMEM push', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const joined: KakaoTalkPushMemberEvent[] = []
       listener.on('member_joined', (event) => joined.push(event))
 
       await listener.start()
-      mockSessionInstance.simulatePush('NEWMEM', {
+      client.emitPush('NEWMEM', {
         chatId: { high: 0, low: 100 },
         chatLog: { authorId: 42 },
       })
@@ -155,14 +168,14 @@ describe('KakaoTalkListener', () => {
     })
 
     it('emits member_left on DELMEM push', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const left: KakaoTalkPushMemberEvent[] = []
       listener.on('member_left', (event) => left.push(event))
 
       await listener.start()
-      mockSessionInstance.simulatePush('DELMEM', {
+      client.emitPush('DELMEM', {
         chatId: { high: 0, low: 100 },
         chatLog: { authorId: 42 },
       })
@@ -176,14 +189,14 @@ describe('KakaoTalkListener', () => {
 
   describe('read events', () => {
     it('emits read on DECUNREAD push with watermark', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const reads: KakaoTalkPushReadEvent[] = []
       listener.on('read', (event) => reads.push(event))
 
       await listener.start()
-      mockSessionInstance.simulatePush('DECUNREAD', {
+      client.emitPush('DECUNREAD', {
         chatId: { high: 0, low: 100 },
         userId: 42,
         watermark: { high: 0, low: 999 },
@@ -199,22 +212,22 @@ describe('KakaoTalkListener', () => {
 
   describe('kakaotalk_event catch-all', () => {
     it('emits kakaotalk_event for every push event', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const events: KakaoTalkPushGenericEvent[] = []
       listener.on('kakaotalk_event', (event) => events.push(event))
 
       await listener.start()
-      mockSessionInstance.simulatePush('MSG', {
+      client.emitPush('MSG', {
         chatId: { high: 0, low: 1 },
         chatLog: { logId: { high: 0, low: 2 }, authorId: 1, message: 'hi', type: 1, sendAt: 1 },
       })
-      mockSessionInstance.simulatePush('NEWMEM', {
+      client.emitPush('NEWMEM', {
         chatId: { high: 0, low: 1 },
         chatLog: { authorId: 1 },
       })
-      mockSessionInstance.simulatePush('CUSTOM_EVENT', { some: 'data' })
+      client.emitPush('CUSTOM_EVENT', { some: 'data' })
 
       expect(events.length).toBe(3)
       expect(events[0].type).toBe('MSG')
@@ -224,112 +237,72 @@ describe('KakaoTalkListener', () => {
   })
 
   describe('stop', () => {
-    it('closes session and prevents reconnection', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+    it('unsubscribes from client push and session events', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
 
       await listener.start()
+      expect(client.pushHandlers.size).toBe(1)
+      expect(client.sessionHandlers.size).toBe(1)
 
       listener.stop()
-      mockSessionInstance.simulateClose()
 
-      await new Promise((r) => setTimeout(r, 50))
-      expect(mockLogin).toHaveBeenCalledTimes(1)
+      expect(client.pushHandlers.size).toBe(0)
+      expect(client.sessionHandlers.size).toBe(0)
     })
   })
 
-  describe('reconnection', () => {
-    it('reconnects on session close when still running', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+  describe('disconnected event', () => {
+    it('emits disconnected when the client session drops', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
 
-      const disconnected: boolean[] = []
-      listener.on('disconnected', () => disconnected.push(true))
-
-      await listener.start()
-      mockSessionInstance.simulateClose()
-
-      expect(disconnected.length).toBe(1)
-
-      await new Promise((r) => setTimeout(r, 1500))
-      expect(mockLogin.mock.calls.length).toBeGreaterThanOrEqual(2)
-    })
-
-    it('emits error and reconnects on login failure', async () => {
-      let callCount = 0
-      mockLogin.mockImplementation(() => {
-        callCount++
-        if (callCount === 1) return Promise.reject(new Error('network_error'))
-        return Promise.resolve({})
-      })
-
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
-
-      const errors: Error[] = []
-      listener.on('error', (err) => errors.push(err))
+      const disconnects: number[] = []
+      listener.on('disconnected', () => disconnects.push(1))
 
       await listener.start()
+      client.emitSessionEvent({ type: 'disconnected' })
 
-      await new Promise((r) => setTimeout(r, 1500))
-
-      expect(errors.length).toBe(1)
-      expect(errors[0].message).toBe('network_error')
-      expect(mockLogin.mock.calls.length).toBeGreaterThanOrEqual(2)
-    })
-  })
-
-  describe('CHANGESVR', () => {
-    it('resets reconnect attempts to 0 on CHANGESVR push', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
-
-      await listener.start()
-      ;(listener as any).reconnectAttempts = 5
-
-      mockSessionInstance.simulatePush('CHANGESVR', {})
-
-      expect((listener as any).reconnectAttempts).toBe(0)
+      expect(disconnects.length).toBe(1)
     })
   })
 
   describe('KICKOUT', () => {
-    it('emits error and stops without reconnecting', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+    it('emits error and stops the listener when the client reports a kicked session', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
 
       const errors: Error[] = []
       listener.on('error', (err) => errors.push(err))
 
       await listener.start()
-      mockSessionInstance.simulatePush('KICKOUT', {})
+      client.emitSessionEvent({ type: 'kicked', reason: 'Session kicked — another device logged in' })
 
       expect(errors.length).toBe(1)
       expect(errors[0].message).toContain('kicked')
-      expect((listener as any).running).toBe(false)
-
-      await new Promise((r) => setTimeout(r, 50))
-      expect(mockLogin).toHaveBeenCalledTimes(1)
+      expect((listener as unknown as { running: boolean }).running).toBe(false)
+      expect(client.pushHandlers.size).toBe(0)
+      expect(client.sessionHandlers.size).toBe(0)
     })
   })
 
   describe('on/off/once', () => {
     it('off removes listener', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const messages: KakaoTalkPushMessageEvent[] = []
       const handler = (event: KakaoTalkPushMessageEvent) => messages.push(event)
       listener.on('message', handler)
 
       await listener.start()
-      mockSessionInstance.simulatePush('MSG', {
+      client.emitPush('MSG', {
         chatId: { high: 0, low: 1 },
         chatLog: { logId: { high: 0, low: 1 }, authorId: 1, message: 'first', type: 1, sendAt: 1 },
       })
 
       listener.off('message', handler)
-      mockSessionInstance.simulatePush('MSG', {
+      client.emitPush('MSG', {
         chatId: { high: 0, low: 1 },
         chatLog: { logId: { high: 0, low: 2 }, authorId: 1, message: 'second', type: 1, sendAt: 2 },
       })
@@ -339,18 +312,18 @@ describe('KakaoTalkListener', () => {
     })
 
     it('once fires only once', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+      const { listener: l, client } = createListener()
+      listener = l
 
       const messages: KakaoTalkPushMessageEvent[] = []
       listener.once('message', (event) => messages.push(event))
 
       await listener.start()
-      mockSessionInstance.simulatePush('MSG', {
+      client.emitPush('MSG', {
         chatId: { high: 0, low: 1 },
         chatLog: { logId: { high: 0, low: 1 }, authorId: 1, message: 'first', type: 1, sendAt: 1 },
       })
-      mockSessionInstance.simulatePush('MSG', {
+      client.emitPush('MSG', {
         chatId: { high: 0, low: 1 },
         chatLog: { logId: { high: 0, low: 2 }, authorId: 1, message: 'second', type: 1, sendAt: 2 },
       })
@@ -360,17 +333,24 @@ describe('KakaoTalkListener', () => {
     })
   })
 
-  describe('start after stop', () => {
-    it('resets reconnect attempts on fresh start', async () => {
-      const client = createMockClient()
-      listener = new KakaoTalkListener(client)
+  describe('error during start', () => {
+    it('emits error and tears down subscriptions when acquireSession fails', async () => {
+      const client = new FakeClient()
+      client.acquireImpl = async () => {
+        throw new Error('login_failed')
+      }
+      const l = new KakaoTalkListener(client as unknown as KakaoTalkClient)
+      listener = l
+
+      const errors: Error[] = []
+      listener.on('error', (err) => errors.push(err))
 
       await listener.start()
-      ;(listener as any).reconnectAttempts = 5
-      listener.stop()
 
-      await listener.start()
-      expect((listener as any).reconnectAttempts).toBe(0)
+      expect(errors.length).toBe(1)
+      expect(errors[0].message).toBe('login_failed')
+      expect(client.pushHandlers.size).toBe(0)
+      expect(client.sessionHandlers.size).toBe(0)
     })
   })
 })

--- a/src/platforms/kakaotalk/listener.test.ts
+++ b/src/platforms/kakaotalk/listener.test.ts
@@ -352,5 +352,31 @@ describe('KakaoTalkListener', () => {
       expect(client.pushHandlers.size).toBe(0)
       expect(client.sessionHandlers.size).toBe(0)
     })
+
+    it('can be restarted after a failed start()', async () => {
+      // given — a client whose first acquire fails but later succeeds
+      const client = new FakeClient()
+      let attempts = 0
+      client.acquireImpl = async () => {
+        attempts++
+        if (attempts === 1) throw new Error('login_failed')
+      }
+      const l = new KakaoTalkListener(client as unknown as KakaoTalkClient)
+      listener = l
+
+      const errors: Error[] = []
+      listener.on('error', (err) => errors.push(err))
+
+      // when — first start() fails, then we try again
+      await listener.start()
+      expect(errors.length).toBe(1)
+
+      await listener.start()
+
+      // then — second start succeeds (subscriptions re-attached, acquire was retried)
+      expect(attempts).toBe(2)
+      expect(client.pushHandlers.size).toBe(1)
+      expect(client.sessionHandlers.size).toBe(1)
+    })
   })
 })

--- a/src/platforms/kakaotalk/listener.ts
+++ b/src/platforms/kakaotalk/listener.ts
@@ -49,6 +49,7 @@ export class KakaoTalkListener {
       }
     } catch (error) {
       this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+      this.running = false
       this.teardown()
     }
   }

--- a/src/platforms/kakaotalk/listener.ts
+++ b/src/platforms/kakaotalk/listener.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events'
 
-import type { KakaoTalkClient } from './client'
-import { LocoSession } from './protocol/session'
+import type { KakaoSessionEvent, KakaoTalkClient } from './client'
 import type { LocoPacket } from './protocol/types'
 import type {
   KakaoTalkListenerEventMap,
@@ -10,9 +9,6 @@ import type {
   KakaoTalkPushMessageEvent,
   KakaoTalkPushReadEvent,
 } from './types'
-
-const RECONNECT_BASE_DELAY = 1_000
-const RECONNECT_MAX_DELAY = 30_000
 
 type EventKey = keyof KakaoTalkListenerEventMap
 
@@ -27,11 +23,9 @@ function longToString(v: unknown): string {
 export class KakaoTalkListener {
   private client: KakaoTalkClient
   private running = false
-  private session: LocoSession | null = null
   private emitter = new EventEmitter()
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
-  private reconnectAttempts = 0
-  private userId: string | null = null
+  private unsubscribePush: (() => void) | null = null
+  private unsubscribeSession: (() => void) | null = null
 
   constructor(client: KakaoTalkClient) {
     this.client = client
@@ -40,17 +34,32 @@ export class KakaoTalkListener {
   async start(): Promise<void> {
     if (this.running) return
     this.running = true
-    this.reconnectAttempts = 0
-    await this.connect()
+
+    this.unsubscribePush = this.client.onPush((packet) => this.handlePush(packet))
+    this.unsubscribeSession = this.client.onSessionEvent((event) => this.handleSessionEvent(event))
+
+    const alreadyConnected = this.client.isConnected()
+
+    try {
+      await this.client.acquireSession()
+      if (!this.running) return
+      if (alreadyConnected) {
+        const { userId } = this.client.getCredentials()
+        this.emitter.emit('connected', { userId })
+      }
+    } catch (error) {
+      this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+      this.teardown()
+    }
   }
 
   stop(): void {
-    this.running = false
-    this.clearTimers()
-    if (this.session) {
-      this.session.close()
-      this.session = null
+    if (!this.running) {
+      this.teardown()
+      return
     }
+    this.running = false
+    this.teardown()
   }
 
   on<K extends EventKey>(event: K, listener: (...args: KakaoTalkListenerEventMap[K]) => void): this {
@@ -68,41 +77,28 @@ export class KakaoTalkListener {
     return this
   }
 
-  private async connect(): Promise<void> {
+  private teardown(): void {
+    this.unsubscribePush?.()
+    this.unsubscribePush = null
+    this.unsubscribeSession?.()
+    this.unsubscribeSession = null
+  }
+
+  private handleSessionEvent(event: KakaoSessionEvent): void {
     if (!this.running) return
 
-    try {
-      const { oauthToken, userId, deviceUuid, deviceType } = this.client.getCredentials()
-      if (!this.running) return
-
-      this.userId = userId
-      const session = new LocoSession()
-
-      session.onPush((packet) => this.handlePush(packet))
-      session.onClose(() => {
-        if (this.session !== session) return
-        this.session = null
-        if (this.running) {
-          this.emitter.emit('disconnected')
-          this.scheduleReconnect()
-        }
-      })
-
-      await session.login(oauthToken, userId, deviceUuid, undefined, deviceType)
-
-      if (!this.running) {
-        session.close()
-        return
-      }
-
-      this.reconnectAttempts = 0
-      this.session = session
-      this.emitter.emit('connected', { userId })
-    } catch (error) {
-      this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
-      if (this.running) {
-        this.scheduleReconnect()
-      }
+    switch (event.type) {
+      case 'connected':
+        this.emitter.emit('connected', { userId: event.userId })
+        break
+      case 'disconnected':
+        this.emitter.emit('disconnected')
+        break
+      case 'kicked':
+        this.emitter.emit('error', new Error(event.reason))
+        this.running = false
+        this.teardown()
+        break
     }
   }
 
@@ -162,42 +158,11 @@ export class KakaoTalkListener {
         break
       }
 
-      case 'CHANGESVR': {
-        this.reconnectAttempts = 0
-        const prev = this.session
-        this.session = null
-        prev?.close()
-        this.connect()
-        break
-      }
-
-      case 'KICKOUT': {
-        this.emitter.emit('error', new Error('Session kicked — another device logged in'))
-        this.running = false
-        this.session?.close()
-        this.session = null
-        break
-      }
-
       default: {
         const event: KakaoTalkPushGenericEvent = { type: method, ...body }
         this.emitter.emit('kakaotalk_event', event)
         break
       }
-    }
-  }
-
-  private scheduleReconnect(): void {
-    this.clearTimers()
-    const delay = Math.min(RECONNECT_BASE_DELAY * 2 ** this.reconnectAttempts, RECONNECT_MAX_DELAY)
-    this.reconnectAttempts++
-    this.reconnectTimer = setTimeout(() => this.connect(), delay)
-  }
-
-  private clearTimers(): void {
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
     }
   }
 }


### PR DESCRIPTION
## Summary

`KakaoTalkClient` and `KakaoTalkListener` each opened their own `LocoSession` authenticated with the same `device_uuid`. The KakaoTalk LOCO server enforces one active session per `(device_uuid, slot)`, so the second `LOGINLIST` evicted the first with `KICKOUT`. With both halves used together — the documented SDK pattern — every `sendMessage` displaced the listener and every listener reconnect displaced the client. A structural ping-pong, surfacing as the literal error \`Session kicked — another device logged in\`.

This PR makes `KakaoTalkClient` the sole session owner. The listener subscribes to the client's shared session instead of opening its own.

## Root cause

Two sockets, same `duuid`:

- \`src/platforms/kakaotalk/listener.ts\` ➜ \`new LocoSession()\` + own \`session.login(...)\`
- \`src/platforms/kakaotalk/client.ts\` ➜ \`new LocoSession()\` + own \`session.login(...)\`
- \`LocoSession.login\` always sends \`LOGINLIST { duuid, dtype: 2 }\` — both halves claim the same slot.

Each new login displaced the previous one. The listener's exponential-backoff reconnect and the client's \`executeWithReconnect\` closed the loop, producing the ping-pong.

## What changed

\`KakaoTalkClient\` now owns the \`LocoSession\` lifecycle and exposes hooks the listener uses:

| Hook | Purpose |
| --- | --- |
| \`acquireSession()\` | Open or reuse the shared session (idempotent, concurrent-safe). |
| \`onPush(handler)\` | Subscribe to multiplexed push packets; returns unsubscriber. |
| \`onSessionEvent(handler)\` | Subscribe to \`connected\` / \`disconnected\` / \`kicked\`. |
| \`isConnected()\` | Cheap status probe used by the listener on \`start()\`. |

\`KakaoTalkListener\` is now a thin subscriber:

- No more private \`LocoSession\`, \`reconnectAttempts\`, \`scheduleReconnect\`, \`RECONNECT_BASE_DELAY/MAX_DELAY\`, \`clearTimers\`.
- \`start()\` ➜ subscribe + \`client.acquireSession()\`.
- \`stop()\` ➜ unsubscribe; the client owns the socket.
- Listener reconnect coherence comes for free: when the client opens a replacement session via \`executeWithReconnect\`, the listener's subscriptions transparently follow.

## Critical care preserved

- The \`closed\` flag race protection (commit \`7874e41\`) — kept.
- The session-identity comparison in \`executeWithReconnect\` (commit \`a722dd1\`) — kept.
- Concurrent \`sendMessage\` + \`start()\` race — guarded via shared \`initPromise\`.
- Real \`KICKOUT\` (a different physical device logging in) still propagates to the listener as the canonical error and stops it (\`running = false\`); only **self-inflicted** KICKOUTs are eliminated.

## Tests

TDD — wrote the failing tests first, watched them fail, then refactored. New file \`src/platforms/kakaotalk/client-listener-integration.test.ts\` covers:

1. **One session for both** — client + listener together construct \`LocoSession\` exactly once and send exactly one \`LOGINLIST\`.
2. **No self-KICKOUT** — 10 outbound calls interleaved with 10 inbound pushes still hold the single-session invariant.
3. **Real KICKOUT propagates** — server-pushed \`KICKOUT\` surfaces as the canonical error and stops the listener.
4. **Reconnect coherence** — a TCP-level disconnect emits \`disconnected\` once; the next API call opens exactly one replacement session that the listener also rides.
5. **Listener-only usage** — push events still work without API calls.
6. **Client-only usage** — API calls still work without a listener.

\`listener.test.ts\` was rewritten against a \`FakeClient\` double so it tests the listener's subscription contract directly, instead of mocking \`LocoSession\` underneath. The previous mock pattern hid the bug this PR fixes.

## Verification

\`\`\`text
bun run typecheck   ✓
bun run lint        ✓ (0 warnings, 0 errors)
bun test src/platforms/kakaotalk/   ✓ 106 pass / 0 fail
\`\`\`

(Pre-existing \`token-extractor.test.ts\` failures on \`main\` are unrelated host-machine artifacts and remain unchanged.)

## Out of scope

- The 5-minute live e2e smoke script suggested in the task brief is not included here. The mock-based integration test exercises the same invariant deterministically and does not require sub-device credentials. Happy to add a credential-gated e2e probe in a follow-up if you want it under \`e2e/\`.

## Backwards compatibility

The public API surface of \`KakaoTalkClient\` and \`KakaoTalkListener\` is unchanged for end-users. The new \`acquireSession\` / \`onPush\` / \`onSessionEvent\` / \`isConnected\` methods are additive. Downstream consumers (e.g. typeclaw's adapter) that just call \`client.sendMessage\` and \`new KakaoTalkListener(client).start()\` keep working without any changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LOCO session eviction by sharing a single session between `KakaoTalkClient` and `KakaoTalkListener`, and improves reliability by dispatching pushes only from the active session and allowing the listener to restart after a failed start. Also keeps safe reconnect and migration so both halves move together without dropping pushes.

- **Bug Fixes**
  - One shared `LocoSession` owned by `KakaoTalkClient`; listener subscribes and no longer manages its own socket or timers.
  - Prevents duplicate `LOGINLIST` and self-KICKOUTs; centralized invalidation and a single in-flight reconnect in `executeWithReconnect()`.
  - `CHANGESVR` triggers active migration; listener reattaches. `KICKOUT` still surfaces as an error and stops the listener.
  - Tightened push dispatch: only the currently adopted session fans out; pre-adoption/post-invalidation pushes are dropped.
  - Listener restart fixed: `start()` resets `running` and unsubscribes on failure so a later `start()` works.
  - New client hooks: `acquireSession()`, `onPush()`, `onSessionEvent()`, `isConnected()`; no breaking changes.
  - Tests updated: shared-session invariants, `CHANGESVR` migration, concurrent retry deduping, pre-adoption push drop, and listener restart.
  - Docs/SKILL.md: no updates.

<sup>Written for commit 9cc979714e83e73d2a93fa53c2a38d61bb5e5ed5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

