### PR TITLE
Lower KakaoTalk LOCO ping interval to 20s

### DIFF
--- a/src/platforms/kakaotalk/protocol/config.ts
+++ b/src/platforms/kakaotalk/protocol/config.ts
@@ -36,7 +36,7 @@ export const LANG = 'ko'
 export const COUNTRY_ISO = 'KR'
 export const PROTOCOL_VERSION = '1'
 
-export const PING_INTERVAL_MS = 300_000
+export const PING_INTERVAL_MS = 20_000
 
 export interface LocoDeviceConfig {
   os: string


### PR DESCRIPTION
## Summary

Reduces `PING_INTERVAL_MS` from 300 000 ms (5 min) to 20 000 ms (20 s) for KakaoTalk LOCO keepalive pings on PC sub-device and Android tablet sessions.

## Why

At 5-minute intervals, silent disconnects (NAT timeout, proxy eviction, mobile data handoff) go undetected for up to 5 minutes. The session appears alive but all outgoing LOCO commands fail or hang until the next reconnect attempt. Lowering to 20 s means the keepalive path detects a broken connection and triggers reconnection within at most 20 s instead of 300 s.

A secondary benefit is keeping NAT and stateful-proxy state warm: many mobile carriers and corporate proxies expire UDP/TCP mappings after 30–60 s of silence. 20 s stays well under that threshold.

## Trade-off

~14 extra small PING frames per minute per active session (each PING/PONG exchange is a handful of bytes). At typical usage volumes this is negligible.

## Change

`src/platforms/kakaotalk/protocol/config.ts`

```diff
-export const PING_INTERVAL_MS = 300_000
+export const PING_INTERVAL_MS = 20_000
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered `PING_INTERVAL_MS` for KakaoTalk LOCO keepalive to 20s on PC sub-device and Android tablet sessions to detect broken connections faster and keep NAT/proxy state warm. This reduces worst-case reconnects from 5m to 20s with negligible overhead; no SKILL.md or docs updates.

<sup>Written for commit 0932e23a38e3679a463aeeabc33a99eced0e86b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

