### PR TITLE
Expose KakaoTalk auth primitives, KakaoMarkReadResult, and Slack message metadata fields

### DIFF
--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -13,8 +13,11 @@ export type {
   KakaoEmoticonKind,
   KakaoEmoticonMessageType,
   KakaoFileExtra,
+  KakaoLoginResult,
+  KakaoMarkReadResult,
   KakaoMember,
   KakaoMessage,
+  KakaoMultiPhotoExtra,
   KakaoPhotoExtra,
   KakaoProfile,
   KakaoSendResult,
@@ -33,6 +36,7 @@ export {
   KakaoAccountCredentialsSchema,
   KakaoChatSchema,
   KakaoConfigSchema,
+  KakaoMarkReadResultSchema,
   KakaoMemberSchema,
   KakaoMessageSchema,
   KakaoProfileSchema,
@@ -42,6 +46,8 @@ export {
   KakaoTalkPushMessageEventSchema,
   KakaoTalkPushReadEventSchema,
 } from './types'
+export { attemptLogin, generateDeviceUuid, loginFlow, registerDevice, requestPasscode } from './auth/kakao-login'
+export type { LoginCredentials } from './auth/kakao-login'
 export { sha1Hex } from './media-upload'
 export { detectImageDimensions } from './image-meta'
 export type { AttachmentInput, AttachmentPlan, ResolvedAttachment, SingleAttachmentKind } from './attachment-router'

--- a/src/platforms/slackbot/types.ts
+++ b/src/platforms/slackbot/types.ts
@@ -334,6 +334,18 @@ export interface SlackSocketModeMessageEvent {
   event_ts?: string
   edited?: { user: string; ts: string }
   hidden?: boolean
+  // Set on every reply within a thread; identifies the author of the message
+  // the thread is rooted at. Useful for deciding whether a reply targets the
+  // bot, another human, or an unknown parent.
+  parent_user_id?: string
+  // Client-generated UUID on user-authored messages, stable across Slack-side
+  // resends of the same gesture. Primary dedupe key for the "one user action
+  // surfaces as two events" case.
+  client_msg_id?: string
+  // Attachments delivered inline on the same message event. Slack does not
+  // fire a separate file_share envelope for messages we receive over Socket
+  // Mode, so consumers reading attachments off `message` events look here.
+  files?: SlackFile[]
   [key: string]: unknown
 }
 
@@ -345,6 +357,10 @@ export interface SlackSocketModeAppMentionEvent {
   ts: string
   thread_ts?: string
   event_ts?: string
+  // `app_mention` envelopes do not always carry `client_msg_id`, but typing
+  // it keeps the promotion to a message-shaped event lossless if Slack ever
+  // starts sending it on this event.
+  client_msg_id?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Summary

A downstream consumer (typeclaw) currently maintains a chunk of local TypeScript declarations and a `dist/`-deep dynamic import purely because `agent-messenger` does not expose a handful of types and helpers that its public surface already implies. This PR closes those gaps with a strictly additive, two-file change.

After this lands, the downstream code can:

- Delete its `KakaoLoginResult`, `LoginCredentials`, `AttemptLoginFn`, `LoginFlowFn`, `LoginFlowOptions`, `LoginFlowResult`, and `KakaoMarkReadResult` mirror declarations.
- Drop two `createRequire` + `await import('agent-messenger/dist/src/platforms/kakaotalk/auth/kakao-login.js')` workarounds that bypass the exports gate and tightly couple to the `dist/` layout.
- Stop re-declaring `parent_user_id`, `client_msg_id`, and `files` on top of `SlackSocketModeMessageEvent` (and `client_msg_id` on `SlackSocketModeAppMentionEvent`) at every consumer.

## Changes

### `agent-messenger/kakaotalk` barrel

1. **Re-export `KakaoMarkReadResult` + `KakaoMarkReadResultSchema`.** `KakaoTalkClient.markRead()` already returns this shape, but the type was unreachable from the public barrel — typeclaw 2.16.x had to inline the interface byte-for-byte just to type the call site. Both already live in `types.ts`; only the index re-export was missing.

2. **Re-export `KakaoLoginResult` and `KakaoMultiPhotoExtra`.** Same story: defined in `types.ts`, omitted from the barrel. `KakaoLoginResult` in particular is the return type of every auth helper in this module, so not exposing it forced every consumer to mirror it.

3. **Export the auth primitives from `./auth/kakao-login`:** `loginFlow`, `attemptLogin`, `requestPasscode`, `registerDevice`, `generateDeviceUuid`, and the `LoginCredentials` type. These already worked at runtime — typeclaw was reaching them via `dist/src/platforms/kakaotalk/auth/kakao-login.js` after a `require.resolve('agent-messenger/package.json')` dance. That bypass was load-bearing for KakaoTalk sub-device token renewal, but it pins the consumer to the current `dist/` directory layout. Exposing them through the documented entry point removes that coupling without changing runtime behavior.

### `agent-messenger/slackbot` event types

Type three load-bearing fields on `SlackSocketModeMessageEvent` and one on `SlackSocketModeAppMentionEvent`. All four were previously reachable only through the catch-all `[key: string]: unknown` index signature, which forced consumers to either redeclare the type or write `as` casts at every read site.

| Field | Event | Why it matters |
| --- | --- | --- |
| `parent_user_id?: string` | message | Set on every reply within a thread; identifies the author of the thread root. Required to distinguish "reply targets the bot" from "reply between two humans" without a separate API call. |
| `client_msg_id?: string` | message, app_mention | Client-generated UUID, stable across Slack-side resends of the same gesture. The canonical dedupe key for "one user action surfaces as two envelopes". |
| `files?: SlackFile[]` | message | Inline attachments — Slack does not fire a separate `file_share` envelope over Socket Mode, so any consumer touching message attachments has to read `event.files` directly. |

The `[key: string]: unknown` index signature stays in place on both events, so forward compatibility is unaffected: any field Slack adds in the future still type-checks against the unknown branch, and existing consumers that read additional fields off these events are not broken.

## Worked example: the auth deep-path import

What typeclaw had to write before this PR (excerpt from `src/init/kakaotalk-auth.ts`):

```ts
// agent-messenger does not export `loginFlow` from its public `exports` map
// (only the runtime client + credential manager), so we resolve the package's
// installed location and import the implementation file directly.
async function resolveLoginFlow(): Promise<LoginFlowFn> {
  const require = createRequire(import.meta.url)
  const pkgJson = require.resolve('agent-messenger/package.json')
  const pkgDir = pkgJson.replace(/\/package\.json$/, '')
  const mod = (await import(`${pkgDir}/dist/src/platforms/kakaotalk/auth/kakao-login.js`)) as {
    loginFlow: LoginFlowFn
  }
  return mod.loginFlow
}
```

After this PR, that whole helper collapses to:

```ts
import { loginFlow } from 'agent-messenger/kakaotalk'
```

Same story for `attemptLogin` (used by `kakao-renewal.ts` for the token-refresh cron).

## What's intentionally not in this PR

- **`KakaoTalkClient` / `KakaoTalkListener` as explicit interfaces.** The upstream classes have private fields, and TypeScript treats those nominally, so consumer test fakes that match the public surface get rejected. typeclaw works around this with structural duck-types and an `as unknown as` bridge. Promoting them to interfaces is a bigger structural change (splitting type from impl, or `Pick`-style derivation across multiple files) and warrants a separate PR with API-surface review. Left out here to keep this change strictly additive.
- **A root `agent-messenger` export or `agent-messenger/types` subpath.** Out of scope for this PR; the platform-specific subpaths already work for the consumer.

## Verification

- `bun typecheck` — clean
- `bun lint` (oxlint) — 0 warnings, 0 errors
- `bun test src/` — pass on every suite I touched. The 4 pre-existing failures in `src/platforms/slack/token-extractor.test.ts` are environment-leak issues (the test box has a real Slack desktop install whose tokens bleed into the test fixtures); they fail identically on `main` and are unrelated to this PR.

Diff is +22 / -0 across two files (`src/platforms/kakaotalk/index.ts`, `src/platforms/slackbot/types.ts`). No runtime code is touched; no schemas change shape; no existing exports are renamed or removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose KakaoTalk auth functions and missing Kakao types from `agent-messenger/kakaotalk`, and type key Slack message metadata fields to eliminate deep imports and local type mirrors. No runtime changes; strictly additive API.

- **New Features**
  - KakaoTalk: Re-export `KakaoMarkReadResult` (+ `KakaoMarkReadResultSchema`), `KakaoLoginResult`, and `KakaoMultiPhotoExtra`; export `loginFlow`, `attemptLogin`, `requestPasscode`, `registerDevice`, `generateDeviceUuid`, and `LoginCredentials` from `agent-messenger/kakaotalk`.
  - Slack: Type `parent_user_id`, `client_msg_id`, and `files` on `SlackSocketModeMessageEvent`, and `client_msg_id` on `SlackSocketModeAppMentionEvent` (index signature retained for forward compatibility).

- **Migration**
  - No breaking changes.
  - Replace deep imports of `dist/.../kakao-login.js` with `import { loginFlow } from 'agent-messenger/kakaotalk'`.
  - Remove local mirrors of Kakao and Slack event types where used.
  - Docs: No SKILL.md or docs updates needed.

<sup>Written for commit 299ce9e0cb4c70a7c40f476b9030631c6120fafc. Summary will update on new commits. <a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

