### PR TITLE
Refresh Slack tokens across all known workspaces when team id is unknown

### DIFF
--- a/src/platforms/slack/commands/auth.ts
+++ b/src/platforms/slack/commands/auth.ts
@@ -106,7 +106,9 @@ async function extractAction(options: {
 
         if (options.debug) {
           const domain = workspaceDomains[ws.workspace_id]
-          const target = domain ? `${ws.workspace_id} (${domain}.slack.com)` : `${ws.workspace_id} (trying all known domains)`
+          const target = domain
+            ? `${ws.workspace_id} (${domain}.slack.com)`
+            : `${ws.workspace_id} (trying all known domains)`
           debug(`[debug] Attempting web token refresh for ${target}...`)
         }
         const refreshed = await tryWebTokenRefresh(ws, workspaceDomains)

--- a/src/platforms/slack/commands/auth.ts
+++ b/src/platforms/slack/commands/auth.ts
@@ -106,19 +106,19 @@ async function extractAction(options: {
 
         if (options.debug) {
           const domain = workspaceDomains[ws.workspace_id]
-          debug(
-            `[debug] Attempting web token refresh for ${ws.workspace_id}${domain ? ` (${domain}.slack.com)` : ''}...`,
-          )
+          const target = domain ? `${ws.workspace_id} (${domain}.slack.com)` : `${ws.workspace_id} (trying all known domains)`
+          debug(`[debug] Attempting web token refresh for ${target}...`)
         }
         const refreshed = await tryWebTokenRefresh(ws, workspaceDomains)
         if (refreshed) {
           ws.token = refreshed.token
+          ws.workspace_id = refreshed.workspace_id
           ws.workspace_name = refreshed.workspace_name
           validWorkspaces.push(ws)
           await credManager.setWorkspace(ws)
 
           if (options.debug) {
-            debug(`[debug] ✓ Web refresh succeeded: ${refreshed.workspace_name}`)
+            debug(`[debug] ✓ Web refresh succeeded: ${refreshed.workspace_id}/${refreshed.workspace_name}`)
           }
         } else if (options.debug) {
           debug('[debug] ✗ Web refresh failed')

--- a/src/platforms/slack/ensure-auth.test.ts
+++ b/src/platforms/slack/ensure-auth.test.ts
@@ -10,10 +10,12 @@ let extractSpy: ReturnType<typeof spyOn>
 let extractCookieSpy: ReturnType<typeof spyOn>
 let getWorkspaceDomainsSpy: ReturnType<typeof spyOn>
 let testAuthSpy: ReturnType<typeof spyOn>
+let loginSpy: ReturnType<typeof spyOn>
 let setWorkspaceSpy: ReturnType<typeof spyOn>
 let loadSpy: ReturnType<typeof spyOn>
 let setCurrentWorkspaceSpy: ReturnType<typeof spyOn>
 let fetchSpy: ReturnType<typeof spyOn>
+let activeToken: string | null = null
 
 beforeEach(() => {
   getWorkspaceSpy = spyOn(CredentialManager.prototype, 'getWorkspace').mockResolvedValue(null)
@@ -30,6 +32,15 @@ beforeEach(() => {
   extractCookieSpy = spyOn(TokenExtractor.prototype, 'extractCookie').mockResolvedValue('xoxd-fresh-cookie')
 
   getWorkspaceDomainsSpy = spyOn(TokenExtractor.prototype, 'getWorkspaceDomains').mockReturnValue({})
+
+  activeToken = null
+  loginSpy = spyOn(SlackClient.prototype, 'login').mockImplementation(function (
+    this: SlackClient,
+    credentials?: { token: string; cookie: string },
+  ) {
+    activeToken = credentials?.token ?? null
+    return Promise.resolve(this)
+  })
 
   testAuthSpy = spyOn(SlackClient.prototype, 'testAuth').mockResolvedValue({
     user_id: 'U123',
@@ -55,12 +66,23 @@ afterEach(() => {
   extractSpy?.mockRestore()
   extractCookieSpy?.mockRestore()
   getWorkspaceDomainsSpy?.mockRestore()
+  loginSpy?.mockRestore()
   testAuthSpy?.mockRestore()
   setWorkspaceSpy?.mockRestore()
   loadSpy?.mockRestore()
   setCurrentWorkspaceSpy?.mockRestore()
   fetchSpy?.mockRestore()
 })
+
+function authResponseByToken(map: Record<string, { team_id: string; team?: string } | Error>) {
+  testAuthSpy.mockImplementation(() => {
+    const token = activeToken ?? '<no-token>'
+    const result = map[token]
+    if (!result) throw new Error('invalid_auth')
+    if (result instanceof Error) throw result
+    return Promise.resolve({ user_id: 'U1', user: 'user', team: result.team, team_id: result.team_id })
+  })
+}
 
 describe('ensureSlackAuth', () => {
   it('skips extraction when stored credentials are valid', async () => {
@@ -295,8 +317,8 @@ describe('ensureSlackAuth', () => {
   })
 
   it('falls back to other known domains when workspace_id has no domain mapping', async () => {
-    // given — token has workspace_id 'unknown' (extractor couldn't resolve team id),
-    // but cookie is valid for the second domain in root-state.json
+    // given — workspace_id 'unknown' (extractor couldn't resolve team id); cookie is valid
+    // for the second candidate domain in root-state.json
     extractSpy.mockResolvedValue([
       { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
     ])
@@ -315,13 +337,8 @@ describe('ensureSlackAuth', () => {
       return Promise.resolve(new Response('', { status: 500 }))
     })
 
-    // The first testAuth call is from the loop's main path with the stale local token (fails),
-    // the second is the first domain candidate (fails), the third is the second candidate (succeeds).
-    let authCalls = 0
-    testAuthSpy.mockImplementation(() => {
-      authCalls++
-      if (authCalls < 3) throw new Error('invalid_auth')
-      return Promise.resolve({ user_id: 'U1', team_id: 'T_OTHER_B', user: 'user', team: 'Other B' })
+    authResponseByToken({
+      'xoxc-fresh-b': { team_id: 'T_OTHER_B', team: 'Other B' },
     })
 
     // when
@@ -342,7 +359,7 @@ describe('ensureSlackAuth', () => {
   })
 
   it('stops trying domains once a refresh+verify succeeds', async () => {
-    // given — first candidate domain succeeds; later domains must not be attempted
+    // given — exact-match domain succeeds on first attempt; the fallback domain must not be fetched
     extractSpy.mockResolvedValue([
       { workspace_id: 'T_TARGET', workspace_name: 'target', token: 'xoxc-stale', cookie: 'xoxd-valid' },
     ])
@@ -353,11 +370,8 @@ describe('ensureSlackAuth', () => {
 
     fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh"</html>', { status: 200 }))
 
-    let authCalls = 0
-    testAuthSpy.mockImplementation(() => {
-      authCalls++
-      if (authCalls === 1) throw new Error('invalid_auth')
-      return Promise.resolve({ user_id: 'U1', team_id: 'T_TARGET', user: 'user', team: 'Target' })
+    authResponseByToken({
+      'xoxc-fresh': { team_id: 'T_TARGET', team: 'Target' },
     })
 
     // when
@@ -368,10 +382,7 @@ describe('ensureSlackAuth', () => {
       'https://target-domain.slack.com/ssb/redirect',
       expect.objectContaining({ headers: { Cookie: 'd=xoxd-valid' } }),
     )
-    expect(fetchSpy).not.toHaveBeenCalledWith(
-      'https://other-domain.slack.com/ssb/redirect',
-      expect.anything(),
-    )
+    expect(fetchSpy).not.toHaveBeenCalledWith('https://other-domain.slack.com/ssb/redirect', expect.anything())
   })
 
   it('returns failure when no known domain validates the cookie', async () => {
@@ -394,6 +405,115 @@ describe('ensureSlackAuth', () => {
     expect(fetchSpy).toHaveBeenCalledWith('https://a.slack.com/ssb/redirect', expect.anything())
     expect(fetchSpy).toHaveBeenCalledWith('https://b.slack.com/ssb/redirect', expect.anything())
     expect(setWorkspaceSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips domains with non-subdomain characters', async () => {
+    // given — a tampered root-state.json with a domain that contains a dot/slash/colon
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({
+      T_EVIL: 'attacker.com#',
+      T_GOOD: 'good',
+    })
+
+    fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh"</html>', { status: 200 }))
+    authResponseByToken({ 'xoxc-fresh': { team_id: 'T_GOOD', team: 'Good' } })
+
+    // when
+    await ensureSlackAuth()
+
+    // then — the bad domain is never fetched; the good domain succeeds
+    expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('attacker.com'), expect.anything())
+    expect(fetchSpy).toHaveBeenCalledWith('https://good.slack.com/ssb/redirect', expect.anything())
+    expect(setWorkspaceSpy).toHaveBeenCalledWith(expect.objectContaining({ workspace_id: 'T_GOOD' }))
+  })
+
+  it('rejects refresh result when testAuth returns empty team_id', async () => {
+    // given — the fresh token verifies but Slack returns no team_id
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({ T_A: 'a' })
+    fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh"</html>', { status: 200 }))
+    testAuthSpy.mockResolvedValue({ user_id: 'U1', team_id: '', user: 'user', team: undefined })
+
+    // when
+    await ensureSlackAuth()
+
+    // then — nothing is saved despite successful refresh+login
+    expect(setWorkspaceSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not resolve multiple unknown workspaces to the same team', async () => {
+    // given — two unknown tokens share a cookie that validates against the first candidate domain.
+    // Naive iteration would resolve both to T_A; the resolved-team-id tracker must prevent the
+    // second unknown from claiming an already-saved team.
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale-1', cookie: 'xoxd-valid' },
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale-2', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({ T_A: 'a', T_B: 'b' })
+
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.startsWith('https://a.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-a"</html>', { status: 200 }))
+      }
+      if (url.startsWith('https://b.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-b"</html>', { status: 200 }))
+      }
+      return Promise.resolve(new Response('', { status: 500 }))
+    })
+    authResponseByToken({
+      'xoxc-fresh-a': { team_id: 'T_A', team: 'A' },
+      'xoxc-fresh-b': { team_id: 'T_B', team: 'B' },
+    })
+
+    // when
+    await ensureSlackAuth()
+
+    // then — T_A and T_B each saved exactly once
+    const savedIds = setWorkspaceSpy.mock.calls.map((c) => (c[0] as { workspace_id: string }).workspace_id)
+    expect(savedIds.sort()).toEqual(['T_A', 'T_B'])
+  })
+
+  it('caches refresh attempts per (cookie, domain) within one extraction', async () => {
+    // given — two unknown tokens with the same cookie; both will iterate the same domains
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale-1', cookie: 'xoxd-valid' },
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale-2', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({ T_A: 'a', T_B: 'b' })
+
+    fetchSpy.mockResolvedValue(new Response('', { status: 500 }))
+    testAuthSpy.mockRejectedValue(new Error('invalid_auth'))
+
+    // when
+    await ensureSlackAuth()
+
+    // then — each domain fetched at most once across both workspaces (2 total, not 4)
+    const refreshCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('/ssb/redirect'))
+    expect(refreshCalls.length).toBe(2)
+  })
+
+  it('caps domain attempts at MAX_DOMAIN_ATTEMPTS', async () => {
+    // given — 20 candidate domains; only the first 16 should be attempted
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+    ])
+    const manyDomains: Record<string, string> = {}
+    for (let i = 0; i < 20; i++) manyDomains[`T_${i}`] = `dom${i}`
+    getWorkspaceDomainsSpy.mockReturnValue(manyDomains)
+
+    fetchSpy.mockResolvedValue(new Response('', { status: 500 }))
+    testAuthSpy.mockRejectedValue(new Error('invalid_auth'))
+
+    // when
+    await ensureSlackAuth()
+
+    // then — exactly 16 refresh attempts
+    const refreshCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('/ssb/redirect'))
+    expect(refreshCalls.length).toBe(16)
   })
 
   it('skips web refresh when workspace has no cookie', async () => {

--- a/src/platforms/slack/ensure-auth.test.ts
+++ b/src/platforms/slack/ensure-auth.test.ts
@@ -278,7 +278,7 @@ describe('ensureSlackAuth', () => {
     )
   })
 
-  it('skips web refresh when no domain is known for workspace', async () => {
+  it('skips web refresh when domain map is empty', async () => {
     // given — domain mapping is empty
     extractSpy.mockResolvedValue([
       { workspace_id: 'T-stale', workspace_name: 'stale-ws', token: 'xoxc-stale', cookie: 'xoxd-valid' },
@@ -291,6 +291,108 @@ describe('ensureSlackAuth', () => {
 
     // then — no fetch attempt, workspace not saved
     expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('ssb/redirect'), expect.anything())
+    expect(setWorkspaceSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to other known domains when workspace_id has no domain mapping', async () => {
+    // given — token has workspace_id 'unknown' (extractor couldn't resolve team id),
+    // but cookie is valid for the second domain in root-state.json
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({
+      T_OTHER_A: 'other-a',
+      T_OTHER_B: 'other-b',
+    })
+
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.startsWith('https://other-a.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-a"</html>', { status: 200 }))
+      }
+      if (url.startsWith('https://other-b.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-b"</html>', { status: 200 }))
+      }
+      return Promise.resolve(new Response('', { status: 500 }))
+    })
+
+    // The first testAuth call is from the loop's main path with the stale local token (fails),
+    // the second is the first domain candidate (fails), the third is the second candidate (succeeds).
+    let authCalls = 0
+    testAuthSpy.mockImplementation(() => {
+      authCalls++
+      if (authCalls < 3) throw new Error('invalid_auth')
+      return Promise.resolve({ user_id: 'U1', team_id: 'T_OTHER_B', user: 'user', team: 'Other B' })
+    })
+
+    // when
+    await ensureSlackAuth()
+
+    // then — both candidate domains were tried; the workspace saves with the resolved team_id
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://other-a.slack.com/ssb/redirect',
+      expect.objectContaining({ headers: { Cookie: 'd=xoxd-valid' } }),
+    )
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://other-b.slack.com/ssb/redirect',
+      expect.objectContaining({ headers: { Cookie: 'd=xoxd-valid' } }),
+    )
+    expect(setWorkspaceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace_id: 'T_OTHER_B', token: 'xoxc-fresh-b', workspace_name: 'Other B' }),
+    )
+  })
+
+  it('stops trying domains once a refresh+verify succeeds', async () => {
+    // given — first candidate domain succeeds; later domains must not be attempted
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'T_TARGET', workspace_name: 'target', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({
+      T_TARGET: 'target-domain',
+      T_OTHER: 'other-domain',
+    })
+
+    fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh"</html>', { status: 200 }))
+
+    let authCalls = 0
+    testAuthSpy.mockImplementation(() => {
+      authCalls++
+      if (authCalls === 1) throw new Error('invalid_auth')
+      return Promise.resolve({ user_id: 'U1', team_id: 'T_TARGET', user: 'user', team: 'Target' })
+    })
+
+    // when
+    await ensureSlackAuth()
+
+    // then — the exact-match domain is tried, fallback domain is not
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://target-domain.slack.com/ssb/redirect',
+      expect.objectContaining({ headers: { Cookie: 'd=xoxd-valid' } }),
+    )
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      'https://other-domain.slack.com/ssb/redirect',
+      expect.anything(),
+    )
+  })
+
+  it('returns failure when no known domain validates the cookie', async () => {
+    // given — none of the domains in the map produce a valid token+cookie pair
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({
+      T_A: 'a',
+      T_B: 'b',
+    })
+
+    fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh"</html>', { status: 200 }))
+    testAuthSpy.mockRejectedValue(new Error('invalid_auth'))
+
+    // when
+    await ensureSlackAuth()
+
+    // then — every candidate is tried, none save
+    expect(fetchSpy).toHaveBeenCalledWith('https://a.slack.com/ssb/redirect', expect.anything())
+    expect(fetchSpy).toHaveBeenCalledWith('https://b.slack.com/ssb/redirect', expect.anything())
     expect(setWorkspaceSpy).not.toHaveBeenCalled()
   })
 

--- a/src/platforms/slack/ensure-auth.ts
+++ b/src/platforms/slack/ensure-auth.ts
@@ -21,21 +21,29 @@ export async function ensureSlackAuth(): Promise<void> {
     const workspaces = await extractor.extract()
     const workspaceDomains = extractor.getWorkspaceDomains()
 
-    const validWorkspaces = []
+    const validWorkspaces: ExtractedWorkspace[] = []
+    const resolvedTeamIds = new Set<string>()
+    const refreshCache = new Map<string, RefreshResult | null>()
+
     for (const ws of workspaces) {
       try {
         const client = await new SlackClient().login({ token: ws.token, cookie: ws.cookie })
         const authInfo = await client.testAuth()
+        if (!authInfo.team_id) throw new Error('testAuth returned empty team_id')
         ws.workspace_id = authInfo.team_id
         ws.workspace_name = authInfo.team || ws.workspace_name
-        await credManager.setWorkspace(ws)
-        validWorkspaces.push(ws)
+        if (!resolvedTeamIds.has(ws.workspace_id)) {
+          resolvedTeamIds.add(ws.workspace_id)
+          await credManager.setWorkspace(ws)
+          validWorkspaces.push(ws)
+        }
       } catch {
-        const refreshed = await tryWebTokenRefresh(ws, workspaceDomains)
-        if (refreshed) {
+        const refreshed = await tryWebTokenRefresh(ws, workspaceDomains, { resolvedTeamIds, refreshCache })
+        if (refreshed && !resolvedTeamIds.has(refreshed.workspace_id)) {
           ws.token = refreshed.token
           ws.workspace_id = refreshed.workspace_id
           ws.workspace_name = refreshed.workspace_name
+          resolvedTeamIds.add(ws.workspace_id)
           await credManager.setWorkspace(ws)
           validWorkspaces.push(ws)
         }
@@ -55,13 +63,26 @@ export async function ensureSlackAuth(): Promise<void> {
   }
 }
 
-// Hard cap to avoid issuing dozens of HTTP requests for workspaces with very large domain maps.
+// Bound worst-case HTTP traffic for users with very large root-state.json workspace lists.
 const MAX_DOMAIN_ATTEMPTS = 16
+
+// Slack workspace subdomains match `^[a-z][a-z0-9-]*$` per signup rules; validating here
+// prevents a tampered root-state.json from steering the cookie-bearing fetch to a non-Slack
+// host (e.g. a domain value containing `.`, `/`, `:`, `@`, `#`, or `?`).
+const SLACK_DOMAIN_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/
+
+export type RefreshResult = { token: string; workspace_id: string; workspace_name: string }
+
+export type RefreshContext = {
+  resolvedTeamIds?: Set<string>
+  refreshCache?: Map<string, RefreshResult | null>
+}
 
 export async function tryWebTokenRefresh(
   ws: ExtractedWorkspace,
   workspaceDomains: Record<string, string>,
-): Promise<{ token: string; workspace_id: string; workspace_name: string } | null> {
+  context: RefreshContext = {},
+): Promise<RefreshResult | null> {
   if (!ws.cookie) return null
 
   // Try the domain that maps to this workspace_id first (when known), then fall back to
@@ -72,15 +93,21 @@ export async function tryWebTokenRefresh(
   const candidates = orderCandidateDomains(ws.workspace_id, workspaceDomains)
   if (candidates.length === 0) return null
 
-  for (const { workspace_id, domain } of candidates) {
-    const result = await refreshAndVerify(ws.cookie, domain, ws.workspace_name)
-    if (result) {
-      return {
-        token: result.token,
-        workspace_id: result.workspace_id || workspace_id,
-        workspace_name: result.workspace_name,
-      }
+  for (const { domain } of candidates) {
+    if (!SLACK_DOMAIN_REGEX.test(domain)) continue
+
+    const cacheKey = `${ws.cookie}\u0000${domain}`
+    const cached = context.refreshCache?.get(cacheKey)
+    let result: RefreshResult | null
+    if (cached !== undefined) {
+      result = cached
+    } else {
+      result = await refreshAndVerify(ws.cookie, domain, ws.workspace_name)
+      context.refreshCache?.set(cacheKey, result)
     }
+    if (!result) continue
+    if (context.resolvedTeamIds?.has(result.workspace_id)) continue
+    return result
   }
   return null
 }
@@ -98,17 +125,14 @@ function orderCandidateDomains(
   return entries.slice(0, MAX_DOMAIN_ATTEMPTS)
 }
 
-async function refreshAndVerify(
-  cookie: string,
-  domain: string,
-  fallbackName: string,
-): Promise<{ token: string; workspace_id: string; workspace_name: string } | null> {
+async function refreshAndVerify(cookie: string, domain: string, fallbackName: string): Promise<RefreshResult | null> {
   try {
     const freshToken = await refreshTokenFromWeb(domain, cookie)
     if (!freshToken) return null
 
     const client = await new SlackClient().login({ token: freshToken, cookie })
     const authInfo = await client.testAuth()
+    if (!authInfo.team_id) return null
     return {
       token: freshToken,
       workspace_id: authInfo.team_id,

--- a/src/platforms/slack/ensure-auth.ts
+++ b/src/platforms/slack/ensure-auth.ts
@@ -34,6 +34,7 @@ export async function ensureSlackAuth(): Promise<void> {
         const refreshed = await tryWebTokenRefresh(ws, workspaceDomains)
         if (refreshed) {
           ws.token = refreshed.token
+          ws.workspace_id = refreshed.workspace_id
           ws.workspace_name = refreshed.workspace_name
           await credManager.setWorkspace(ws)
           validWorkspaces.push(ws)
@@ -54,21 +55,65 @@ export async function ensureSlackAuth(): Promise<void> {
   }
 }
 
+// Hard cap to avoid issuing dozens of HTTP requests for workspaces with very large domain maps.
+const MAX_DOMAIN_ATTEMPTS = 16
+
 export async function tryWebTokenRefresh(
   ws: ExtractedWorkspace,
   workspaceDomains: Record<string, string>,
-): Promise<{ token: string; workspace_name: string } | null> {
+): Promise<{ token: string; workspace_id: string; workspace_name: string } | null> {
   if (!ws.cookie) return null
-  const domain = workspaceDomains[ws.workspace_id]
-  if (!domain) return null
 
+  // Try the domain that maps to this workspace_id first (when known), then fall back to
+  // every other known domain. Slack tokens extracted from LevelDB blobs sometimes carry
+  // workspace_id="unknown" because the regex window around the xoxc- bytes does not
+  // contain the T... team id; in that case the cookie may still be valid for one of the
+  // other workspaces the user is signed into.
+  const candidates = orderCandidateDomains(ws.workspace_id, workspaceDomains)
+  if (candidates.length === 0) return null
+
+  for (const { workspace_id, domain } of candidates) {
+    const result = await refreshAndVerify(ws.cookie, domain, ws.workspace_name)
+    if (result) {
+      return {
+        token: result.token,
+        workspace_id: result.workspace_id || workspace_id,
+        workspace_name: result.workspace_name,
+      }
+    }
+  }
+  return null
+}
+
+function orderCandidateDomains(
+  workspaceId: string,
+  workspaceDomains: Record<string, string>,
+): Array<{ workspace_id: string; domain: string }> {
+  const entries = Object.entries(workspaceDomains).map(([workspace_id, domain]) => ({ workspace_id, domain }))
+  const exact = entries.findIndex((e) => e.workspace_id === workspaceId)
+  if (exact > 0) {
+    const [match] = entries.splice(exact, 1)
+    entries.unshift(match)
+  }
+  return entries.slice(0, MAX_DOMAIN_ATTEMPTS)
+}
+
+async function refreshAndVerify(
+  cookie: string,
+  domain: string,
+  fallbackName: string,
+): Promise<{ token: string; workspace_id: string; workspace_name: string } | null> {
   try {
-    const freshToken = await refreshTokenFromWeb(domain, ws.cookie)
+    const freshToken = await refreshTokenFromWeb(domain, cookie)
     if (!freshToken) return null
 
-    const client = await new SlackClient().login({ token: freshToken, cookie: ws.cookie })
+    const client = await new SlackClient().login({ token: freshToken, cookie })
     const authInfo = await client.testAuth()
-    return { token: freshToken, workspace_name: authInfo.team || ws.workspace_name }
+    return {
+      token: freshToken,
+      workspace_id: authInfo.team_id,
+      workspace_name: authInfo.team || fallbackName,
+    }
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

`agent-slack auth extract` silently drops workspaces whose team id can't be recovered from the LevelDB blob bytes — even when the cookie is still valid for those workspaces. This PR fixes the recovery path so `tryWebTokenRefresh` succeeds via `ssb/redirect` instead of giving up, and hardens it against several follow-on issues surfaced in self-review.

## Symptom

With multiple workspaces signed into the Slack desktop app, `agent-slack auth extract --debug` would show:

```
[debug] Found 2 workspace(s)
[debug] - T_REAL: token=xoxc-..., cookie=present
[debug] - unknown: token=xoxc-..., cookie=present
[debug] Found 4 workspace domain(s) in root-state.json
[debug] Testing credentials for T_REAL...
[debug] ✗ Invalid: An API error occurred: invalid_auth
[debug] Attempting web token refresh for T_REAL (real.slack.com)...
[debug] ✓ Web refresh succeeded: Real Team
[debug] Testing credentials for unknown...
[debug] ✗ Invalid: An API error occurred: invalid_auth
[debug] Attempting web token refresh for unknown...
[debug] ✗ Web refresh failed
{"workspaces":["T_REAL/Real Team"],"current":"T_REAL"}
```

Only one of two workspaces survives. The missing workspace's cookie is still valid and a fresh token is reachable — we just never try.

## Root cause

`token-extractor.ts` scans a ±500-byte window around each `xoxc-` token in Chromium's IndexedDB blobs to recover the `T...` team id. When Slack's LevelDB layout puts the team id outside that window, the extractor returns `workspace_id: "unknown"`.

Then `tryWebTokenRefresh` did:

```ts
const domain = workspaceDomains[ws.workspace_id]  // "unknown" → undefined
if (!domain) return null                          // give up
```

So the cookie was never actually tried against any domain. `root-state.json` already enumerates every workspace's domain (the debug log confirms 4 domains are found) — we just weren't using them as fallback candidates.

## Fix

`tryWebTokenRefresh` now iterates every known domain from `root-state.json` when the exact match isn't conclusive. Self-review caught three correctness/security holes in the naive version, all addressed below:

### 1. Multi-domain fallback (the original bug)

1. **Exact match first** — preserves existing happy-path latency (one HTTP request) for the common case where `workspace_id` is correctly resolved from the blob.
2. **Fallback to other domains** — when the exact-match domain refresh fails or the workspace id is `"unknown"`, walk every other domain from `getWorkspaceDomains()` and try `ssb/redirect` against each with the same cookie.
3. **Use `testAuth()` to identify the real team** — when a refreshed token validates, `auth.test` returns the canonical `team_id`/`team`, which we propagate back to the caller so the credential store keys the entry correctly (no more `"unknown"` workspace ids persisted).
4. **Hard cap at 16 attempts** — bounds worst-case HTTP traffic for users with very large workspace lists.

### 2. Domain validation (security)

`root-state.json` is a JSON file Slack writes locally. The initial implementation interpolated its `domain` field straight into the fetch URL, which meant a tampered or corrupt value containing `.`, `/`, `:`, `@`, `#`, or `?` could redirect the cookie-bearing request to an arbitrary host. Domains are now matched against `/^[a-zA-Z0-9][a-zA-Z0-9-]*$/` before any fetch is issued; invalid entries are skipped.

### 3. Empty `team_id` guard

`testAuth()`'s response shape allows `team_id` to be missing. The first version's `result.workspace_id || candidate_id` fallback would persist the candidate's domain-key id even if Slack returned malformed data. Empty `team_id` is now treated as verification failure and the next candidate is tried.

### 4. Resolved-team tracking + cache

Slack desktop uses one shared `d=` cookie for all of a user's workspaces. With two `"unknown"` tokens, the naive loop would resolve both to whichever candidate domain succeeded first, silently dropping every other workspace.

- `ensureSlackAuth` now maintains a `Set<string>` of resolved team ids and a `Map<(cookie, domain) → result>` cache.
- `tryWebTokenRefresh` skips candidates whose resolved team is already saved.
- The per-`(cookie, domain)` cache prevents the same probe from being repeated for every workspace sharing a cookie.

The return shape gained a `workspace_id` field; both call sites in `ensure-auth.ts` and `commands/auth.ts` now assign it to `ws.workspace_id` after a successful refresh.

## Tests

8 new tests (plus 1 renamed and 1 retooled). The 4 existing tests are unchanged in intent.

| Test | Covers |
|---|---|
| `skips web refresh when domain map is empty` (renamed from `...when no domain is known for workspace`) | Empty map → no HTTP attempts |
| `falls back to other known domains when workspace_id has no domain mapping` | Core bug fix; second candidate validates |
| `stops trying domains once a refresh+verify succeeds` | First success short-circuits remaining candidates |
| `returns failure when no known domain validates the cookie` | All candidates fail → nothing saved |
| **NEW** `skips domains with non-subdomain characters` | Domain validation: `attacker.com#` never reached |
| **NEW** `rejects refresh result when testAuth returns empty team_id` | Empty-team_id guard |
| **NEW** `does not resolve multiple unknown workspaces to the same team` | Resolved-team-id tracker |
| **NEW** `caches refresh attempts per (cookie, domain) within one extraction` | Per-cookie-domain cache |
| **NEW** `caps domain attempts at MAX_DOMAIN_ATTEMPTS` | Hard cap of 16 |

The mock harness was also retooled: tests now identify refreshes by the **token value passed to `SlackClient.login()`** instead of by call counter. The previous `authCalls < 3` style was brittle against harmless implementation reordering. The new `authResponseByToken()` helper makes intent explicit and tests robust to refactors.

```
28 pass / 0 fail in ensure-auth.test.ts (was 20 before this PR)
```

Full suite passes are unchanged compared to `main` — the 4 pre-existing `token-extractor.test.ts` failures (unrelated test-env isolation issue) are not introduced by this PR.

## Out of scope

A deeper fix would be to widen the team-id window in `extractTokenFromBuffer` (currently 500 bytes) or add a third extraction strategy that doesn't depend on co-located bytes. That's a riskier change touching the LevelDB parser and is left for follow-up — this PR keeps the surface area minimal and makes the existing `ssb/redirect` recovery actually do its job, safely.