### PR TITLE
Expose DiscordBotListenerOptions from discordbot barrel

### DIFF
--- a/src/platforms/discordbot/index.test.ts
+++ b/src/platforms/discordbot/index.test.ts
@@ -17,6 +17,7 @@ import {
   DiscordReactionSchema,
   DiscordUserSchema,
 } from '@/platforms/discordbot/index'
+import type { DiscordBotListenerOptions } from '@/platforms/discordbot/index'
 
 it('DiscordBotClient is exported from barrel', () => {
   expect(typeof DiscordBotClient).toBe('function')
@@ -32,6 +33,11 @@ it('DiscordBotCredentialManager is exported from barrel', () => {
 
 it('DiscordBotListener is exported from barrel', () => {
   expect(typeof DiscordBotListener).toBe('function')
+})
+
+it('DiscordBotListenerOptions type is exported from barrel', () => {
+  const options: DiscordBotListenerOptions = { intents: 0 }
+  expect(options.intents).toBe(0)
 })
 
 it('DiscordGatewayOpcode is exported from barrel', () => {

--- a/src/platforms/discordbot/index.ts
+++ b/src/platforms/discordbot/index.ts
@@ -1,6 +1,7 @@
 export { DiscordBotClient } from './client'
 export { DiscordBotCredentialManager } from './credential-manager'
 export { DiscordBotListener } from './listener'
+export type { DiscordBotListenerOptions } from './listener'
 export type {
   DiscordBotConfig,
   DiscordBotCredentials,

--- a/src/platforms/discordbot/listener.ts
+++ b/src/platforms/discordbot/listener.ts
@@ -24,6 +24,10 @@ const DEFAULT_INTENTS =
 
 type EventKey = keyof DiscordBotListenerEventMap
 
+export interface DiscordBotListenerOptions {
+  intents?: number
+}
+
 export class DiscordBotListener {
   private client: DiscordBotClient
   private intents: number
@@ -43,7 +47,7 @@ export class DiscordBotListener {
   private cachedUser: { id: string; username: string } | null = null
   private generation = 0
 
-  constructor(client: DiscordBotClient, options?: { intents?: number }) {
+  constructor(client: DiscordBotClient, options?: DiscordBotListenerOptions) {
     this.client = client
     this.intents = options?.intents ?? DEFAULT_INTENTS
   }


### PR DESCRIPTION
## Summary

Names the `DiscordBotListener` constructor's options object as `DiscordBotListenerOptions` and re-exports it from `agent-messenger/discordbot`, bringing the discordbot barrel to full parity with the slackbot barrel (which already ships `SlackBotListenerOptions`).

## Why

SDK consumers building wrappers around `DiscordBotListener` had to either redeclare `{ intents?: number }` inline or import the underlying type from a non-public path. The slackbot barrel already documents its listener options as a first-class type (`SlackBotListenerOptions`); doing the same here closes the asymmetry and makes it possible to write strongly-typed factories without leaking inline object literal types into consumer codebases.

## Changes

- `src/platforms/discordbot/listener.ts` — extract the inline constructor parameter type into `export interface DiscordBotListenerOptions { intents?: number }`. The constructor signature becomes `constructor(client: DiscordBotClient, options?: DiscordBotListenerOptions)`. Structural compatibility means every existing call site keeps compiling unchanged.
- `src/platforms/discordbot/index.ts` — re-export the new interface as a type alongside the existing `DiscordBotListener` value export, matching the slackbot barrel layout.
- `src/platforms/discordbot/index.test.ts` — assert the type is reachable from the barrel and accepts `{ intents }`.

No runtime, protocol, or CLI behaviour changes.

## Tests

- `bun typecheck` clean
- `bun lint` clean
- `bun run build` emits `dist/src/platforms/discordbot/index.d.ts` re-exporting the new type and `dist/src/platforms/discordbot/listener.d.ts` declaring the interface
- `bun test src/platforms/discordbot/` → 245 pass / 0 fail (existing listener tests already exercise `{ intents }` at runtime)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a named `DiscordBotListenerOptions` type and re-export it from `agent-messenger/discordbot` for parity with Slack and better typing. No runtime changes; no SKILL.md or docs updates.

- **New Features**
  - Added `export interface DiscordBotListenerOptions { intents?: number }` and used it in the `DiscordBotListener` constructor.
  - Re-exported `DiscordBotListenerOptions` from the `discordbot` barrel.
  - Added a test to validate the type is available from the barrel.

<sup>Written for commit c65d9f9fba6b7b119a759af6203c8bb4cde8d5f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

