### PR TITLE
Fall back to OpenLink name for open-chat titles

### DIFF
--- a/docs/content/docs/cli/kakaotalk.mdx
+++ b/docs/content/docs/cli/kakaotalk.mdx
@@ -138,7 +138,7 @@ Output includes:
 - `chat_id` — numeric chat room ID
 - `type` — chat type (1:1, group, open chat)
 - `display_name` — comma-separated member names
-- `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`)
+- `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`). For open chats (`OM` / `OD`) without a user-set title, falls back to the OpenLink room name (one extra `INFOLINK` LOCO call per such chat).
 - `active_members` — number of active members
 - `unread_count` — unread message count
 - `last_message` — most recent message preview, including `author_name` when the sender's nickname is known from the chat list (otherwise `null`)

--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -47,6 +47,8 @@ const results = await client.getChats({ search: 'Alice' })
 
 // Resolve user-set room titles via CHATINFO (one extra LOCO call per chat).
 // Each KakaoChat gets a `title: string | null` matching the in-app room name.
+// For open chats with no user-set title, the SDK falls back to the OpenLink
+// link name via an additional INFOLINK call (only for OM / OD chats).
 const titled = await client.getChats({ resolveTitles: true })
 
 // Resolve a single chat's title directly (returns null on error or missing title)

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -298,7 +298,7 @@ Output includes:
 - `chat_id` — numeric chat room ID
 - `type` — chat type (1:1, group, open chat)
 - `display_name` — comma-separated member names
-- `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`)
+- `title` — user-set room title (only populated with `--resolve-titles`; otherwise `null`). For open chats (`OM` / `OD`) without a user-set title, falls back to the OpenLink room name (one extra `INFOLINK` LOCO call per such chat).
 - `active_members` — number of active members
 - `unread_count` — unread message count
 - `last_message` — most recent message preview, including `author_name` when the sender's nickname is known from the chat list (otherwise `null`)

--- a/skills/agent-kakaotalk/references/common-patterns.md
+++ b/skills/agent-kakaotalk/references/common-patterns.md
@@ -55,6 +55,8 @@ agent-kakaotalk message send "$TARGET_CHAT" "Hey Alice!"
 
 **When to use**: First time interacting with a chat, or when the user references a chat by name.
 
+> Note: `display_name` joins the chat's member nicknames. For the user-set room title (matching the KakaoTalk app), see [Pattern 9](#pattern-9-resolve-canonical-room-titles).
+
 ## Pattern 3: Monitor Chat for New Messages
 
 **Use case**: Watch a chat room and respond to new messages
@@ -221,7 +223,53 @@ echo "$UNREAD" | jq -r '.[] | "  \(.display_name // "Unknown") — \(.unread_cou
 
 **When to use**: Morning catch-up, checking for urgent messages, triage.
 
-## Pattern 9: Error Handling and Retry
+## Pattern 9: Resolve Canonical Room Titles
+
+**Use case**: Show user-set room names (matching the official KakaoTalk app) instead of comma-joined member nicknames
+
+By default, `chat list` returns `display_name` built from the chat's "display members" (a comma-joined nickname list — e.g. `"Alice, Bob, Charlie"`). The `--resolve-titles` flag fetches each chat's user-set title via the LOCO `CHATINFO` command and surfaces it in a separate `title` field.
+
+For open chats (`OM` / `OD`) without a user-set title, the CLI additionally consults the OpenLink record via `INFOLINK` and uses the link name as a fallback. This matches what KakaoTalk shows for open-chat rooms in the app sidebar.
+
+```bash
+#!/bin/bash
+
+# Without --resolve-titles: title is null, display_name is member nicknames
+agent-kakaotalk chat list | jq '.[0] | {chat_id, display_name, title}'
+# {
+#   "chat_id": "9876543210",
+#   "display_name": "Alice, Bob, Charlie",
+#   "title": null
+# }
+
+# With --resolve-titles: title is the user-set room name
+agent-kakaotalk chat list --resolve-titles | jq '.[0] | {chat_id, display_name, title}'
+# {
+#   "chat_id": "9876543210",
+#   "display_name": "Alice, Bob, Charlie",
+#   "title": "Project Standup"
+# }
+
+# Render the best available name (title preferred, display_name fallback)
+agent-kakaotalk chat list --resolve-titles \
+  | jq -r '.[] | "\(.chat_id): \(.title // .display_name // "Untitled")"'
+```
+
+**When to use**: User-facing chat pickers, room-name displays in summaries, anywhere you want output that matches what the user sees in the KakaoTalk app.
+
+**Cost**: One extra LOCO call per chat (CHATINFO). Open chats without a user-set title pay one additional call (INFOLINK). For large account snapshots this multiplies quickly — leave the flag off for hot paths.
+
+**SDK equivalent**:
+
+```typescript
+// Resolve titles for the whole list
+const chats = await client.getChats({ resolveTitles: true })
+
+// Single-chat lookup (returns null on error or missing title)
+const title = await client.getChatTitle('9876543210')
+```
+
+## Pattern 10: Error Handling and Retry
 
 **Use case**: Robust message sending with retries
 

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -8,6 +8,7 @@ const mockGetChatList = mock(() => Promise.resolve({}))
 const mockGetChatLogs = mock(() => Promise.resolve({}))
 const mockGetChatInfo = mock(() => Promise.resolve({}))
 const mockGetChannelInfo = mock(() => Promise.resolve({}))
+const mockGetOpenLinkInfo = mock(() => Promise.resolve({}))
 const mockSyncMessages = mock(() => Promise.resolve({}))
 const mockSendMessage = mock(() => Promise.resolve({}))
 const mockClose = mock(() => {})
@@ -21,6 +22,7 @@ mock.module('./protocol/session', () => ({
     getChatLogs = mockGetChatLogs
     getChatInfo = mockGetChatInfo
     getChannelInfo = mockGetChannelInfo
+    getOpenLinkInfo = mockGetOpenLinkInfo
     syncMessages = mockSyncMessages
     sendMessage = mockSendMessage
     close = mockClose
@@ -39,6 +41,7 @@ function resetAllMocks() {
   mockGetChatLogs.mockReset()
   mockGetChatInfo.mockReset()
   mockGetChannelInfo.mockReset()
+  mockGetOpenLinkInfo.mockReset()
   mockSyncMessages.mockReset()
   mockSendMessage.mockReset()
   mockClose.mockReset()
@@ -489,6 +492,149 @@ describe('KakaoTalkClient', () => {
       expect(title).toBeNull()
       expect(mockGetChannelInfo).not.toHaveBeenCalled()
       expect(mockLogin).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('falls back to INFOLINK link name for open chats with no TITLE meta', async () => {
+      const openChatLogin = {
+        chatDatas: [
+          {
+            c: 500,
+            t: 'OM',
+            li: makeLong(7777),
+            k: ['User1', 'User2'],
+            i: [10, 20],
+            a: 2,
+            n: 0,
+            o: 1700000000,
+            l: null,
+            ll: makeLong(1),
+          },
+        ],
+        lastTokenId: makeLong(0),
+        lastChatId: makeLong(0),
+        eof: true,
+      }
+      mockLogin.mockResolvedValue(openChatLogin)
+      mockGetChannelInfo.mockResolvedValueOnce({ body: { chatInfo: { chatMetas: [] } } })
+      mockGetOpenLinkInfo.mockResolvedValueOnce({ body: { ols: [{ ln: 'Open Group Title' }] } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('500')
+
+      expect(title).toBe('Open Group Title')
+      expect(mockGetChannelInfo).toHaveBeenCalledTimes(1)
+      expect(mockGetOpenLinkInfo).toHaveBeenCalledTimes(1)
+
+      client.close()
+    })
+
+    it('does not call INFOLINK for non-open chats (regular MultiChat)', async () => {
+      mockGetChannelInfo.mockResolvedValueOnce({ body: { chatInfo: { chatMetas: [] } } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('100')
+
+      expect(title).toBeNull()
+      expect(mockGetOpenLinkInfo).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('does not call INFOLINK when CHATINFO already returned a TITLE meta', async () => {
+      const openChatLogin = {
+        chatDatas: [
+          {
+            c: 500,
+            t: 'OM',
+            li: makeLong(7777),
+            k: [],
+            i: [],
+            a: 1,
+            n: 0,
+            o: 1700000000,
+            l: null,
+            ll: makeLong(1),
+          },
+        ],
+        lastTokenId: makeLong(0),
+        lastChatId: makeLong(0),
+        eof: true,
+      }
+      mockLogin.mockResolvedValue(openChatLogin)
+      mockGetChannelInfo.mockResolvedValueOnce({
+        body: { chatInfo: { chatMetas: [{ type: 3, content: 'User Set Title' }] } },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('500')
+
+      expect(title).toBe('User Set Title')
+      expect(mockGetOpenLinkInfo).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('returns null when INFOLINK fails for open chats', async () => {
+      const openChatLogin = {
+        chatDatas: [
+          {
+            c: 500,
+            t: 'OD',
+            li: makeLong(7777),
+            k: [],
+            i: [],
+            a: 1,
+            n: 0,
+            o: 1700000000,
+            l: null,
+            ll: makeLong(1),
+          },
+        ],
+        lastTokenId: makeLong(0),
+        lastChatId: makeLong(0),
+        eof: true,
+      }
+      mockLogin.mockResolvedValue(openChatLogin)
+      mockGetChannelInfo.mockResolvedValueOnce({ body: { chatInfo: { chatMetas: [] } } })
+      mockGetOpenLinkInfo.mockRejectedValueOnce(new Error('INFOLINK timeout'))
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('500')
+
+      expect(title).toBeNull()
+
+      client.close()
+    })
+
+    it('returns null when open chat has no link id (li missing)', async () => {
+      const openChatLogin = {
+        chatDatas: [
+          {
+            c: 500,
+            t: 'OM',
+            k: [],
+            i: [],
+            a: 1,
+            n: 0,
+            o: 1700000000,
+            l: null,
+            ll: makeLong(1),
+          },
+        ],
+        lastTokenId: makeLong(0),
+        lastChatId: makeLong(0),
+        eof: true,
+      }
+      mockLogin.mockResolvedValue(openChatLogin)
+      mockGetChannelInfo.mockResolvedValueOnce({ body: { chatInfo: { chatMetas: [] } } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const title = await client.getChatTitle('500')
+
+      expect(title).toBeNull()
+      expect(mockGetOpenLinkInfo).not.toHaveBeenCalled()
 
       client.close()
     })

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -159,6 +159,27 @@ function extractTitle(body: Record<string, unknown>): string | null {
   return typeof content === 'string' && content.length > 0 ? content : null
 }
 
+interface OpenLinkInfoResponse {
+  ols?: Array<{ ln?: unknown }>
+}
+
+function extractOpenLinkName(body: Record<string, unknown>): string | null {
+  const ols = (body as OpenLinkInfoResponse).ols
+  if (!Array.isArray(ols) || ols.length === 0) return null
+  const ln = ols[0]?.ln
+  return typeof ln === 'string' && ln.length > 0 ? ln : null
+}
+
+const OPEN_CHAT_TYPES = new Set(['OM', 'OD'])
+
+function isOpenChat(chat: ChatData): boolean {
+  return typeof chat.t === 'string' && OPEN_CHAT_TYPES.has(chat.t)
+}
+
+function getOpenLinkId(chat: ChatData): Long | null {
+  return bsonToLong(chat.li) ?? null
+}
+
 function matchesSearch(chat: ChatData, term: string): boolean {
   const names = (chat.k ?? []) as string[]
   const lower = term.toLowerCase()
@@ -581,7 +602,7 @@ export class KakaoTalkClient {
         }
 
         const titles = options?.resolveTitles
-          ? await Promise.all(results.map((chat) => this.fetchChatTitle(session, parseLong(String(chat.c)))))
+          ? await Promise.all(results.map((chat) => this.fetchChatTitle(session, parseLong(String(chat.c)), chat)))
           : null
 
         return results.map((chat, i) => formatChat(chat, titles ? titles[i] : null, this.nameCache))
@@ -603,15 +624,30 @@ export class KakaoTalkClient {
     } catch {
       return null
     }
-    return this.executeWithReconnect(async ({ session }) => {
-      return this.fetchChatTitle(session, parsed)
+    return this.executeWithReconnect(async ({ session, loginResult }) => {
+      const chat = (loginResult.chatDatas ?? []).find((c) => String(c.c) === chatId)
+      return this.fetchChatTitle(session, parsed, chat)
     })
   }
 
-  private async fetchChatTitle(session: LocoSession, chatId: Long): Promise<string | null> {
+  private async fetchChatTitle(session: LocoSession, chatId: Long, chat: ChatData | undefined): Promise<string | null> {
+    let title: string | null = null
     try {
       const response = await session.getChannelInfo(chatId)
-      return extractTitle(response.body as Record<string, unknown>)
+      title = extractTitle(response.body as Record<string, unknown>)
+    } catch {
+      title = null
+    }
+
+    if (title) return title
+    if (!chat || !isOpenChat(chat)) return null
+
+    const linkId = getOpenLinkId(chat)
+    if (!linkId) return null
+
+    try {
+      const response = await session.getOpenLinkInfo([linkId])
+      return extractOpenLinkName(response.body as Record<string, unknown>)
     } catch {
       return null
     }

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -160,6 +160,17 @@ export class LocoSession {
     return this.connection.sendPacket('CHATINFO', { chatId })
   }
 
+  /**
+   * Fetch open-link info (INFOLINK) for one or more openchat links. The
+   * response body has shape `{ ols: OpenLinkStruct[] }` where each struct's
+   * `ln` field carries the open-chat link name — the canonical fallback when
+   * an open chat has no user-set TITLE meta.
+   */
+  async getOpenLinkInfo(linkIds: Long[]): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return this.connection.sendPacket('INFOLINK', { lis: linkIds })
+  }
+
   async getChatList(lastTokenId?: Long, lastChatId?: Long): Promise<LocoPacket> {
     if (!this.connection) throw new Error('Not connected')
     return this.connection.sendPacket('LCHATLIST', {


### PR DESCRIPTION
## Summary

Closes the open-chat gap left by [PR #185](https://github.com/agent-messenger/agent-messenger/pull/185). When an open chat (\`chat.t === 'OM'\` or \`'OD'\`) has no user-set TITLE meta, fetch the OpenLink struct via the LOCO \`INFOLINK\` command and use its \`ln\` (link name) as the title. This matches what the official KakaoTalk app shows for open chats.

## Why

PR #185 resolved \`title\` from \`chatInfo.chatMetas\` (TITLE meta type 3). For regular group chats this is correct. For open chats, however, most rooms don't have a user-set TITLE meta — the canonical room name lives on the associated OpenLink struct as \`ln\`.

Without this fallback, users running \`agent-kakaotalk chat list --resolve-titles\` see \`title: null\` for every open chat and have to fall back to \`display_name\` (member nicknames), which is exactly the problem #185 set out to fix.

## What changed

- Adds \`LocoSession.getOpenLinkInfo(linkIds: Long[])\` → sends LOCO \`INFOLINK { lis }\`, returns body with \`ols: OpenLinkStruct[]\`. Cross-confirmed against [node-kakao's INFOLINK call](https://github.com/storycraft/node-kakao/blob/8512e4699e2cd4c26516b80d38b57b2f85a6cc8a/src/talk/openlink/talk-open-link-session.ts#L61) and the [InfoLinkRes / OpenLinkStruct definitions](https://github.com/storycraft/node-kakao/blob/8512e4699e2cd4c26516b80d38b57b2f85a6cc8a/src/packet/struct/openlink.ts#L21).
- Updates \`KakaoTalkClient.fetchChatTitle\` to look at \`chat.t\` (open-chat type detection) and \`chat.li\` (link id). Only fires INFOLINK when CHATINFO returned no title AND the chat is an open chat AND \`li\` is present.
- \`KakaoTalkClient.getChatTitle\` now resolves the chat from the login snapshot to access the open-chat fields.

## Wire-call profile

| Chat type | TITLE meta present? | LOCO calls per chat |
|---|---|---|
| Any non-open chat (\`MultiChat\`, \`DirectChat\`, \`MemoChat\`, \`PlusChat\`) | yes / no | 1 (CHATINFO) |
| Open chat (\`OM\` / \`OD\`) | yes | 1 (CHATINFO) |
| Open chat (\`OM\` / \`OD\`) | no | 2 (CHATINFO + INFOLINK) |

Open chats without TITLE meta — the new case — pay one additional round trip. All chats remain inside the existing opt-in \`--resolve-titles\` flow; default behavior is unchanged.

## Tests

5 new test cases:
- Open chat without TITLE meta → INFOLINK called → returns \`ln\`
- Non-open chat without TITLE → INFOLINK NOT called → returns null
- Open chat WITH TITLE meta → INFOLINK NOT called (avoid wasted call)
- Open chat with INFOLINK failure → returns null
- Open chat with no \`li\` field → returns null, INFOLINK NOT called

\`\`\`
153 pass, 0 fail
325 expect() calls
\`\`\`

## Out of scope

- \`MEMBER\` / \`GETMEM\` LOCO commands for full member coverage (separate PR)
- Caching INFOLINK results across calls (open chats rarely change link names; could batch \`lis: [...]\` for many chats — left as a follow-up if anyone hits the latency)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open chats without a user-set title now fall back to the OpenLink name via `INFOLINK` when `--resolve-titles` is used, matching the KakaoTalk app. Only those open chats make one extra call; other chats are unchanged.

- New Features
  - Added `LocoSession.getOpenLinkInfo(linkIds)` to send `INFOLINK` and read `ols[].ln`.
  - `KakaoTalkClient.getChatTitle` checks `t`/`li` and calls `INFOLINK` only when `TITLE` meta is missing on open chats (`OM`/`OD`).

Docs updated: CLI, SDK, `skills/agent-kakaotalk/SKILL.md`, and common-patterns.

<sup>Written for commit 29e0c293c6461cd3657d256cfa643f37e14948f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

