### PR TITLE
Add classifyKakaoChat helper to KakaoTalk SDK

### DIFF
--- a/src/platforms/kakaotalk/chat-classifier.test.ts
+++ b/src/platforms/kakaotalk/chat-classifier.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+
+import { classifyKakaoChat } from './chat-classifier'
+
+describe('classifyKakaoChat', () => {
+  it('classifies a normal DM (type 11, 2 members) as dm', () => {
+    expect(classifyKakaoChat({ type: 11, active_members: 2 })).toBe('dm')
+  })
+
+  it('classifies a normal group (type 10, 5 members) as group', () => {
+    expect(classifyKakaoChat({ type: 10, active_members: 5 })).toBe('group')
+  })
+
+  it('classifies legacy DM (type 9, 2 members) as dm via member-count fallback', () => {
+    expect(classifyKakaoChat({ type: 9, active_members: 2 })).toBe('dm')
+  })
+
+  it('classifies a 3-member group (type 10) as group, not dm', () => {
+    expect(classifyKakaoChat({ type: 10, active_members: 3 })).toBe('group')
+  })
+
+  for (const type of [2, 13, 14, 15, 16]) {
+    it(`classifies open-chat type ${type} as open regardless of member count`, () => {
+      expect(classifyKakaoChat({ type, active_members: 1 })).toBe('open')
+      expect(classifyKakaoChat({ type, active_members: 2 })).toBe('open')
+      expect(classifyKakaoChat({ type, active_members: 50 })).toBe('open')
+    })
+  }
+
+  it('classifies a 1-member chat (lone room) as dm', () => {
+    expect(classifyKakaoChat({ type: 11, active_members: 1 })).toBe('dm')
+  })
+})

--- a/src/platforms/kakaotalk/chat-classifier.ts
+++ b/src/platforms/kakaotalk/chat-classifier.ts
@@ -1,0 +1,31 @@
+import type { KakaoChat } from './types'
+
+export type KakaoChatKind = 'dm' | 'group' | 'open' | 'unknown'
+
+// OpenChat-family `type` codes observed on the wire. KakaoTalk's LOCO
+// protocol exposes a numeric `type` field with no documented mapping; these
+// five codes consistently identify OpenChat rooms across normal OpenChat,
+// OpenChat DMs, and the various OpenChat sub-types seen in production.
+const OPEN_CHAT_TYPE_CODES: ReadonlySet<number> = new Set([2, 13, 14, 15, 16])
+
+/**
+ * Classify a KakaoTalk chat as `'dm'`, `'group'`, `'open'`, or `'unknown'`.
+ *
+ * REGRESSION GUARD: An earlier implementation hard-coded `0=dm`, `1=group`,
+ * `2=open` on the raw `type` number. Modern KakaoTalk uses codes like `11`
+ * for normal DMs and `10` for normal groups, so the old mapping silently
+ * classified every real DM as `'unknown'` and bucketed it as a group. Do
+ * NOT "simplify" this back to a pure type-code mapping without verifying
+ * against a real KakaoTalk session.
+ *
+ * `'unknown'` is reserved for future protocol drift; the current heuristic
+ * never returns it, but it is part of the union so consumers can handle
+ * the case defensively.
+ */
+export function classifyKakaoChat(chat: Pick<KakaoChat, 'type' | 'active_members'>): KakaoChatKind {
+  if (OPEN_CHAT_TYPE_CODES.has(chat.type)) return 'open'
+  // active_members counts the logged-in user, so a 1:1 DM is exactly 2
+  // (self + one other) and a "lone" room with only self is 1.
+  if (chat.active_members <= 2) return 'dm'
+  return 'group'
+}

--- a/src/platforms/kakaotalk/index.test.ts
+++ b/src/platforms/kakaotalk/index.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from 'bun:test'
 
 import {
+  classifyKakaoChat,
   CredentialManager,
   KakaoAccountCredentialsSchema,
   KakaoCredentialManager,
@@ -71,4 +72,8 @@ it('KakaoTalkPushReadEventSchema is exported from barrel', () => {
 
 it('KakaoProfileSchema is exported from barrel', () => {
   expect(typeof KakaoProfileSchema.parse).toBe('function')
+})
+
+it('classifyKakaoChat is exported from barrel', () => {
+  expect(typeof classifyKakaoChat).toBe('function')
 })

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -1,4 +1,6 @@
 export { KakaoTalkClient, KakaoTalkError } from './client'
+export { classifyKakaoChat } from './chat-classifier'
+export type { KakaoChatKind } from './chat-classifier'
 export { KakaoCredentialManager, CredentialManager } from './credential-manager'
 export { KakaoTalkListener } from './listener'
 export type { PendingLoginState } from './credential-manager'


### PR DESCRIPTION
## Summary

Adds a public `classifyKakaoChat(chat: KakaoChat)` helper to the `agent-messenger/kakaotalk` SDK module. It returns `'dm' | 'group' | 'open' | 'unknown'` by inspecting the LOCO protocol's undocumented `type` field and falls back to `active_members` count to disambiguate DM vs group when the type code alone isn't decisive.

## Why — regression guard

KakaoTalk's LOCO protocol exposes a numeric `type` field on each chat object with no public documentation. An earlier downstream implementation hard-coded `0 = dm`, `1 = group`, `2 = open` on the raw value. Modern KakaoTalk uses codes like `11` for normal DMs and `10` for normal groups, so that mapping silently classified every real DM as `'unknown'` — breaking DM-routing logic in any consumer that relied on it.

The corrected heuristic:

- Recognizes the **OpenChat-family codes** `2, 13, 14, 15, 16` and returns `'open'` for any of them, regardless of `active_members`.
- Returns `'dm'` when `active_members <= 2` for all other type codes (covering type 11 and the `active_members` fallback for legacy or future codes). `active_members` counts the logged-in user, so a 1:1 DM is exactly 2 (self + one other).
- Returns `'group'` otherwise.

This protocol-level knowledge has no other home — it is reverse-engineered from real KakaoTalk sessions. It was previously living in a downstream consumer as a shim, requiring each consumer to independently reverse-engineer the same mapping. Upstreaming it means future consumers of `agent-messenger/kakaotalk` get the correct behavior by default, and the regression-guard JSDoc travels with the code.

## What's added

- **`src/platforms/kakaotalk/chat-classifier.ts`** — `classifyKakaoChat` function, `KakaoChatKind` type alias, and the private `OPEN_CHAT_TYPE_CODES` constant (`[2, 13, 14, 15, 16]`). The function body includes a regression-guard JSDoc warning against simplifying back to a pure type-code mapping.
- **`src/platforms/kakaotalk/chat-classifier.test.ts`** — 7 test cases: normal DM (type 11), normal group (type 10), legacy/unknown code with member-count fallback (type 9), 3-member group edge case, all 5 OpenChat codes with varying member counts, and a 1-member chat.
- **`src/platforms/kakaotalk/index.ts`** — barrel-exports `classifyKakaoChat` and `KakaoChatKind`.
- **`src/platforms/kakaotalk/index.test.ts`** — barrel-export smoke test for `classifyKakaoChat`.

## Out of scope

A downstream consumer also maps the chat kind to workspace bucket strings (`@kakao-dm`, `@kakao-group`, `@kakao-open`). Those strings are app-specific naming conventions that belong to the consumer, not to Kakao's protocol. Only the platform-level classification belongs upstream; `kakaoWorkspaceForType` is intentionally not included in this PR.

## Known limitation — wire-format / public-type drift

The current SDK has a small inconsistency that this PR deliberately does *not* fix:

- `client.ts:formatChat` projects the wire `ChatData.t` field into `KakaoChat.type` via `chat.t as number` (an unchecked TypeScript cast).
- `client.ts:isOpenChat` (used internally by `fetchChatTitle`) recognizes OpenChat by *string* codes `'OM'` and `'OD'` on the same `chat.t` field, and a few open-chat test fixtures supply string `t` values.
- The new `classifyKakaoChat` operates on the public `KakaoChat.type` and recognizes *numeric* codes (2, 13, 14, 15, 16).

If the wire ever surfaces `'OM'`/`'OD'` strings into `KakaoChat.type` at runtime, those chats will fall through the numeric `Set.has()` check and be classified by `active_members`, not as `'open'`. Reconciling this — either by normalizing wire-type codes inside `formatChat`, or by typing `KakaoChat.type` as `number | string` and teaching the classifier both shapes — is a larger refactor that doesn't belong in an "upstream the helper" PR. The classifier matches the modern numeric codes that the downstream consumer has been validating against in production; aligning `formatChat` with the same numeric-only contract is a logical follow-up.

## Tests

```
156 pass, 0 fail (11 files — full src/platforms/kakaotalk/ suite)
```

Pre-merge checks: `bun typecheck`, `bun lint`, `bun run format:check` all clean.
