### PR TITLE
Auto-resolve KakaoTalk message author names

### DIFF
--- a/docs/content/docs/cli/kakaotalk.mdx
+++ b/docs/content/docs/cli/kakaotalk.mdx
@@ -141,7 +141,7 @@ Output includes:
 - `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`)
 - `active_members` — number of active members
 - `unread_count` — unread message count
-- `last_message` — most recent message preview
+- `last_message` — most recent message preview, including `author_name` when the sender's nickname is known from the chat list (otherwise `null`)
 
 ### Message Commands
 
@@ -166,6 +166,7 @@ Each message includes:
 - `log_id` — unique message identifier
 - `type` — message type (1 = text, 2 = photo, etc.)
 - `author_id` — sender's user ID
+- `author_name` — sender's nickname when known from the chat list (otherwise `null`; only the room's "display members" are cached)
 - `message` — message text content
 - `sent_at` — Unix timestamp (milliseconds)
 

--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -67,6 +67,8 @@ const more = await client.getMessages('9876543210', { count: 100 })
 const newer = await client.getMessages('9876543210', { from: '123456789' })
 ```
 
+Each `KakaoMessage` carries an `author_name: string | null`. The SDK auto-populates this from the same chat-list response that already arrives at login (no extra LOCO calls). It resolves for "display members" — the small set of nicknames KakaoTalk includes in the chat list — and is `null` for everyone else.
+
 ### Sending
 
 ```typescript

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -301,7 +301,7 @@ Output includes:
 - `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`)
 - `active_members` — number of active members
 - `unread_count` — unread message count
-- `last_message` — most recent message preview
+- `last_message` — most recent message preview, including `author_name` when the sender's nickname is known from the chat list (otherwise `null`)
 
 ### Message Commands
 
@@ -327,6 +327,7 @@ Each message includes:
 - `log_id` — unique message identifier
 - `type` — message type (1 = text, 2 = photo, etc.)
 - `author_id` — sender's user ID
+- `author_name` — sender's nickname when known from the chat list (otherwise `null`; only the room's "display members" are cached)
 - `message` — message text content
 - `sent_at` — Unix timestamp (milliseconds)
 
@@ -364,6 +365,7 @@ All commands output JSON by default for AI consumption:
   "unread_count": 5,
   "last_message": {
     "author_id": "1111111111",
+    "author_name": "Alice",
     "message": "Hello everyone!",
     "sent_at": 1705312200000
   }

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -46,13 +46,15 @@ function resetAllMocks() {
   mockOnPush.mockReset()
 }
 
-// LOCO protocol uses plain numbers for chat.c, but Long-like objects for logIds/cursors
+// LOCO protocol uses plain numbers for chat.c, but Long-like objects for logIds/cursors.
+// `i` and `k` are paired arrays — i[n] is the user_id, k[n] is the nickname.
 const DEFAULT_LOGIN_RESULT = {
   chatDatas: [
     {
       c: 100,
       t: 1,
       k: ['Alice', 'Bob'],
+      i: [1, 2],
       a: 2,
       n: 3,
       o: 1700000000,
@@ -63,6 +65,7 @@ const DEFAULT_LOGIN_RESULT = {
       c: 200,
       t: 2,
       k: ['Charlie'],
+      i: [3],
       a: 1,
       n: 0,
       o: 1699999000,
@@ -131,6 +134,7 @@ describe('KakaoTalkClient', () => {
       expect(chats[0].unread_count).toBe(3)
       expect(chats[0].last_message).toEqual({
         author_id: 1,
+        author_name: 'Alice',
         message: 'hi',
         sent_at: 1700000000,
       })
@@ -139,6 +143,63 @@ describe('KakaoTalkClient', () => {
       expect(chats[1].last_message).toBeNull()
 
       client.close()
+    })
+
+    it('populates last_message.author_name from paired chat.i / chat.k arrays', async () => {
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats()
+
+      expect(chats[0].last_message?.author_name).toBe('Alice')
+    })
+
+    it('returns null author_name when authorId is not in the paired arrays', async () => {
+      const customLogin = {
+        ...DEFAULT_LOGIN_RESULT,
+        chatDatas: [
+          {
+            c: 100,
+            t: 1,
+            k: ['Alice'],
+            i: [1],
+            a: 1,
+            n: 0,
+            o: 1700000000,
+            l: { authorId: 99, message: 'from a stranger', sendAt: 1700000000 },
+            ll: makeLong(999),
+          },
+        ],
+      }
+      mockLogin.mockResolvedValue(customLogin)
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats()
+
+      expect(chats[0].last_message?.author_id).toBe(99)
+      expect(chats[0].last_message?.author_name).toBeNull()
+    })
+
+    it('returns null author_name when chat.i is missing (no paired data)', async () => {
+      const customLogin = {
+        ...DEFAULT_LOGIN_RESULT,
+        chatDatas: [
+          {
+            c: 100,
+            t: 1,
+            k: ['Alice'],
+            a: 1,
+            n: 0,
+            o: 1700000000,
+            l: { authorId: 1, message: 'hi', sendAt: 1700000000 },
+            ll: makeLong(999),
+          },
+        ],
+      }
+      mockLogin.mockResolvedValue(customLogin)
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats()
+
+      expect(chats[0].last_message?.author_name).toBeNull()
     })
 
     it('does not call CHATINFO when resolveTitles is not set (default behavior preserved)', async () => {
@@ -471,6 +532,7 @@ describe('KakaoTalkClient', () => {
         log_id: '10',
         type: 1,
         author_id: 42,
+        author_name: null,
         message: 'hello',
         sent_at: 1700000001,
       })
@@ -478,9 +540,35 @@ describe('KakaoTalkClient', () => {
         log_id: '11',
         type: 1,
         author_id: 43,
+        author_name: null,
         message: 'world',
         sent_at: 1700000002,
       })
+
+      client.close()
+    })
+
+    it('resolves author_name for known members from the chat list cache', async () => {
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: {
+          status: 0,
+          chatLogs: [
+            { logId: makeLong(1), chatId: 100, type: 1, authorId: 1, message: 'from Alice', sendAt: 100 },
+            { logId: makeLong(2), chatId: 100, type: 1, authorId: 2, message: 'from Bob', sendAt: 200 },
+            { logId: makeLong(3), chatId: 100, type: 1, authorId: 99, message: 'from a stranger', sendAt: 300 },
+          ],
+          eof: true,
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      // Trigger login so the cache is populated from DEFAULT_LOGIN_RESULT
+      await client.getChats()
+      const messages = await client.getMessages('100')
+
+      expect(messages[0].author_name).toBe('Alice')
+      expect(messages[1].author_name).toBe('Bob')
+      expect(messages[2].author_name).toBeNull()
 
       client.close()
     })

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -37,6 +37,58 @@ interface SessionState {
   loginResult: LoginListResponse
 }
 
+class MemberNameCache {
+  private byChatId = new Map<string, Map<number, string>>()
+
+  ingest(chatDatas: readonly ChatData[]): void {
+    for (const chat of chatDatas) {
+      const ids = chat.i as Array<{ low: number; high: number } | number> | undefined
+      const names = chat.k as string[] | undefined
+      if (!Array.isArray(ids) || !Array.isArray(names)) continue
+
+      const chatId = String(chat.c)
+      let map = this.byChatId.get(chatId)
+      if (!map) {
+        map = new Map()
+        this.byChatId.set(chatId, map)
+      }
+
+      const len = Math.min(ids.length, names.length)
+      for (let i = 0; i < len; i++) {
+        const numericId = toNumericUserId(ids[i])
+        if (numericId === null) continue
+        const name = names[i]
+        if (typeof name === 'string' && name.length > 0) {
+          map.set(numericId, name)
+        }
+      }
+    }
+  }
+
+  lookup(chatId: string, userId: number): string | null {
+    return this.byChatId.get(chatId)?.get(userId) ?? null
+  }
+
+  forget(chatId: string): void {
+    this.byChatId.delete(chatId)
+  }
+
+  clear(): void {
+    this.byChatId.clear()
+  }
+}
+
+function toNumericUserId(v: unknown): number | null {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null
+  if (v && typeof v === 'object' && 'low' in v && 'high' in v) {
+    const { low, high } = v as { low: number; high: number }
+    // chatDatas[].i entries are member user IDs. KakaoTalk user IDs fit in
+    // 53 bits — safe to flatten the BSON Long pair to a JS number for keying.
+    return (high >>> 0) * 0x100000000 + (low >>> 0)
+  }
+  return null
+}
+
 function bsonToLong(v: unknown): Long | undefined {
   if (v && typeof v === 'object' && 'high' in v && 'low' in v) {
     const { high, low } = v as { high: number; low: number }
@@ -60,13 +112,14 @@ function parseLong(s: string): Long {
   return new Long(low, high)
 }
 
-function formatChat(chat: ChatData, title: string | null = null): KakaoChat {
+function formatChat(chat: ChatData, title: string | null, nameCache: MemberNameCache): KakaoChat {
   const memberNames = (chat.k ?? []) as string[]
   const lastLog = chat.l as Record<string, unknown> | null
   const displayName = memberNames.join(', ') || null
+  const chatId = String(chat.c)
 
   return {
-    chat_id: String(chat.c),
+    chat_id: chatId,
     type: chat.t as number,
     display_name: displayName,
     title,
@@ -75,6 +128,7 @@ function formatChat(chat: ChatData, title: string | null = null): KakaoChat {
     last_message: lastLog
       ? {
           author_id: lastLog.authorId as number,
+          author_name: nameCache.lookup(chatId, lastLog.authorId as number),
           message: lastLog.message as string,
           sent_at: lastLog.sendAt as number,
         }
@@ -246,13 +300,19 @@ function mergeSyncState(previous: SyncState | undefined, loginResult: LoginListR
   return next
 }
 
-function formatMessages(logs: Array<Record<string, unknown>>, count: number): KakaoMessage[] {
+function formatMessages(
+  logs: Array<Record<string, unknown>>,
+  count: number,
+  chatId: string,
+  nameCache: MemberNameCache,
+): KakaoMessage[] {
   logs.sort((a, b) => (a.sendAt as number) - (b.sendAt as number))
 
   return logs.slice(-count).map((log) => ({
     log_id: longToString(log.logId),
     type: log.type as number,
     author_id: log.authorId as number,
+    author_name: nameCache.lookup(chatId, log.authorId as number),
     message: log.message as string,
     sent_at: log.sendAt as number,
   }))
@@ -268,6 +328,7 @@ export class KakaoTalkClient {
   private closed = false
   private pushHandlers = new Set<KakaoPushHandler>()
   private sessionEventHandlers = new Set<KakaoSessionEventHandler>()
+  private nameCache = new MemberNameCache()
 
   async login(
     credentials?: { oauthToken: string; userId: string; deviceUuid?: string; deviceType?: KakaoDeviceType },
@@ -409,6 +470,8 @@ export class KakaoTalkClient {
       const newSyncState = mergeSyncState(syncState, loginResult)
       await saveSyncState(this.deviceUuid!, newSyncState)
 
+      this.nameCache.ingest((loginResult.chatDatas ?? []) as ChatData[])
+
       return { session, loginResult }
     } catch (error) {
       session.close()
@@ -504,6 +567,7 @@ export class KakaoTalkClient {
             if (chatDatas.length === 0) break
 
             collectChats(chatDatas, allChats, seenChatIds)
+            this.nameCache.ingest(chatDatas)
             cursor = body
             pages++
           }
@@ -520,7 +584,7 @@ export class KakaoTalkClient {
           ? await Promise.all(results.map((chat) => this.fetchChatTitle(session, parseLong(String(chat.c)))))
           : null
 
-        return results.map((chat, i) => formatChat(chat, titles ? titles[i] : null))
+        return results.map((chat, i) => formatChat(chat, titles ? titles[i] : null, this.nameCache))
       } catch (error) {
         throw wrapError(error, 'get_chats_failed')
       }
@@ -577,7 +641,7 @@ export class KakaoTalkClient {
               (log) => longToString(log.chatId) === chatId,
             )
             if (batch.length === 0) {
-              return formatMessages(allMessages, count)
+              return formatMessages(allMessages, count, chatId, this.nameCache)
             }
 
             for (const log of batch) {
@@ -590,7 +654,7 @@ export class KakaoTalkClient {
 
             const maxLog = findMaxLogId(batch, 'logId')
             if (!maxLog || maxLog.equals(cur) || response.body.eof) {
-              return formatMessages(allMessages, count)
+              return formatMessages(allMessages, count, chatId, this.nameCache)
             }
 
             cur = maxLog
@@ -603,7 +667,7 @@ export class KakaoTalkClient {
 
         if (allMessages.length > 0) {
           warn(`[agent-kakaotalk] Warning: message fetch capped at ${MAX_PAGES} pages. Results may be incomplete.`)
-          return formatMessages(allMessages, count)
+          return formatMessages(allMessages, count, chatId, this.nameCache)
         }
 
         // Fetch fresh lastLogId via CHATONROOM (not the stale login-time snapshot)
@@ -640,7 +704,7 @@ export class KakaoTalkClient {
           warn(`[agent-kakaotalk] Warning: message fetch capped at ${MAX_PAGES} pages. Results may be incomplete.`)
         }
 
-        return formatMessages(allMessages, count)
+        return formatMessages(allMessages, count, chatId, this.nameCache)
       } catch (error) {
         throw wrapError(error, 'get_messages_failed')
       }
@@ -737,5 +801,10 @@ export class KakaoTalkClient {
     this.initPromise = null
     this.pushHandlers.clear()
     this.sessionEventHandlers.clear()
+    this.nameCache.clear()
+  }
+
+  lookupAuthorName(chatId: string, authorId: number): string | null {
+    return this.nameCache.lookup(chatId, authorId)
   }
 }

--- a/src/platforms/kakaotalk/listener.test.ts
+++ b/src/platforms/kakaotalk/listener.test.ts
@@ -16,6 +16,7 @@ class FakeClient {
   sessionHandlers = new Set<KakaoSessionEventHandler>()
   acquireImpl: () => Promise<void> = async () => {}
   connected = false
+  lookupAuthorName: (chatId: string, authorId: number) => string | null = () => null
 
   async acquireSession(): Promise<unknown> {
     this.acquireCalls++
@@ -141,9 +142,37 @@ describe('KakaoTalkListener', () => {
       expect(messages[0].chat_id).toBe('100')
       expect(messages[0].log_id).toBe('200')
       expect(messages[0].author_id).toBe(42)
+      expect(messages[0].author_name).toBeNull()
       expect(messages[0].message).toBe('hello world')
       expect(messages[0].message_type).toBe(1)
       expect(messages[0].sent_at).toBe(1700000000)
+    })
+
+    it('resolves author_name from client.lookupAuthorName when available', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      client.lookupAuthorName = (chatId: string, authorId: number) => {
+        if (chatId === '100' && authorId === 42) return 'Alice'
+        return null
+      }
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 200 },
+          authorId: 42,
+          message: 'hello',
+          type: 1,
+          sendAt: 1700000000,
+        },
+      })
+
+      expect(messages[0].author_name).toBe('Alice')
     })
   })
 

--- a/src/platforms/kakaotalk/listener.ts
+++ b/src/platforms/kakaotalk/listener.ts
@@ -109,11 +109,14 @@ export class KakaoTalkListener {
     switch (method) {
       case 'MSG': {
         const chatLog = body.chatLog as Record<string, unknown>
+        const chatId = longToString(body.chatId)
+        const authorId = chatLog.authorId as number
         const event: KakaoTalkPushMessageEvent = {
           type: 'MSG',
-          chat_id: longToString(body.chatId),
+          chat_id: chatId,
           log_id: longToString(chatLog.logId),
-          author_id: chatLog.authorId as number,
+          author_id: authorId,
+          author_name: this.client.lookupAuthorName?.(chatId, authorId) ?? null,
           message: chatLog.message as string,
           message_type: chatLog.type as number,
           sent_at: chatLog.sendAt as number,

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -78,6 +78,7 @@ export interface KakaoChat {
   unread_count: number
   last_message: {
     author_id: number
+    author_name: string | null
     message: string
     sent_at: number
   } | null
@@ -87,6 +88,7 @@ export interface KakaoMessage {
   log_id: string
   type: number
   author_id: number
+  author_name: string | null
   message: string
   sent_at: number
 }
@@ -109,6 +111,7 @@ export const KakaoChatSchema = z.object({
   last_message: z
     .object({
       author_id: z.number(),
+      author_name: z.string().nullable(),
       message: z.string(),
       sent_at: z.number(),
     })
@@ -119,6 +122,7 @@ export const KakaoMessageSchema = z.object({
   log_id: z.string(),
   type: z.number(),
   author_id: z.number(),
+  author_name: z.string().nullable(),
   message: z.string(),
   sent_at: z.number(),
 })
@@ -185,6 +189,7 @@ export interface KakaoTalkPushMessageEvent {
   chat_id: string
   log_id: string
   author_id: number
+  author_name: string | null
   message: string
   message_type: number
   sent_at: number
@@ -230,6 +235,7 @@ export const KakaoTalkPushMessageEventSchema = z.object({
   chat_id: z.string(),
   log_id: z.string(),
   author_id: z.number(),
+  author_name: z.string().nullable(),
   message: z.string(),
   message_type: z.number(),
   sent_at: z.number(),

--- a/src/tui/adapters/kakaotalk-adapter.ts
+++ b/src/tui/adapters/kakaotalk-adapter.ts
@@ -39,7 +39,7 @@ export class KakaoTalkAdapter implements PlatformAdapter {
     return messages.map((msg) => ({
       id: msg.log_id,
       channelId,
-      author: String(msg.author_id),
+      author: msg.author_name || String(msg.author_id),
       content: msg.message ?? '',
       timestamp: String(msg.sent_at),
     }))


### PR DESCRIPTION
## Summary

Surfaces sender nicknames on every \`KakaoMessage\`, \`KakaoChat.last_message\`, and real-time \`MSG\` push event. **No new LOCO calls** — uses paired \`chat.i\` (user IDs) and \`chat.k\` (nicknames) arrays that already arrive in the existing \`LOGINLIST\` / \`LCHATLIST\` responses.

## Why

Until now, the SDK only consumed \`chat.k\` for \`display_name\` and discarded the parallel \`chat.i\` array. Every message and push event therefore exposed only \`author_id\` (a numeric ID), forcing consumers to resolve names themselves.

This is the cheapest of the four follow-up improvements after [PR #185](https://github.com/agent-messenger/agent-messenger/pull/185): no new wire calls, no new flags, no new rate-limit risk.

## What changed

| Surface | Before | After |
|---|---|---|
| \`KakaoChat.last_message\` | \`{ author_id, message, sent_at }\` | adds \`author_name: string \\| null\` |
| \`KakaoMessage\` | no name | adds \`author_name: string \\| null\` |
| \`KakaoTalkPushMessageEvent\` | no name | adds \`author_name: string \\| null\` |
| \`KakaoTalkClient\` | (no API) | adds \`lookupAuthorName(chatId, userId): string \\| null\` |
| TUI adapter | renders \`String(author_id)\` | prefers \`author_name\` when present |

## How it works

A small \`MemberNameCache\` keyed by \`chat_id\` ingests \`(i[n], k[n])\` pairs at every chat-list response — login snapshot AND every paginated \`LCHATLIST\` page. Lookups are O(1) per message. Cache lives on the client instance and is cleared on \`close()\`.

\`\`\`
LOGINLIST/LCHATLIST → chat.i + chat.k (paired by index)
                               │
                               ▼
                    MemberNameCache.ingest()
                               │
                               ▼
                  Map<chat_id, Map<user_id, nickname>>
                               │
                  ┌────────────┼────────────┐
                  ▼            ▼            ▼
            getChats()   getMessages()  KakaoTalkListener
              (last       (per          (per push MSG
               message)    message)      event)
\`\`\`

## Limitations (documented in CLI/SDK docs and SKILL.md)

The cache only covers **"display members"** — the small subset of nicknames KakaoTalk includes inline in the chat list (typically up to ~5 per room). For larger groups, most senders will resolve to \`null\`.

Full coverage requires the LOCO \`MEMBER\` / \`GETMEM\` commands, which is a separate follow-up PR.

## Tests

- Existing test fixtures updated to include the paired \`i\` array, with assertions on \`author_name\` propagation through \`getChats\`, \`getMessages\`, and listener push events
- New negative tests: missing \`i\` array → null, unknown \`author_id\` → null, listener with no \`lookupAuthorName\` → null (defensive)

\`\`\`
153 pass, 0 fail
324 expect() calls
\`\`\`

## Out of scope

- \`MEMBER\` / \`GETMEM\` LOCO commands for full member coverage (separate PR)
- Open-chat title fallback via \`INFOLINK\` (separate PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-resolve KakaoTalk sender names from existing `LOGINLIST`/`LCHATLIST` `chat.i`/`chat.k` arrays with no new LOCO calls. Adds `author_name` to `KakaoMessage`, `KakaoChat.last_message`, and `KakaoTalkPushMessageEvent`, plus `KakaoTalkClient.lookupAuthorName(chatId, userId)`; docs and `SKILL.md` updated.

- **New Features**
  - Per-chat in-memory userId → nickname cache (keyed by `chat_id`), ingested at login and each `LCHATLIST` page; cleared on `close()`.
  - TUI adapter displays `author_name` when present.
  - Limitation: resolves only chat-list “display members”; others return `null`.

<sup>Written for commit 6f294f8ac01976c74465783783a0b9b656fac414. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

