### PR TITLE
Send photos, videos, audio, files, and multi-photo galleries on KakaoTalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 | Threads                    |  ✅   |   ✅    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Channels & Users           |  ✅   |   ✅    |  ✅   |  ✅   | partial  |    —     |  ✅   |   ✅    |     —     |    —      |         ✅          |
 | Reactions                  |  ✅   |   ✅    |  ✅   |   —   |    —     |    ✅     |   —   |   —    |     —     |    —      |         —           |
-| File uploads               |  ✅   |   ✅    |  ✅   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
+| File uploads               |  ✅   |   ✅    |  ✅   |   —   |    —     |    —     |   —   |   —    |     —     |    ✅     |         —           |
 | File downloads             |  ✅   |    —    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Workspace snapshots        |  ✅   |   ✅    |  ✅   |  ✅   |    —     |    —     |   —   |   —    |     —     |    —      |         ✅          |
 | Multi-workspace / account  |  ✅   |   ✅    |  ✅   |   —   |    ✅     |    ✅     |  ✅   |   ✅    |    ✅     |    ✅     |         ✅          |

--- a/docs/content/docs/cli/kakaotalk.mdx
+++ b/docs/content/docs/cli/kakaotalk.mdx
@@ -209,12 +209,12 @@ agent-kakaotalk message upload <chat-id> ./report.pdf
 
 Routing rules:
 
-| Filename / MIME                             | Sent as | KakaoTalk renders it as                       |
-| ------------------------------------------- | ------- | --------------------------------------------- |
-| `image/*` (`.jpg`, `.png`, `.gif`, `.webp`) | photo   | Inline image with tap-to-zoom                 |
-| `video/*` (`.mp4`, `.mov`, `.webm`)         | video   | Inline player with play button                |
-| `audio/*` (`.m4a`, `.mp3`, `.wav`, `.ogg`)  | audio   | Voice-message bubble with waveform            |
-| anything else                               | file    | Generic file attachment with download icon    |
+| Filename / MIME                             | Sent as | KakaoTalk renders it as                    |
+| ------------------------------------------- | ------- | ------------------------------------------ |
+| `image/*` (`.jpg`, `.png`, `.gif`, `.webp`) | photo   | Inline image with tap-to-zoom              |
+| `video/*` (`.mp4`, `.mov`, `.webm`)         | video   | Inline player with play button             |
+| `audio/*` (`.m4a`, `.mp3`, `.wav`, `.ogg`)  | audio   | Voice-message bubble with waveform         |
+| anything else                               | file    | Generic file attachment with download icon |
 
 Pass 2+ files (or `--as multi`) to send a multi-photo gallery in one message. Override the auto-routing with `--as <photo|video|audio|file|multi>` when you need explicit control — for example, to send an `.mp4` as a generic downloadable file instead of an inline video. Use `--mime <type>` to override MIME detection (handy for extension-less files).
 

--- a/docs/content/docs/cli/kakaotalk.mdx
+++ b/docs/content/docs/cli/kakaotalk.mdx
@@ -176,10 +176,55 @@ agent-kakaotalk message list <chat-id> --pretty
 agent-kakaotalk message send <chat-id> "Hello world"
 agent-kakaotalk message send <chat-id> "Hello world" --pretty
 
+# Send a file (auto-routes by MIME: photo / video / audio / generic file)
+agent-kakaotalk message upload <chat-id> ./photo.jpg
+agent-kakaotalk message upload <chat-id> ./clip.mp4
+agent-kakaotalk message upload <chat-id> ./voice.m4a
+agent-kakaotalk message upload <chat-id> ./report.pdf
+
+# Send a multi-photo gallery (2+ images in one message)
+agent-kakaotalk message upload <chat-id> ./img1.jpg ./img2.jpg ./img3.jpg
+
+# Force a specific kind (override auto-routing)
+agent-kakaotalk message upload <chat-id> ./clip.mp4 --as file
+agent-kakaotalk message upload <chat-id> ./data.bin --mime application/octet-stream
+
+# Mark messages as read up to a given log ID
+agent-kakaotalk message mark-read <chat-id> <log-id>
+agent-kakaotalk message mark-read <chat-id> <log-id> --link-id <li>   # open chats only
+
 # Use a specific account
 agent-kakaotalk message list <chat-id> --account <account-id>
 agent-kakaotalk message send <chat-id> "Hello" --account <account-id>
+agent-kakaotalk message upload <chat-id> ./photo.jpg --account <account-id>
 ```
+
+#### Sending Attachments
+
+`message upload` sends photos, videos, audio, and arbitrary files to a chat. The CLI sniffs the MIME type from the filename and dispatches to the matching KakaoTalk message type, so the common case is a single command and a file path:
+
+```bash
+agent-kakaotalk message upload <chat-id> ./report.pdf
+```
+
+Routing rules:
+
+| Filename / MIME                             | Sent as | KakaoTalk renders it as                       |
+| ------------------------------------------- | ------- | --------------------------------------------- |
+| `image/*` (`.jpg`, `.png`, `.gif`, `.webp`) | photo   | Inline image with tap-to-zoom                 |
+| `video/*` (`.mp4`, `.mov`, `.webm`)         | video   | Inline player with play button                |
+| `audio/*` (`.m4a`, `.mp3`, `.wav`, `.ogg`)  | audio   | Voice-message bubble with waveform            |
+| anything else                               | file    | Generic file attachment with download icon    |
+
+Pass 2+ files (or `--as multi`) to send a multi-photo gallery in one message. Override the auto-routing with `--as <photo|video|audio|file|multi>` when you need explicit control — for example, to send an `.mp4` as a generic downloadable file instead of an inline video. Use `--mime <type>` to override MIME detection (handy for extension-less files).
+
+Output (JSON by default; `--pretty` pretty-prints the same JSON):
+
+```json
+{ "success": true, "status_code": 0, "chat_id": "9876543210", "log_id": "3846830417126748160", "sent_at": 1779509936 }
+```
+
+All attachment kinds use the same SHIP / POST / COMPLETE LOCO pipeline (and MSHIP / MPOST / FORWARD for multi-photo). Each upload opens one fresh TCP+LOCO connection per attachment; multi-photo opens N connections in parallel.
 
 Each message includes:
 
@@ -246,7 +291,7 @@ Output includes:
 
 ## Limitations
 
-- No file upload or download
+- No file download
 - No channel/chat room creation or management
 - No friend list management
 - No reactions or emoji
@@ -254,7 +299,7 @@ Output includes:
 - No open chat browsing or joining
 - No search across chats
 
-- Read-only for rich content: photos, stickers, files, and other non-text messages are exposed via the `attachment` field on each message, but sending them is not supported
+- Read-only for stickers: sticker / animated-sticker messages are exposed via the `attachment` field on each message, but sending stickers is not supported
 - Chat IDs are numeric and not human-readable — use `chat list` to discover them
 
 ## Troubleshooting

--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -94,6 +94,38 @@ const result = await client.sendMessage('9876543210', 'Hello from SDK!')
 // → KakaoSendResult { success, status_code, chat_id, log_id, sent_at }
 ```
 
+#### Attachments
+
+`sendAttachment` is the single entry point for outbound photos, videos, audio, files, and multi-photo galleries. It accepts either one buffer or an array of `{ data, filename, mime? }` tuples; MIME is sniffed from the filename when not given, and the client dispatches to the right LOCO message_type internally.
+
+```typescript
+// Single attachment — MIME inferred from the filename extension
+//   image/* → photo, video/* → video, audio/* → audio, anything else → file
+await client.sendAttachment('9876543210', photoBytes, 'cat.jpg')
+await client.sendAttachment('9876543210', pdfBytes, 'report.pdf')
+
+// Force a specific MIME (extension-less files, or to send a video as a generic file)
+await client.sendAttachment('9876543210', mp4Bytes, 'clip.mp4', 'application/octet-stream')
+
+// Multiple attachments — the client picks the right wire flow:
+//   all-image (length >= 2) → multi-photo gallery (sendMultiPhoto under the hood)
+//   mixed kinds              → sequential individual sends, fail-fast on first error
+//   length === 1             → equivalent to the single-buffer overload
+await client.sendAttachment('9876543210', [
+  { data: photo1, filename: 'a.jpg' },
+  { data: photo2, filename: 'b.png' },
+  { data: photo3, filename: 'c.webp' },
+])
+
+await client.sendAttachment('9876543210', [
+  { data: photo, filename: 'screenshot.png' },
+  { data: spec, filename: 'spec.pdf' },
+])
+// → KakaoSendResult of the last successful send (or the first failure, if any)
+```
+
+The typed helpers `sendPhoto`, `sendVideo`, `sendAudio`, `sendFile`, and `sendMultiPhoto` remain available when you want to bypass MIME sniffing and dispatch to a specific message_type explicitly.
+
 ### Cleanup
 
 ```typescript

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -580,6 +580,11 @@ try {
   const chatId = chats[0].chat_id
   const result = await client.sendMessage(chatId, 'Hello from SDK!')
 
+  // Send a file (photo / video / audio / file auto-routed by MIME). Pass
+  // an array to send several at once — all-image arrays become a gallery.
+  const photo = await Bun.file('./photo.jpg').bytes()
+  await client.sendAttachment(chatId, photo, 'photo.jpg')
+
   // Read messages
   const messages = await client.getMessages(chatId, { count: 50 })
 } finally {
@@ -595,14 +600,13 @@ See the [KakaoTalk SDK documentation](https://agent-messenger.dev/docs/sdk/kakao
 ## Limitations
 
 - Auto-extraction of email/password from the desktop app is **macOS and Windows only** (KakaoTalk desktop is not available on Linux). Linux users must pass `--email` and `--password` (or `--password-file`) explicitly — the LOCO protocol, login flow, and all messaging features work on Linux.
-- No file upload or download
 - No channel/chat room creation or management
 - No friend list management
 - No reactions or emoji
 - No message editing or deletion
 - No open chat (오픈채팅) browsing or joining
 - No search across chats
-- Read-only for rich content: photos, stickers, files, and other non-text messages are exposed via the `attachment` field on each message, but sending them is not supported
+- Stickers / emoticons cannot be sent (inbound stickers expose pack/path metadata, but the sticker store requires desktop-app purchase flows the SDK does not replicate). Photos, videos, audio, and arbitrary files can both be received and sent — see [`message upload`](#message-commands) and [`KakaoTalkClient.sendAttachment`](#sdk-programmatic-usage).
 - Chat IDs are numeric and not human-readable — use `chat list` to discover them
 
 ## Troubleshooting

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -335,6 +335,20 @@ agent-kakaotalk message list <chat-id> --pretty
 agent-kakaotalk message send <chat-id> "Hello world"
 agent-kakaotalk message send <chat-id> "Hello world" --pretty
 
+# Send a file (auto-routes by MIME: photo / video / audio / generic file)
+agent-kakaotalk message upload <chat-id> ./photo.jpg
+agent-kakaotalk message upload <chat-id> ./clip.mp4
+agent-kakaotalk message upload <chat-id> ./voice.m4a
+agent-kakaotalk message upload <chat-id> ./report.pdf
+
+# Send a multi-photo gallery (2+ images in one message)
+agent-kakaotalk message upload <chat-id> ./img1.jpg ./img2.jpg ./img3.jpg
+
+# Force a specific kind (override auto-routing)
+agent-kakaotalk message upload <chat-id> ./clip.mp4 --as file       # send as generic file, not video
+agent-kakaotalk message upload <chat-id> ./image --as photo         # extension-less file
+agent-kakaotalk message upload <chat-id> ./data.bin --mime application/octet-stream
+
 # Mark messages as read up to a given log ID
 agent-kakaotalk message mark-read <chat-id> <log-id>
 agent-kakaotalk message mark-read <chat-id> <log-id> --pretty
@@ -343,8 +357,48 @@ agent-kakaotalk message mark-read <chat-id> <log-id> --link-id <li>   # open cha
 # Use a specific account
 agent-kakaotalk message list <chat-id> --account <account-id>
 agent-kakaotalk message send <chat-id> "Hello" --account <account-id>
+agent-kakaotalk message upload <chat-id> ./photo.jpg --account <account-id>
 agent-kakaotalk message mark-read <chat-id> <log-id> --account <account-id>
 ```
+
+#### Sending Attachments
+
+`message upload` sends photos, videos, audio, and arbitrary files to a chat. The CLI sniffs the MIME type from the filename and dispatches to the matching KakaoTalk message type, so the common case is a single command and a file path:
+
+```bash
+agent-kakaotalk message upload <chat-id> ./report.pdf
+```
+
+Routing rules:
+
+| Filename / MIME | Sent as | KakaoTalk renders it as |
+| --- | --- | --- |
+| `image/*` (`.jpg`, `.png`, `.gif`, `.webp`) | photo | Inline image with tap-to-zoom |
+| `video/*` (`.mp4`, `.mov`, `.webm`) | video | Inline player with play button |
+| `audio/*` (`.m4a`, `.mp3`, `.wav`, `.ogg`) | audio | Voice-message bubble with waveform |
+| anything else | file | Generic file attachment with download icon |
+
+Multi-photo galleries (one message that contains several images): pass 2+ files and the CLI uses the gallery flow automatically.
+
+```bash
+agent-kakaotalk message upload <chat-id> ./img1.jpg ./img2.jpg ./img3.jpg
+```
+
+Override the auto-routing with `--as <photo|video|audio|file|multi>` when you need explicit control — for example, to send an `.mp4` as a generic downloadable file instead of an inline video. Use `--mime <type>` to override MIME detection (handy for extension-less files or when the caller knows better than the filename).
+
+Output (JSON by default; `--pretty` pretty-prints the same JSON):
+
+```json
+{ "success": true, "status_code": 0, "chat_id": "9876543210", "log_id": "3846830417126748160", "sent_at": 1779509936 }
+```
+
+The process exits non-zero when `success` is `false`.
+
+Notes:
+- All attachment kinds use the same SHIP / POST / COMPLETE LOCO pipeline (and MSHIP / MPOST / FORWARD for multi-photo). The server registers the chatlog itself once the upload finishes; no follow-up text message is needed.
+- KakaoTalk caps single-message attachment sizes server-side (currently ~300MB for files, ~20MB per image in multi-photo). The CLI surfaces the server's status code on rejection.
+- Filenames are preserved on the recipient side for `file` kind, used as a display label for `audio`, and ignored for `photo` / `video` (the client renders the bytes directly).
+- Each upload opens one fresh TCP+LOCO connection per attachment. Multi-photo opens N connections in parallel.
 
 #### Mark as Read
 
@@ -368,7 +422,7 @@ Notes:
 
 Each message includes:
 - `log_id` — unique message identifier
-- `type` — message type (1 = text, 2 = photo, 12 = sticker, 20 = animated sticker, etc.)
+- `type` — message type (1 = text, 2 = photo, 3 = video, 5 = audio, 12 = sticker, 18 = file, 20 = animated sticker, 27 = multi-photo, etc.)
 - `author_id` — sender's user ID
 - `author_name` — sender's nickname when known from the chat list (otherwise `null`; only the room's "display members" are cached)
 - `message` — message text content (empty string for non-text messages like stickers)

--- a/skills/agent-kakaotalk/references/common-patterns.md
+++ b/skills/agent-kakaotalk/references/common-patterns.md
@@ -55,9 +55,48 @@ agent-kakaotalk message send "$TARGET_CHAT" "Hey Alice!"
 
 **When to use**: First time interacting with a chat, or when the user references a chat by name.
 
-> Note: `display_name` joins the chat's member nicknames. For the user-set room title (matching the KakaoTalk app), see [Pattern 9](#pattern-9-resolve-canonical-room-titles).
+> Note: `display_name` joins the chat's member nicknames. For the user-set room title (matching the KakaoTalk app), see [Pattern 10](#pattern-10-resolve-canonical-room-titles).
 
-## Pattern 3: Monitor Chat for New Messages
+## Pattern 3: Send Files, Photos, Videos, and Audio
+
+**Use case**: Upload an attachment to a chat (photo, video, voice, generic file, or multi-photo gallery)
+
+```bash
+#!/bin/bash
+
+CHAT_ID="9876543210"
+
+# Single file — MIME is sniffed from the filename and routed to the right kind
+agent-kakaotalk message upload "$CHAT_ID" ./photo.jpg     # → photo (inline preview)
+agent-kakaotalk message upload "$CHAT_ID" ./clip.mp4      # → video (inline player)
+agent-kakaotalk message upload "$CHAT_ID" ./voice.m4a     # → audio (voice bubble)
+agent-kakaotalk message upload "$CHAT_ID" ./report.pdf    # → file (download icon)
+
+# Multi-photo gallery — pass 2+ files and the CLI uses the gallery flow
+agent-kakaotalk message upload "$CHAT_ID" ./img1.jpg ./img2.jpg ./img3.jpg
+
+# Force a specific kind to override auto-routing
+agent-kakaotalk message upload "$CHAT_ID" ./clip.mp4 --as file   # send as generic file, not inline video
+
+# Override MIME detection for extension-less files
+agent-kakaotalk message upload "$CHAT_ID" ./data.bin --mime application/octet-stream
+
+# With error handling
+RESULT=$(agent-kakaotalk message upload "$CHAT_ID" ./photo.jpg)
+SUCCESS=$(echo "$RESULT" | jq -r '.success')
+if [ "$SUCCESS" = "true" ]; then
+  echo "Uploaded as log_id $(echo "$RESULT" | jq -r '.log_id')"
+else
+  echo "Upload failed: $(echo "$RESULT" | jq -r '.status_code')"
+  exit 1
+fi
+```
+
+**When to use**: Sending screenshots, generated reports, deployment artifacts, voice notes, or photo bundles to a chat.
+
+**Routing rules**: `image/*` → photo, `video/*` → video, `audio/*` → audio (voice memo), everything else → generic file. The full SHIP / POST / COMPLETE LOCO pipeline is handled internally — no separate "send text after upload" step is needed. KakaoTalk caps single-message attachment sizes server-side; the CLI surfaces the server's status code on rejection.
+
+## Pattern 4: Monitor Chat for New Messages
 
 **Use case**: Watch a chat room and respond to new messages
 
@@ -91,7 +130,7 @@ done
 
 **Limitations**: Polling-based, not real-time. Each poll establishes a LOCO connection, so use reasonable intervals (10s+).
 
-## Pattern 4: Read Recent Chat History
+## Pattern 5: Read Recent Chat History
 
 **Use case**: Catch up on what happened in a chat
 
@@ -113,7 +152,7 @@ echo "$MESSAGES" | jq -r '.[] | "\(.author_id): \(.message // "[non-text]")"'
 
 **When to use**: Context gathering, summarizing conversations, catching up on missed messages.
 
-## Pattern 5: Fetch More Messages
+## Pattern 6: Fetch More Messages
 
 **Use case**: Read more messages than the default 20
 
@@ -148,7 +187,7 @@ NEW_MESSAGES=$(agent-kakaotalk message list "$CHAT_ID" --from "$LAST_SEEN")
 
 **Pagination details**: The CLI now prefers KakaoTalk's `MCHATLOGS` flow for history reads, fetching message batches from the requested `--from` point and returning the last N messages after deduplication and ascending sort. If that path cannot provide results, it falls back to `CHATONROOM` + `SYNCMSG` for compatibility. As a safety net, both paths are capped at 50 internal pages. A warning is printed to stderr only when that cap is actually hit and the returned history may be incomplete.
 
-## Pattern 6: Multi-Chat Broadcast
+## Pattern 7: Multi-Chat Broadcast
 
 **Use case**: Send the same message to multiple chats
 
@@ -176,7 +215,7 @@ done
 
 **When to use**: Announcements, notifications across multiple chats.
 
-## Pattern 7: Multi-Account Operations
+## Pattern 8: Multi-Account Operations
 
 **Use case**: Manage and operate across multiple KakaoTalk accounts
 
@@ -201,7 +240,7 @@ agent-kakaotalk auth status --account 1111111111
 
 **When to use**: Managing multiple KakaoTalk identities, sending messages as different accounts, or checking status across accounts.
 
-## Pattern 8: Unread Message Summary
+## Pattern 9: Unread Message Summary
 
 **Use case**: Check which chats have unread messages
 
@@ -223,7 +262,7 @@ echo "$UNREAD" | jq -r '.[] | "  \(.display_name // "Unknown") — \(.unread_cou
 
 **When to use**: Morning catch-up, checking for urgent messages, triage.
 
-## Pattern 9: Resolve Canonical Room Titles
+## Pattern 10: Resolve Canonical Room Titles
 
 **Use case**: Show user-set room names (matching the official KakaoTalk app) instead of comma-joined member nicknames
 
@@ -269,7 +308,7 @@ const chats = await client.getChats({ resolveTitles: true })
 const title = await client.getChatTitle('9876543210')
 ```
 
-## Pattern 10: Error Handling and Retry
+## Pattern 11: Error Handling and Retry
 
 **Use case**: Robust message sending with retries
 

--- a/skills/agent-kakaotalk/references/common-patterns.md
+++ b/skills/agent-kakaotalk/references/common-patterns.md
@@ -493,9 +493,9 @@ The `deviceType` determines the LOCO protocol identity: `'tablet'` sends `os: 'a
 
 ### Auto-Reconnect
 
-`getChats`, `getMessages`, and `sendMessage` automatically reconnect once when the LOCO session dies (e.g. the KakaoTalk desktop app reclaims the session or the network drops). The reconnect is transparent — callers don't need to handle session-drop errors.
+`getChats`, `getMessages`, `sendMessage`, and `sendAttachment` (plus the underlying typed helpers `sendPhoto` / `sendVideo` / `sendAudio` / `sendFile` / `sendMultiPhoto`) automatically reconnect once when the LOCO session dies (e.g. the KakaoTalk desktop app reclaims the session or the network drops). The reconnect is transparent — callers don't need to handle session-drop errors.
 
-Reconnect only triggers on actual session death. Operation-level errors (invalid chat ID, server rejection, etc.) are thrown immediately without retry, so side effects like `sendMessage` are never duplicated.
+Reconnect only triggers on actual session death. Operation-level errors (invalid chat ID, server rejection, etc.) are thrown immediately without retry, so side effects like `sendMessage` or `sendAttachment` are never duplicated.
 
 ## See Also
 

--- a/src/platforms/kakaotalk/attachment-router.test.ts
+++ b/src/platforms/kakaotalk/attachment-router.test.ts
@@ -30,6 +30,13 @@ describe('resolveAttachment', () => {
     expect(r.mime).toBe('image/png')
   })
 
+  it('routes upper-case and mixed-case MIME overrides the same as lower-case', () => {
+    expect(resolveAttachment({ data: bytes, filename: 'x.bin', mime: 'IMAGE/JPEG' }).kind).toBe('photo')
+    expect(resolveAttachment({ data: bytes, filename: 'x.bin', mime: 'Video/MP4' }).kind).toBe('video')
+    expect(resolveAttachment({ data: bytes, filename: 'x.bin', mime: 'Audio/MPEG' }).kind).toBe('audio')
+    expect(resolveAttachment({ data: bytes, filename: 'x.bin', mime: 'IMAGE/PNG' }).mime).toBe('image/png')
+  })
+
   it('preserves data and filename verbatim', () => {
     const r = resolveAttachment({ data: bytes, filename: 'cat picture.jpg' })
     expect(r.data).toBe(bytes)

--- a/src/platforms/kakaotalk/attachment-router.test.ts
+++ b/src/platforms/kakaotalk/attachment-router.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test'
+
+import { planAttachments, resolveAttachment } from './attachment-router'
+
+const bytes = new Uint8Array([0])
+
+describe('resolveAttachment', () => {
+  it('classifies image MIME as photo', () => {
+    expect(resolveAttachment({ data: bytes, filename: 'x.jpg' }).kind).toBe('photo')
+    expect(resolveAttachment({ data: bytes, filename: 'x.png', mime: 'image/png' }).kind).toBe('photo')
+  })
+
+  it('classifies video MIME as video', () => {
+    expect(resolveAttachment({ data: bytes, filename: 'x.mp4' }).kind).toBe('video')
+  })
+
+  it('classifies audio MIME as audio', () => {
+    expect(resolveAttachment({ data: bytes, filename: 'x.m4a' }).kind).toBe('audio')
+  })
+
+  it('classifies everything else as file', () => {
+    expect(resolveAttachment({ data: bytes, filename: 'x.pdf' }).kind).toBe('file')
+    expect(resolveAttachment({ data: bytes, filename: 'x.zip' }).kind).toBe('file')
+    expect(resolveAttachment({ data: bytes, filename: 'x.unknown-ext' }).kind).toBe('file')
+  })
+
+  it('uses explicit mime override over filename inference', () => {
+    const r = resolveAttachment({ data: bytes, filename: 'x.pdf', mime: 'image/png' })
+    expect(r.kind).toBe('photo')
+    expect(r.mime).toBe('image/png')
+  })
+
+  it('preserves data and filename verbatim', () => {
+    const r = resolveAttachment({ data: bytes, filename: 'cat picture.jpg' })
+    expect(r.data).toBe(bytes)
+    expect(r.filename).toBe('cat picture.jpg')
+  })
+})
+
+describe('planAttachments', () => {
+  it('throws on empty array', () => {
+    expect(() => planAttachments([])).toThrow(/empty/i)
+  })
+
+  it('returns single for a one-element array', () => {
+    const plan = planAttachments([{ data: bytes, filename: 'x.jpg' }])
+    expect(plan.kind).toBe('single')
+    if (plan.kind !== 'single') return
+    expect(plan.resolved.kind).toBe('photo')
+  })
+
+  it('returns single (not multiphoto) for a one-photo array', () => {
+    const plan = planAttachments([{ data: bytes, filename: 'a.png' }])
+    expect(plan.kind).toBe('single')
+  })
+
+  it('returns multiphoto when every item resolves to photo', () => {
+    const plan = planAttachments([
+      { data: bytes, filename: 'a.jpg' },
+      { data: bytes, filename: 'b.png' },
+      { data: bytes, filename: 'c.webp' },
+    ])
+    expect(plan.kind).toBe('multiphoto')
+    if (plan.kind !== 'multiphoto') return
+    expect(plan.items.length).toBe(3)
+  })
+
+  it('returns sequential for mixed kinds (image + file)', () => {
+    const plan = planAttachments([
+      { data: bytes, filename: 'photo.jpg' },
+      { data: bytes, filename: 'spec.pdf' },
+    ])
+    expect(plan.kind).toBe('sequential')
+    if (plan.kind !== 'sequential') return
+    expect(plan.resolved.map((r) => r.kind)).toEqual(['photo', 'file'])
+  })
+
+  it('returns sequential for all-video (multiphoto is image-only)', () => {
+    const plan = planAttachments([
+      { data: bytes, filename: 'a.mp4' },
+      { data: bytes, filename: 'b.mp4' },
+    ])
+    expect(plan.kind).toBe('sequential')
+    if (plan.kind !== 'sequential') return
+    expect(plan.resolved.every((r) => r.kind === 'video')).toBe(true)
+  })
+
+  it('honors explicit mime overrides when classifying for the photo gate', () => {
+    const plan = planAttachments([
+      { data: bytes, filename: 'a.pdf', mime: 'image/jpeg' },
+      { data: bytes, filename: 'b.bin', mime: 'image/png' },
+    ])
+    expect(plan.kind).toBe('multiphoto')
+  })
+})

--- a/src/platforms/kakaotalk/attachment-router.ts
+++ b/src/platforms/kakaotalk/attachment-router.ts
@@ -1,0 +1,48 @@
+import { guessMimeFromFilename } from './media-upload'
+
+export type AttachmentInput = {
+  data: Uint8Array | Buffer
+  filename: string
+  mime?: string
+}
+
+export type SingleAttachmentKind = 'photo' | 'video' | 'audio' | 'file'
+
+export type ResolvedAttachment = {
+  kind: SingleAttachmentKind
+  mime: string
+  data: Uint8Array | Buffer
+  filename: string
+}
+
+export type AttachmentPlan =
+  | { kind: 'single'; resolved: ResolvedAttachment }
+  | { kind: 'multiphoto'; items: readonly AttachmentInput[] }
+  | { kind: 'sequential'; resolved: readonly ResolvedAttachment[] }
+
+export function resolveAttachment(input: AttachmentInput): ResolvedAttachment {
+  const mime = input.mime ?? guessMimeFromFilename(input.filename)
+  const kind: SingleAttachmentKind = mime.startsWith('image/')
+    ? 'photo'
+    : mime.startsWith('video/')
+      ? 'video'
+      : mime.startsWith('audio/')
+        ? 'audio'
+        : 'file'
+  return { kind, mime, data: input.data, filename: input.filename }
+}
+
+export function planAttachments(items: readonly AttachmentInput[]): AttachmentPlan {
+  if (items.length === 0) {
+    throw new Error('sendAttachment received an empty attachments array')
+  }
+  if (items.length === 1) {
+    return { kind: 'single', resolved: resolveAttachment(items[0]!) }
+  }
+  const resolved = items.map(resolveAttachment)
+  // MULTIPHOTO (message_type 27) is image-only by KakaoTalk's wire protocol.
+  if (resolved.every((r) => r.kind === 'photo')) {
+    return { kind: 'multiphoto', items: items.slice() }
+  }
+  return { kind: 'sequential', resolved }
+}

--- a/src/platforms/kakaotalk/attachment-router.ts
+++ b/src/platforms/kakaotalk/attachment-router.ts
@@ -21,7 +21,9 @@ export type AttachmentPlan =
   | { kind: 'sequential'; resolved: readonly ResolvedAttachment[] }
 
 export function resolveAttachment(input: AttachmentInput): ResolvedAttachment {
-  const mime = input.mime ?? guessMimeFromFilename(input.filename)
+  // MIME types are case-insensitive per RFC 2045 §5.1; normalize so an `Image/JPEG`
+  // override still routes to `photo` instead of falling through to `file`.
+  const mime = (input.mime ?? guessMimeFromFilename(input.filename)).toLowerCase()
   const kind: SingleAttachmentKind = mime.startsWith('image/')
     ? 'photo'
     : mime.startsWith('video/')

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -7,17 +7,24 @@ import { Long } from 'bson'
 import { getConfigDir } from '@/shared/utils/config-dir'
 import { warn } from '@/shared/utils/stderr'
 
+import { detectImageDimensions } from './image-meta'
+import { guessMimeFromFilename, sha1Hex } from './media-upload'
+import { uploadMediaToLoco, uploadMultiMediaEntry } from './protocol/media-uploader'
 import { LANG, PC_OS_NAME, getLocoDeviceConfig } from './protocol/config'
 import { LocoSession } from './protocol/session'
 import type { ChatListResponse, LocoPacket, LoginListResponse, SyncState } from './protocol/types'
-import type {
-  KakaoChat,
-  KakaoDeviceType,
-  KakaoMarkReadResult,
-  KakaoMember,
-  KakaoMessage,
-  KakaoProfile,
-  KakaoSendResult,
+import {
+  KAKAO_MESSAGE_TYPE,
+  type KakaoChat,
+  type KakaoDeviceType,
+  type KakaoFileExtra,
+  type KakaoMarkReadResult,
+  type KakaoMember,
+  type KakaoMessage,
+  type KakaoMultiPhotoExtra,
+  type KakaoPhotoExtra,
+  type KakaoProfile,
+  type KakaoSendResult,
 } from './types'
 
 export type KakaoSessionEvent =
@@ -891,6 +898,274 @@ export class KakaoTalkClient {
         }
       } catch (error) {
         throw wrapError(error, 'send_message_failed')
+      }
+    })
+  }
+
+  async sendAttachment(
+    chatId: string,
+    data: Uint8Array | Buffer,
+    filename: string,
+    mimeType?: string,
+  ): Promise<KakaoSendResult> {
+    const mime = mimeType ?? guessMimeFromFilename(filename)
+    if (mime.startsWith('image/')) {
+      return this.sendPhoto(chatId, data, filename)
+    }
+    if (mime.startsWith('video/')) {
+      return this.sendVideo(chatId, data, filename)
+    }
+    if (mime.startsWith('audio/')) {
+      return this.sendAudio(chatId, data, filename)
+    }
+    return this.sendFile(chatId, data, filename, mime)
+  }
+
+  async sendPhoto(chatId: string, photo: Uint8Array | Buffer, filename = 'image.jpg'): Promise<KakaoSendResult> {
+    this.ensureAuth()
+    const data = photo instanceof Uint8Array ? photo : new Uint8Array(photo)
+    const dim = detectImageDimensions(data)
+    const checksum = await sha1Hex(data)
+    const ext = filename.includes('.') ? filename.split('.').pop()! : 'jpg'
+
+    return this.sendMediaViaLoco({
+      chatId,
+      data,
+      msgType: KAKAO_MESSAGE_TYPE.PHOTO,
+      filename,
+      checksum,
+      extension: ext,
+      width: dim.width,
+      height: dim.height,
+      errorCode: 'send_photo_failed',
+    })
+  }
+
+  async sendVideo(chatId: string, video: Uint8Array | Buffer, filename = 'video.mp4'): Promise<KakaoSendResult> {
+    this.ensureAuth()
+    const data = video instanceof Uint8Array ? video : new Uint8Array(video)
+    const checksum = await sha1Hex(data)
+    const ext = filename.includes('.') ? filename.split('.').pop()! : 'mp4'
+
+    return this.sendMediaViaLoco({
+      chatId,
+      data,
+      msgType: KAKAO_MESSAGE_TYPE.VIDEO,
+      filename,
+      checksum,
+      extension: ext,
+      errorCode: 'send_video_failed',
+    })
+  }
+
+  async sendAudio(chatId: string, audio: Uint8Array | Buffer, filename = 'audio.m4a'): Promise<KakaoSendResult> {
+    this.ensureAuth()
+    const data = audio instanceof Uint8Array ? audio : new Uint8Array(audio)
+    const checksum = await sha1Hex(data)
+    const ext = filename.includes('.') ? filename.split('.').pop()! : 'm4a'
+
+    return this.sendMediaViaLoco({
+      chatId,
+      data,
+      msgType: KAKAO_MESSAGE_TYPE.AUDIO,
+      filename,
+      checksum,
+      extension: ext,
+      errorCode: 'send_audio_failed',
+    })
+  }
+
+  async sendFile(
+    chatId: string,
+    file: Uint8Array | Buffer,
+    filename: string,
+    mimeType = 'application/octet-stream',
+  ): Promise<KakaoSendResult> {
+    void mimeType
+    this.ensureAuth()
+    const data = file instanceof Uint8Array ? file : new Uint8Array(file)
+    const checksum = await sha1Hex(data)
+    const ext = filename.includes('.') ? filename.split('.').pop()! : ''
+
+    return this.sendMediaViaLoco({
+      chatId,
+      data,
+      msgType: KAKAO_MESSAGE_TYPE.FILE,
+      filename,
+      checksum,
+      extension: ext,
+      errorCode: 'send_file_failed',
+    })
+  }
+
+  async sendMultiPhoto(
+    chatId: string,
+    photos: Array<{ data: Uint8Array | Buffer; filename?: string }>,
+  ): Promise<KakaoSendResult> {
+    this.ensureAuth()
+    if (photos.length < 2) {
+      throw new KakaoTalkError(
+        'sendMultiPhoto requires at least 2 photos; use sendPhoto for a single image',
+        'send_multi_photo_failed',
+      )
+    }
+
+    const prepared = await Promise.all(
+      photos.map(async (p, i) => {
+        const bytes = p.data instanceof Uint8Array ? p.data : new Uint8Array(p.data)
+        const filename = p.filename ?? `image-${i + 1}.jpg`
+        const dim = detectImageDimensions(bytes)
+        const checksum = (await sha1Hex(bytes)).toLowerCase()
+        const ext = filename.includes('.') ? filename.split('.').pop()! : 'jpg'
+        return { bytes, filename, dim, checksum, ext }
+      }),
+    )
+
+    const parsedChatId = parseChatId(chatId)
+
+    return this.executeWithReconnect(async ({ session }) => {
+      try {
+        const mshipResp = await session.shipMultiMedia(
+          parsedChatId,
+          KAKAO_MESSAGE_TYPE.MULTIPHOTO,
+          prepared.map((p) => p.bytes.byteLength),
+          prepared.map((p) => p.checksum),
+          prepared.map((p) => p.ext),
+        )
+
+        if (mshipResp.statusCode !== 0) {
+          throw new KakaoTalkError(
+            `MSHIP rejected (status ${mshipResp.statusCode})`,
+            'send_multi_photo_failed',
+          )
+        }
+
+        const body = mshipResp.body as Record<string, unknown>
+        const kl = body.kl as string[] | undefined
+        const vhl = body.vhl as string[] | undefined
+        const pl = body.pl as number[] | undefined
+        if (!kl || !vhl || !pl || kl.length !== prepared.length) {
+          throw new KakaoTalkError(
+            `MSHIP response missing arrays: kl=${kl?.length} vhl=${vhl?.length} pl=${pl?.length}`,
+            'send_multi_photo_failed',
+          )
+        }
+
+        await Promise.all(
+          prepared.map((p, i) =>
+            uploadMultiMediaEntry({
+              shipToken: kl[i]!,
+              shipHost: vhl[i]!,
+              shipPort: pl[i]!,
+              chatId: parsedChatId,
+              msgType: KAKAO_MESSAGE_TYPE.MULTIPHOTO,
+              userId: this.userId!,
+              filename: p.filename,
+              data: p.bytes,
+              width: p.dim.width,
+              height: p.dim.height,
+              deviceType: this.deviceType,
+            }),
+          ),
+        )
+
+        const extra: KakaoMultiPhotoExtra = {
+          kl,
+          wl: prepared.map((p) => p.dim.width),
+          hl: prepared.map((p) => p.dim.height),
+          mtl: prepared.map((p) => p.dim.mimeType),
+          sl: prepared.map((p) => p.bytes.byteLength),
+          csl: prepared.map((p) => p.checksum),
+          cmtl: prepared.map(() => ''),
+        }
+
+        const forwardResp = await session.forwardChat(
+          parsedChatId,
+          KAKAO_MESSAGE_TYPE.MULTIPHOTO,
+          extra as unknown as Record<string, unknown>,
+        )
+
+        return {
+          success: forwardResp.statusCode === 0,
+          status_code: forwardResp.statusCode,
+          chat_id: chatId,
+          log_id: longToString((forwardResp.body as Record<string, unknown>).logId),
+          sent_at: ((forwardResp.body as Record<string, unknown>).sendAt as number | undefined) ?? 0,
+        }
+      } catch (error) {
+        throw wrapError(error, 'send_multi_photo_failed')
+      }
+    })
+  }
+
+  private async sendMediaViaLoco(opts: {
+    chatId: string
+    data: Uint8Array
+    msgType: number
+    filename: string
+    checksum: string
+    extension: string
+    width?: number
+    height?: number
+    errorCode: string
+  }): Promise<KakaoSendResult> {
+    const parsedChatId = parseChatId(opts.chatId)
+    return this.executeWithReconnect(async ({ session }) => {
+      try {
+        const shipResp = await session.shipMedia(
+          parsedChatId,
+          opts.msgType,
+          opts.data.byteLength,
+          opts.checksum,
+          opts.extension,
+        )
+
+        if (shipResp.statusCode !== 0) {
+          throw new KakaoTalkError(
+            `SHIP rejected (status ${shipResp.statusCode})`,
+            opts.errorCode,
+          )
+        }
+
+        const body = shipResp.body as Record<string, unknown>
+        const shipToken = body.k as string | undefined
+        const shipHost = body.vh as string | undefined
+        const shipPort = body.p as number | undefined
+
+        if (typeof shipToken !== 'string' || typeof shipHost !== 'string' || typeof shipPort !== 'number') {
+          throw new KakaoTalkError(
+            `SHIP response missing fields: k=${shipToken} vh=${shipHost} p=${shipPort}`,
+            opts.errorCode,
+          )
+        }
+
+        const uploadRes = await uploadMediaToLoco({
+          shipToken,
+          shipHost,
+          shipPort,
+          chatId: parsedChatId,
+          msgType: opts.msgType,
+          userId: this.userId!,
+          filename: opts.filename,
+          data: opts.data,
+          width: opts.width,
+          height: opts.height,
+          deviceType: this.deviceType,
+        })
+
+        const completeBody = uploadRes.completePacket?.body as Record<string, unknown> | undefined
+        const chatLog = completeBody?.chatLog as Record<string, unknown> | undefined
+        const logId = chatLog?.logId
+
+        return {
+          success: uploadRes.completePacket !== null && uploadRes.postStatusCode === 0,
+          status_code: uploadRes.postStatusCode,
+          chat_id: opts.chatId,
+          log_id: longToString(logId),
+          sent_at: (chatLog?.sendAt as number | undefined) ?? 0,
+        }
+      } catch (error) {
+        throw wrapError(error, opts.errorCode)
       }
     })
   }

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -18,12 +18,10 @@ import {
   KAKAO_MESSAGE_TYPE,
   type KakaoChat,
   type KakaoDeviceType,
-  type KakaoFileExtra,
   type KakaoMarkReadResult,
   type KakaoMember,
   type KakaoMessage,
   type KakaoMultiPhotoExtra,
-  type KakaoPhotoExtra,
   type KakaoProfile,
   type KakaoSendResult,
 } from './types'
@@ -1073,9 +1071,17 @@ export class KakaoTalkClient {
         const kl = body.kl as string[] | undefined
         const vhl = body.vhl as string[] | undefined
         const pl = body.pl as number[] | undefined
-        if (!kl || !vhl || !pl || kl.length !== prepared.length) {
+        if (
+          !kl ||
+          !vhl ||
+          !pl ||
+          kl.length !== prepared.length ||
+          vhl.length !== prepared.length ||
+          pl.length !== prepared.length
+        ) {
           throw new KakaoTalkError(
-            `MSHIP response missing arrays: kl=${kl?.length} vhl=${vhl?.length} pl=${pl?.length}`,
+            `MSHIP response arrays do not match prepared.length=${prepared.length}: ` +
+              `kl=${kl?.length} vhl=${vhl?.length} pl=${pl?.length}`,
             'send_multi_photo_failed',
           )
         }

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -7,10 +7,11 @@ import { Long } from 'bson'
 import { getConfigDir } from '@/shared/utils/config-dir'
 import { warn } from '@/shared/utils/stderr'
 
+import { type AttachmentInput, type ResolvedAttachment, planAttachments } from './attachment-router'
 import { detectImageDimensions } from './image-meta'
-import { guessMimeFromFilename, sha1Hex } from './media-upload'
-import { uploadMediaToLoco, uploadMultiMediaEntry } from './protocol/media-uploader'
+import { sha1Hex } from './media-upload'
 import { LANG, PC_OS_NAME, getLocoDeviceConfig } from './protocol/config'
+import { uploadMediaToLoco, uploadMultiMediaEntry } from './protocol/media-uploader'
 import { LocoSession } from './protocol/session'
 import type { ChatListResponse, LocoPacket, LoginListResponse, SyncState } from './protocol/types'
 import {
@@ -907,18 +908,49 @@ export class KakaoTalkClient {
     data: Uint8Array | Buffer,
     filename: string,
     mimeType?: string,
+  ): Promise<KakaoSendResult>
+  async sendAttachment(chatId: string, attachments: ReadonlyArray<AttachmentInput>): Promise<KakaoSendResult>
+  async sendAttachment(
+    chatId: string,
+    dataOrAttachments: Uint8Array | Buffer | ReadonlyArray<AttachmentInput>,
+    filename?: string,
+    mimeType?: string,
   ): Promise<KakaoSendResult> {
-    const mime = mimeType ?? guessMimeFromFilename(filename)
-    if (mime.startsWith('image/')) {
-      return this.sendPhoto(chatId, data, filename)
+    const inputs: ReadonlyArray<AttachmentInput> = Array.isArray(dataOrAttachments)
+      ? dataOrAttachments
+      : [{ data: dataOrAttachments, filename: filename!, mime: mimeType }]
+    const plan = planAttachments(inputs)
+    switch (plan.kind) {
+      case 'single':
+        return this.dispatchSingleAttachment(chatId, plan.resolved)
+      case 'multiphoto':
+        return this.sendMultiPhoto(
+          chatId,
+          plan.items.map((it) => ({ data: it.data, filename: it.filename })),
+        )
+      case 'sequential': {
+        let last: KakaoSendResult | null = null
+        for (const r of plan.resolved) {
+          const result = await this.dispatchSingleAttachment(chatId, r)
+          if (!result.success) return result
+          last = result
+        }
+        return last!
+      }
     }
-    if (mime.startsWith('video/')) {
-      return this.sendVideo(chatId, data, filename)
+  }
+
+  private dispatchSingleAttachment(chatId: string, r: ResolvedAttachment): Promise<KakaoSendResult> {
+    switch (r.kind) {
+      case 'photo':
+        return this.sendPhoto(chatId, r.data, r.filename)
+      case 'video':
+        return this.sendVideo(chatId, r.data, r.filename)
+      case 'audio':
+        return this.sendAudio(chatId, r.data, r.filename)
+      case 'file':
+        return this.sendFile(chatId, r.data, r.filename, r.mime)
     }
-    if (mime.startsWith('audio/')) {
-      return this.sendAudio(chatId, data, filename)
-    }
-    return this.sendFile(chatId, data, filename, mime)
   }
 
   async sendPhoto(chatId: string, photo: Uint8Array | Buffer, filename = 'image.jpg'): Promise<KakaoSendResult> {
@@ -1034,10 +1066,7 @@ export class KakaoTalkClient {
         )
 
         if (mshipResp.statusCode !== 0) {
-          throw new KakaoTalkError(
-            `MSHIP rejected (status ${mshipResp.statusCode})`,
-            'send_multi_photo_failed',
-          )
+          throw new KakaoTalkError(`MSHIP rejected (status ${mshipResp.statusCode})`, 'send_multi_photo_failed')
         }
 
         const body = mshipResp.body as Record<string, unknown>
@@ -1121,10 +1150,7 @@ export class KakaoTalkClient {
         )
 
         if (shipResp.statusCode !== 0) {
-          throw new KakaoTalkError(
-            `SHIP rejected (status ${shipResp.statusCode})`,
-            opts.errorCode,
-          )
+          throw new KakaoTalkError(`SHIP rejected (status ${shipResp.statusCode})`, opts.errorCode)
         }
 
         const body = shipResp.body as Record<string, unknown>

--- a/src/platforms/kakaotalk/commands/message.ts
+++ b/src/platforms/kakaotalk/commands/message.ts
@@ -78,6 +78,9 @@ async function uploadAction(
       }
     })
     console.log(formatOutput(result, options.pretty))
+    if (!result.success) {
+      process.exit(1)
+    }
   } catch (error) {
     handleError(error as Error)
   }

--- a/src/platforms/kakaotalk/commands/message.ts
+++ b/src/platforms/kakaotalk/commands/message.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+
 import { Command } from 'commander'
 
 import { handleError } from '@/shared/utils/error-handler'
@@ -27,6 +30,53 @@ async function sendAction(
 ): Promise<void> {
   try {
     const result = await withKakaoClient(options, (client) => client.sendMessage(chatId, text))
+    console.log(formatOutput(result, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+type UploadKind = 'auto' | 'photo' | 'video' | 'audio' | 'file' | 'multi'
+
+async function uploadAction(
+  chatId: string,
+  filePaths: string[],
+  options: { account?: string; pretty?: boolean; as?: UploadKind; mime?: string },
+): Promise<void> {
+  try {
+    const kind: UploadKind = options.as ?? (filePaths.length > 1 ? 'multi' : 'auto')
+
+    const result = await withKakaoClient(options, async (client) => {
+      if (kind === 'multi') {
+        if (filePaths.length < 2) {
+          throw new Error('--as=multi requires 2 or more files')
+        }
+        return client.sendMultiPhoto(
+          chatId,
+          filePaths.map((p) => ({ data: readFileSync(resolve(p)), filename: basename(p) })),
+        )
+      }
+
+      if (filePaths.length !== 1) {
+        throw new Error(`--as=${kind} accepts exactly one file path`)
+      }
+      const path = resolve(filePaths[0]!)
+      const data = readFileSync(path)
+      const filename = basename(path)
+
+      switch (kind) {
+        case 'auto':
+          return client.sendAttachment(chatId, data, filename, options.mime)
+        case 'photo':
+          return client.sendPhoto(chatId, data, filename)
+        case 'video':
+          return client.sendVideo(chatId, data, filename)
+        case 'audio':
+          return client.sendAudio(chatId, data, filename)
+        case 'file':
+          return client.sendFile(chatId, data, filename, options.mime ?? 'application/octet-stream')
+      }
+    })
     console.log(formatOutput(result, options.pretty))
   } catch (error) {
     handleError(error as Error)
@@ -71,6 +121,19 @@ export const messageCommand = new Command('message')
       .option('--account <id>', 'Use a specific KakaoTalk account')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
+  )
+  .addCommand(
+    new Command('upload')
+      .description(
+        'Send one or more files to a chat. MIME is sniffed from the filename (or --mime) and dispatched to the matching KakaoTalk message_type. Pass 2+ files (or --as=multi) for a multi-photo gallery.',
+      )
+      .argument('<chat-id>', 'Chat room ID')
+      .argument('<file-paths...>', 'One or more file paths')
+      .option('--account <id>', 'Use a specific KakaoTalk account')
+      .option('--as <kind>', 'Force a specific kind: auto | photo | video | audio | file | multi')
+      .option('--mime <type>', 'Override MIME type (otherwise inferred from filename)')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(uploadAction),
   )
   .addCommand(
     new Command('mark-read')

--- a/src/platforms/kakaotalk/image-meta.test.ts
+++ b/src/platforms/kakaotalk/image-meta.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test'
+
+import { detectImageDimensions } from './image-meta'
+
+function buildPng(width: number, height: number, opts?: { skipTrailingMagic?: boolean }): Uint8Array {
+  const buf = new Uint8Array(24)
+  const sig = opts?.skipTrailingMagic
+    ? [0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x00, 0x00]
+    : [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  buf.set(sig, 0)
+  const view = new DataView(buf.buffer)
+  view.setUint32(16, width, false)
+  view.setUint32(20, height, false)
+  return buf
+}
+
+function buildGif(version: '87a' | '89a' | 'XXa', width: number, height: number): Uint8Array {
+  const buf = new Uint8Array(10)
+  buf.set([0x47, 0x49, 0x46], 0)
+  if (version === '87a') buf.set([0x38, 0x37, 0x61], 3)
+  else if (version === '89a') buf.set([0x38, 0x39, 0x61], 3)
+  else buf.set([0x00, 0x00, 0x00], 3)
+  const view = new DataView(buf.buffer)
+  view.setUint16(6, width, true)
+  view.setUint16(8, height, true)
+  return buf
+}
+
+function buildJpeg(opts: {
+  width: number
+  height: number
+  prefixFillBytes?: number
+  includeStandaloneMarkers?: boolean
+}): Uint8Array {
+  const parts: number[] = [0xff, 0xd8]
+  if (opts.includeStandaloneMarkers) {
+    parts.push(0xff, 0xd0, 0xff, 0xd9)
+  }
+  for (let i = 0; i < (opts.prefixFillBytes ?? 0); i++) parts.push(0xff)
+  parts.push(0xff, 0xc0)
+  parts.push(0x00, 0x11)
+  parts.push(0x08)
+  parts.push((opts.height >> 8) & 0xff, opts.height & 0xff)
+  parts.push((opts.width >> 8) & 0xff, opts.width & 0xff)
+  for (let i = 0; i < 10; i++) parts.push(0x00)
+  return new Uint8Array(parts)
+}
+
+describe('detectImageDimensions', () => {
+  it('reads PNG dimensions when the full 8-byte signature is present', () => {
+    const dim = detectImageDimensions(buildPng(320, 240))
+    expect(dim).toEqual({ width: 320, height: 240, mimeType: 'image/png' })
+  })
+
+  it('rejects PNG-look-alikes that share only the first 4 bytes', () => {
+    expect(() => detectImageDimensions(buildPng(1, 1, { skipTrailingMagic: true }))).toThrow(/Unsupported/)
+  })
+
+  it('reads GIF87a and GIF89a dimensions', () => {
+    expect(detectImageDimensions(buildGif('87a', 100, 200))).toEqual({
+      width: 100,
+      height: 200,
+      mimeType: 'image/gif',
+    })
+    expect(detectImageDimensions(buildGif('89a', 64, 32))).toEqual({
+      width: 64,
+      height: 32,
+      mimeType: 'image/gif',
+    })
+  })
+
+  it('rejects GIF-look-alikes with the wrong version bytes', () => {
+    expect(() => detectImageDimensions(buildGif('XXa', 100, 200))).toThrow(/Unsupported/)
+  })
+
+  it('reads JPEG dimensions from a plain SOF0 marker', () => {
+    const dim = detectImageDimensions(buildJpeg({ width: 800, height: 600 }))
+    expect(dim).toEqual({ width: 800, height: 600, mimeType: 'image/jpeg' })
+  })
+
+  it('reads JPEG dimensions when 0xFF fill bytes precede the SOF marker', () => {
+    const dim = detectImageDimensions(buildJpeg({ width: 1280, height: 720, prefixFillBytes: 5 }))
+    expect(dim).toEqual({ width: 1280, height: 720, mimeType: 'image/jpeg' })
+  })
+
+  it('reads JPEG dimensions past standalone markers (RST/SOI/EOI) without desyncing', () => {
+    const dim = detectImageDimensions(buildJpeg({ width: 42, height: 99, includeStandaloneMarkers: true }))
+    expect(dim).toEqual({ width: 42, height: 99, mimeType: 'image/jpeg' })
+  })
+})

--- a/src/platforms/kakaotalk/image-meta.ts
+++ b/src/platforms/kakaotalk/image-meta.ts
@@ -51,16 +51,38 @@ export function detectImageDimensions(buffer: Uint8Array): ImageDimensions {
   throw new Error('Unsupported image format (expected JPEG, PNG, GIF, or WebP)')
 }
 
+// Full PNG signature: 89 50 4E 47 0D 0A 1A 0A — checking only the first 4 bytes
+// would let a file that happens to start with "\x89PNG" but isn't really a PNG
+// reach the dimension reader and either crash or return garbage. The trailing
+// CRLF/EOF/LF bytes pin it to a real PNG header.
 function isPng(b: Uint8Array): boolean {
-  return b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47
+  return (
+    b[0] === 0x89 &&
+    b[1] === 0x50 &&
+    b[2] === 0x4e &&
+    b[3] === 0x47 &&
+    b[4] === 0x0d &&
+    b[5] === 0x0a &&
+    b[6] === 0x1a &&
+    b[7] === 0x0a
+  )
 }
 
 function isJpeg(b: Uint8Array): boolean {
   return b[0] === 0xff && b[1] === 0xd8
 }
 
+// GIF signature is "GIF87a" or "GIF89a". Checking only "GIF" would match any
+// payload that starts with those three bytes (other Compuserve formats, etc.).
 function isGif(b: Uint8Array): boolean {
-  return b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46
+  return (
+    b[0] === 0x47 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x38 &&
+    (b[4] === 0x37 || b[4] === 0x39) &&
+    b[5] === 0x61
+  )
 }
 
 function isWebp(b: Uint8Array): boolean {
@@ -78,6 +100,16 @@ function isWebp(b: Uint8Array): boolean {
 
 // JPEG dimensions live in an SOF (Start Of Frame) marker (0xFFC0..0xFFCF except
 // 0xFFC4, 0xFFC8, 0xFFCC which are not SOF). We scan markers until we hit one.
+//
+// The scan has to handle two JPEG quirks (ITU-T T.81 §B.1):
+//   1. Fill bytes — any number of 0xFF bytes may precede a marker, so on a
+//      0xFF byte we look at the next byte for the actual marker code and skip
+//      forward by 1 if it's another 0xFF (without trying to read a length).
+//   2. Standalone markers — SOI/EOI/RST0-7/TEM (0xFFD0..0xFFD9, 0xFF01) have
+//      no length field, so we step past them with a fixed +2 instead of
+//      reading garbage as a segment length.
+// Treating either case as a length-prefixed segment desynchronizes the scan
+// and either skips past the SOF or runs off the end of the buffer.
 function readJpegDimensions(buffer: Uint8Array): { width: number; height: number } {
   const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   let i = 2
@@ -87,10 +119,18 @@ function readJpegDimensions(buffer: Uint8Array): { width: number; height: number
       continue
     }
     const marker = buffer[i + 1] ?? 0
+    if (marker === 0xff) {
+      i++
+      continue
+    }
     if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
       const height = view.getUint16(i + 5, false)
       const width = view.getUint16(i + 7, false)
       return { width, height }
+    }
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+      i += 2
+      continue
     }
     const segmentLength = view.getUint16(i + 2, false)
     i += 2 + segmentLength

--- a/src/platforms/kakaotalk/image-meta.ts
+++ b/src/platforms/kakaotalk/image-meta.ts
@@ -1,0 +1,136 @@
+export interface ImageDimensions {
+  width: number
+  height: number
+  mimeType: string
+}
+
+// Extracts width/height/mime by reading the file's magic bytes and headers
+// directly. Avoids pulling in `image-size` or `sharp` so the SDK stays
+// dependency-light. Supports JPEG, PNG, GIF, WebP — the formats KakaoTalk
+// actually renders inline. Throws for anything else (including truncated
+// headers whose magic matches but whose length is short of the dimension
+// fields, to avoid an unhandled DataView RangeError); the caller should fall
+// back to `sendFile` (type=18) for unknown types.
+export function detectImageDimensions(buffer: Uint8Array): ImageDimensions {
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+  if (isPng(buffer)) {
+    if (buffer.length < 24) {
+      throw new Error('Truncated PNG: header is shorter than 24 bytes')
+    }
+    return {
+      width: view.getUint32(16, false),
+      height: view.getUint32(20, false),
+      mimeType: 'image/png',
+    }
+  }
+
+  if (isJpeg(buffer)) {
+    const dim = readJpegDimensions(buffer)
+    return { ...dim, mimeType: 'image/jpeg' }
+  }
+
+  if (isGif(buffer)) {
+    if (buffer.length < 10) {
+      throw new Error('Truncated GIF: header is shorter than 10 bytes')
+    }
+    return {
+      width: view.getUint16(6, true),
+      height: view.getUint16(8, true),
+      mimeType: 'image/gif',
+    }
+  }
+
+  if (isWebp(buffer)) {
+    if (buffer.length < 16) {
+      throw new Error('Truncated WebP: header is shorter than 16 bytes')
+    }
+    return { ...readWebpDimensions(buffer), mimeType: 'image/webp' }
+  }
+
+  throw new Error('Unsupported image format (expected JPEG, PNG, GIF, or WebP)')
+}
+
+function isPng(b: Uint8Array): boolean {
+  return b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47
+}
+
+function isJpeg(b: Uint8Array): boolean {
+  return b[0] === 0xff && b[1] === 0xd8
+}
+
+function isGif(b: Uint8Array): boolean {
+  return b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46
+}
+
+function isWebp(b: Uint8Array): boolean {
+  return (
+    b[0] === 0x52 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x46 &&
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50
+  )
+}
+
+// JPEG dimensions live in an SOF (Start Of Frame) marker (0xFFC0..0xFFCF except
+// 0xFFC4, 0xFFC8, 0xFFCC which are not SOF). We scan markers until we hit one.
+function readJpegDimensions(buffer: Uint8Array): { width: number; height: number } {
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  let i = 2
+  while (i < buffer.length - 9) {
+    if (buffer[i] !== 0xff) {
+      i++
+      continue
+    }
+    const marker = buffer[i + 1] ?? 0
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      const height = view.getUint16(i + 5, false)
+      const width = view.getUint16(i + 7, false)
+      return { width, height }
+    }
+    const segmentLength = view.getUint16(i + 2, false)
+    i += 2 + segmentLength
+  }
+  throw new Error('JPEG SOF marker not found')
+}
+
+// WebP supports several variants: VP8 (lossy), VP8L (lossless), VP8X (extended).
+// Dimensions live at different offsets per variant; we cover all three.
+function readWebpDimensions(buffer: Uint8Array): { width: number; height: number } {
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  const fourCC = String.fromCharCode(buffer[12]!, buffer[13]!, buffer[14]!, buffer[15]!)
+
+  if (fourCC === 'VP8 ') {
+    if (buffer.length < 30) {
+      throw new Error('Truncated WebP VP8: header is shorter than 30 bytes')
+    }
+    const width = view.getUint16(26, true) & 0x3fff
+    const height = view.getUint16(28, true) & 0x3fff
+    return { width, height }
+  }
+  if (fourCC === 'VP8L') {
+    if (buffer.length < 25) {
+      throw new Error('Truncated WebP VP8L: header is shorter than 25 bytes')
+    }
+    const b0 = buffer[21]!
+    const b1 = buffer[22]!
+    const b2 = buffer[23]!
+    const b3 = buffer[24]!
+    const width = 1 + (((b1 & 0x3f) << 8) | b0)
+    const height = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6))
+    return { width, height }
+  }
+  if (fourCC === 'VP8X') {
+    if (buffer.length < 31) {
+      throw new Error('Truncated WebP VP8X: header is shorter than 31 bytes')
+    }
+    const width = 1 + (view.getUint32(24, true) & 0xffffff)
+    const height = 1 + (view.getUint32(27, true) & 0xffffff)
+    return { width, height }
+  }
+  throw new Error(`Unsupported WebP variant: ${fourCC}`)
+}

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -44,3 +44,5 @@ export {
 } from './types'
 export { sha1Hex } from './media-upload'
 export { detectImageDimensions } from './image-meta'
+export type { AttachmentInput, AttachmentPlan, ResolvedAttachment, SingleAttachmentKind } from './attachment-router'
+export { planAttachments, resolveAttachment } from './attachment-router'

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -12,8 +12,10 @@ export type {
   KakaoDeviceType,
   KakaoEmoticonKind,
   KakaoEmoticonMessageType,
+  KakaoFileExtra,
   KakaoMember,
   KakaoMessage,
+  KakaoPhotoExtra,
   KakaoProfile,
   KakaoSendResult,
   KakaoTalkListenerEventMap,
@@ -27,6 +29,7 @@ export type {
 export {
   KAKAO_EMOTICON_KIND_BY_TYPE,
   KAKAO_EMOTICON_MESSAGE_TYPES,
+  KAKAO_MESSAGE_TYPE,
   KakaoAccountCredentialsSchema,
   KakaoChatSchema,
   KakaoConfigSchema,
@@ -39,3 +42,5 @@ export {
   KakaoTalkPushMessageEventSchema,
   KakaoTalkPushReadEventSchema,
 } from './types'
+export { sha1Hex } from './media-upload'
+export { detectImageDimensions } from './image-meta'

--- a/src/platforms/kakaotalk/media-upload.ts
+++ b/src/platforms/kakaotalk/media-upload.ts
@@ -1,0 +1,44 @@
+// SHA-1 hex (uppercase, 40 chars) — required as the `cs` (checksum) field
+// on SHIP requests and on the inbound photo `extra` JSON. Verified by inbound
+// capture of a real KakaoTalk client photo (2026-05).
+export async function sha1Hex(data: Uint8Array): Promise<string> {
+  const hashBuf = await crypto.subtle.digest('SHA-1', data)
+  return Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, '0').toUpperCase())
+    .join('')
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  webm: 'video/webm',
+  mkv: 'video/x-matroska',
+  m4v: 'video/x-m4v',
+  m4a: 'audio/m4a',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  pdf: 'application/pdf',
+  csv: 'text/csv',
+  txt: 'text/plain',
+  json: 'application/json',
+  zip: 'application/zip',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+}
+
+export function guessMimeFromFilename(filename: string): string {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0 || dot === filename.length - 1) return 'application/octet-stream'
+  const ext = filename.slice(dot + 1).toLowerCase()
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream'
+}

--- a/src/platforms/kakaotalk/protocol/connection.ts
+++ b/src/platforms/kakaotalk/protocol/connection.ts
@@ -50,6 +50,17 @@ export class LocoConnection {
     await this.write(handshakePacket)
   }
 
+  // Writes raw bytes onto the LOCO stream after applying the same AES-128-GCM
+  // framing as encrypted packets — used by the media-upload POST step where
+  // the protocol expects the file payload to follow the POST request inside
+  // the same encrypted channel (chunked into N frames automatically by the
+  // crypto layer's 4-byte-size + nonce + ciphertext + tag wrapping).
+  async writeRaw(data: Buffer): Promise<void> {
+    if (!this.crypto) throw new Error('crypto not initialised')
+    const encrypted = this.crypto.encrypt(data)
+    await this.write(encrypted)
+  }
+
   async sendPacket(method: string, body: Record<string, unknown> = {}): Promise<LocoPacket> {
     const packetId = ++this.packetIdCounter
     const packet: LocoPacket = {

--- a/src/platforms/kakaotalk/protocol/media-uploader.ts
+++ b/src/platforms/kakaotalk/protocol/media-uploader.ts
@@ -1,10 +1,9 @@
 import { Long } from 'bson'
 
-import { LANG, MCCMNC, getLocoDeviceConfig } from './config'
+import type { KakaoDeviceType } from '../types'
+import { MCCMNC, getLocoDeviceConfig } from './config'
 import { LocoConnection } from './connection'
 import type { LocoPacket } from './types'
-
-import type { KakaoDeviceType } from '../types'
 
 export interface UploadToLocoOptions {
   shipToken: string
@@ -52,10 +51,7 @@ export async function uploadMultiMediaEntry(opts: UploadToLocoOptions): Promise<
   return runPostStreamComplete(opts, 'MPOST')
 }
 
-async function runPostStreamComplete(
-  opts: UploadToLocoOptions,
-  opcode: 'POST' | 'MPOST',
-): Promise<UploadToLocoResult> {
+async function runPostStreamComplete(opts: UploadToLocoOptions, opcode: 'POST' | 'MPOST'): Promise<UploadToLocoResult> {
   const device = getLocoDeviceConfig(opts.deviceType)
 
   const conn = new LocoConnection()

--- a/src/platforms/kakaotalk/protocol/media-uploader.ts
+++ b/src/platforms/kakaotalk/protocol/media-uploader.ts
@@ -1,0 +1,133 @@
+import { Long } from 'bson'
+
+import { LANG, MCCMNC, getLocoDeviceConfig } from './config'
+import { LocoConnection } from './connection'
+import type { LocoPacket } from './types'
+
+import type { KakaoDeviceType } from '../types'
+
+export interface UploadToLocoOptions {
+  shipToken: string
+  shipHost: string
+  shipPort: number
+  chatId: Long
+  msgType: number
+  userId: string
+  filename: string
+  data: Uint8Array
+  width?: number
+  height?: number
+  deviceType: KakaoDeviceType
+  onProgress?: (sent: number, total: number) => void
+}
+
+export interface UploadToLocoResult {
+  completePacket: LocoPacket | null
+  postStatusCode: number
+  postOffset: number
+}
+
+const DEFAULT_NETWORK_TYPE = 0
+const DEFAULT_COMPLETE_TIMEOUT_MS = 60_000
+
+// Drives the SHIP → connect → POST → stream → COMPLETE pipeline that KakaoTalk
+// uses for chat-media uploads. The caller has already done SHIP on the main
+// session and received {k, vh, p}; this opens a dedicated TCP+LOCO connection
+// to (vh, p), sends POST with the ticket + chat metadata, streams the raw file
+// bytes, and waits for the server's COMPLETE push that triggers the actual
+// chat-message registration.
+//
+// Field names (u/k/t/s/c/mid/w/h/mm/nt/os/av/f/ns) match the APK's
+// `SR/g0.java` (PostJob) verbatim. The COMPLETE handshake is a server-pushed
+// packet whose body contains the resulting chatLog struct.
+export async function uploadMediaToLoco(opts: UploadToLocoOptions): Promise<UploadToLocoResult> {
+  return runPostStreamComplete(opts, 'POST')
+}
+
+// Single-entry MPOST upload — runs the same connect → POST → stream → COMPLETE
+// pipeline as uploadMediaToLoco but with MPOST as the opcode (used after MSHIP
+// for each entry in a multi-photo batch). Callers fan-out across all entries
+// in parallel and then issue one FORWARD to register the gallery message.
+export async function uploadMultiMediaEntry(opts: UploadToLocoOptions): Promise<UploadToLocoResult> {
+  return runPostStreamComplete(opts, 'MPOST')
+}
+
+async function runPostStreamComplete(
+  opts: UploadToLocoOptions,
+  opcode: 'POST' | 'MPOST',
+): Promise<UploadToLocoResult> {
+  const device = getLocoDeviceConfig(opts.deviceType)
+
+  const conn = new LocoConnection()
+  await conn.connectSecure(opts.shipHost, opts.shipPort)
+
+  const totalSize = opts.data.byteLength
+  let completeResolve: ((p: LocoPacket | null) => void) | null = null
+  let completeTimeout: ReturnType<typeof setTimeout> | null = null
+  const completePromise = new Promise<LocoPacket | null>((resolve) => {
+    completeResolve = resolve
+    completeTimeout = setTimeout(() => {
+      completeTimeout = null
+      resolve(null)
+    }, DEFAULT_COMPLETE_TIMEOUT_MS)
+  })
+  conn.onPush((push) => {
+    if (push.method === 'COMPLETE' && completeResolve) {
+      if (completeTimeout) {
+        clearTimeout(completeTimeout)
+        completeTimeout = null
+      }
+      completeResolve(push)
+      completeResolve = null
+    }
+  })
+
+  try {
+    const postBody: Record<string, unknown> = {
+      k: opts.shipToken,
+      s: totalSize,
+      t: opts.msgType,
+      u: Long.fromString(opts.userId),
+      os: device.os,
+      av: device.appVersion,
+      nt: DEFAULT_NETWORK_TYPE,
+      mm: MCCMNC,
+    }
+    if (opcode === 'POST') {
+      postBody.f = opts.filename
+      postBody.c = opts.chatId
+      postBody.mid = Long.ONE
+      postBody.ns = true
+      if (typeof opts.width === 'number') postBody.w = opts.width
+      if (typeof opts.height === 'number') postBody.h = opts.height
+    } else {
+      postBody.dt = 0
+      postBody.scp = 0
+    }
+
+    const postResp = await conn.sendPacket(opcode, postBody)
+    const postOffsetRaw = (postResp.body as Record<string, unknown>).o
+    const postOffset = typeof postOffsetRaw === 'number' ? postOffsetRaw : 0
+
+    const bytesToSend = opts.data.subarray(postOffset)
+    if (bytesToSend.length > 0) {
+      await conn.writeRaw(Buffer.from(bytesToSend))
+      opts.onProgress?.(totalSize, totalSize)
+    }
+
+    const completePacket = await completePromise
+    const postStatusCode = postResp.statusCode
+
+    return {
+      completePacket,
+      postStatusCode,
+      postOffset,
+    }
+  } finally {
+    if (completeTimeout) {
+      clearTimeout(completeTimeout)
+      completeTimeout = null
+    }
+    conn.close()
+  }
+}

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -129,12 +129,7 @@ export class LocoSession {
   // Sends a WRITE with non-text message_type plus the JSON-stringified `extra`
   // payload that KakaoTalk clients render as the attachment (photo, file, etc).
   // See types.ts → KakaoPhotoExtra / KakaoFileExtra for the per-type shape.
-  async sendAttachment(
-    chatId: Long,
-    type: number,
-    extra: Record<string, unknown>,
-    caption = '',
-  ): Promise<LocoPacket> {
+  async sendAttachment(chatId: Long, type: number, extra: Record<string, unknown>, caption = ''): Promise<LocoPacket> {
     if (!this.connection) throw new Error('Not connected')
     return this.connection.sendPacket('WRITE', {
       chatId,
@@ -148,13 +143,7 @@ export class LocoSession {
   // SHIP — request a media-upload ticket. Reserves a slot on a media LOCO
   // server and returns the token (k), host (vh), and port (p) the client must
   // connect to next. Sent on the main session.
-  async shipMedia(
-    chatId: Long,
-    type: number,
-    size: number,
-    checksum: string,
-    extension: string,
-  ): Promise<LocoPacket> {
+  async shipMedia(chatId: Long, type: number, size: number, checksum: string, extension: string): Promise<LocoPacket> {
     if (!this.connection) throw new Error('Not connected')
     const body: Record<string, unknown> = {
       c: chatId,
@@ -189,12 +178,7 @@ export class LocoSession {
   // FORWARD — used after MPOST: registers a multi-attachment chatlog as one
   // message. Same shape as WRITE but the server routes the attachment to
   // multi-media rendering (galleries, multi-photo posts).
-  async forwardChat(
-    chatId: Long,
-    type: number,
-    extra: Record<string, unknown>,
-    caption = '',
-  ): Promise<LocoPacket> {
+  async forwardChat(chatId: Long, type: number, extra: Record<string, unknown>, caption = ''): Promise<LocoPacket> {
     if (!this.connection) throw new Error('Not connected')
     return this.connection.sendPacket('FORWARD', {
       chatId,

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -126,6 +126,89 @@ export class LocoSession {
     })
   }
 
+  // Sends a WRITE with non-text message_type plus the JSON-stringified `extra`
+  // payload that KakaoTalk clients render as the attachment (photo, file, etc).
+  // See types.ts → KakaoPhotoExtra / KakaoFileExtra for the per-type shape.
+  async sendAttachment(
+    chatId: Long,
+    type: number,
+    extra: Record<string, unknown>,
+    caption = '',
+  ): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return this.connection.sendPacket('WRITE', {
+      chatId,
+      msg: caption,
+      type,
+      noSeen: false,
+      extra: JSON.stringify(extra),
+    })
+  }
+
+  // SHIP — request a media-upload ticket. Reserves a slot on a media LOCO
+  // server and returns the token (k), host (vh), and port (p) the client must
+  // connect to next. Sent on the main session.
+  async shipMedia(
+    chatId: Long,
+    type: number,
+    size: number,
+    checksum: string,
+    extension: string,
+  ): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    const body: Record<string, unknown> = {
+      c: chatId,
+      t: type,
+      s: Long.fromNumber(size),
+      cs: checksum,
+    }
+    if (extension.length > 0) body.e = extension
+    return this.connection.sendPacket('SHIP', body)
+  }
+
+  // MSHIP — multi-file equivalent of SHIP. Per-file fields become parallel
+  // arrays (sl/csl/el) and the response carries kl/vhl/pl arrays the caller
+  // must fan out across — one MPOST connection per entry.
+  async shipMultiMedia(
+    chatId: Long,
+    type: number,
+    sizes: number[],
+    checksums: string[],
+    extensions: string[],
+  ): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return this.connection.sendPacket('MSHIP', {
+      c: chatId,
+      t: type,
+      sl: sizes.map((s) => Long.fromNumber(s)),
+      csl: checksums,
+      el: extensions,
+    })
+  }
+
+  // FORWARD — used after MPOST: registers a multi-attachment chatlog as one
+  // message. Same shape as WRITE but the server routes the attachment to
+  // multi-media rendering (galleries, multi-photo posts).
+  async forwardChat(
+    chatId: Long,
+    type: number,
+    extra: Record<string, unknown>,
+    caption = '',
+  ): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return this.connection.sendPacket('FORWARD', {
+      chatId,
+      msg: caption,
+      type,
+      noSeen: false,
+      extra: JSON.stringify(extra),
+    })
+  }
+
+  getConnection(): LocoConnection | null {
+    return this.connection
+  }
+
   async syncMessages(chatId: Long, count = 20, cursor?: Long, maxLogId?: Long): Promise<LocoPacket> {
     if (!this.connection) throw new Error('Not connected')
     return this.connection.sendPacket('SYNCMSG', {

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -119,6 +119,63 @@ export interface KakaoSendResult {
   sent_at: number
 }
 
+// LOCO message_type values. Source: KakaoTalk APK 26.4.2 + typeclaw inbound parser.
+export const KAKAO_MESSAGE_TYPE = {
+  TEXT: 1,
+  PHOTO: 2,
+  VIDEO: 3,
+  AUDIO: 5,
+  FILE: 18,
+  MULTIPHOTO: 27,
+} as const
+
+// PHOTO `extra` keys verified by inbound capture of a real KakaoTalk client
+// photo message (2026-05). The bare minimum the receiver needs to render
+// the inline preview is k/s/w/h/mt/cs — url and thumbnailUrl are server-issued
+// pre-signed URLs that the recipient regenerates locally from k, so we don't
+// supply them on outbound.
+export interface KakaoPhotoExtra {
+  k: string
+  s: number
+  w: number
+  h: number
+  mt: string
+  cs: string
+  url?: string
+  thumbnailUrl?: string
+  thumbnailWidth?: number
+  thumbnailHeight?: number
+  expire?: number
+}
+
+export interface KakaoFileExtra {
+  k: string
+  s: number
+  name: string
+  mt: string
+  cs: string
+  expire?: number
+  url?: string
+}
+
+// MULTIPHOTO extra — each per-file field of KakaoPhotoExtra becomes a
+// parallel array. Verified by inbound capture of a real multi-photo message
+// (2026-05). csl uses lowercase hex (unlike PHOTO's cs which is uppercase).
+export interface KakaoMultiPhotoExtra {
+  kl: string[]
+  wl: number[]
+  hl: number[]
+  mtl: string[]
+  sl: number[]
+  csl: string[]
+  cmtl?: string[]
+  imageUrls?: string[]
+  thumbnailUrls?: string[]
+  thumbnailWidths?: number[]
+  thumbnailHeights?: number[]
+  expire?: number
+}
+
 export interface KakaoMarkReadResult {
   success: boolean
   status_code: number


### PR DESCRIPTION
## Summary

Adds the missing send-side of the KakaoTalk attachment protocol. Until now, `KakaoTalkClient` could only send text — sticker, photo, video, audio, file, and multi-photo all hit a "text-only platform" wall at the SDK boundary. This PR implements the full **SHIP / POST / MPOST / FORWARD / COMPLETE** pipeline that KakaoTalk uses internally and exposes it through a single `sendAttachment` entry point: pass one buffer or an array of `{ data, filename, mime? }` tuples and the client picks the right LOCO `message_type` for you.

A new `agent-kakaotalk message upload` CLI subcommand wires it up for AI agents and human callers alike. MIME is auto-detected from the filename, so the common case is a single command and a file path — no flags needed.

## What's added

### SDK — primary entry point (`KakaoTalkClient`)

```typescript
import { KakaoTalkClient } from 'agent-messenger/kakaotalk'
const client = await new KakaoTalkClient().login()

// One buffer — MIME inferred from the filename (image/* → photo, video/* → video,
// audio/* → audio, anything else → file). The MIME can be overridden.
await client.sendAttachment(chatId, photoBytes, 'cat.jpg')
await client.sendAttachment(chatId, mp4Bytes, 'clip.mp4', 'application/octet-stream')

// Array of buffers — the client picks the right batch shape:
//   all-image (length >= 2) → multi-photo gallery (one chat bubble)
//   mixed kinds            → sequential individual sends, fail-fast on first error
//   length === 1            → equivalent to the single-buffer overload
await client.sendAttachment(chatId, [
  { data: a, filename: 'a.jpg' },
  { data: b, filename: 'b.png' },
])
await client.sendAttachment(chatId, [
  { data: photo, filename: 'screenshot.png' },
  { data: spec,  filename: 'spec.pdf' },
])
```

`sendAttachment` is the API surface AI agents (and downstream like typeclaw) should target. Callers never have to pick between photo / video / audio / file / multi-photo themselves — the dispatcher reads the MIME and decides. The routing rule is intentionally narrow:

- Single buffer **or** length-1 array → single typed send (`PHOTO` / `VIDEO` / `AUDIO` / `FILE`).
- Length-2+ array, every item resolves to an image MIME → `MULTIPHOTO` gallery.
- Length-2+ array with any non-image entry → individual typed sends one after another, fail-fast on first error.

KakaoTalk's `MULTIPHOTO` message_type 27 is image-only on the wire, which is why mixed batches fall back to sequential sends instead of a partial gallery — that would render as two visually disconnected groups in the recipient's chat. The routing decision is extracted into a pure `planAttachments` helper in `src/platforms/kakaotalk/attachment-router.ts` so each branch is independently unit-testable without mocking the LOCO protocol.

### SDK — underlying typed methods

For library users who want to bypass MIME sniffing and pin the wire-level `message_type` themselves (rare; debugging edge cases or pre-validating a buffer's kind), the underlying methods stay exported:

| Typed method | KakaoTalk `message_type` | Pipeline |
| --- | --- | --- |
| `sendPhoto(chat, buffer, filename?)` | 2 (PHOTO) | SHIP → POST → stream → COMPLETE |
| `sendVideo(chat, buffer, filename?)` | 3 (VIDEO) | SHIP → POST → stream → COMPLETE |
| `sendAudio(chat, buffer, filename?)` | 5 (AUDIO) | SHIP → POST → stream → COMPLETE |
| `sendFile(chat, buffer, filename, mime?)` | 18 (FILE) | SHIP → POST → stream → COMPLETE |
| `sendMultiPhoto(chat, photos[])` | 27 (MULTIPHOTO) | MSHIP → MPOST × N → FORWARD |

These are the wire-protocol primitives `sendAttachment` dispatches to — not separate APIs. Prefer `sendAttachment` for new code; reach for the typed methods only when you need to skip the dispatcher (e.g. force a `.mp4` to upload as `FILE` rather than `VIDEO` — `sendAttachment` can do the same via the `mime` override).

### CLI subcommand (`agent-kakaotalk`)

```
agent-kakaotalk message upload <chat-id> <file...> [--as <kind>] [--mime <type>] [--account <id>] [--pretty]
```

The CLI mirrors the SDK's primary entry point — one verb (`upload`) that accepts one or many files and dispatches internally. Flags are optional:

```bash
# Common case: just hand it a file
agent-kakaotalk message upload <chat-id> ./photo.jpg
agent-kakaotalk message upload <chat-id> ./report.pdf
agent-kakaotalk message upload <chat-id> ./a.jpg ./b.png ./c.webp   # → multi-photo gallery

# Edge cases: force a kind or override MIME
agent-kakaotalk message upload <chat-id> ./clip.mp4 --as file       # force generic-file upload
agent-kakaotalk message upload <chat-id> ./image --as photo         # extension-less file
agent-kakaotalk message upload <chat-id> ./data.bin --mime application/octet-stream
```

Output is JSON by default (`{ success, status_code, chat_id, log_id, sent_at }`); `--pretty` pretty-prints; the process exits non-zero on `success: false`.

### Public types

- `KAKAO_MESSAGE_TYPE` — integer constants for `TEXT`/`PHOTO`/`VIDEO`/`AUDIO`/`FILE`/`MULTIPHOTO`, verified against the KakaoTalk Android client.
- `KakaoPhotoExtra`, `KakaoFileExtra`, `KakaoMultiPhotoExtra` — JSON payload shapes for the LOCO `extra` field on each attachment kind.
- `AttachmentInput`, `AttachmentPlan`, `ResolvedAttachment`, `SingleAttachmentKind` — types for the array overload's input/plan shape, exported alongside the pure routing helpers `planAttachments` and `resolveAttachment` so downstream consumers (typeclaw, others) can reuse the same dispatch without re-implementing the heuristic.

## Wire format (validated against live LOCO captures)

The whole pipeline was reverse-engineered from the KakaoTalk Android client (`SR/s0.java`, `SR/g0.java`, `SR/Z.java`, `SR/C21467S.java` after `jadx -d` decompilation) and cross-checked against inbound packets captured from a real KakaoTalk client sending the same kinds of messages.

### SHIP — reserve an upload slot (single attachment)

Sent on the main session. Returns a ticket `{k, vh, p}` the client must connect to next.

```jsonc
// request
{ "c": <chatId>, "t": 2, "s": <size>, "cs": "<sha1-hex-upper>", "e": "jpg" }
// response
{ "k": "talkm/.../i_abc.jpeg", "vh": "121.53.x.y", "p": 5223, "status": 0 }
```

### POST — upload a single attachment

Sent on a fresh TCP+LOCO connection to `(vh, p)`. After the server returns the resume offset, the raw file bytes are streamed on the same encrypted channel, and the server pushes `COMPLETE` carrying the resulting chatlog — no follow-up `WRITE` needed.

```jsonc
{ "k": "<ship token>", "s": <size>, "f": "img.jpg", "t": 2,
  "c": <chatId>, "mid": 1, "ns": true,
  "u": <userId>, "os": "android", "av": "25.9.2",
  "nt": 0, "mm": "99999",
  "w": 1206, "h": 2622 }
```

### MSHIP / MPOST — multi-photo

`MSHIP` returns parallel arrays `{kl, vhl, pl, vh6l, mtl}`. Each entry gets its own fresh TCP+LOCO connection running `MPOST` (slimmer body — no `mid`/`c`/`ns`/`f`, but **requires `dt` and `scp`** which `POST` doesn't). Each MPOST stream produces its own `COMPLETE`. Once all entries finish, the client issues one `FORWARD` to register the gallery chatlog.

```jsonc
// MPOST request (verified against SR/Z.java)
{ "u": <userId>, "k": "<token>", "t": 27, "s": <size>,
  "mm": "99999", "nt": 0, "os": "android", "av": "25.9.2",
  "dt": 0, "scp": 0 }
```

### Attachment payloads on the LOCO chatlog

```jsonc
// PHOTO (type=2)
{ "k": "talkm/.../i_xxx.png", "w": 32, "h": 32, "s": 97,
  "cs": "D5F7C2FD67...",  // uppercase 40-char hex
  "mt": "image/png" }

// FILE (type=18)
{ "k": "talkm/.../doc.pdf", "s": 542, "name": "doc.pdf",
  "mt": "application/pdf", "cs": "..." }

// MULTIPHOTO (type=27) — parallel arrays
{ "kl": [...], "wl": [...], "hl": [...], "mtl": [...],
  "sl": [...], "csl": [...],  // lowercase hex (different from single PHOTO!)
  "cmtl": ["", ""] }
```

Notable quirk: **`cs` is uppercase on single PHOTO/FILE, `csl` is lowercase on MULTIPHOTO.** The SDK matches the wire format on each path; documented in `KakaoMultiPhotoExtra` JSDoc.

## End-to-end validation

Sent and rendered correctly to a live KakaoTalk DM, screenshots in the comments below:

- KakaoTalk Android client 26.4.2 — `com.kakao.talk/SR/s0.java` (`ShipJob`), `SR/Z.java` (`MpostJob`), `SR/g0.java` (`PostJob`), `SR/C21467S.java` (`MShipJob`), `QR/EnumC19957d.java` (LOCO opcode table)
- [storycraft/node-kakao](https://github.com/storycraft/node-kakao/blob/stable/src/talk/channel/talk-channel-session.ts) — TS reference for the `uploadMedia` / `uploadMultiMedia` flow
- [KiwiTalk/loco.rs](https://github.com/KiwiTalk/loco.rs) — Rust reference for the LOCO packet layout

## Commits

```
0727c4c  Add writeRaw helper for streaming bytes onto an encrypted LOCO channel
1dc8f74  Add SHIP, MSHIP, sendAttachment, and forwardChat to LocoSession
e159dd4  Add KakaoTalk media-upload pipeline for POST and MPOST
464ed52  Add dependency-free image dimension detector for JPEG/PNG/GIF/WebP
90c047b  Add SHA-1 checksum and MIME-from-filename helpers
6634389  Add KakaoTalk message_type constants and attachment extra types
b005c04  Expose sendPhoto, sendVideo, sendAudio, sendFile, sendMultiPhoto, and sendAttachment on the client
e1854f5  Add `message upload` CLI subcommand for KakaoTalk
6e15584  Export new KakaoTalk attachment types and helpers from the barrel
bbb4818  Accept arrays of attachments in `sendAttachment` via overload (+ attachment-router unit tests, SDK docs, SKILL.md)
```

Marked as draft pending live screenshots in the PR comments and any review feedback on the API surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds send-side support for KakaoTalk attachments (photos, videos, audio, files, multi-photo galleries) with a single `sendAttachment` API and a new `agent-kakaotalk message upload` CLI. Adds array input routing, improves image header parsing, and updates docs and `SKILL.md`.

- **New Features**
  - Client: `sendAttachment` with array overload; typed `sendPhoto`/`sendVideo`/`sendAudio`/`sendFile`/`sendMultiPhoto`; pure `planAttachments`/`resolveAttachment` helpers (exported).
  - Protocol: `SHIP`/`MSHIP` ticketing; `POST`/`MPOST` upload with encrypted raw streaming via `writeRaw`; server-pushed `COMPLETE`; `FORWARD` for galleries.
  - CLI: `agent-kakaotalk message upload <chat-id> <file...>` with `--as <photo|video|audio|file|multi>` and `--mime <type>`; 2+ images send a gallery.
  - Types/Utils: `KAKAO_MESSAGE_TYPE`, `KakaoPhotoExtra`, `KakaoFileExtra`, `KakaoMultiPhotoExtra`; `detectImageDimensions`, `sha1Hex`, `guessMimeFromFilename` (exported via `index.ts`).
  - No new runtime dependencies.

- **Bug Fixes**
  - Image meta: stricter PNG (full 8‑byte signature), GIF (`87a`/`89a`), and JPEG marker parsing; new unit tests.
  - MIME routing: case-insensitive overrides in `attachment-router` so `Image/JPEG` resolves to photo.
  - Multi-photo: validate `MSHIP` `kl`/`vhl`/`pl` array lengths before `MPOST` fan-out.
  - CLI: `message upload` exits non-zero on logical send failures.
  - CI: formatting fixes and removal of an unused import; no behavior changes.
  - Docs updated: `skills/agent-kakaotalk/SKILL.md`, `docs/cli/kakaotalk.mdx`, `docs/sdk/kakaotalk.mdx`, capability table in README.

<sup>Written for commit 527e641c4ae9971da9f322b743458d17e509d48b. Summary will update on new commits. <a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

