### PR TITLE
Add kakao-loco-capture.ts diagnostic script

### DIFF
--- a/scripts/kakao-loco-capture.ts
+++ b/scripts/kakao-loco-capture.ts
@@ -1,0 +1,423 @@
+#!/usr/bin/env bun
+/**
+ * KakaoTalk LOCO wire-format capture (diagnostic only).
+ *
+ * Issues a small, throttled set of LOCO requests against a real account and
+ * writes the BSON response bodies to /tmp for offline schema inspection. PII
+ * is redacted (user IDs hashed, profile URLs scrubbed, message content elided)
+ * before anything is written to disk.
+ *
+ * Defaults are intentionally conservative: 3 chats max, 1500ms between LOCO
+ * calls, dry-run unless `--confirm` is passed. The goal is to avoid bursting
+ * KakaoTalk's servers from a real account during local investigation.
+ *
+ * Usage:
+ *   bun scripts/kakao-loco-capture.ts                 # Dry-run plan (no LOCO calls)
+ *   bun scripts/kakao-loco-capture.ts --confirm       # Execute with defaults
+ *   bun scripts/kakao-loco-capture.ts --chat-id 123 --confirm
+ *   bun scripts/kakao-loco-capture.ts --commands CHATINFO,CHATONROOM --confirm
+ *
+ * NOT shipped to npm consumers: this is a developer tool under scripts/, never
+ * imported by published code.
+ */
+
+import { createHash } from 'node:crypto'
+import { writeFileSync } from 'node:fs'
+
+import { Long } from 'bson'
+
+import { KakaoTalkClient } from '../src/platforms/kakaotalk/client'
+import type { LocoSession } from '../src/platforms/kakaotalk/protocol/session'
+
+const SUPPORTED_COMMANDS = ['CHATINFO', 'CHATONROOM', 'MEMBER', 'GETMEM', 'INFOLINK', 'LCHATLIST'] as const
+type Command = (typeof SUPPORTED_COMMANDS)[number]
+
+interface Args {
+  chatId: string | null
+  maxChats: number
+  delayMs: number
+  commands: Command[]
+  confirm: boolean
+  account: string | null
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    chatId: null,
+    maxChats: 3,
+    delayMs: 1500,
+    commands: [...SUPPORTED_COMMANDS],
+    confirm: false,
+    account: null,
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--confirm') {
+      args.confirm = true
+      continue
+    }
+    const next = argv[i + 1]
+    if (arg === '--chat-id' && next) {
+      args.chatId = next
+      i++
+    } else if (arg === '--max-chats' && next) {
+      args.maxChats = Math.max(1, Number.parseInt(next, 10) || 1)
+      i++
+    } else if (arg === '--delay-ms' && next) {
+      args.delayMs = Math.max(0, Number.parseInt(next, 10) || 0)
+      i++
+    } else if (arg === '--commands' && next) {
+      const requested = next.split(',').map((s) => s.trim().toUpperCase())
+      const unknown = requested.filter((c): c is Command => !SUPPORTED_COMMANDS.includes(c as Command))
+      if (unknown.length > 0) {
+        throw new Error(`Unknown commands: ${unknown.join(', ')}. Supported: ${SUPPORTED_COMMANDS.join(', ')}`)
+      }
+      args.commands = requested as Command[]
+      i++
+    } else if (arg === '--account' && next) {
+      args.account = next
+      i++
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown flag: ${arg}`)
+    }
+  }
+
+  return args
+}
+
+function printHelp(): void {
+  console.log(`
+kakao-loco-capture — diagnostic LOCO wire dumper (developer tool)
+
+Usage:
+  bun scripts/kakao-loco-capture.ts [options]
+
+Options:
+  --chat-id <id>      Probe only this chat (skips --max-chats limit for the chosen chat)
+  --max-chats <n>     Number of chats to probe from your login snapshot (default: 3)
+  --delay-ms <n>      Delay between LOCO calls in ms (default: 1500)
+  --commands <list>   Comma-separated subset of: ${SUPPORTED_COMMANDS.join(', ')}
+                      (default: all)
+  --account <id>      Use a specific KakaoTalk account
+  --confirm           Actually issue LOCO calls. Without this, prints the plan only.
+  --help, -h          Show this help
+
+Output: /tmp/kakao-loco-capture-<timestamp>.json (PII redacted)
+`)
+}
+
+async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function hashUserId(id: unknown): string {
+  if (id === null || id === undefined) return '<null>'
+  return `user_${createHash('sha256').update(String(id)).digest('hex').slice(0, 8)}`
+}
+
+function isLong(v: unknown): v is { low: number; high: number } {
+  return typeof v === 'object' && v !== null && 'low' in v && 'high' in v
+}
+
+const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi
+const USERID_KEYS = new Set(['userId', 'authorId', 'uid', 'i', 'mid', 'mids', 'memberIds', 'memberId', 'olu', 'opt'])
+const CONTENT_KEYS = new Set(['message', 'msg', 'content', 'statusMessage', 'desc', 'description'])
+
+function redact(value: unknown, key?: string): unknown {
+  if (value === null || value === undefined) return value
+  if (isLong(value)) {
+    if (key && USERID_KEYS.has(key)) return hashUserId(`${value.high}_${value.low}`)
+    return { __long: true, low: value.low, high: value.high }
+  }
+  if (typeof value === 'number') {
+    if (key && USERID_KEYS.has(key)) return hashUserId(value)
+    return value
+  }
+  if (typeof value === 'string') {
+    if (key && CONTENT_KEYS.has(key)) {
+      return value.length > 32 ? `<redacted:${value.length}chars>` : '<redacted>'
+    }
+    return value.replace(URL_PATTERN, '<url>')
+  }
+  if (typeof value === 'boolean') return value
+  if (Array.isArray(value)) {
+    return value.map((v) => redact(v, key))
+  }
+  if (typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = redact(v, k)
+    }
+    return out
+  }
+  return value
+}
+
+function parseLong(s: string): Long {
+  const big = BigInt(s)
+  const low = Number(big & 0xffffffffn)
+  const high = Number((big >> 32n) & 0xffffffffn)
+  return new Long(low, high)
+}
+
+interface CaptureEntry {
+  command: Command
+  chatId: string
+  status: 'ok' | 'error'
+  status_code?: number
+  body?: unknown
+  error?: string
+  duration_ms: number
+}
+
+interface SessionWithConnection {
+  connection: { sendPacket: (method: string, body: Record<string, unknown>) => Promise<unknown> } | null
+}
+
+async function sendRaw(
+  session: LocoSession,
+  command: string,
+  body: Record<string, unknown>,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  // Diagnostic-only escape hatch: reach into the session's private connection to
+  // send commands that aren't yet exposed as typed methods (MEMBER/GETMEM/INFOLINK).
+  // This is intentional in a developer tool; production code should add typed
+  // methods to LocoSession (PRs 3 & 4 will).
+  const conn = (session as unknown as SessionWithConnection).connection
+  if (!conn) throw new Error('LocoSession has no active connection')
+  const packet = (await conn.sendPacket(command, body)) as { statusCode: number; body: Record<string, unknown> }
+  return packet
+}
+
+async function probe(
+  session: LocoSession,
+  command: Command,
+  chat: Record<string, unknown>,
+  delayMs: number,
+): Promise<CaptureEntry> {
+  const chatId = parseLong(String(chat.c))
+  const chatIdStr = String(chat.c)
+  const start = Date.now()
+
+  await sleep(delayMs)
+
+  try {
+    let body: Record<string, unknown>
+    let statusCode = 0
+
+    switch (command) {
+      case 'CHATINFO': {
+        const res = await session.getChannelInfo(chatId)
+        body = res.body
+        statusCode = res.statusCode
+        break
+      }
+      case 'CHATONROOM': {
+        const res = await session.getChatInfo(chatId)
+        body = res.body
+        statusCode = res.statusCode
+        break
+      }
+      case 'LCHATLIST': {
+        const res = await session.getChatList()
+        body = res.body
+        statusCode = res.statusCode
+        break
+      }
+      case 'MEMBER': {
+        const memberIds = (chat.i as Array<{ low: number; high: number }> | undefined) ?? []
+        const sample = memberIds.slice(0, 3).map((m) => new Long(m.low, m.high))
+        if (sample.length === 0) {
+          return {
+            command,
+            chatId: chatIdStr,
+            status: 'error',
+            error: 'no member ids available in chat data — skipping',
+            duration_ms: Date.now() - start,
+          }
+        }
+        const res = await sendRaw(session, 'MEMBER', { chatId, memberIds: sample })
+        body = res.body
+        statusCode = res.statusCode
+        break
+      }
+      case 'GETMEM': {
+        const res = await sendRaw(session, 'GETMEM', { chatId })
+        body = res.body
+        statusCode = res.statusCode
+        break
+      }
+      case 'INFOLINK': {
+        const linkId = chat.li
+        if (!linkId) {
+          return {
+            command,
+            chatId: chatIdStr,
+            status: 'error',
+            error: 'not an open chat (no `li` field) — skipping',
+            duration_ms: Date.now() - start,
+          }
+        }
+        const res = await sendRaw(session, 'INFOLINK', { lis: [linkId], ref: 'EW' })
+        body = res.body
+        statusCode = res.statusCode
+        break
+      }
+    }
+
+    return {
+      command,
+      chatId: chatIdStr,
+      status: 'ok',
+      status_code: statusCode,
+      body: redact(body),
+      duration_ms: Date.now() - start,
+    }
+  } catch (error) {
+    return {
+      command,
+      chatId: chatIdStr,
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+      duration_ms: Date.now() - start,
+    }
+  }
+}
+
+function selfCheckRedact(): void {
+  // Defensive: any change that breaks redaction would silently leak PII into the
+  // capture file. Verify on every run against a known fixture before any LOCO
+  // calls happen. Fail loud if the contract changes.
+  const fixture = {
+    chatInfo: {
+      type: 'MultiChat',
+      chatMetas: [
+        { type: 3, content: 'My Group' },
+        { type: 1, content: 'Pinned message body' },
+      ],
+      displayMembers: [{ userId: 42, nickName: 'Alice', profileImageUrl: 'https://kakao.com/p/alice.jpg' }],
+    },
+    authorId: 1234567890,
+    message: 'secret hi',
+    l: { low: 999, high: 0 },
+  }
+  const out = redact(fixture) as Record<string, unknown>
+  const info = out.chatInfo as Record<string, unknown>
+  const display = (info.displayMembers as Array<Record<string, unknown>>)[0]
+  const metas = info.chatMetas as Array<Record<string, unknown>>
+
+  const failures: string[] = []
+  if (out.authorId === 1234567890) failures.push('authorId not hashed')
+  if (display.userId === 42) failures.push('displayMembers[].userId not hashed')
+  if ((display.profileImageUrl as string) !== '<url>') failures.push('profileImageUrl not scrubbed')
+  if (out.message !== '<redacted>') failures.push('message content not redacted')
+  if (metas[0].content !== '<redacted>') failures.push('chatMetas content not redacted')
+  if (typeof out.l !== 'object' || (out.l as Record<string, unknown>).__long !== true) {
+    failures.push('non-user Long not preserved as tagged shape')
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`redact() self-check failed:\n  - ${failures.join('\n  - ')}`)
+  }
+}
+
+async function main(): Promise<void> {
+  selfCheckRedact()
+
+  const args = parseArgs(process.argv.slice(2))
+
+  console.log('kakao-loco-capture — plan:')
+  console.log(`  max_chats: ${args.maxChats}`)
+  console.log(`  delay_ms:  ${args.delayMs}`)
+  console.log(`  commands:  ${args.commands.join(', ')}`)
+  console.log(`  chat_id:   ${args.chatId ?? '<from login snapshot>'}`)
+  console.log(`  account:   ${args.account ?? '<current>'}`)
+  console.log(`  confirm:   ${args.confirm}`)
+  console.log()
+
+  if (!args.confirm) {
+    console.log('Dry run (no --confirm). Re-run with --confirm to actually issue LOCO calls.')
+    return
+  }
+
+  const client = new KakaoTalkClient()
+  await client.login(undefined, args.account ?? undefined)
+
+  try {
+    const allChats = await client.getChats()
+    if (allChats.length === 0) {
+      console.error('No chats in login snapshot. Aborting.')
+      return
+    }
+
+    const session = await client.acquireSession()
+
+    const sessionState = (
+      client as unknown as { state: { loginResult: { chatDatas?: Array<Record<string, unknown>> } } }
+    ).state
+    const chatDatas = sessionState?.loginResult?.chatDatas ?? []
+
+    let targets: Array<Record<string, unknown>>
+    if (args.chatId) {
+      const match = chatDatas.find((c) => String(c.c) === args.chatId)
+      if (!match) {
+        console.error(`chat ${args.chatId} not in login snapshot`)
+        return
+      }
+      targets = [match]
+    } else {
+      targets = chatDatas.slice(0, args.maxChats)
+    }
+
+    console.log(`Probing ${targets.length} chat(s) with ${args.commands.length} command(s) each...`)
+    console.log(`Estimated wire calls: ${targets.length * args.commands.length}`)
+    console.log(`Estimated duration: ~${Math.ceil((targets.length * args.commands.length * args.delayMs) / 1000)}s`)
+    console.log()
+
+    const entries: CaptureEntry[] = []
+
+    if (args.commands.includes('LCHATLIST')) {
+      entries.push({
+        command: 'LCHATLIST',
+        chatId: '<login_snapshot>',
+        status: 'ok',
+        body: redact({ chatDatas: chatDatas.slice(0, args.maxChats) }),
+        duration_ms: 0,
+      })
+    }
+
+    for (const chat of targets) {
+      for (const command of args.commands) {
+        if (command === 'LCHATLIST') continue
+        const result = await probe(session, command, chat, args.delayMs)
+        const tag = result.status === 'ok' ? 'ok ' : 'ERR'
+        console.log(
+          `  [${tag}] ${command.padEnd(10)} chat=${result.chatId} ${result.duration_ms}ms${result.error ? `: ${result.error}` : ''}`,
+        )
+        entries.push(result)
+      }
+    }
+
+    const outPath = `/tmp/kakao-loco-capture-${new Date().toISOString().replace(/[:.]/g, '-')}.json`
+    const payload = {
+      captured_at: new Date().toISOString(),
+      args: { ...args, account: args.account ? '<redacted>' : null },
+      entries,
+    }
+    writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`)
+    console.log()
+    console.log(`Wrote ${entries.length} entries to ${outPath}`)
+  } finally {
+    client.close()
+  }
+}
+
+main().catch((error) => {
+  console.error('kakao-loco-capture failed:', error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Adds a small developer script under \`scripts/\` that captures a few KakaoTalk LOCO response bodies (with PII redaction) into \`/tmp/\`, used for offline schema inspection while building follow-up SDK features (member name resolution, open-chat title fallback, MEMBER/GETMEM commands).

This is **diagnostic-only** code: it lives under \`scripts/\`, is never imported by published code, and is excluded from the npm package by the existing \`prepublishOnly\` flow.

## Why

While building [PR #185](https://github.com/agent-messenger/agent-messenger/pull/185), I had to infer LOCO field names (\`chatMetas[].type === 3\` for room title, paired \`i\`/\`k\` arrays for member nicknames, etc.) from three reference impls (node-kakao, openkakao, loco-wrapper). They mostly agree but disagree on subtle points (e.g. whether \`ll\` is \`lastLogId\` or \`lastSeenLogId\`). Before adding more code that depends on those inferred shapes, I want a reproducible way to verify against a real account.

## What it captures

| Command | Why |
|---|---|
| \`CHATINFO\` | Returns \`chatInfo.chatMetas\` (room title, notice, etc.) — confirms TITLE meta location used by PR #185 |
| \`CHATONROOM\` | Returns members + watermarks — confirms what's currently discarded |
| \`MEMBER\` (sample IDs) | Returns full member structs with \`nickName\`, \`pi\`, \`mt\`, \`ptp\` — input shape for upcoming Fix 3 |
| \`GETMEM\` | Paginated member list for >100-member rooms |
| \`INFOLINK\` | Returns \`OpenLinkStruct.ln\` — fallback room title for open chats (Fix 4) |
| \`LCHATLIST\` | Login-snapshot \`chatDatas\` shape — verifies \`i\`/\`k\` pairing assumptions for Fix 2 |

## Safety

- **No-burst defaults**: max 3 chats, 1500ms between LOCO calls (~ less than 1 req/sec). Dry-run unless \`--confirm\` is passed.
- **PII redaction before write**: numeric user IDs hashed to \`user_xxxxxxxx\` opaque tokens, profile URLs replaced with \`<url>\`, message/notice content elided.
- **Self-check on every run**: validates \`redact()\` against a known fixture *before* any LOCO call. Fails loud if redaction is broken — prevents a future bug from silently leaking real user IDs to disk.
- **Lives outside the npm package**: \`scripts/\` is excluded by the existing publish flow.

## Usage

\`\`\`bash
# Plan only (no LOCO calls — default)
bun scripts/kakao-loco-capture.ts

# Execute with defaults: 3 chats, all 6 commands, 1500ms between calls
bun scripts/kakao-loco-capture.ts --confirm

# Surgical: one specific chat, two commands
bun scripts/kakao-loco-capture.ts --chat-id 9876543210 --commands CHATINFO,CHATONROOM --confirm

# Slower for extra caution
bun scripts/kakao-loco-capture.ts --delay-ms 3000 --max-chats 1 --confirm
\`\`\`

Output: \`/tmp/kakao-loco-capture-<ISO-timestamp>.json\`

## Implementation notes

- Reaches into \`LocoSession\`'s private \`connection\` via a documented escape hatch to send LOCO commands that aren't yet typed methods (\`MEMBER\`, \`GETMEM\`, \`INFOLINK\`). Future PRs (3 & 4) will replace this with proper typed methods on \`LocoSession\`.
- No tests file added: bunfig.toml's test \`root\` is \`./src\`, expanding test discovery to \`scripts/\` would be tangential to this PR's goal. The startup self-check provides equivalent coverage for the security-relevant \`redact()\` logic.

## Out of scope

- Adding typed \`session.getMembers\` / \`session.getOpenLink\` methods (PRs 3 & 4 will add these)
- Auto-running the script in CI (it requires a real account)
- Implementing the SDK features the captured data will inform

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a developer-only `scripts/kakao-loco-capture.ts` to capture KakaoTalk LOCO responses with PII redaction for offline schema inspection. Helps validate field shapes for upcoming SDK work without affecting the published package.

- **New Features**
  - Captures `CHATINFO`, `CHATONROOM`, `MEMBER`, `GETMEM`, `INFOLINK`, and a `LCHATLIST` snapshot to `/tmp/kakao-loco-capture-<timestamp>.json`.
  - Safe defaults: dry-run unless `--confirm`, max 3 chats, 1500ms delay; redaction self-check runs before any request.
  - Uses a temporary `LocoSession` escape hatch for untyped commands; lives under `scripts/` and is excluded from npm.
  - Docs: No platform source changes; SKILL.md/docs unchanged.

<sup>Written for commit 9f647658a75c3fe1dbf5c41eec5ab27ef35df54c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

