### PR TITLE
Slackbot: support blocks/attachments/unfurl options in postMessage

### DIFF
--- a/docs/content/docs/sdk/slackbot.mdx
+++ b/docs/content/docs/sdk/slackbot.mdx
@@ -58,6 +58,17 @@ const msg = await client.postMessage('C0ACZKTDDC0', 'Hello world')
 const reply = await client.postMessage('C0ACZKTDDC0', 'Reply', { thread_ts: '1234567890.123456' })
 // → SlackMessage { ts, text, type, user?, thread_ts? }
 
+// Send a Block Kit message — `text` is used as the fallback/notification text
+await client.postMessage('C0ACZKTDDC0', 'Build finished', {
+  blocks: [{ type: 'section', text: { type: 'mrkdwn', text: '*Build finished*' } }],
+})
+
+// Other supported pass-through options (forwarded as-is to chat.postMessage):
+//   attachments?: unknown[]
+//   unfurl_links?: boolean
+//   unfurl_media?: boolean
+//   mrkdwn?: boolean
+
 // Read a channel's recent messages (default limit: 20, supports cursor pagination)
 const history = await client.getConversationHistory('C0ACZKTDDC0')
 const limited = await client.getConversationHistory('C0ACZKTDDC0', { limit: 50 })

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -365,7 +365,6 @@ Credentials stored in `~/.config/agent-messenger/slackbot-credentials.json` (060
 - Bot can only edit/delete its own messages
 - Bot must be invited to private channels
 - No scheduled messages
-- Plain text messages only (no blocks/formatting)
 
 ## Troubleshooting
 

--- a/src/platforms/slackbot/client.test.ts
+++ b/src/platforms/slackbot/client.test.ts
@@ -243,6 +243,73 @@ describe('SlackBotClient', () => {
       expect(result.ts).toBe('1234567890.123456')
       expect(result.text).toBe('Hello')
     })
+
+    it('does not pass blocks/attachments when omitted', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+
+      // when
+      await client.postMessage('C123', 'Hello')
+
+      // then
+      expect(mockChat.postMessage).toHaveBeenCalledWith({
+        channel: 'C123',
+        text: 'Hello',
+        thread_ts: undefined,
+        blocks: undefined,
+        attachments: undefined,
+        unfurl_links: undefined,
+        unfurl_media: undefined,
+        mrkdwn: undefined,
+      })
+    })
+
+    it('forwards blocks to chat.postMessage', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+      const blocks = [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: '*hello*' },
+        },
+      ]
+
+      // when
+      await client.postMessage('C123', 'Hello', { blocks })
+
+      // then
+      expect(mockChat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'C123', text: 'Hello', blocks }),
+      )
+    })
+
+    it('forwards thread_ts, attachments, and unfurl/mrkdwn flags', async () => {
+      // given
+      const client = await new SlackBotClient().login({ token: 'xoxb-test-token' })
+      const attachments = [{ text: 'attached' }]
+
+      // when
+      await client.postMessage('C123', 'Hello', {
+        thread_ts: '1234567890.000001',
+        attachments,
+        unfurl_links: false,
+        unfurl_media: false,
+        mrkdwn: true,
+      })
+
+      // then
+      expect(mockChat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C123',
+          text: 'Hello',
+          thread_ts: '1234567890.000001',
+          attachments,
+          unfurl_links: false,
+          unfurl_media: false,
+          mrkdwn: true,
+        }),
+      )
+    })
   })
 
   describe('getConversationHistory', () => {

--- a/src/platforms/slackbot/client.ts
+++ b/src/platforms/slackbot/client.ts
@@ -103,12 +103,28 @@ export class SlackBotClient {
     })
   }
 
-  async postMessage(channel: string, text: string, options?: { thread_ts?: string }): Promise<SlackMessage> {
+  async postMessage(
+    channel: string,
+    text: string,
+    options?: {
+      thread_ts?: string
+      blocks?: unknown[]
+      attachments?: unknown[]
+      unfurl_links?: boolean
+      unfurl_media?: boolean
+      mrkdwn?: boolean
+    },
+  ): Promise<SlackMessage> {
     return this.withRetry(async () => {
       const response = await this.ensureAuth().chat.postMessage({
         channel,
         text,
         thread_ts: options?.thread_ts,
+        blocks: options?.blocks as any,
+        attachments: options?.attachments as any,
+        unfurl_links: options?.unfurl_links,
+        unfurl_media: options?.unfurl_media,
+        mrkdwn: options?.mrkdwn,
       })
       this.checkResponse(response)
 


### PR DESCRIPTION
## Summary

Widens `SlackBotClient.postMessage` to thread Block Kit `blocks`, plus `attachments`, `unfurl_links`, `unfurl_media`, and `mrkdwn` straight through to `chat.postMessage`. Same retry-on-rate-limit and response shape as before.

## Why

Slack's plain-text rendering of `*bold*`, `##`, and tables looks bad in chat. Block Kit fixes that, but the previous `postMessage(channel, text, { thread_ts })` signature only exposed `thread_ts`, forcing downstream consumers to either give up Block Kit formatting entirely or reach into `SlackBotClient`'s private `client: WebClient` field via subclass shims — fragile, since any rename of the private field or any change in SDK response shape silently breaks the shim.

The fields added are exactly what `chat.postMessage` already accepts; this is type widening at the public API, no behavior change.

## Changes

- `src/platforms/slackbot/client.ts` — extend `postMessage` options with `blocks`, `attachments`, `unfurl_links`, `unfurl_media`, `mrkdwn`; pass them through to the SDK call.
- `src/platforms/slackbot/client.test.ts` — three new tests:
  - Regression guard: omitted options stay `undefined` on the SDK call (no accidental over-eager forwarding).
  - `blocks` are forwarded to `chat.postMessage`.
  - `thread_ts`, `attachments`, `unfurl_*`, `mrkdwn` are forwarded together.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun run format:check` — clean on changed files
- `bun test src/platforms/slackbot/` — 178 pass, 0 fail
- Pre-existing `token-extractor.test.ts` failures (which read real local Slack browser data) reproduce on `main` and are unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded `SlackBotClient.postMessage` to pass through `blocks`, `attachments`, `unfurl_links`, `unfurl_media`, and `mrkdwn` to Slack `chat.postMessage`. Enables Block Kit messages while keeping retries and response mapping the same.

- **Migration**
  - No changes required for consumers.
  - Docs updated: added a Block Kit example in `docs/sdk/slackbot.mdx`; removed the "plain text only" limitation from `skills/agent-slackbot/SKILL.md`.

<sup>Written for commit 249e473b8ece694e4ae5137b862f8d717e0beff5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

