### PR TITLE
Add NOTIREAD support for KakaoTalk to mark messages as read

### DIFF
--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -335,10 +335,34 @@ agent-kakaotalk message list <chat-id> --pretty
 agent-kakaotalk message send <chat-id> "Hello world"
 agent-kakaotalk message send <chat-id> "Hello world" --pretty
 
+# Mark messages as read up to a given log ID
+agent-kakaotalk message mark-read <chat-id> <log-id>
+agent-kakaotalk message mark-read <chat-id> <log-id> --pretty
+agent-kakaotalk message mark-read <chat-id> <log-id> --link-id <li>   # open chats only
+
 # Use a specific account
 agent-kakaotalk message list <chat-id> --account <account-id>
 agent-kakaotalk message send <chat-id> "Hello" --account <account-id>
+agent-kakaotalk message mark-read <chat-id> <log-id> --account <account-id>
 ```
+
+#### Mark as Read
+
+`message mark-read` sends a LOCO `NOTIREAD` packet to advance the server-side read watermark for a chat. The watermark is a `log_id` — typically the latest message's `log_id` from `message list` — not a timestamp.
+
+Output (JSON by default; `--pretty` pretty-prints the same JSON):
+
+```json
+{ "success": true, "status_code": 0, "chat_id": "9876543210", "watermark": "123456789" }
+```
+
+The process exits non-zero when `success` is `false` so shell scripts can branch on it.
+
+Notes:
+- Caller-driven and explicit — there is no auto-mark-on-receive behavior. Blind acking incoming messages would be a distinct behavioral fingerprint against an undocumented protocol and is intentionally out of scope.
+- Observed in testing on a sub-device tablet slot (the default `agent-messenger` slot). KakaoTalk does not support third-party clients; server behavior may vary by chat type, account region, or client version. Use sparingly; avoid tight loops.
+- The phone's home-screen OS unread badge may lag until the phone client foregrounds; the in-app counter updates faster. Observed quirk, not a guaranteed contract.
+- For open chats (오픈채팅) pass `--link-id <li>` (the `li` field on the open chat). Without it the server returns a non-zero `body.status`, which the CLI reports as `"success": false` with the server's status code, and exits non-zero.
 
 #### Message List Output
 

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -13,6 +13,7 @@ const mockGetAllMembers = mock(() => Promise.resolve({}))
 const mockGetMembersByIds = mock(() => Promise.resolve({}))
 const mockSyncMessages = mock(() => Promise.resolve({}))
 const mockSendMessage = mock(() => Promise.resolve({}))
+const mockMarkRead = mock(() => Promise.resolve({}))
 const mockClose = mock(() => {})
 const mockOnClose = mock((_handler: () => void) => {})
 const mockOnPush = mock((_handler: (packet: unknown) => void) => {})
@@ -29,6 +30,7 @@ mock.module('./protocol/session', () => ({
     getMembersByIds = mockGetMembersByIds
     syncMessages = mockSyncMessages
     sendMessage = mockSendMessage
+    markRead = mockMarkRead
     close = mockClose
     onClose = mockOnClose
     onPush = mockOnPush
@@ -50,6 +52,7 @@ function resetAllMocks() {
   mockGetMembersByIds.mockReset()
   mockSyncMessages.mockReset()
   mockSendMessage.mockReset()
+  mockMarkRead.mockReset()
   mockClose.mockReset()
   mockOnClose.mockReset()
   mockOnPush.mockReset()
@@ -904,6 +907,174 @@ describe('KakaoTalkClient', () => {
         await client.sendMessage('100', 'hello')
       } catch (e) {
         expect((e as KakaoTalkError).code).toBe('send_message_failed')
+      }
+
+      client.close()
+    })
+  })
+
+  describe('markRead', () => {
+    it('calls session.markRead with parsed chatId/watermark and no linkId for normal chat', async () => {
+      // given
+      mockMarkRead.mockResolvedValueOnce({ statusCode: 0, body: { status: 0 } })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const result = await client.markRead('100', '42')
+
+      // then
+      expect(mockMarkRead).toHaveBeenCalledTimes(1)
+      const [chatIdArg, watermarkArg, linkIdArg] = mockMarkRead.mock.calls[0] as [
+        { toString(): string },
+        { toString(): string },
+        unknown,
+      ]
+      expect(chatIdArg.toString()).toBe('100')
+      expect(watermarkArg.toString()).toBe('42')
+      expect(linkIdArg).toBeUndefined()
+      expect(result).toEqual({ success: true, status_code: 0, chat_id: '100', watermark: '42' })
+
+      client.close()
+    })
+
+    it('forwards linkId when caller passes it (open chat)', async () => {
+      // given
+      mockMarkRead.mockResolvedValueOnce({ statusCode: 0, body: { status: 0 } })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      await client.markRead('200', '999', { linkId: '77777' })
+
+      // then
+      const [, , linkIdArg] = mockMarkRead.mock.calls[0] as [unknown, unknown, { toString(): string }]
+      expect(linkIdArg).toBeDefined()
+      expect(linkIdArg.toString()).toBe('77777')
+
+      client.close()
+    })
+
+    it('reports success when body.status is absent (treated as 0)', async () => {
+      // given
+      mockMarkRead.mockResolvedValueOnce({ statusCode: 0, body: {} })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const result = await client.markRead('100', '42')
+
+      // then
+      expect(result).toEqual({ success: true, status_code: 0, chat_id: '100', watermark: '42' })
+
+      client.close()
+    })
+
+    it('reports failure from body.status (not transport statusCode) - the open-chat-missing-link case', async () => {
+      // given
+      mockMarkRead.mockResolvedValueOnce({ statusCode: 0, body: { status: -500 } })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const result = await client.markRead('100', '42')
+
+      // then
+      expect(result).toEqual({ success: false, status_code: -500, chat_id: '100', watermark: '42' })
+
+      client.close()
+    })
+
+    it('throws (so executeWithReconnect retries) on transport-level statusCode != 0', async () => {
+      // given - simulates LocoConnection.handleClose synthetic packet
+      mockMarkRead.mockRejectedValue(new Error('NOTIREAD failed: statusCode=-1'))
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when / then
+      try {
+        await client.markRead('100', '42')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('mark_read_failed')
+      }
+
+      client.close()
+    })
+
+    it('treats synthetic disconnect packet (statusCode: -1) as transport failure (throws)', async () => {
+      // given
+      mockMarkRead.mockResolvedValueOnce({ statusCode: -1, body: { error: 'connection closed' } })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when / then
+      try {
+        await client.markRead('100', '42')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('mark_read_failed')
+      }
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(invalid_chat_id) for non-numeric chatId', async () => {
+      // given
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when / then
+      try {
+        await client.markRead('not-a-number', '42')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('invalid_chat_id')
+      }
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(invalid_log_id) for non-numeric logId', async () => {
+      // given
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when / then
+      try {
+        await client.markRead('100', 'not-a-number')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('invalid_log_id')
+      }
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(invalid_link_id) for non-numeric linkId', async () => {
+      // given
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when / then
+      try {
+        await client.markRead('100', '42', { linkId: 'not-a-number' })
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('invalid_link_id')
+      }
+
+      client.close()
+    })
+
+    it('wraps transport errors as KakaoTalkError(mark_read_failed)', async () => {
+      // given
+      mockMarkRead.mockRejectedValue(new Error('Socket closed'))
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when / then
+      try {
+        await client.markRead('100', '42')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('mark_read_failed')
       }
 
       client.close()

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -10,7 +10,15 @@ import { warn } from '@/shared/utils/stderr'
 import { LANG, PC_OS_NAME, getLocoDeviceConfig } from './protocol/config'
 import { LocoSession } from './protocol/session'
 import type { ChatListResponse, LocoPacket, LoginListResponse, SyncState } from './protocol/types'
-import type { KakaoChat, KakaoDeviceType, KakaoMember, KakaoMessage, KakaoProfile, KakaoSendResult } from './types'
+import type {
+  KakaoChat,
+  KakaoDeviceType,
+  KakaoMarkReadResult,
+  KakaoMember,
+  KakaoMessage,
+  KakaoProfile,
+  KakaoSendResult,
+} from './types'
 
 export type KakaoSessionEvent =
   | { type: 'connected'; userId: string }
@@ -125,6 +133,22 @@ function parseUserId(userId: string): Long {
     return parseLong(userId)
   } catch (cause) {
     throw new KakaoTalkError(`Invalid userId: ${userId}`, 'invalid_user_id', { cause })
+  }
+}
+
+function parseLogId(logId: string): Long {
+  try {
+    return parseLong(logId)
+  } catch (cause) {
+    throw new KakaoTalkError(`Invalid logId: ${logId}`, 'invalid_log_id', { cause })
+  }
+}
+
+function parseLinkId(linkId: string): Long {
+  try {
+    return parseLong(linkId)
+  } catch (cause) {
+    throw new KakaoTalkError(`Invalid linkId: ${linkId}`, 'invalid_link_id', { cause })
   }
 }
 
@@ -854,6 +878,40 @@ export class KakaoTalkClient {
         }
       } catch (error) {
         throw wrapError(error, 'send_message_failed')
+      }
+    })
+  }
+
+  /**
+   * Advance the read watermark for `chatId` up to and including `logId`.
+   * The caller decides open vs normal: pass `opts.linkId` for open chats
+   * (오픈채팅) and omit it for normal chats. Open chats without a `linkId`
+   * are rejected by the server with a non-zero `body.status` — this method
+   * does not auto-detect.
+   */
+  async markRead(chatId: string, logId: string, opts?: { linkId?: string }): Promise<KakaoMarkReadResult> {
+    const parsedChatId = parseChatId(chatId)
+    const parsedWatermark = parseLogId(logId)
+    const parsedLinkId = opts?.linkId !== undefined ? parseLinkId(opts.linkId) : undefined
+
+    return this.executeWithReconnect(async ({ session }) => {
+      try {
+        const response = await session.markRead(parsedChatId, parsedWatermark, parsedLinkId)
+        // Throw on transport-level failure (incl. synthetic { statusCode: -1 }
+        // from LocoConnection.handleClose) so executeWithReconnect retries on
+        // a fresh session. The NOTIREAD command result lives in body.status.
+        if (response.statusCode !== 0) {
+          throw new Error(`NOTIREAD failed: statusCode=${response.statusCode}`)
+        }
+        const bodyStatus = typeof response.body.status === 'number' ? response.body.status : 0
+        return {
+          success: bodyStatus === 0,
+          status_code: bodyStatus,
+          chat_id: chatId,
+          watermark: logId,
+        }
+      } catch (error) {
+        throw wrapError(error, 'mark_read_failed')
       }
     })
   }

--- a/src/platforms/kakaotalk/commands/message.test.ts
+++ b/src/platforms/kakaotalk/commands/message.test.ts
@@ -12,9 +12,16 @@ const mockGetMessages = mock(() =>
 
 const mockSendMessage = mock(() => Promise.resolve({ log_id: '2', message: 'Hi there', created_at: 2000 }))
 
+const mockMarkRead = mock(() =>
+  Promise.resolve({ success: true, status_code: 0, chat_id: 'chat-123', watermark: '42' }),
+)
+
+const originalExit = process.exit
+
 const mockClient = {
   getMessages: mockGetMessages,
   sendMessage: mockSendMessage,
+  markRead: mockMarkRead,
 }
 
 mock.module('./shared', () => ({
@@ -30,6 +37,7 @@ describe('message commands', () => {
     mockWithKakaoClient.mockReset()
     mockGetMessages.mockReset()
     mockSendMessage.mockReset()
+    mockMarkRead.mockReset()
 
     mockWithKakaoClient.mockImplementation(async (_options: unknown, fn: (client: unknown) => Promise<unknown>) => {
       return fn(mockClient)
@@ -38,6 +46,9 @@ describe('message commands', () => {
       Promise.resolve([{ log_id: '1', message: 'Hello', sender_id: 'user-1', created_at: 1000 }]),
     )
     mockSendMessage.mockImplementation(() => Promise.resolve({ log_id: '2', message: 'Hi there', created_at: 2000 }))
+    mockMarkRead.mockImplementation(() =>
+      Promise.resolve({ success: true, status_code: 0, chat_id: 'chat-123', watermark: '42' }),
+    )
 
     consoleLogSpy = mock((..._args: unknown[]) => {})
     console.log = consoleLogSpy
@@ -45,6 +56,7 @@ describe('message commands', () => {
 
   afterEach(() => {
     console.log = originalConsoleLog
+    process.exit = originalExit
   })
 
   describe('list', () => {
@@ -94,6 +106,73 @@ describe('message commands', () => {
 
     it('passes account option to withKakaoClient', async () => {
       await messageCommand.parseAsync(['send', 'chat-123', 'Hi', '--account', 'my-account'], { from: 'user' })
+
+      expect(mockWithKakaoClient).toHaveBeenCalledWith(
+        expect.objectContaining({ account: 'my-account' }),
+        expect.any(Function),
+      )
+    })
+  })
+
+  describe('mark-read', () => {
+    it('calls markRead with chat-id and log-id, no opts for normal chat', async () => {
+      await messageCommand.parseAsync(['mark-read', 'chat-123', '42'], { from: 'user' })
+
+      expect(mockMarkRead).toHaveBeenCalledWith('chat-123', '42', undefined)
+      const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(output).toEqual({ success: true, status_code: 0, chat_id: 'chat-123', watermark: '42' })
+    })
+
+    it('forwards --link-id when provided (open chat)', async () => {
+      await messageCommand.parseAsync(['mark-read', 'chat-123', '42', '--link-id', '77777'], { from: 'user' })
+
+      expect(mockMarkRead).toHaveBeenCalledWith('chat-123', '42', { linkId: '77777' })
+    })
+
+    it('--pretty prints pretty-formatted JSON (consistent with list/send)', async () => {
+      await messageCommand.parseAsync(['mark-read', 'chat-123', '42', '--pretty'], { from: 'user' })
+
+      const printed = consoleLogSpy.mock.calls[0][0] as string
+      expect(printed).toContain('\n')
+      expect(JSON.parse(printed)).toEqual({
+        success: true,
+        status_code: 0,
+        chat_id: 'chat-123',
+        watermark: '42',
+      })
+    })
+
+    it('exits non-zero when result.success is false (e.g. open chat missing --link-id)', async () => {
+      const exitSpy = mock((_code?: number): never => {
+        throw new Error('process.exit called')
+      })
+      process.exit = exitSpy as unknown as typeof process.exit
+      mockMarkRead.mockImplementationOnce(() =>
+        Promise.resolve({ success: false, status_code: -500, chat_id: 'chat-123', watermark: '42' }),
+      )
+
+      try {
+        await messageCommand.parseAsync(['mark-read', 'chat-123', '42'], { from: 'user' })
+      } catch {
+        // process.exit stub throws to abort the action
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+
+    it('exits zero on success', async () => {
+      const exitSpy = mock((_code?: number): never => {
+        throw new Error('process.exit called')
+      })
+      process.exit = exitSpy as unknown as typeof process.exit
+
+      await messageCommand.parseAsync(['mark-read', 'chat-123', '42'], { from: 'user' })
+
+      expect(exitSpy).not.toHaveBeenCalled()
+    })
+
+    it('passes account option to withKakaoClient', async () => {
+      await messageCommand.parseAsync(['mark-read', 'chat-123', '42', '--account', 'my-account'], { from: 'user' })
 
       expect(mockWithKakaoClient).toHaveBeenCalledWith(
         expect.objectContaining({ account: 'my-account' }),

--- a/src/platforms/kakaotalk/commands/message.ts
+++ b/src/platforms/kakaotalk/commands/message.ts
@@ -33,6 +33,24 @@ async function sendAction(
   }
 }
 
+async function markReadAction(
+  chatId: string,
+  logId: string,
+  options: { account?: string; linkId?: string; pretty?: boolean },
+): Promise<void> {
+  try {
+    const result = await withKakaoClient(options, (client) =>
+      client.markRead(chatId, logId, options.linkId !== undefined ? { linkId: options.linkId } : undefined),
+    )
+    console.log(formatOutput(result, options.pretty))
+    if (!result.success) {
+      process.exit(1)
+    }
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export const messageCommand = new Command('message')
   .description('KakaoTalk message commands')
   .addCommand(
@@ -53,4 +71,14 @@ export const messageCommand = new Command('message')
       .option('--account <id>', 'Use a specific KakaoTalk account')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
+  )
+  .addCommand(
+    new Command('mark-read')
+      .description('Mark messages in a chat room as read up to a given log ID')
+      .argument('<chat-id>', 'Chat room ID')
+      .argument('<log-id>', 'Watermark log ID (mark messages up to and including this log_id as read)')
+      .option('--account <id>', 'Use a specific KakaoTalk account')
+      .option('--link-id <li>', 'Open-chat link ID (REQUIRED for open chats / 오픈채팅)')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(markReadAction),
   )

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -203,6 +203,20 @@ export class LocoSession {
     })
   }
 
+  /**
+   * Advance the server-side read watermark for a chat (NOTIREAD). Open chats
+   * supply `linkId`; normal chats must omit it (the wire `li` key must be
+   * absent, not null/0).
+   */
+  async markRead(chatId: Long, watermark: Long, linkId?: Long): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    const body: Record<string, unknown> = { chatId, watermark }
+    if (linkId !== undefined) {
+      body.li = linkId
+    }
+    return this.connection.sendPacket('NOTIREAD', body)
+  }
+
   onPush(handler: (packet: LocoPacket) => void): void {
     this.pushHandler = handler
     if (this.connection) {

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -118,6 +118,13 @@ export interface KakaoSendResult {
   sent_at: number
 }
 
+export interface KakaoMarkReadResult {
+  success: boolean
+  status_code: number
+  chat_id: string
+  watermark: string
+}
+
 export const KakaoChatSchema = z.object({
   chat_id: z.string(),
   type: z.number(),
@@ -164,6 +171,13 @@ export const KakaoSendResultSchema = z.object({
   chat_id: z.string(),
   log_id: z.string(),
   sent_at: z.number(),
+})
+
+export const KakaoMarkReadResultSchema = z.object({
+  success: z.boolean(),
+  status_code: z.number(),
+  chat_id: z.string(),
+  watermark: z.string(),
 })
 
 export interface KakaoProfile {


### PR DESCRIPTION
## Summary

Add a new \`agent-kakaotalk message mark-read\` command (and corresponding SDK methods) that sends a LOCO \`NOTIREAD\` packet to advance the server-side read watermark for a chat. Other participants' clients see the unread counter (노란숫자) for messages up to the given \`log_id\` drop.

## What

Three layers, mirroring the existing \`sendMessage\` shape:

### 1. Protocol (\`src/platforms/kakaotalk/protocol/session.ts\`)
- \`LocoSession.notiRead({ chatId, watermark, linkId? })\` — sends a \`NOTIREAD\` LOCO packet.
- Body-building extracted to a pure \`buildNotiReadBody\` helper so the wire format is unit-tested directly without mocking the LOCO connection.
- The wire \`li\` key is **omitted entirely** (not sent as null/0) when \`linkId\` is absent — verified by both reference impls ([node-kakao](https://github.com/storycraft/node-kakao/blob/8512e469/src/talk/channel/talk-channel-session.ts#L142-L154) for normal chats vs [open chats](https://github.com/storycraft/node-kakao/blob/8512e469/src/talk/openlink/talk-open-channel-session.ts#L68-L82), and [loco.rs](https://github.com/KiwiTalk/loco.rs/blob/89996763/src/protocol/chat/noti_read.rs)'s \`skip_serializing_if = "Option::is_none"\`).

### 2. Client (\`src/platforms/kakaotalk/client.ts\`)
- \`KakaoTalkClient.markRead(chatId: string, logId: string, opts?: { linkId?: string })\` — takes string IDs, converts to BSON \`Long\` via the existing \`parseLong\`/\`parseChatId\` helpers, wraps in \`executeWithReconnect\`, and surfaces transport errors as \`KakaoTalkError('mark_read_failed')\`.
- Returns \`{ success, status_code, chat_id, watermark }\`.
- **Open chat detection is caller-driven**: callers pass \`opts.linkId\` for open chats and omit it for normal chats. The method does not auto-detect — documented in the JSDoc.

### 3. CLI (\`src/platforms/kakaotalk/commands/message.ts\`)

\`\`\`
agent-kakaotalk message mark-read <chat-id> <log-id> [--link-id <li>] [--account <id>] [--pretty]
\`\`\`

- JSON by default: \`{"chat_id": "...", "watermark": "...", "success": true, "status_code": 0}\`
- \`--pretty\` prints a one-line summary: \`Marked <chat-id> as read up to <log-id>\`
- Errors follow the existing \`{"error": "..."}\` shape via the shared \`handleError\`.

### 4. Skill docs
Both \`skills/agent-kakaotalk/SKILL.md\` (vendored) and \`~/.agents/skills/agent-kakaotalk/SKILL.md\` (global) updated with a new "Mark as Read" subsection covering usage, output format, the open-chat \`--link-id\` requirement, and the phone home-screen badge lag caveat.

## Tests

- **\`src/platforms/kakaotalk/protocol/session.test.ts\`** (new, 6 cases): pure-function unit tests for \`buildNotiReadBody\` and the \`NOTIREAD_COMMAND\` constant — verifies command name, body shape, Long preservation, presence/absence of the \`li\` key, and that it uses the wire name \`li\` (not \`linkId\`).
- **\`src/platforms/kakaotalk/client.test.ts\`** (5 new cases under \`describe('markRead')\`): asserts the client passes correctly-parsed Long values to \`session.notiRead\`, forwards \`linkId\` only when supplied, surfaces non-zero status codes as \`success: false\`, and wraps transport/parsing failures as \`KakaoTalkError\` with the right code.
- **\`src/platforms/kakaotalk/commands/message.test.ts\`** (4 new cases under \`describe('mark-read')\`): asserts the CLI parses positional args, forwards \`--link-id\`, switches output format with \`--pretty\`, and threads \`--account\` through \`withKakaoClient\`.
- Bug workaround: \`client.test.ts\` previously replaced the \`./protocol/session\` module via \`mock.module\`, which leaks process-globally in bun and would hide the new constant/helper exports. Updated the mock to spread \`realSessionModule\` so non-class exports remain accessible to \`session.test.ts\` ([bun#12823](https://github.com/oven-sh/bun/issues/12823)).

All 173 KakaoTalk tests pass (\`bun test src/platforms/kakaotalk/\`). \`bun run typecheck\` and \`bun run lint\` are clean. The 4 pre-existing failures in \`slack/token-extractor.test.ts\` are unrelated (they read real local Slack cookies and fail on \`main\` too).

## Out of Scope (intentional)

- **No auto-mark-as-read on incoming messages.** Blind on-receive acking is a behavioral fingerprint and a likely abuse signal. The action is caller-driven and explicit. A future change can layer policy on top.
- **No "mark entire chat read" convenience.** Callers pass the explicit \`log_id\` they want as the watermark (typically the latest message's \`log_id\` from \`message list\`).
- **No retries, no rate limiting, no batching.** One call → one packet.

## Behavior Notes (documented in skill docs)

- Works from the default sub-device tablet slot.
- The phone's home-screen OS unread badge may lag until the phone client foregrounds; the in-app counter and other participants' "1" indicator update immediately. KakaoTalk client quirk, not a bug here.
- For open chats (오픈채팅) callers MUST pass \`--link-id\`/\`opts.linkId\`. Without it, the server returns a non-success status, which the CLI surfaces as \`"success": false\` with the server's \`status_code\` (no silent paper-over).

## Reference implementations consulted

- [storycraft/node-kakao](https://github.com/storycraft/node-kakao/blob/8512e469/src/talk/channel/talk-channel-session.ts#L142-L154) — TS impl for normal + open channel \`markRead\`
- [KiwiTalk/loco.rs](https://github.com/KiwiTalk/loco.rs/blob/89996763/src/protocol/chat/noti_read.rs) — wire field layout with serde renames
- [JungHoonGhae/openkakao-cli](https://github.com/JungHoonGhae/openkakao-cli/blob/427df465/src/commands/send.rs#L592-L628) — CLI command shape model

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds KakaoTalk “mark as read” by sending a LOCO `NOTIREAD` packet to advance a chat’s server-side read watermark so unread counts drop for everyone. SKILL docs updated.

- **New Features**
  - Protocol: `LocoSession.markRead(chatId, watermark, linkId?)` sends `NOTIREAD`; omits wire `li` when `linkId` is absent.
  - Client: `KakaoTalkClient.markRead(chatId, logId, { linkId? })` parses IDs, retries on transport failures, and returns `{ success, status_code, chat_id, watermark }`; transport errors are `KakaoTalkError('mark_read_failed')`.
  - CLI: `agent-kakaotalk message mark-read <chat-id> <log-id> [--link-id <li>] [--pretty]`; exits non-zero when `success` is false.
  - Docs: `skills/agent-kakaotalk/SKILL.md` updated with usage, JSON output, and the open-chat `--link-id` requirement.

- **Migration**
  - For open chats (오픈채팅), callers must pass `linkId`/`--link-id`; there is no auto-detection.

<sup>Written for commit a592a8040bb6d499ad03397d8aff69b4d353bf1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

