### PR TITLE
Resolve KakaoTalk room titles via CHATINFO

### DIFF
--- a/docs/content/docs/cli/kakaotalk.mdx
+++ b/docs/content/docs/cli/kakaotalk.mdx
@@ -128,6 +128,9 @@ agent-kakaotalk chat list --all
 # Search for a chat by display name
 agent-kakaotalk chat list --search "Alice"
 agent-kakaotalk chat list --all --search "project"
+
+# Resolve user-set room titles (one extra LOCO call per chat — slower but matches the in-app room name)
+agent-kakaotalk chat list --resolve-titles
 ```
 
 Output includes:
@@ -135,6 +138,7 @@ Output includes:
 - `chat_id` — numeric chat room ID
 - `type` — chat type (1:1, group, open chat)
 - `display_name` — comma-separated member names
+- `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`)
 - `active_members` — number of active members
 - `unread_count` — unread message count
 - `last_message` — most recent message preview

--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -44,6 +44,13 @@ const allChats = await client.getChats({ all: true })
 
 // Search chats by display name
 const results = await client.getChats({ search: 'Alice' })
+
+// Resolve user-set room titles via CHATINFO (one extra LOCO call per chat).
+// Each KakaoChat gets a `title: string | null` matching the in-app room name.
+const titled = await client.getChats({ resolveTitles: true })
+
+// Resolve a single chat's title directly (returns null on error or missing title)
+const title = await client.getChatTitle('9876543210')
 ```
 
 ### Messages

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -359,6 +359,7 @@ All commands output JSON by default for AI consumption:
   "chat_id": "9876543210",
   "type": 2,
   "display_name": "Alice, Bob",
+  "title": null,
   "active_members": 3,
   "unread_count": 5,
   "last_message": {

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -288,12 +288,17 @@ agent-kakaotalk chat list
 agent-kakaotalk chat list --pretty
 agent-kakaotalk chat list --account <account-id>
 agent-kakaotalk chat list --account <account-id> --pretty
+
+# Resolve user-set room titles via CHATINFO (one extra LOCO call per chat;
+# slower, but matches the room name shown in the official KakaoTalk app)
+agent-kakaotalk chat list --resolve-titles
 ```
 
 Output includes:
 - `chat_id` — numeric chat room ID
 - `type` — chat type (1:1, group, open chat)
 - `display_name` — comma-separated member names
+- `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`)
 - `active_members` — number of active members
 - `unread_count` — unread message count
 - `last_message` — most recent message preview

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -7,6 +7,7 @@ const mockLogin = mock(() => Promise.resolve({}))
 const mockGetChatList = mock(() => Promise.resolve({}))
 const mockGetChatLogs = mock(() => Promise.resolve({}))
 const mockGetChatInfo = mock(() => Promise.resolve({}))
+const mockGetChannelInfo = mock(() => Promise.resolve({}))
 const mockSyncMessages = mock(() => Promise.resolve({}))
 const mockSendMessage = mock(() => Promise.resolve({}))
 const mockClose = mock(() => {})
@@ -19,6 +20,7 @@ mock.module('./protocol/session', () => ({
     getChatList = mockGetChatList
     getChatLogs = mockGetChatLogs
     getChatInfo = mockGetChatInfo
+    getChannelInfo = mockGetChannelInfo
     syncMessages = mockSyncMessages
     sendMessage = mockSendMessage
     close = mockClose
@@ -36,6 +38,7 @@ function resetAllMocks() {
   mockGetChatList.mockReset()
   mockGetChatLogs.mockReset()
   mockGetChatInfo.mockReset()
+  mockGetChannelInfo.mockReset()
   mockSyncMessages.mockReset()
   mockSendMessage.mockReset()
   mockClose.mockReset()
@@ -123,6 +126,7 @@ describe('KakaoTalkClient', () => {
 
       expect(chats).toHaveLength(2)
       expect(chats[0].display_name).toBe('Alice, Bob')
+      expect(chats[0].title).toBeNull()
       expect(chats[0].active_members).toBe(2)
       expect(chats[0].unread_count).toBe(3)
       expect(chats[0].last_message).toEqual({
@@ -131,7 +135,92 @@ describe('KakaoTalkClient', () => {
         sent_at: 1700000000,
       })
       expect(chats[1].display_name).toBe('Charlie')
+      expect(chats[1].title).toBeNull()
       expect(chats[1].last_message).toBeNull()
+
+      client.close()
+    })
+
+    it('does not call CHATINFO when resolveTitles is not set (default behavior preserved)', async () => {
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      await client.getChats()
+
+      expect(mockGetChannelInfo).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('resolves user-set titles via CHATINFO when resolveTitles=true', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({
+        body: {
+          chatInfo: {
+            chatMetas: [
+              { type: 1, content: '{"notice":"hello"}', revision: makeLong(1), updatedAt: 0 },
+              { type: 3, content: 'Renamed Chat', revision: makeLong(2), updatedAt: 0 },
+            ],
+          },
+        },
+      })
+      mockGetChannelInfo.mockResolvedValueOnce({
+        body: {
+          chatInfo: {
+            chatMetas: [],
+          },
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ resolveTitles: true })
+
+      expect(mockGetChannelInfo).toHaveBeenCalledTimes(2)
+      expect(chats[0].title).toBe('Renamed Chat')
+      expect(chats[0].display_name).toBe('Alice, Bob')
+      expect(chats[1].title).toBeNull()
+      expect(chats[1].display_name).toBe('Charlie')
+
+      client.close()
+    })
+
+    it('returns null title when chatInfo or chatMetas is missing', async () => {
+      mockGetChannelInfo.mockResolvedValue({ body: {} })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ resolveTitles: true })
+
+      for (const chat of chats) {
+        expect(chat.title).toBeNull()
+      }
+
+      client.close()
+    })
+
+    it('swallows CHATINFO failures and returns null title (does not poison list)', async () => {
+      mockGetChannelInfo.mockRejectedValueOnce(new Error('CHATINFO timed out'))
+      mockGetChannelInfo.mockResolvedValueOnce({
+        body: { chatInfo: { chatMetas: [{ type: 3, content: 'OK Title' }] } },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ resolveTitles: true })
+
+      expect(chats).toHaveLength(2)
+      expect(chats[0].title).toBeNull()
+      expect(chats[1].title).toBe('OK Title')
+
+      client.close()
+    })
+
+    it('ignores empty-string title content and returns null', async () => {
+      mockGetChannelInfo.mockResolvedValue({
+        body: { chatInfo: { chatMetas: [{ type: 3, content: '' }] } },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ resolveTitles: true })
+
+      for (const chat of chats) {
+        expect(chat.title).toBeNull()
+      }
 
       client.close()
     })
@@ -303,6 +392,31 @@ describe('KakaoTalkClient', () => {
       } catch (e) {
         expect((e as KakaoTalkError).code).toBe('login_failed')
       }
+
+      client.close()
+    })
+
+    it('exposes getChatTitle() for single-chat title resolution', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({
+        body: { chatInfo: { chatMetas: [{ type: 3, content: 'Direct Lookup' }] } },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('100')
+
+      expect(title).toBe('Direct Lookup')
+      expect(mockGetChannelInfo).toHaveBeenCalledTimes(1)
+
+      client.close()
+    })
+
+    it('getChatTitle() returns null on CHATINFO failure', async () => {
+      mockGetChannelInfo.mockRejectedValueOnce(new Error('Network error'))
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('100')
+
+      expect(title).toBeNull()
 
       client.close()
     })

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -421,6 +421,17 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('getChatTitle() returns null on invalid chatId without contacting LOCO', async () => {
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('not-a-number')
+
+      expect(title).toBeNull()
+      expect(mockGetChannelInfo).not.toHaveBeenCalled()
+      expect(mockLogin).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
     it('wraps getChatList failure as KakaoTalkError with code get_chats_failed', async () => {
       const loginResult = { ...DEFAULT_LOGIN_RESULT, eof: false }
       mockLogin.mockResolvedValue(loginResult)

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -533,8 +533,14 @@ export class KakaoTalkClient {
    * fire-and-forget per chat — failures don't poison the whole `getChats` call.
    */
   async getChatTitle(chatId: string): Promise<string | null> {
+    let parsed: Long
+    try {
+      parsed = parseLong(chatId)
+    } catch {
+      return null
+    }
     return this.executeWithReconnect(async ({ session }) => {
-      return this.fetchChatTitle(session, parseLong(chatId))
+      return this.fetchChatTitle(session, parsed)
     })
   }
 

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -60,7 +60,7 @@ function parseLong(s: string): Long {
   return new Long(low, high)
 }
 
-function formatChat(chat: ChatData): KakaoChat {
+function formatChat(chat: ChatData, title: string | null = null): KakaoChat {
   const memberNames = (chat.k ?? []) as string[]
   const lastLog = chat.l as Record<string, unknown> | null
   const displayName = memberNames.join(', ') || null
@@ -69,6 +69,7 @@ function formatChat(chat: ChatData): KakaoChat {
     chat_id: String(chat.c),
     type: chat.t as number,
     display_name: displayName,
+    title,
     active_members: chat.a as number,
     unread_count: chat.n as number,
     last_message: lastLog
@@ -79,6 +80,29 @@ function formatChat(chat: ChatData): KakaoChat {
         }
       : null,
   }
+}
+
+const META_TYPE_TITLE = 3
+
+interface ChannelMetaEntry {
+  type?: number
+  content?: string
+}
+
+interface ChannelInfoResponse {
+  chatInfo?: {
+    chatMetas?: ChannelMetaEntry[]
+  }
+}
+
+function extractTitle(body: Record<string, unknown>): string | null {
+  const info = (body as ChannelInfoResponse).chatInfo
+  const metas = info?.chatMetas
+  if (!Array.isArray(metas)) return null
+
+  const titleMeta = metas.find((m) => m?.type === META_TYPE_TITLE)
+  const content = titleMeta?.content
+  return typeof content === 'string' && content.length > 0 ? content : null
 }
 
 function matchesSearch(chat: ChatData, term: string): boolean {
@@ -446,7 +470,7 @@ export class KakaoTalkClient {
     }
   }
 
-  async getChats(options?: { all?: boolean; search?: string }): Promise<KakaoChat[]> {
+  async getChats(options?: { all?: boolean; search?: string; resolveTitles?: boolean }): Promise<KakaoChat[]> {
     return this.executeWithReconnect(async ({ session, loginResult }) => {
       try {
         const allChats: ChatData[] = []
@@ -492,11 +516,35 @@ export class KakaoTalkClient {
           results = allChats.filter((c) => matchesSearch(c, options.search!))
         }
 
-        return results.map(formatChat)
+        const titles = options?.resolveTitles
+          ? await Promise.all(results.map((chat) => this.fetchChatTitle(session, parseLong(String(chat.c)))))
+          : null
+
+        return results.map((chat, i) => formatChat(chat, titles ? titles[i] : null))
       } catch (error) {
         throw wrapError(error, 'get_chats_failed')
       }
     })
+  }
+
+  /**
+   * Resolve the user-set room title via CHATINFO. Returns null on any error
+   * (network, malformed response, or no TITLE meta present). Designed to be
+   * fire-and-forget per chat — failures don't poison the whole `getChats` call.
+   */
+  async getChatTitle(chatId: string): Promise<string | null> {
+    return this.executeWithReconnect(async ({ session }) => {
+      return this.fetchChatTitle(session, parseLong(chatId))
+    })
+  }
+
+  private async fetchChatTitle(session: LocoSession, chatId: Long): Promise<string | null> {
+    try {
+      const response = await session.getChannelInfo(chatId)
+      return extractTitle(response.body as Record<string, unknown>)
+    } catch {
+      return null
+    }
   }
 
   async getMessages(chatId: string, options?: { count?: number; from?: string }): Promise<KakaoMessage[]> {

--- a/src/platforms/kakaotalk/commands/chat.ts
+++ b/src/platforms/kakaotalk/commands/chat.ts
@@ -9,11 +9,12 @@ async function listAction(options: {
   account?: string
   all?: boolean
   search?: string
+  resolveTitles?: boolean
   pretty?: boolean
 }): Promise<void> {
   try {
     const chats = await withKakaoClient(options, (client) =>
-      client.getChats({ all: options.all, search: options.search }),
+      client.getChats({ all: options.all, search: options.search, resolveTitles: options.resolveTitles }),
     )
     console.log(formatOutput(chats, options.pretty))
   } catch (error) {
@@ -29,6 +30,7 @@ export const chatCommand = new Command('chat')
       .option('--account <id>', 'Use a specific KakaoTalk account')
       .option('--all', 'Fetch all chats (paginate beyond login snapshot)')
       .option('--search <name>', 'Search for a chat by display name')
+      .option('--resolve-titles', 'Fetch user-set room titles via CHATINFO (slower; one extra LOCO call per chat)')
       .option('--pretty', 'Pretty print JSON output')
       .action(listAction),
   )

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -149,6 +149,17 @@ export class LocoSession {
     return this.connection.sendPacket('CHATONROOM', { chatId })
   }
 
+  /**
+   * Fetch detailed channel info (CHATINFO). Unlike CHATONROOM, this returns
+   * a `chatInfo` sub-document containing `chatMetas` (room title, notice, etc.)
+   * and `displayMembers` (user_id ↔ nickname pairs). Used to resolve the
+   * canonical user-set room title.
+   */
+  async getChannelInfo(chatId: Long): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return this.connection.sendPacket('CHATINFO', { chatId })
+  }
+
   async getChatList(lastTokenId?: Long, lastChatId?: Long): Promise<LocoPacket> {
     if (!this.connection) throw new Error('Not connected')
     return this.connection.sendPacket('LCHATLIST', {

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -73,6 +73,7 @@ export interface KakaoChat {
   chat_id: string
   type: number
   display_name: string | null
+  title: string | null
   active_members: number
   unread_count: number
   last_message: {
@@ -102,6 +103,7 @@ export const KakaoChatSchema = z.object({
   chat_id: z.string(),
   type: z.number(),
   display_name: z.string().nullable(),
+  title: z.string().nullable(),
   active_members: z.number(),
   unread_count: z.number(),
   last_message: z

--- a/src/tui/adapters/kakaotalk-adapter.ts
+++ b/src/tui/adapters/kakaotalk-adapter.ts
@@ -29,7 +29,7 @@ export class KakaoTalkAdapter implements PlatformAdapter {
     const chats = await client.getChats()
     return chats.map((chat) => ({
       id: chat.chat_id,
-      name: chat.display_name || `Chat ${chat.chat_id}`,
+      name: chat.title || chat.display_name || `Chat ${chat.chat_id}`,
     }))
   }
 

--- a/src/tui/adapters/kakaotalk-adapter.ts
+++ b/src/tui/adapters/kakaotalk-adapter.ts
@@ -26,7 +26,7 @@ export class KakaoTalkAdapter implements PlatformAdapter {
 
   async getChannels(): Promise<UnifiedChannel[]> {
     const client = this.ensureClient()
-    const chats = await client.getChats()
+    const chats = await client.getChats({ resolveTitles: true })
     return chats.map((chat) => ({
       id: chat.chat_id,
       name: chat.title || chat.display_name || `Chat ${chat.chat_id}`,


### PR DESCRIPTION
## Summary

Adds opt-in resolution of user-set KakaoTalk room titles, fixing the long-standing issue where `chat list` showed comma-joined member nicknames (e.g. `\"Alice, Bob, Charlie\"`) instead of the actual room name users see in the official app (e.g. `\"Project Standup\"`, the open-chat title, etc.).

## Why

The chat name shown in the KakaoTalk app is stored as a typed meta entry on the channel — specifically `chatInfo.chatMetas[].type === 3` (`KnownChannelMetaType.TITLE`). Confirmed by cross-referencing three independent reverse-engineered LOCO implementations:

- [storycraft/node-kakao](https://github.com/storycraft/node-kakao/blob/8512e4699e2cd4c26516b80d38b57b2f85a6cc8a/src/talk/channel/talk-normal-channel.ts#L116-L119) (TypeScript) — \`metaMap[KnownChannelMetaType.TITLE]\`
- [NetRiceCake/loco-wrapper](https://github.com/NetRiceCake/loco-wrapper/blob/6d5f6477f64cc0e6baf6bb4a11480c6216ec7fab/src/main/java/com/github/netricecake/kakao/TalkClient.java#L187-L198) (Java) — \`chatMetas[0].content\`
- [JungHoonGhae/openkakao](https://github.com/JungHoonGhae/openkakao/blob/4f592b512f6e23229bb8092443d780d9799e96fc/src/commands/analytics.rs#L26-L56) (Rust) — \`chatInfo.name\`

These metas are returned by the LOCO `CHATINFO` command (note: distinct from `CHATONROOM`, which the existing `getChatInfo()` actually sends — different shape, no `chatMetas`).

## Changes

- **`LocoSession.getChannelInfo(chatId)`** — new method sending `CHATINFO` (the existing misleadingly-named `getChatInfo()` keeps sending `CHATONROOM` for `lastLogId`)
- **`KakaoChat.title: string | null`** — new field alongside `display_name`; `null` when no user-set title or when resolution fails
- **`KakaoTalkClient.getChats({ resolveTitles })`** — opt-in flag; when set, fires one `CHATINFO` per chat in parallel
- **`KakaoTalkClient.getChatTitle(chatId)`** — direct single-chat title lookup
- **`agent-kakaotalk chat list --resolve-titles`** — CLI flag exposing the option
- **TUI adapter** — prefers `title` over `display_name` when present

## Behavior

- **Default behavior preserved.** Without `--resolve-titles` / `resolveTitles: true`, output is identical to before. No extra LOCO calls.
- **Failures are isolated.** A failed `CHATINFO` for one chat returns `title: null` for that chat and does not poison the rest of the list.
- **Empty content rejected.** A meta entry with empty string content is treated as no title (returns `null`).

## Trade-offs

`--resolve-titles` issues N extra LOCO round-trips (one per chat). Acceptable because (a) it's opt-in, (b) calls are parallelized, (c) the existing CHATONROOM code path already does this for `getMessages` so the latency profile is well-understood. A future optimization could batch via a single command if the LOCO protocol supports it (none of the reference impls do today).

## Out of scope (future work)

- **Open-chat fallback to `openLink.linkName`** when no TITLE meta exists. Requires implementing `INFOLINK` LOCO command — separate PR.
- **Per-message sender names** (Issue 2 from investigation). Requires either parsing `i`/`k` arrays from `LOGINLIST`/`LCHATLIST` or adding `MEMBER`/`GETMEM` LOCO commands — separate PR.

## Tests

- Existing tests updated to assert `title: null` default
- New tests cover: TITLE meta present, missing chatInfo/chatMetas, CHATINFO failure, empty-string content, single-chat \`getChatTitle()\`, default-off (no extra LOCO call)

\`\`\`
117 pass
0 fail
279 expect() calls
\`\`\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in KakaoTalk room title resolution via CHATINFO so chat lists and the TUI show the actual room name. Default SDK/CLI behavior is unchanged unless `resolveTitles`/`--resolve-titles` is used.

- New Features
  - Added `LocoSession.getChannelInfo()` sending `CHATINFO`.
  - Added `KakaoChat.title` alongside `display_name`.
  - `KakaoTalkClient.getChats({ resolveTitles })` resolves titles in parallel.
  - `KakaoTalkClient.getChatTitle(chatId)` for single-chat lookup; returns `null` on invalid IDs.
  - `agent-kakaotalk chat list --resolve-titles` CLI flag.
  - TUI resolves titles and prefers `title` over `display_name`.

- Docs
  - Updated CLI and SDK docs and `skills/agent-kakaotalk/SKILL.md` to cover `--resolve-titles`, `resolveTitles`, and the `title` field; SKILL.md JSON example now includes `title`.

<sup>Written for commit 65c026425f0fd3b9c3c332533758ced9a69cfb7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

