### PR TITLE
Re-export SlackBotEntry and SlackBotWorkspace from slackbot barrel

### DIFF
--- a/src/platforms/slackbot/index.test.ts
+++ b/src/platforms/slackbot/index.test.ts
@@ -5,8 +5,10 @@ import {
   SlackBotConfigSchema,
   SlackBotCredentialManager,
   SlackBotCredentialsSchema,
+  SlackBotEntrySchema,
   SlackBotError,
   SlackBotListener,
+  SlackBotWorkspaceSchema,
   SlackChannelSchema,
   SlackFileSchema,
   SlackMessageSchema,
@@ -36,6 +38,14 @@ it('SlackBotConfigSchema is exported from barrel', () => {
 
 it('SlackBotCredentialsSchema is exported from barrel', () => {
   expect(typeof SlackBotCredentialsSchema.parse).toBe('function')
+})
+
+it('SlackBotEntrySchema is exported from barrel', () => {
+  expect(typeof SlackBotEntrySchema.parse).toBe('function')
+})
+
+it('SlackBotWorkspaceSchema is exported from barrel', () => {
+  expect(typeof SlackBotWorkspaceSchema.parse).toBe('function')
 })
 
 it('SlackChannelSchema is exported from barrel', () => {

--- a/src/platforms/slackbot/index.ts
+++ b/src/platforms/slackbot/index.ts
@@ -5,7 +5,9 @@ export type { SlackBotListenerOptions } from './listener'
 export type {
   SlackBotConfig,
   SlackBotCredentials,
+  SlackBotEntry,
   SlackBotListenerEventMap,
+  SlackBotWorkspace,
   SlackChannel,
   SlackFile,
   SlackMessage,
@@ -34,7 +36,9 @@ export type {
 export {
   SlackBotConfigSchema,
   SlackBotCredentialsSchema,
+  SlackBotEntrySchema,
   SlackBotError,
+  SlackBotWorkspaceSchema,
   SlackChannelSchema,
   SlackFileSchema,
   SlackMessageSchema,


### PR DESCRIPTION
## Summary
Surfaces the two remaining credential-shape types — `SlackBotEntry` / `SlackBotWorkspace` — and their Zod schemas through the `agent-messenger/slackbot` barrel so the whole `SlackBotConfig` graph is reachable from SDK consumers.

## Why
`SlackBotConfig` (already re-exported) is a `Record<string, SlackBotWorkspace>`, and `SlackBotWorkspace` in turn holds a `Record<string, SlackBotEntry>`. Without the inner two types in the barrel, anyone walking the config tree from `agent-messenger/slackbot` had to either reach into `agent-messenger/slackbot/types` (not a documented entry point) or redeclare the structural types locally. Their Zod schemas (`SlackBotEntrySchema`, `SlackBotWorkspaceSchema`) were unreachable for the same reason, so consumers couldn't validate persisted credential snapshots without bypassing the public surface either. Every other named export in `src/platforms/slackbot/{client,listener,credential-manager,types}.ts` was already re-exported; these four were the only gaps.

## Changes
- `src/platforms/slackbot/index.ts` — add `SlackBotEntry`, `SlackBotWorkspace` to the `export type` block and `SlackBotEntrySchema`, `SlackBotWorkspaceSchema` to the runtime `export` block (alphabetised, matching the existing layout and the kakaotalk pattern).
- `src/platforms/slackbot/index.test.ts` — extend the barrel test to assert both new schemas are reachable from `@/platforms/slackbot/index` and expose `.parse`.

No runtime behaviour, public API, or CLI surface changes. Strictly additive re-exports.

## Tests
- `bun typecheck` clean
- `bun run lint` clean
- `bun run build` emits `dist/src/platforms/slackbot/index.d.ts` with the four new names present
- `bun test src/platforms/slackbot/` → 180 pass / 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported `SlackBotEntry`, `SlackBotWorkspace`, and their Zod schemas (`SlackBotEntrySchema`, `SlackBotWorkspaceSchema`) from the `agent-messenger/slackbot` barrel so consumers can traverse and validate the full `SlackBotConfig` graph. SKILL.md/docs: no updates needed; additive exports only.

<sup>Written for commit ca9c75b7aeab51aac9ad11f3c3a0e829afd6d525. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

