### PR TITLE
Expose parsed attachment field on KakaoTalk messages

### DIFF
--- a/docs/content/docs/cli/kakaotalk.mdx
+++ b/docs/content/docs/cli/kakaotalk.mdx
@@ -184,10 +184,11 @@ agent-kakaotalk message send <chat-id> "Hello" --account <account-id>
 Each message includes:
 
 - `log_id` — unique message identifier
-- `type` — message type (1 = text, 2 = photo, etc.)
+- `type` — message type (1 = text, 2 = photo, 12 = sticker, 20 = animated sticker, etc.)
 - `author_id` — sender's user ID
 - `author_name` — sender's nickname when known from the chat list (otherwise `null`; only the room's "display members" are cached)
-- `message` — message text content
+- `message` — message text content (empty string for non-text messages like stickers)
+- `attachment` — parsed JSON metadata for non-text messages (e.g. photo URL/dimensions, sticker path), or `null` for plain text. Shape varies by `type`; treat as an opaque object and narrow per message type.
 - `sent_at` — Unix timestamp (milliseconds)
 
 #### Fetching More Messages
@@ -253,7 +254,7 @@ Output includes:
 - No open chat browsing or joining
 - No search across chats
 
-- Plain text messages only (no photos, videos, or rich content)
+- Read-only for rich content: photos, stickers, files, and other non-text messages are exposed via the `attachment` field on each message, but sending them is not supported
 - Chat IDs are numeric and not human-readable — use `chat list` to discover them
 
 ## Troubleshooting

--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -71,6 +71,8 @@ const newer = await client.getMessages('9876543210', { from: '123456789' })
 
 Each `KakaoMessage` carries an `author_name: string | null`. The SDK auto-populates this from the same chat-list response that already arrives at login (no extra LOCO calls). It resolves for "display members" — the small set of nicknames KakaoTalk includes in the chat list — and is `null` for everyone else.
 
+Each `KakaoMessage` also carries an `attachment: Record<string, unknown> | null`. For text messages this is `null`. For non-text messages (photos, videos, files, stickers, etc.) it is the parsed LOCO attachment payload — a JSON object whose shape varies by `type`. Photo messages use fields like `k` (CDN key), `w`/`h` (dimensions), `mt` (mime type), and `url`; sticker messages use `path`/`emoticonItemPath`. Treat it as opaque and narrow per `type`.
+
 ### Members
 
 ```typescript

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -368,10 +368,11 @@ Notes:
 
 Each message includes:
 - `log_id` — unique message identifier
-- `type` — message type (1 = text, 2 = photo, etc.)
+- `type` — message type (1 = text, 2 = photo, 12 = sticker, 20 = animated sticker, etc.)
 - `author_id` — sender's user ID
 - `author_name` — sender's nickname when known from the chat list (otherwise `null`; only the room's "display members" are cached)
-- `message` — message text content
+- `message` — message text content (empty string for non-text messages like stickers)
+- `attachment` — parsed JSON metadata for non-text messages (e.g. photo URL/dimensions, sticker path), or `null` for plain text. Shape varies by `type`; treat as an opaque object and narrow per message type.
 - `sent_at` — Unix timestamp (milliseconds)
 
 #### Fetching More Messages
@@ -547,7 +548,7 @@ See the [KakaoTalk SDK documentation](https://agent-messenger.dev/docs/sdk/kakao
 - No message editing or deletion
 - No open chat (오픈채팅) browsing or joining
 - No search across chats
-- Plain text messages only (no photos, videos, or rich content)
+- Read-only for rich content: photos, stickers, files, and other non-text messages are exposed via the `attachment` field on each message, but sending them is not supported
 - Chat IDs are numeric and not human-readable — use `chat list` to discover them
 
 ## Troubleshooting

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -774,6 +774,7 @@ describe('KakaoTalkClient', () => {
         author_id: 42,
         author_name: null,
         message: 'hello',
+        attachment: null,
         sent_at: 1700000001,
       })
       expect(messages[1]).toEqual({
@@ -782,6 +783,7 @@ describe('KakaoTalkClient', () => {
         author_id: 43,
         author_name: null,
         message: 'world',
+        attachment: null,
         sent_at: 1700000002,
       })
 
@@ -855,6 +857,65 @@ describe('KakaoTalkClient', () => {
 
       expect(messages[0].message).toBe('first')
       expect(messages[1].message).toBe('second')
+
+      client.close()
+    })
+
+    it('parses chatLog.attachment JSON for photo messages', async () => {
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: {
+          status: 0,
+          chatLogs: [
+            {
+              logId: makeLong(20),
+              chatId: 100,
+              type: 2,
+              authorId: 42,
+              message: '사진',
+              sendAt: 1700000010,
+              attachment: '{"k":"path/to/img.jpg","w":1320,"h":2868,"mt":"image/jpeg"}',
+            },
+          ],
+          eof: true,
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100')
+
+      expect(messages[0].attachment).toEqual({
+        k: 'path/to/img.jpg',
+        w: 1320,
+        h: 2868,
+        mt: 'image/jpeg',
+      })
+
+      client.close()
+    })
+
+    it('returns null attachment for malformed JSON', async () => {
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: {
+          status: 0,
+          chatLogs: [
+            {
+              logId: makeLong(21),
+              chatId: 100,
+              type: 1,
+              authorId: 42,
+              message: 'broken',
+              sendAt: 1700000011,
+              attachment: 'not-json',
+            },
+          ],
+          eof: true,
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100')
+
+      expect(messages[0].attachment).toBeNull()
 
       client.close()
     })

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -113,6 +113,18 @@ function longToString(v: unknown): string {
   return String(v ?? 0)
 }
 
+function parseAttachmentJson(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    const attachment = parsed as Record<string, unknown>
+    return Object.keys(attachment).length > 0 ? attachment : null
+  } catch {
+    return null
+  }
+}
+
 function parseLong(s: string): Long {
   const big = BigInt(s)
   const low = Number(big & 0xffffffffn)
@@ -422,6 +434,7 @@ function formatMessages(
     author_id: log.authorId as number,
     author_name: nameCache.lookup(chatId, log.authorId as number),
     message: log.message as string,
+    attachment: parseAttachmentJson(log.attachment),
     sent_at: log.sendAt as number,
   }))
 }

--- a/src/platforms/kakaotalk/listener.test.ts
+++ b/src/platforms/kakaotalk/listener.test.ts
@@ -412,6 +412,153 @@ describe('KakaoTalkListener', () => {
     })
   })
 
+  describe('attachment field', () => {
+    it('parses chatLog.attachment JSON into a structured field', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 200 },
+          authorId: 42,
+          message: '사진',
+          type: 2,
+          sendAt: 1700000000,
+          attachment:
+            '{"k":"abc/photo.jpg","w":1320,"h":2868,"s":438315,"mt":"image/jpeg","url":"https://talk.kakaocdn.net/p"}',
+        },
+      })
+
+      expect(messages[0].attachment).toEqual({
+        k: 'abc/photo.jpg',
+        w: 1320,
+        h: 2868,
+        s: 438315,
+        mt: 'image/jpeg',
+        url: 'https://talk.kakaocdn.net/p',
+      })
+    })
+
+    it('returns null when attachment is "{}" (text messages have no payload)', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 201 },
+          authorId: 42,
+          message: 'hi',
+          type: 1,
+          sendAt: 1700000001,
+          attachment: '{}',
+        },
+      })
+
+      expect(messages[0].attachment).toBeNull()
+    })
+
+    it('returns null when attachment is absent', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 202 },
+          authorId: 42,
+          message: 'hi',
+          type: 1,
+          sendAt: 1700000002,
+        },
+      })
+
+      expect(messages[0].attachment).toBeNull()
+    })
+
+    it('returns null when attachment is an empty string', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 203 },
+          authorId: 42,
+          message: '',
+          type: 1,
+          sendAt: 1700000003,
+          attachment: '',
+        },
+      })
+
+      expect(messages[0].attachment).toBeNull()
+    })
+
+    it('returns null when attachment is malformed JSON', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 204 },
+          authorId: 42,
+          message: '',
+          type: 1,
+          sendAt: 1700000004,
+          attachment: 'not-json{',
+        },
+      })
+
+      expect(messages[0].attachment).toBeNull()
+    })
+
+    it('returns null when attachment is a JSON array (non-object)', async () => {
+      const { listener: l, client } = createListener()
+      listener = l
+
+      const messages: KakaoTalkPushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      client.emitPush('MSG', {
+        chatId: { high: 0, low: 100 },
+        chatLog: {
+          logId: { high: 0, low: 205 },
+          authorId: 42,
+          message: '',
+          type: 1,
+          sendAt: 1700000005,
+          attachment: '[1,2,3]',
+        },
+      })
+
+      expect(messages[0].attachment).toBeNull()
+    })
+  })
+
   describe('member events', () => {
     it('emits member_joined on NEWMEM push', async () => {
       const { listener: l, client } = createListener()

--- a/src/platforms/kakaotalk/listener.ts
+++ b/src/platforms/kakaotalk/listener.ts
@@ -31,13 +31,12 @@ function parseAttachmentJson(raw: unknown): Record<string, unknown> | null {
   if (typeof raw !== 'string' || raw.length === 0) return null
   try {
     const parsed = JSON.parse(raw) as unknown
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>
-    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    const attachment = parsed as Record<string, unknown>
+    return Object.keys(attachment).length > 0 ? attachment : null
   } catch {
     return null
   }
-  return null
 }
 
 function nonEmptyString(value: unknown): string | null {
@@ -148,6 +147,8 @@ export class KakaoTalkListener {
         const authorName = this.client.lookupAuthorName?.(chatId, authorId) ?? null
         const sentAt = chatLog.sendAt as number
 
+        const attachment = parseAttachmentJson(chatLog.attachment)
+
         const messageEvent: KakaoTalkPushMessageEvent = {
           type: 'MSG',
           chat_id: chatId,
@@ -156,12 +157,12 @@ export class KakaoTalkListener {
           author_name: authorName,
           message: chatLog.message as string,
           message_type: messageType,
+          attachment,
           sent_at: sentAt,
         }
         this.emitter.emit('message', messageEvent)
 
         if (isEmoticonType(messageType)) {
-          const attachment = parseAttachmentJson(chatLog.attachment)
           const stickerPath = nonEmptyString(attachment?.path) ?? nonEmptyString(attachment?.emoticonItemPath)
           const emoticonEvent: KakaoTalkPushEmoticonEvent = {
             type: 'EMOTICON',

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -90,6 +90,7 @@ export interface KakaoMessage {
   author_id: number
   author_name: string | null
   message: string
+  attachment: Record<string, unknown> | null
   sent_at: number
 }
 
@@ -148,6 +149,7 @@ export const KakaoMessageSchema = z.object({
   author_id: z.number(),
   author_name: z.string().nullable(),
   message: z.string(),
+  attachment: z.record(z.string(), z.unknown()).nullable(),
   sent_at: z.number(),
 })
 
@@ -237,6 +239,7 @@ export interface KakaoTalkPushMessageEvent {
   author_name: string | null
   message: string
   message_type: number
+  attachment: Record<string, unknown> | null
   sent_at: number
 }
 
@@ -314,6 +317,7 @@ export const KakaoTalkPushMessageEventSchema = z.object({
   author_name: z.string().nullable(),
   message: z.string(),
   message_type: z.number(),
+  attachment: z.record(z.string(), z.unknown()).nullable(),
   sent_at: z.number(),
 })
 


### PR DESCRIPTION
## Summary

KakaoTalk's LOCO `chatLog` carries an `attachment` field — a JSON string with rich metadata for every non-text message. Today this field is dropped at the listener and `getMessages` boundary, so consumers see e.g. a photo as just `{ message: '사진', message_type: 2 }` with no URL, dimensions, or mime type.

This PR parses `attachment` into a structured `Record<string, unknown> | null` and exposes it on:

- `KakaoMessage` (returned from `client.getMessages()`)
- `KakaoTalkPushMessageEvent` (real-time push via `KakaoTalkListener`)

## Wire format (validated against live LOCO captures)

\`\`\`jsonc
// photo (type=2)
"attachment": "{\"k\":\"path/to/img.jpg\",\"w\":1320,\"h\":2868,\"s\":438315,\"cs\":\"...\",\"mt\":\"image/jpeg\",\"thumbnailUrl\":\"https://talk.kakaocdn.net/...\",\"url\":\"https://talk.kakaocdn.net/...\",\"expire\":1779779121254}"

// plain text (type=1)
"attachment": "{}"

// emoticon (type=12)
"attachment": "{\"path\":\"2222149.emot_004.png\",\"emoticonItemPath\":\"2222149.emot_004.png\",\"name\":\"(emoticon)\"}"
\`\`\`

The parser is intentionally untyped (`Record<string, unknown> | null`) — different message types use different schemas (photo uses short codes `k`/`w`/`h`/`s`/`mt`, emoticon uses `path`/`emoticonItemPath`/`name`, etc.). Consumers narrow the shape themselves based on `message_type`.

## Defensive parsing

| Input | Output |
| --- | --- |
| valid JSON object with keys | parsed object |
| `"{}"` (text-message payload) | **`null`** |
| missing field | `null` |
| empty string | `null` |
| malformed JSON | `null` (no throw) |
| JSON array / primitive | `null` |

Consumers can use a simple truthiness check (`if (msg.attachment)`) without needing to also test `Object.keys(msg.attachment).length`.

## Tests

8 new unit tests:

- `listener.test.ts` (6 cases) — photo attachment parsing, `{}` → null, missing field, empty string, malformed JSON, JSON array rejection
- `client.test.ts` (2 cases) — photo attachment parsing via `getMessages`, malformed JSON

\`\`\`
182 pass, 0 fail across the full src/platforms/kakaotalk/ suite
\`\`\`

## Self-review changes

After opening this PR, ran a multi-agent self-review. Addressed:

- **`{}` semantics**: the original parser returned `{}` (truthy empty object) for text messages, forcing consumers to write `if (msg.attachment && Object.keys(msg.attachment).length)`. Now normalized to `null`.
- **Fixed misleading test name** at `listener.test.ts` (test said "returns null when attachment is '{}'" but asserted `{}`).
- **Docs sync**: `skills/agent-kakaotalk/SKILL.md` updated to document the new `attachment` field in message list output, and removed the now-false "Plain text messages only" claim from the Limitations section.

## Notes for reviewers

- The two existing `getMessages` snapshot assertions were updated to include the new `attachment: null` field.
- Helpers (`parseAttachmentJson`) are duplicated in `listener.ts` and `client.ts` to match the existing pattern in this module (e.g. `longToString` is also duplicated). Extracting them to a shared `loco-utils.ts` is a sensible follow-up but kept out of scope to minimize this PR's diff.
- This change is complementary to #198 (typed emoticon event). The two PRs touch overlapping lines in `listener.ts` and `types.ts`; trivial merge conflict expected if both land — the second to merge will need a quick rebase.