### PR TITLE
Pre-rollout self-review fixes for agent-kakaotalk v2.13.0

### DIFF
--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -103,7 +103,7 @@ Once closed, any subsequent method call throws a `KakaoTalkError` with code `cli
 
 ## KakaoTalkListener
 
-Real-time event listener that receives push events from KakaoTalk via the LOCO protocol. Manages its own LOCO session with automatic reconnection.
+Real-time event listener that receives push events from KakaoTalk via the LOCO protocol. Subscribes to the underlying client's LOCO session.
 
 ```typescript
 import { KakaoTalkClient, KakaoTalkListener } from 'agent-messenger/kakaotalk'
@@ -131,7 +131,7 @@ listener.on('read', (event) => {
   console.log(`User ${event.user_id} read ${event.chat_id} up to ${event.watermark}`)
 })
 
-listener.on('disconnected', () => console.log('Reconnecting...'))
+listener.on('disconnected', () => console.log('LOCO session dropped'))
 listener.on('error', (err) => console.error(err))
 
 await listener.start()
@@ -140,20 +140,26 @@ await listener.start()
 
 ### Events
 
-| Event             | Payload                     | Description                           |
-| ----------------- | --------------------------- | ------------------------------------- |
-| `message`         | `KakaoTalkPushMessageEvent` | New message received                  |
-| `member_joined`   | `KakaoTalkPushMemberEvent`  | Member joined a chat                  |
-| `member_left`     | `KakaoTalkPushMemberEvent`  | Member left a chat                    |
-| `read`            | `KakaoTalkPushReadEvent`    | Read receipt (unread count decreased) |
-| `kakaotalk_event` | `KakaoTalkPushGenericEvent` | Catch-all for all push events         |
-| `connected`       | `{ userId: string }`        | Connected to LOCO server              |
-| `disconnected`    | —                           | Disconnected (will auto-reconnect)    |
-| `error`           | `Error`                     | Connection or protocol error          |
+| Event             | Payload                     | Description                             |
+| ----------------- | --------------------------- | --------------------------------------- |
+| `message`         | `KakaoTalkPushMessageEvent` | New message received                    |
+| `member_joined`   | `KakaoTalkPushMemberEvent`  | Member joined a chat                    |
+| `member_left`     | `KakaoTalkPushMemberEvent`  | Member left a chat                      |
+| `read`            | `KakaoTalkPushReadEvent`    | Read receipt (unread count decreased)   |
+| `kakaotalk_event` | `KakaoTalkPushGenericEvent` | Catch-all for all push events           |
+| `connected`       | `{ userId: string }`        | Connected to LOCO server                |
+| `disconnected`    | —                           | LOCO session dropped (see Reconnection) |
+| `error`           | `Error`                     | Connection or protocol error            |
 
 ### Reconnection
 
-The listener automatically reconnects with exponential backoff (1s → 2s → 4s → ... → 30s max) when the connection drops. Server-requested migrations (`CHANGESVR`) trigger immediate reconnection. If the session is kicked by another device (`KICKOUT`), the listener stops and emits an error.
+The listener does not implement a reconnection loop. Behavior on session drop:
+
+- **Server-requested migration (`CHANGESVR`)** — The client invalidates the session, emits `disconnected`, and immediately establishes a new session in the background. Subscribers receive `connected` again once it succeeds. No action required.
+- **Network drop or peer close** — The client emits `disconnected` and clears its session state. The next SDK API call (`getChats`, `getMessages`, `sendMessage`) will lazily re-establish the session via `executeWithReconnect`. The listener itself stays passive — to resume push delivery after a drop, call `await client.acquireSession()` (or any API call) from your `disconnected` handler.
+- **Kicked by another device (`KICKOUT`)** — The listener stops and emits `error`. This is terminal; you must `login()` a new client to recover.
+
+If you need a long-running listener that survives network drops, wrap `acquireSession()` in your own retry loop driven by the `disconnected` event.
 
 ## KakaoCredentialManager
 

--- a/scripts/kakao-loco-capture.ts
+++ b/scripts/kakao-loco-capture.ts
@@ -3,9 +3,9 @@
  * KakaoTalk LOCO wire-format capture (diagnostic only).
  *
  * Issues a small, throttled set of LOCO requests against a real account and
- * writes the BSON response bodies to /tmp for offline schema inspection. PII
- * is redacted (user IDs hashed, profile URLs scrubbed, message content elided)
- * before anything is written to disk.
+ * writes the BSON response bodies to a temp file for offline schema inspection.
+ * PII is redacted (user IDs hashed, profile URLs scrubbed, message content
+ * elided, member nicknames replaced) before anything is written to disk.
  *
  * Defaults are intentionally conservative: 3 chats max, 1500ms between LOCO
  * calls, dry-run unless `--confirm` is passed. The goal is to avoid bursting
@@ -23,6 +23,8 @@
 
 import { createHash } from 'node:crypto'
 import { writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { Long } from 'bson'
 
@@ -69,7 +71,7 @@ function parseArgs(argv: string[]): Args {
       i++
     } else if (arg === '--commands' && next) {
       const requested = next.split(',').map((s) => s.trim().toUpperCase())
-      const unknown = requested.filter((c): c is Command => !SUPPORTED_COMMANDS.includes(c as Command))
+      const unknown = requested.filter((c) => !SUPPORTED_COMMANDS.includes(c as Command))
       if (unknown.length > 0) {
         throw new Error(`Unknown commands: ${unknown.join(', ')}. Supported: ${SUPPORTED_COMMANDS.join(', ')}`)
       }
@@ -106,7 +108,7 @@ Options:
   --confirm           Actually issue LOCO calls. Without this, prints the plan only.
   --help, -h          Show this help
 
-Output: /tmp/kakao-loco-capture-<timestamp>.json (PII redacted)
+Output: <tmpdir>/kakao-loco-capture-<timestamp>.json (PII redacted)
 `)
 }
 
@@ -127,6 +129,14 @@ function isLong(v: unknown): v is { low: number; high: number } {
 const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi
 const USERID_KEYS = new Set(['userId', 'authorId', 'uid', 'i', 'mid', 'mids', 'memberIds', 'memberId', 'olu', 'opt'])
 const CONTENT_KEYS = new Set(['message', 'msg', 'content', 'statusMessage', 'desc', 'description'])
+// Keys whose string values are display names / nicknames. Replaced with a
+// length-tagged placeholder so wire-shape inspection stays useful while the
+// real names never reach disk.
+const NAME_KEYS = new Set(['nickName', 'name', 'fullName', 'authorName', 'author_name', 'k', 'ln'])
+
+function redactName(value: string): string {
+  return value.length > 0 ? `<name:${value.length}chars>` : '<name>'
+}
 
 function redact(value: unknown, key?: string): unknown {
   if (value === null || value === undefined) return value
@@ -142,10 +152,18 @@ function redact(value: unknown, key?: string): unknown {
     if (key && CONTENT_KEYS.has(key)) {
       return value.length > 32 ? `<redacted:${value.length}chars>` : '<redacted>'
     }
+    if (key && NAME_KEYS.has(key)) {
+      return redactName(value)
+    }
     return value.replace(URL_PATTERN, '<url>')
   }
   if (typeof value === 'boolean') return value
   if (Array.isArray(value)) {
+    // For NAME_KEYS that hold arrays of nicknames (notably `k`), redact each
+    // element as a name regardless of its position.
+    if (key && NAME_KEYS.has(key)) {
+      return value.map((v) => (typeof v === 'string' ? redactName(v) : redact(v, key)))
+    }
     return value.map((v) => redact(v, key))
   }
   if (typeof value === 'object') {
@@ -165,6 +183,17 @@ function parseLong(s: string): Long {
   return new Long(low, high)
 }
 
+function toLong(v: unknown): Long | null {
+  if (v && typeof v === 'object' && 'low' in v && 'high' in v) {
+    const { low, high } = v as { low: number; high: number }
+    return new Long(low, high)
+  }
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    return Long.fromNumber(v)
+  }
+  return null
+}
+
 interface CaptureEntry {
   command: Command
   chatId: string
@@ -173,25 +202,6 @@ interface CaptureEntry {
   body?: unknown
   error?: string
   duration_ms: number
-}
-
-interface SessionWithConnection {
-  connection: { sendPacket: (method: string, body: Record<string, unknown>) => Promise<unknown> } | null
-}
-
-async function sendRaw(
-  session: LocoSession,
-  command: string,
-  body: Record<string, unknown>,
-): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  // Diagnostic-only escape hatch: reach into the session's private connection to
-  // send commands that aren't yet exposed as typed methods (MEMBER/GETMEM/INFOLINK).
-  // This is intentional in a developer tool; production code should add typed
-  // methods to LocoSession (PRs 3 & 4 will).
-  const conn = (session as unknown as SessionWithConnection).connection
-  if (!conn) throw new Error('LocoSession has no active connection')
-  const packet = (await conn.sendPacket(command, body)) as { statusCode: number; body: Record<string, unknown> }
-  return packet
 }
 
 async function probe(
@@ -230,8 +240,12 @@ async function probe(
         break
       }
       case 'MEMBER': {
-        const memberIds = (chat.i as Array<{ low: number; high: number }> | undefined) ?? []
-        const sample = memberIds.slice(0, 3).map((m) => new Long(m.low, m.high))
+        const rawIds = (chat.i as Array<unknown> | undefined) ?? []
+        const sample: Long[] = []
+        for (const raw of rawIds.slice(0, 3)) {
+          const id = toLong(raw)
+          if (id) sample.push(id)
+        }
         if (sample.length === 0) {
           return {
             command,
@@ -241,19 +255,19 @@ async function probe(
             duration_ms: Date.now() - start,
           }
         }
-        const res = await sendRaw(session, 'MEMBER', { chatId, memberIds: sample })
+        const res = await session.getMembersByIds(chatId, sample)
         body = res.body
         statusCode = res.statusCode
         break
       }
       case 'GETMEM': {
-        const res = await sendRaw(session, 'GETMEM', { chatId })
+        const res = await session.getAllMembers(chatId)
         body = res.body
         statusCode = res.statusCode
         break
       }
       case 'INFOLINK': {
-        const linkId = chat.li
+        const linkId = toLong(chat.li)
         if (!linkId) {
           return {
             command,
@@ -263,7 +277,7 @@ async function probe(
             duration_ms: Date.now() - start,
           }
         }
-        const res = await sendRaw(session, 'INFOLINK', { lis: [linkId], ref: 'EW' })
+        const res = await session.getOpenLinkInfo([linkId])
         body = res.body
         statusCode = res.statusCode
         break
@@ -304,6 +318,10 @@ function selfCheckRedact(): void {
     },
     authorId: 1234567890,
     message: 'secret hi',
+    k: ['Alice', 'Bob', 'Charlie'],
+    ln: 'My OpenChat Room',
+    name: 'Display Name',
+    fullName: 'Real Name',
     l: { low: 999, high: 0 },
   }
   const out = redact(fixture) as Record<string, unknown>
@@ -315,8 +333,16 @@ function selfCheckRedact(): void {
   if (out.authorId === 1234567890) failures.push('authorId not hashed')
   if (display.userId === 42) failures.push('displayMembers[].userId not hashed')
   if ((display.profileImageUrl as string) !== '<url>') failures.push('profileImageUrl not scrubbed')
+  if ((display.nickName as string) === 'Alice') failures.push('displayMembers[].nickName not redacted')
   if (out.message !== '<redacted>') failures.push('message content not redacted')
   if (metas[0].content !== '<redacted>') failures.push('chatMetas content not redacted')
+  const memberNames = out.k as unknown[]
+  if (!Array.isArray(memberNames) || memberNames.some((n) => typeof n === 'string' && n === 'Alice')) {
+    failures.push('member name array (k) not redacted')
+  }
+  if (out.ln === 'My OpenChat Room') failures.push('open-link name (ln) not redacted')
+  if (out.name === 'Display Name') failures.push('display name not redacted')
+  if (out.fullName === 'Real Name') failures.push('fullName not redacted')
   if (typeof out.l !== 'object' || (out.l as Record<string, unknown>).__long !== true) {
     failures.push('non-user Long not preserved as tagged shape')
   }
@@ -336,7 +362,7 @@ async function main(): Promise<void> {
   console.log(`  delay_ms:  ${args.delayMs}`)
   console.log(`  commands:  ${args.commands.join(', ')}`)
   console.log(`  chat_id:   ${args.chatId ?? '<from login snapshot>'}`)
-  console.log(`  account:   ${args.account ?? '<current>'}`)
+  console.log(`  account:   ${args.account ? '<set>' : '<current>'}`)
   console.log(`  confirm:   ${args.confirm}`)
   console.log()
 
@@ -346,6 +372,23 @@ async function main(): Promise<void> {
   }
 
   const client = new KakaoTalkClient()
+
+  // Signal handler: `finally` does not run on SIGINT/SIGTERM, so wire explicit
+  // cleanup. Without this, Ctrl-C during a long sleep() leaks the LOCO socket
+  // and ping timer.
+  let cleaningUp = false
+  const cleanup = (signal: string) => {
+    if (cleaningUp) return
+    cleaningUp = true
+    console.error(`\nReceived ${signal}, closing LOCO session...`)
+    try {
+      client.close()
+    } catch {}
+    process.exit(130)
+  }
+  process.on('SIGINT', () => cleanup('SIGINT'))
+  process.on('SIGTERM', () => cleanup('SIGTERM'))
+
   await client.login(undefined, args.account ?? undefined)
 
   try {
@@ -403,13 +446,13 @@ async function main(): Promise<void> {
       }
     }
 
-    const outPath = `/tmp/kakao-loco-capture-${new Date().toISOString().replace(/[:.]/g, '-')}.json`
+    const outPath = join(tmpdir(), `kakao-loco-capture-${new Date().toISOString().replace(/[:.]/g, '-')}.json`)
     const payload = {
       captured_at: new Date().toISOString(),
-      args: { ...args, account: args.account ? '<redacted>' : null },
+      args: { ...args, account: args.account ? '<set>' : null, chatId: args.chatId ? '<set>' : null },
       entries,
     }
-    writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`)
+    writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 })
     console.log()
     console.log(`Wrote ${entries.length} entries to ${outPath}`)
   } finally {

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -383,7 +383,7 @@ All commands output JSON by default for AI consumption:
   "active_members": 3,
   "unread_count": 5,
   "last_message": {
-    "author_id": "1111111111",
+    "author_id": 1111111111,
     "author_name": "Alice",
     "message": "Hello everyone!",
     "sent_at": 1705312200000

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -295,6 +295,91 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('resolves open-chat titles via INFOLINK fallback in batch resolveTitles=true path', async () => {
+      // Mixed login snapshot: regular chat (uses CHATINFO TITLE meta), open chat
+      // with TITLE meta (CHATINFO only), open chat without TITLE meta (CHATINFO
+      // empty + INFOLINK fallback). Verifies the batch path wires open-chat
+      // fallback correctly — previously only the single-chat getChatTitle()
+      // path was covered.
+      const mixedLogin = {
+        chatDatas: [
+          {
+            c: 100,
+            t: 1,
+            k: ['Alice'],
+            i: [1],
+            a: 1,
+            n: 0,
+            o: 1700000003,
+            l: null,
+            ll: makeLong(1),
+          },
+          {
+            c: 500,
+            t: 'OM',
+            li: makeLong(7777),
+            k: ['User1'],
+            i: [10],
+            a: 1,
+            n: 0,
+            o: 1700000002,
+            l: null,
+            ll: makeLong(2),
+          },
+          {
+            c: 600,
+            t: 'OD',
+            li: makeLong(8888),
+            k: ['User2'],
+            i: [20],
+            a: 1,
+            n: 0,
+            o: 1700000001,
+            l: null,
+            ll: makeLong(3),
+          },
+        ],
+        lastTokenId: makeLong(0),
+        lastChatId: makeLong(0),
+        eof: true,
+      }
+      mockLogin.mockResolvedValue(mixedLogin)
+
+      // CHATINFO is fired in parallel for all 3 chats; mock by chatId so order
+      // doesn't matter (Promise.all resolves in fire order, not array order).
+      mockGetChannelInfo.mockImplementation((chatId: { low: number; high: number }) => {
+        switch (chatId.low) {
+          case 100:
+            return Promise.resolve({ body: { chatInfo: { chatMetas: [{ type: 3, content: 'Regular Title' }] } } })
+          case 500:
+            return Promise.resolve({ body: { chatInfo: { chatMetas: [{ type: 3, content: 'Open With Title' }] } } })
+          case 600:
+            return Promise.resolve({ body: { chatInfo: { chatMetas: [] } } })
+          default:
+            return Promise.resolve({ body: {} })
+        }
+      })
+      mockGetOpenLinkInfo.mockResolvedValueOnce({ body: { ols: [{ ln: 'Open Link Name' }] } })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ resolveTitles: true })
+
+      const byId = Object.fromEntries(chats.map((c) => [c.chat_id, c]))
+      expect(byId['100'].title).toBe('Regular Title')
+      expect(byId['500'].title).toBe('Open With Title')
+      expect(byId['600'].title).toBe('Open Link Name')
+
+      // INFOLINK fires only for the open chat that lacked a TITLE meta — not
+      // for the regular chat (skipped by isOpenChat) and not for the open
+      // chat that already had a TITLE (skipped by short-circuit).
+      expect(mockGetOpenLinkInfo).toHaveBeenCalledTimes(1)
+      const [linkIds] = mockGetOpenLinkInfo.mock.calls[0] as [Array<{ low: number; high: number }>]
+      expect(linkIds).toHaveLength(1)
+      expect(linkIds[0]).toMatchObject({ low: 8888, high: 0 })
+
+      client.close()
+    })
+
     it('sorts chats by recency (o field descending)', async () => {
       const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
       const chats = await client.getChats()
@@ -1113,6 +1198,44 @@ describe('KakaoTalkClient', () => {
       expect(result).toEqual([])
       expect(mockGetMembersByIds).not.toHaveBeenCalled()
       expect(mockLogin).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('reconnects and retries getMembers after silent disconnect (full executeWithReconnect path)', async () => {
+      // Earlier tests verify assertLocoOk throws on a synthetic-disconnect packet,
+      // but they don't exercise the reconnect path: executeWithReconnect only
+      // retries when the underlying socket also closed (state.session !== this.state.session).
+      // This test fires the captured onClose callback before the rejection so the
+      // client's state is nulled, then verifies the operation is retried against
+      // a fresh session and the second response is returned to the caller.
+      const closeHandlers: Array<() => void> = []
+      mockOnClose.mockImplementation((handler: () => void) => {
+        closeHandlers.push(handler)
+      })
+
+      mockGetAllMembers.mockImplementationOnce(() => {
+        // Fire the close handler captured during the first session's setup —
+        // simulates the LOCO TCP socket closing while the GETMEM is in flight.
+        // executeWithReconnect sees state.session !== this.state.session and retries.
+        const handler = closeHandlers[0]
+        if (handler) handler()
+        return Promise.resolve({ statusCode: -1, body: { error: 'connection closed' } })
+      })
+      mockGetAllMembers.mockResolvedValueOnce({
+        statusCode: 0,
+        body: { members: [{ userId: makeLong(42), nickName: 'Alice', type: 100 }] },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const members = await client.getMembers('100')
+
+      expect(members).toHaveLength(1)
+      expect(members[0].nickname).toBe('Alice')
+      expect(mockGetAllMembers).toHaveBeenCalledTimes(2)
+      // Login fires twice: once for the initial connect, once for the reconnect
+      // after the captured onClose handler invalidated this.state.
+      expect(mockLogin).toHaveBeenCalledTimes(2)
 
       client.close()
     })


### PR DESCRIPTION
## Summary

Pre-rollout self-review of the 11 commits that have landed since v2.12.2 surfaced four issues that would ship broken behavior or misleading docs. This PR fixes them and closes two test-coverage gaps. No production behavior changes — only docs, a developer-only diagnostic script, and tests.

## Why

The KakaoTalk module gained four sizable features since v2.12.2 — auto-resolve message author names ([#187](https://github.com/agent-messenger/agent-messenger/pull/187)), open-chat title resolution ([#188](https://github.com/agent-messenger/agent-messenger/pull/188)), \`MEMBER\`/\`GETMEM\` ([#189](https://github.com/agent-messenger/agent-messenger/pull/189)), and a \`scripts/kakao-loco-capture.ts\` diagnostic tool. Self-review against the actual source found:

1. **\`SKILL.md\` JSON example types \`author_id\` as string.** \`KakaoChat.last_message.author_id\` is \`number\` ([\`types.ts:80\`](https://github.com/agent-messenger/agent-messenger/blob/main/src/platforms/kakaotalk/types.ts#L80), [\`client.ts:146\`](https://github.com/agent-messenger/agent-messenger/blob/main/src/platforms/kakaotalk/client.ts#L146)). Agents using string-equality against the example would silently mismatch real output.
2. **SDK docs claim listener auto-reconnect with exponential backoff.** \`listener.ts\` has no reconnection loop and \`client.ts\` only auto-reconnects on \`CHANGESVR\` (immediate) or lazily on the next API call via \`executeWithReconnect\`. For arbitrary network drops, the listener emits \`disconnected\` and stays passive. The docs described behavior that doesn't exist.
3. **Diagnostic script leaks nicknames.** Header claimed PII redaction, but \`redact()\` had no coverage for \`nickName\`, \`name\`, \`fullName\`, the \`k\` member-name array, or \`ln\` (open-link name). Real names landed in capture files written to \`/tmp\` (world-readable, no \`chmod\`).
4. **Diagnostic script had several latent bugs** — \`finally\` doesn't run on SIGINT (socket leaks on Ctrl-C), private-internal \`sendRaw\` for commands that already have typed methods, member-id mapping that crashed on raw numbers, inverted type predicate on \`--commands\` parsing.

The two coverage gaps:

5. **Silent-disconnect tests don't actually verify reconnect.** [\`634dc38\`](https://github.com/agent-messenger/agent-messenger/commit/634dc38) added detection for \`statusCode: -1\` packets in \`getMembers\`/\`getMembersByIds\`, but the existing tests only assert \`assertLocoOk\` throws — they don't drive \`executeWithReconnect\`'s retry branch (which only fires when the socket also closed and \`this.state.session !== state.session\`). A regression in the reconnect logic would pass.
6. **\`getChats({resolveTitles: true})\` was untested for open chats.** Single-chat \`getChatTitle()\` had thorough open-chat coverage (5 tests), but the batch path was only exercised with regular chats — the fan-out that fires CHATINFO + INFOLINK fallback per chat was never tested for open chats.

## What changed

### \`cfac723\` — Fix \`author_id\` JSON example: number, not string

\`skills/agent-kakaotalk/SKILL.md\` line 386: \`\"author_id\": \"1111111111\"\` → \`\"author_id\": 1111111111\`. One-character fix.

### \`04eec9e\` — Correct KakaoTalkListener reconnection docs to match implementation

\`docs/content/docs/sdk/kakaotalk.mdx\`:

- Header: removed \"Manages its own LOCO session with automatic reconnection.\"
- Events table: \`disconnected\` description now reads \"LOCO session dropped (see Reconnection)\" instead of \"will auto-reconnect\".
- Reconnection section rewritten to document the actual three behaviors:
  - **\`CHANGESVR\`** — client immediately reconnects in the background, no consumer action required
  - **Network drop / peer close** — client emits \`disconnected\`; the next SDK API call lazily re-establishes the session via \`executeWithReconnect\`. Long-running listeners must drive reconnection from the \`disconnected\` event by calling \`acquireSession()\`
  - **\`KICKOUT\`** — listener stops and emits \`error\`; terminal, requires fresh \`login()\`

### \`03ac1a8\` — Harden kakao-loco-capture diagnostic script

\`scripts/kakao-loco-capture.ts\` (+77 / −34):

- **Add \`NAME_KEYS\`** covering \`nickName\`, \`name\`, \`fullName\`, \`authorName\`, \`author_name\`, \`k\`, \`ln\`. String values become \`<name:Nchars>\`. Array values inside name-keyed fields (notably \`k\`) get per-element redaction.
- **Extend \`selfCheckRedact()\`** to assert each name field is scrubbed in the fixture. The fixture now includes \`k: ['Alice', 'Bob', 'Charlie']\`, \`ln: 'My OpenChat Room'\`, \`name\`, \`fullName\` — all asserted-against. A regression in name redaction now fails loud before any LOCO call.
- **SIGINT/SIGTERM handlers**: explicit cleanup before \`process.exit(130)\`. \`finally\` does not run on signal termination, so without these the LOCO socket and ping timer leaked on Ctrl-C.
- **Replace \`sendRaw()\` with typed methods**: \`session.getMembersByIds()\`, \`session.getAllMembers()\`, \`session.getOpenLinkInfo()\` were all added in earlier commits. Drop the \`(session as unknown as SessionWithConnection).connection\` cast and the stale comment claiming the methods didn't exist.
- **\`toLong()\` helper** for member-id and link-id parsing. Handles both BSON \`{low, high}\` and raw numbers (\`chat.i\` can hold either per [\`client.ts:45\`](https://github.com/agent-messenger/agent-messenger/blob/main/src/platforms/kakaotalk/client.ts#L45)). Previous code crashed on the numeric branch.
- **Use \`os.tmpdir()\`** + \`writeFileSync(..., { mode: 0o600 })\` instead of hardcoded \`/tmp\` and the default world-readable mode.
- **Fix inverted type predicate** in \`--commands\` parsing — \`(c): c is Command\` was backwards (filter kept *unsupported* strings, but TypeScript believed the result was \`Command[]\`).
- **Stop printing \`args.account\` to stdout**. JSON payload already redacts; banner now shows \`<set>\` / \`<current>\`. Same treatment for \`chatId\` in the persisted args.

### \`1e505d4\` — Cover silent-disconnect retry and open-chat batch title resolution

\`src/platforms/kakaotalk/client.test.ts\` (+123):

- **\`reconnects and retries getMembers after silent disconnect (full executeWithReconnect path)\`** — captures the \`onClose\` callback registered during connect, then on the first \`getAllMembers\` call invokes that callback (simulating the LOCO TCP socket closing) before resolving with \`{statusCode: -1, body}\`. The close handler nulls \`this.state\`, \`assertLocoOk\` throws, \`executeWithReconnect\` sees \`state.session !== this.state.session\` and retries. Asserts the second call returns members and \`mockLogin\` was called twice (initial + reconnect). Closes the gap where every existing synthetic-disconnect test only verified throwing.

- **\`resolves open-chat titles via INFOLINK fallback in batch resolveTitles=true path\`** — mixed login snapshot with three chats: a regular MultiChat (CHATINFO TITLE meta), an open chat with TITLE meta (CHATINFO only), and an open chat without TITLE meta (CHATINFO empty + INFOLINK fallback). Asserts each chat resolves to the correct source, and that INFOLINK fires exactly once with the correct \`li\` value — verifying both that it skips the regular chat (not an open chat) and the open chat with a TITLE (short-circuit). Uses \`mockImplementation\` keyed on \`chatId.low\` because \`Promise.all\` resolution order is non-deterministic.

## Verification

- \`bun typecheck\` — clean
- \`bun lint\` — 0 warnings, 0 errors
- \`bun run format:check\` — clean on changed files (one pre-existing CSS error in \`docs/src/app/globals.css\` is on \`origin/main\` and unrelated)
- \`bun test src/platforms/kakaotalk/\` — **158 pass, 0 fail** (was 156; +2 from this PR)
- Diagnostic script smoke-tested: \`--help\`, dry-run plan, and \`selfCheckRedact()\` all pass
- The full \`bun run test\` has 9 pre-existing failures (slack token-extractor, channeltalk auth) and a hang on a webex auth flow, all reproducible on \`origin/main\`

## Out of scope

- Implementing the listener auto-reconnect loop the docs originally promised. The current \"caller drives reconnection on \`disconnected\`\" model is what \`listener.ts\` actually does today, and changing the model is a feature decision for a separate PR. This PR only fixes the docs to match reality.
- Refactoring \`MemberNameCache\` to also ingest \`getMembers()\` results (would defeat the \"no extra LOCO calls\" promise of [#187](https://github.com/agent-messenger/agent-messenger/pull/187)).
- Adding a hard ceiling on \`--max-chats\` in the diagnostic script. Conservative defaults (3 chats) and the \`--confirm\` gate are sufficient guardrails for a developer tool.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pre-rollout issues in the KakaoTalk module: corrects docs and `SKILL.md`, hardens the diagnostic capture script to avoid PII leaks, and adds missing tests for reconnect and open-chat title resolution. No production behavior changes.

- **Bug Fixes**
  - `SKILL.md`: `last_message.author_id` example is a number, not a string. Docs updated.
  - SDK docs: reconnection behavior corrected (no auto-retry loop; explains `CHANGESVR`, network drop, and `KICKOUT`).
  - `scripts/kakao-loco-capture.ts`: redact names (`nickName`, `name`, `fullName`, `authorName`, `author_name`, `k`, `ln`); add SIGINT/SIGTERM cleanup; switch to typed session methods; handle numeric and `Long` IDs; fix `--commands` predicate; write to `os.tmpdir()` with 0600; stop printing raw `account`/`chatId`.

- **Tests**
  - Add full retry path test: reconnects and retries `getMembers` after a silent disconnect via `executeWithReconnect`.
  - Add batch `resolveTitles=true` coverage for open chats using `INFOLINK` fallback.

<sup>Written for commit 1e505d40851db95406f5eaef879836eff08f7cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

