### PR TITLE
feat(webex): drive OAuth Device Grant as a stateless two-call agent flow

### DIFF
--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -76,6 +76,12 @@ Note: Messages sent via OAuth Device Grant show "via agent-messenger" because th
 
 Optionally, pass `--token <bot-token>` for bot token auth. Or pass `--client-id <id> --client-secret <secret>` to use your own Webex Integration credentials instead of the built-in ones.
 
+**For AI agents**: `agent-webex auth login` is interactive — it requires a human to approve access in a browser. When run without a TTY (the typical case for AI agents), the command does NOT hang waiting for a browser approval. It returns immediately with `{"next_action": "run_interactive", ...}` and exit code 1. Do not retry the same command. Instead, either:
+
+- Ask the user to run `agent-webex auth login` themselves in their own terminal, or
+- Use `agent-webex auth extract` to read an existing browser session token, or
+- Use `agent-webex auth login --token <bot-or-personal-access-token>` for non-interactive token-based auth.
+
 Env vars `AGENT_WEBEX_CLIENT_ID` / `AGENT_WEBEX_CLIENT_SECRET` can also override the built-in credentials.
 
 ```bash

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -76,11 +76,36 @@ Note: Messages sent via OAuth Device Grant show "via agent-messenger" because th
 
 Optionally, pass `--token <bot-token>` for bot token auth. Or pass `--client-id <id> --client-secret <secret>` to use your own Webex Integration credentials instead of the built-in ones.
 
-**For AI agents**: `agent-webex auth login` is interactive — it requires a human to approve access in a browser. When run without a TTY (the typical case for AI agents), the command does NOT hang waiting for a browser approval. It returns immediately with `{"next_action": "run_interactive", ...}` and exit code 1. Do not retry the same command. Instead, either:
+**For AI agents (non-TTY)**: `agent-webex auth login` exposes the OAuth Device Grant flow as a stateless two-call sequence — no hangs, no polling loops, no on-disk state. Just structured JSON every time.
 
-- Ask the user to run `agent-webex auth login` themselves in their own terminal, or
-- Use `agent-webex auth extract` to read an existing browser session token, or
-- Use `agent-webex auth login --token <bot-or-personal-access-token>` for non-interactive token-based auth.
+**Call 1** (no `--device-code` passed): the command requests a device code from Webex and returns immediately:
+
+```json
+{
+  "next_action": "authorize_in_browser",
+  "verification_uri": "https://login.webex.com/verify",
+  "verification_uri_complete": "https://login.webex.com/verify?userCode=ABC123",
+  "user_code": "ABC123",
+  "device_code": "d8eb0eca-2fee-428e-a59e-5e6d487b33ba",
+  "expires_at": 1779786537203,
+  "message": "Show the user `verification_uri` and `user_code` ..."
+}
+```
+
+Show the user `verification_uri_complete` (or `verification_uri` + `user_code`) in chat. **Remember the `device_code` value** — you will pass it back on the second call. Ask the user to confirm once they have approved access in any browser, on any device.
+
+**Call 2** (`--device-code <device_code>`): pass the `device_code` from Call 1's response. The command makes one polling call to Webex:
+
+- **Success** — returns `{ "authenticated": true, "user": { ... } }`, exit 0.
+- **Still pending** — returns `{ "next_action": "still_pending", "device_code": "...", ... }`, exit 0. The user has not approved yet; confirm with them and retry with the same `--device-code` value.
+- **Expired / failed** — returns `{ "next_action": "restart", "error": "..." }`, exit 1. The device code is no longer usable; start over with another `agent-webex auth login` (no flags) to get a fresh one.
+
+If you passed `--client-id` / `--client-secret` (custom Webex Integration) on Call 1, pass them again on Call 2.
+
+Alternatives that skip the Device Grant flow entirely:
+
+- `agent-webex auth login --token <bot-or-personal-access-token>` — fully unattended, no human required.
+- `agent-webex auth extract` — read an existing browser session token (no auth flow at all).
 
 Env vars `AGENT_WEBEX_CLIENT_ID` / `AGENT_WEBEX_CLIENT_SECRET` can also override the built-in credentials.
 

--- a/src/platforms/instagram/commands/auth.ts
+++ b/src/platforms/instagram/commands/auth.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander'
 
 import { collectBrowserProfileOption } from '@/shared/chromium'
 import { handleError } from '@/shared/utils/error-handler'
+import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { info, warn, error as stderrError, debug } from '@/shared/utils/stderr'
 
@@ -13,10 +14,6 @@ import { InstagramClient, generateAndroidDeviceId, generateDeviceString } from '
 import { InstagramCredentialManager } from '../credential-manager'
 import { InstagramTokenExtractor } from '../token-extractor'
 import { createAccountId } from '../types'
-
-function isInteractive(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
-}
 
 async function promptText(message: string): Promise<string | undefined> {
   const { createInterface } = await import('node:readline/promises')

--- a/src/platforms/kakaotalk/commands/auth.ts
+++ b/src/platforms/kakaotalk/commands/auth.ts
@@ -3,6 +3,7 @@ import { Writable } from 'node:stream'
 import { Command } from 'commander'
 
 import { handleError } from '@/shared/utils/error-handler'
+import { hasTTY, isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { info, error, debug } from '@/shared/utils/stderr'
 
@@ -10,23 +11,6 @@ import { loginFlow } from '../auth/kakao-login'
 import { CredentialManager } from '../credential-manager'
 import { KakaoTokenExtractor } from '../token-extractor'
 import { KAKAO_NEXT_ACTIONS, type KakaoAuthOptions, type KakaoDeviceType, type KakaoLoginResult } from '../types'
-
-function isInteractiveSession(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
-}
-
-function hasTTY(): boolean {
-  try {
-    const { openSync, closeSync } = require('node:fs') as typeof import('node:fs')
-    // CONIN$ is the Windows console input device; /dev/tty is the Unix equivalent
-    const ttyDevice = process.platform === 'win32' ? 'CONIN$' : '/dev/tty'
-    const fd = openSync(ttyDevice, 'r')
-    closeSync(fd)
-    return true
-  } catch {
-    return false
-  }
-}
 
 async function promptPasswordGUI(email?: string): Promise<string | undefined> {
   const { execSync } = require('node:child_process') as typeof import('node:child_process')
@@ -233,7 +217,7 @@ async function promptHiddenTTY(message: string): Promise<string | undefined> {
 async function loginAction(options: KakaoAuthOptions): Promise<void> {
   try {
     const credManager = new CredentialManager()
-    const interactive = isInteractiveSession()
+    const interactive = isInteractive()
 
     let { email, password, deviceType, force } = options
 

--- a/src/platforms/line/commands/auth.ts
+++ b/src/platforms/line/commands/auth.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 
 import { handleError } from '@/shared/utils/error-handler'
+import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { displayQR } from '@/shared/utils/qr'
 import { info } from '@/shared/utils/stderr'
@@ -8,10 +9,6 @@ import { info } from '@/shared/utils/stderr'
 import { LineClient } from '../client'
 import { LineCredentialManager } from '../credential-manager'
 import type { LineDevice } from '../types'
-
-function isInteractiveSession(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
-}
 
 function getDefaultDevice(): LineDevice {
   return 'ANDROIDSECONDARY'
@@ -28,7 +25,7 @@ async function loginAction(options: {
     const credManager = new LineCredentialManager()
     const client = new LineClient(credManager)
     const device: LineDevice = (options.device as LineDevice | undefined) ?? getDefaultDevice()
-    const interactive = isInteractiveSession()
+    const interactive = isInteractive()
 
     if (options.token) {
       const now = new Date().toISOString()

--- a/src/platforms/telegram/commands/auth.ts
+++ b/src/platforms/telegram/commands/auth.ts
@@ -2,6 +2,7 @@ import { Writable } from 'node:stream'
 
 import { Command } from 'commander'
 
+import { isInteractive } from '@/shared/utils/interactive'
 import { info, error as stderrError } from '@/shared/utils/stderr'
 
 import { handleError } from '../../../shared/utils/error-handler'
@@ -57,10 +58,6 @@ function parseApiId(apiId?: string): number | undefined {
   return parsed
 }
 
-function isInteractiveSession(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
-}
-
 async function promptLine(message: string): Promise<string | undefined> {
   const { createInterface } = await import('node:readline/promises')
   const rl = createInterface({
@@ -107,7 +104,7 @@ async function promptHidden(message: string): Promise<string | undefined> {
 }
 
 function shouldUseInteractivePrompts(): boolean {
-  return isInteractiveSession()
+  return isInteractive()
 }
 
 async function fillMissingBootstrappingInputs(
@@ -168,7 +165,7 @@ async function fillMissingBootstrappingInputs(
   }
 
   if (!resolved.apiHash && !existing?.api_hash) {
-    if (!isInteractiveSession()) {
+    if (!isInteractive()) {
       console.log(formatOutput({ error: 'missing_credentials', message: 'Provide --api-hash flag.' }, options.pretty))
       process.exit(1)
     }
@@ -176,7 +173,7 @@ async function fillMissingBootstrappingInputs(
   }
 
   if (!existing && !resolved.phone) {
-    if (!isInteractiveSession()) {
+    if (!isInteractive()) {
       console.log(formatOutput({ next_action: 'provide_phone', message: 'Provide --phone flag.' }, options.pretty))
       process.exit(0)
     }
@@ -288,7 +285,7 @@ export async function promptNextLoginInput(
   result: { next_action?: string },
   options: AuthOptions,
 ): Promise<AuthOptions | null> {
-  if (!isInteractiveSession() && result.next_action) {
+  if (!isInteractive() && result.next_action) {
     return null
   }
 

--- a/src/platforms/webex/commands/auth.test.ts
+++ b/src/platforms/webex/commands/auth.test.ts
@@ -169,30 +169,125 @@ describe('auth commands', () => {
   })
 
   describe('loginAction non-interactive (no TTY)', () => {
-    it('returns next_action=run_interactive and exits when device-grant flow would block', async () => {
+    const device = {
+      deviceCode: 'webex-device-code-abc123',
+      userCode: 'USER-CODE',
+      verificationUri: 'https://webex.com/verify',
+      verificationUriComplete: 'https://webex.com/verify?user_code=USER-CODE',
+      expiresIn: 300,
+      interval: 1,
+    }
+
+    it('first call (no --device-code): requests device code and returns it in JSON', async () => {
       setTTY(false)
-      const requestSpy = protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode').mockResolvedValue({
-        deviceCode: 'd',
-        userCode: 'u',
-        verificationUri: 'https://v',
-        verificationUriComplete: 'https://vc',
-        expiresIn: 300,
-        interval: 0.01,
-      })
+      const requestSpy = protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode').mockResolvedValue(device)
+      const exchangeSpy = protoSpy(WebexCredentialManager.prototype, 'exchangeDeviceCode')
       const pollSpy = protoSpy(WebexCredentialManager.prototype, 'pollDeviceToken')
       const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
 
       await loginAction({ pretty: false })
 
+      expect(requestSpy).toHaveBeenCalled()
+      expect(exchangeSpy).not.toHaveBeenCalled()
+      expect(pollSpy).not.toHaveBeenCalled()
+
       const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
       const output = JSON.parse(lastCall)
-      expect(output.next_action).toBe('run_interactive')
-      expect(output.error).toContain('Interactive login required')
-      expect(output.message).toContain('--token')
-      expect(output.message).toContain('auth extract')
+      expect(output.next_action).toBe('authorize_in_browser')
+      expect(output.verification_uri).toBe(device.verificationUri)
+      expect(output.verification_uri_complete).toBe(device.verificationUriComplete)
+      expect(output.user_code).toBe(device.userCode)
+      expect(output.device_code).toBe(device.deviceCode)
+      expect(output.message).toContain('--device-code')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+    })
+
+    it('does not open a browser on the first non-interactive call', async () => {
+      setTTY(false)
+      protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode').mockResolvedValue(device)
+      protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ pretty: false })
+
+      expect(execSpy).not.toHaveBeenCalled()
+    })
+
+    it('second call (--device-code, pending): returns still_pending and echoes back the device_code', async () => {
+      setTTY(false)
+      protoSpy(WebexCredentialManager.prototype, 'exchangeDeviceCode').mockResolvedValue({ status: 'pending' })
+      const requestSpy = protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode')
+      const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
+
+      expect(requestSpy).not.toHaveBeenCalled()
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.next_action).toBe('still_pending')
+      expect(output.device_code).toBe('webex-device-code-abc123')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+    })
+
+    it('second call (--device-code, success): saves token and returns authenticated=true', async () => {
+      setTTY(false)
+      const exchangeSpy = protoSpy(WebexCredentialManager.prototype, 'exchangeDeviceCode').mockResolvedValue({
+        status: 'success',
+        config: { accessToken: 'at', refreshToken: 'rt', expiresAt: Date.now() + 3_600_000 },
+      })
+      const saveConfigSpy = protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({
+        deviceCode: 'webex-device-code-abc123',
+        clientId: 'my-id',
+        clientSecret: 'my-secret',
+        pretty: false,
+      })
+
+      expect(exchangeSpy).toHaveBeenCalledWith('webex-device-code-abc123', 'my-id', 'my-secret')
+      const savedConfig = saveConfigSpy.mock.calls[0][0] as { tokenType: string; clientId: string }
+      expect(savedConfig.tokenType).toBe('oauth')
+      expect(savedConfig.clientId).toBe('my-id')
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.authenticated).toBe(true)
+      expect(output.user.displayName).toBe('Test User')
+    })
+
+    it('second call (--device-code, expired): returns next_action=restart, exits 1', async () => {
+      setTTY(false)
+      protoSpy(WebexCredentialManager.prototype, 'exchangeDeviceCode').mockResolvedValue({ status: 'expired' })
+      const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.next_action).toBe('restart')
+      expect(output.error).toContain('expired')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+
+    it('--device-code works even with a TTY (interactive sessions can also resume)', async () => {
+      setTTY(true)
+      const exchangeSpy = protoSpy(WebexCredentialManager.prototype, 'exchangeDeviceCode').mockResolvedValue({
+        status: 'success',
+        config: { accessToken: 'at', refreshToken: 'rt', expiresAt: Date.now() + 3_600_000 },
+      })
+      const requestSpy = protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode')
+      const pollSpy = protoSpy(WebexCredentialManager.prototype, 'pollDeviceToken')
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
+
+      expect(exchangeSpy).toHaveBeenCalled()
       expect(requestSpy).not.toHaveBeenCalled()
       expect(pollSpy).not.toHaveBeenCalled()
-      expect(exitSpy).toHaveBeenCalledWith(1)
     })
 
     it('still allows --token login when non-interactive (bot/PAT path)', async () => {
@@ -207,15 +302,6 @@ describe('auth commands', () => {
       const output = JSON.parse(lastCall)
       expect(output.authenticated).toBe(true)
       expect(output.user.displayName).toBe('Test User')
-    })
-
-    it('does not open a browser when non-interactive', async () => {
-      setTTY(false)
-      protoSpy(process, 'exit').mockImplementation(() => undefined as never)
-
-      await loginAction({ pretty: false })
-
-      expect(execSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platforms/webex/commands/auth.test.ts
+++ b/src/platforms/webex/commands/auth.test.ts
@@ -12,6 +12,8 @@ describe('auth commands', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>
   let execSpy: ReturnType<typeof spyOn>
   const protoSpies: ReturnType<typeof spyOn>[] = []
+  let originalStdinTTY: boolean | undefined
+  let originalStdoutTTY: boolean | undefined
   const mockPerson = {
     id: 'person-1',
     displayName: 'Test User',
@@ -27,10 +29,19 @@ describe('auth commands', () => {
     return s
   }
 
+  function setTTY(value: boolean | undefined): void {
+    Object.defineProperty(process.stdin, 'isTTY', { value, writable: true, configurable: true })
+    Object.defineProperty(process.stdout, 'isTTY', { value, writable: true, configurable: true })
+  }
+
   beforeEach(() => {
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
     execSpy = spyOn(childProcess, 'exec').mockImplementation((() => {}) as any)
+    originalStdinTTY = process.stdin.isTTY
+    originalStdoutTTY = process.stdout.isTTY
+    // Default to interactive TTY for existing tests; non-interactive tests override.
+    setTTY(true)
   })
 
   afterEach(() => {
@@ -39,6 +50,12 @@ describe('auth commands', () => {
     execSpy.mockRestore()
     for (const s of protoSpies) s.mockRestore()
     protoSpies.length = 0
+    setTTY(originalStdinTTY)
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalStdoutTTY,
+      writable: true,
+      configurable: true,
+    })
   })
 
   describe('loginAction with --token', () => {
@@ -148,6 +165,57 @@ describe('auth commands', () => {
       const savedConfig = saveSpy.mock.calls[0][0] as { clientId: string; clientSecret: string }
       expect(savedConfig.clientId).toBe('my-id')
       expect(savedConfig.clientSecret).toBe('my-secret')
+    })
+  })
+
+  describe('loginAction non-interactive (no TTY)', () => {
+    it('returns next_action=run_interactive and exits when device-grant flow would block', async () => {
+      setTTY(false)
+      const requestSpy = protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode').mockResolvedValue({
+        deviceCode: 'd',
+        userCode: 'u',
+        verificationUri: 'https://v',
+        verificationUriComplete: 'https://vc',
+        expiresIn: 300,
+        interval: 0.01,
+      })
+      const pollSpy = protoSpy(WebexCredentialManager.prototype, 'pollDeviceToken')
+      const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ pretty: false })
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.next_action).toBe('run_interactive')
+      expect(output.error).toContain('Interactive login required')
+      expect(output.message).toContain('--token')
+      expect(output.message).toContain('auth extract')
+      expect(requestSpy).not.toHaveBeenCalled()
+      expect(pollSpy).not.toHaveBeenCalled()
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+
+    it('still allows --token login when non-interactive (bot/PAT path)', async () => {
+      setTTY(false)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+
+      await loginAction({ token: 'bot-token-123', pretty: false })
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.authenticated).toBe(true)
+      expect(output.user.displayName).toBe('Test User')
+    })
+
+    it('does not open a browser when non-interactive', async () => {
+      setTTY(false)
+      protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ pretty: false })
+
+      expect(execSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -44,12 +44,15 @@ async function resolveClientCredentials(options: {
   return getWebexAppCredentials()
 }
 
-export async function loginAction(options: {
+interface LoginOptions {
   token?: string
+  deviceCode?: string
   clientId?: string
   clientSecret?: string
   pretty?: boolean
-}): Promise<void> {
+}
+
+export async function loginAction(options: LoginOptions): Promise<void> {
   try {
     const credManager = new WebexCredentialManager()
 
@@ -74,19 +77,13 @@ export async function loginAction(options: {
       return
     }
 
+    if (options.deviceCode) {
+      await finishDeviceGrant(credManager, options)
+      return
+    }
+
     if (!isInteractive()) {
-      console.log(
-        formatOutput(
-          {
-            error: 'Interactive login required.',
-            next_action: 'run_interactive',
-            message:
-              'OAuth Device Grant requires a human to approve access in a browser. Ask the user to run `agent-webex auth login` in their own terminal. For non-interactive auth, pass `--token <bot-or-personal-access-token>` instead. Use `agent-webex auth extract` to read an existing browser session token.',
-          },
-          options.pretty,
-        ),
-      )
-      process.exit(1)
+      await startNonInteractiveDeviceGrant(credManager, options)
       return
     }
 
@@ -125,6 +122,81 @@ export async function loginAction(options: {
   } catch (error) {
     handleError(error as Error)
   }
+}
+
+async function startNonInteractiveDeviceGrant(
+  credManager: WebexCredentialManager,
+  options: LoginOptions,
+): Promise<void> {
+  const { clientId } = await resolveClientCredentials(options)
+  const device = await credManager.requestDeviceCode(clientId)
+  const expiresAt = Date.now() + device.expiresIn * 1000
+
+  console.log(
+    formatOutput(
+      {
+        next_action: 'authorize_in_browser',
+        verification_uri: device.verificationUri,
+        verification_uri_complete: device.verificationUriComplete,
+        user_code: device.userCode,
+        device_code: device.deviceCode,
+        expires_at: expiresAt,
+        message:
+          'Show the user `verification_uri` and `user_code` (or just `verification_uri_complete`) and ask them to approve access in any browser. After they approve, run `agent-webex auth login --device-code <device_code>` to retrieve the token. The device code expires at `expires_at`. If you passed `--client-id`/`--client-secret`, pass them again on the second call.',
+      },
+      options.pretty,
+    ),
+  )
+  process.exit(0)
+}
+
+async function finishDeviceGrant(credManager: WebexCredentialManager, options: LoginOptions): Promise<void> {
+  const { clientId, clientSecret } = await resolveClientCredentials(options)
+  const result = await credManager.exchangeDeviceCode(options.deviceCode!, clientId, clientSecret)
+
+  if (result.status === 'success') {
+    await credManager.saveConfig({ ...result.config, clientId, clientSecret, tokenType: 'oauth' })
+    const client = await new WebexClient().login({ token: result.config.accessToken })
+    const person = await client.testAuth()
+    console.log(
+      formatOutput(
+        {
+          authenticated: true,
+          user: { id: person.id, displayName: person.displayName, emails: person.emails },
+        },
+        options.pretty,
+      ),
+    )
+    return
+  }
+
+  if (result.status === 'pending') {
+    console.log(
+      formatOutput(
+        {
+          next_action: 'still_pending',
+          device_code: options.deviceCode,
+          message:
+            'User has not approved access yet. Confirm with the user that they completed authorization in the browser, then run `agent-webex auth login --device-code <device_code>` again to retry.',
+        },
+        options.pretty,
+      ),
+    )
+    process.exit(0)
+    return
+  }
+
+  console.log(
+    formatOutput(
+      {
+        next_action: 'restart',
+        error: result.status === 'expired' ? 'Device code expired.' : `Device code exchange failed: ${result.message}`,
+        message: 'This device code is no longer valid. Run `agent-webex auth login` to start a new login.',
+      },
+      options.pretty,
+    ),
+  )
+  process.exit(1)
 }
 
 export async function statusAction(options: { pretty?: boolean }): Promise<void> {
@@ -294,10 +366,17 @@ export const authCommand = new Command('auth')
   .addCommand(
     new Command('login')
       .description(
-        'Log in to Webex; the OAuth Device Grant flow is interactive and opens a browser. ' +
-          'For non-interactive use (AI agents, CI/CD), pass --token, or run `auth extract`.',
+        'Log in to Webex. In a TTY this opens a browser and waits for approval. ' +
+          'When non-interactive (AI agents, CI/CD): first call starts the OAuth Device Grant flow ' +
+          'and returns a verification URL, user code, and device code. After the user approves in a ' +
+          'browser, call again with --device-code to exchange it for a token. Pass --token for ' +
+          'fully unattended auth.',
       )
       .option('--token <token>', 'Use a bot token or personal access token directly')
+      .option(
+        '--device-code <code>',
+        'OAuth Device Grant code returned from a previous non-interactive `auth login` call',
+      )
       .option('--client-id <id>', 'Webex Integration client ID')
       .option('--client-secret <secret>', 'Webex Integration client secret')
       .option('--pretty', 'Pretty print JSON output')

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -16,6 +16,10 @@ interface ResolvedCredentials {
   clientSecret: string
 }
 
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
+}
+
 async function openBrowser(url: string): Promise<void> {
   const { exec } = await import('node:child_process')
   const command =
@@ -70,6 +74,22 @@ export async function loginAction(options: {
           options.pretty,
         ),
       )
+      return
+    }
+
+    if (!isInteractive()) {
+      console.log(
+        formatOutput(
+          {
+            error: 'Interactive login required.',
+            next_action: 'run_interactive',
+            message:
+              'OAuth Device Grant requires a human to approve access in a browser. Ask the user to run `agent-webex auth login` in their own terminal. For non-interactive auth, pass `--token <bot-or-personal-access-token>` instead. Use `agent-webex auth extract` to read an existing browser session token.',
+          },
+          options.pretty,
+        ),
+      )
+      process.exit(1)
       return
     }
 
@@ -276,7 +296,10 @@ export const authCommand = new Command('auth')
   .description('Authentication commands')
   .addCommand(
     new Command('login')
-      .description('Login to Webex')
+      .description(
+        'Log in to Webex; the OAuth Device Grant flow is interactive and opens a browser. ' +
+          'For non-interactive use (AI agents, CI/CD), pass --token, or run `auth extract`.',
+      )
       .option('--token <token>', 'Use a bot token or personal access token directly')
       .option('--client-id <id>', 'Webex Integration client ID')
       .option('--client-secret <secret>', 'Webex Integration client secret')

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 
 import { collectBrowserProfileOption } from '@/shared/chromium'
 import { handleError } from '@/shared/utils/error-handler'
+import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { info, debug } from '@/shared/utils/stderr'
 
@@ -14,10 +15,6 @@ import { WebexError } from '../types'
 interface ResolvedCredentials {
   clientId: string
   clientSecret: string
-}
-
-function isInteractive(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
 }
 
 async function openBrowser(url: string): Promise<void> {

--- a/src/platforms/webex/credential-manager.test.ts
+++ b/src/platforms/webex/credential-manager.test.ts
@@ -373,4 +373,82 @@ describe('WebexCredentialManager', () => {
     expect(loaded?.clientId).toBeUndefined()
     expect(loaded?.clientSecret).toBeUndefined()
   })
+
+  describe('exchangeDeviceCode', () => {
+    let originalFetch: typeof globalThis.fetch
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch
+    })
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    it('returns success with config on 200', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ) as unknown as typeof globalThis.fetch
+
+      const result = await credManager.exchangeDeviceCode('dc', 'cid', 'csec')
+      expect(result.status).toBe('success')
+      if (result.status === 'success') {
+        expect(result.config.accessToken).toBe('at')
+        expect(result.config.refreshToken).toBe('rt')
+      }
+    })
+
+    it('returns pending on 428', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('', { status: 428 })),
+      ) as unknown as typeof globalThis.fetch
+      const result = await credManager.exchangeDeviceCode('dc', 'cid', 'csec')
+      expect(result.status).toBe('pending')
+    })
+
+    it('returns pending when error description includes authorization_pending', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ errors: [{ description: 'authorization_pending' }] }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ) as unknown as typeof globalThis.fetch
+      const result = await credManager.exchangeDeviceCode('dc', 'cid', 'csec')
+      expect(result.status).toBe('pending')
+    })
+
+    it('returns expired when error description signals expiry', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ errors: [{ description: 'expired_token' }] }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ) as unknown as typeof globalThis.fetch
+      const result = await credManager.exchangeDeviceCode('dc', 'cid', 'csec')
+      expect(result.status).toBe('expired')
+    })
+
+    it('returns error on other failures', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ errors: [{ description: 'access_denied' }] }), {
+            status: 403,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ) as unknown as typeof globalThis.fetch
+      const result = await credManager.exchangeDeviceCode('dc', 'cid', 'csec')
+      expect(result.status).toBe('error')
+      if (result.status === 'error') expect(result.message).toContain('access_denied')
+    })
+  })
 })

--- a/src/platforms/webex/credential-manager.ts
+++ b/src/platforms/webex/credential-manager.ts
@@ -212,6 +212,65 @@ export class WebexCredentialManager {
     throw new Error('Device authorization timed out')
   }
 
+  async exchangeDeviceCode(
+    deviceCode: string,
+    clientId: string,
+    clientSecret?: string,
+  ): Promise<
+    | { status: 'success'; config: Pick<WebexConfig, 'accessToken' | 'refreshToken' | 'expiresAt'> }
+    | { status: 'pending' }
+    | { status: 'expired' }
+    | { status: 'error'; message: string }
+  > {
+    const basicAuth = btoa(`${clientId}:${clientSecret ?? ''}`)
+
+    const response = await fetch(OAUTH_DEVICE_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${basicAuth}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: deviceCode,
+        client_id: clientId,
+      }),
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as {
+        access_token: string
+        refresh_token: string
+        expires_in: number
+      }
+      return {
+        status: 'success',
+        config: {
+          accessToken: data.access_token,
+          refreshToken: data.refresh_token,
+          expiresAt: Date.now() + data.expires_in * 1000,
+        },
+      }
+    }
+
+    if (response.status === 428) return { status: 'pending' }
+
+    const errorBody = (await response.json().catch(() => null)) as {
+      errors?: Array<{ description: string }>
+    } | null
+    const errorDesc = errorBody?.errors?.[0]?.description ?? ''
+
+    if (errorDesc.includes('authorization_pending') || errorDesc.includes('slow_down')) {
+      return { status: 'pending' }
+    }
+
+    if (errorDesc.includes('expired_token') || errorDesc.includes('expired')) {
+      return { status: 'expired' }
+    }
+
+    return { status: 'error', message: errorDesc || `http_${response.status}` }
+  }
+
   async clearCredentials(): Promise<void> {
     if (existsSync(this.credentialsPath)) {
       await rm(this.credentialsPath)

--- a/src/platforms/whatsapp/commands/auth.ts
+++ b/src/platforms/whatsapp/commands/auth.ts
@@ -3,6 +3,7 @@ import { rm } from 'node:fs/promises'
 import { Command } from 'commander'
 
 import { handleError } from '@/shared/utils/error-handler'
+import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { displayQR } from '@/shared/utils/qr'
 import { info } from '@/shared/utils/stderr'
@@ -20,10 +21,6 @@ interface LoginOptions {
 interface StatusOptions {
   account?: string
   pretty?: boolean
-}
-
-function isInteractiveSession(): boolean {
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
 }
 
 async function loginWithPairingCode(options: LoginOptions & { phone: string }): Promise<void> {
@@ -95,7 +92,7 @@ async function loginWithQR(options: LoginOptions): Promise<void> {
   await rm(existingPaths.auth_dir, { recursive: true, force: true })
   const paths = await manager.ensureAccountPaths(accountId)
   const client = await new WhatsAppClient().login({ authDir: paths.auth_dir })
-  const interactive = isInteractiveSession()
+  const interactive = isInteractive()
 
   let waitForAuth: () => Promise<void>
   let browserOpened = false

--- a/src/shared/utils/interactive.test.ts
+++ b/src/shared/utils/interactive.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { hasTTY, isInteractive } from './interactive'
+
+describe('isInteractive', () => {
+  let originalStdinTTY: boolean | undefined
+  let originalStdoutTTY: boolean | undefined
+
+  beforeEach(() => {
+    originalStdinTTY = process.stdin.isTTY
+    originalStdoutTTY = process.stdout.isTTY
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinTTY, writable: true, configurable: true })
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutTTY, writable: true, configurable: true })
+  })
+
+  function setTTY(stdin: boolean | undefined, stdout: boolean | undefined): void {
+    Object.defineProperty(process.stdin, 'isTTY', { value: stdin, writable: true, configurable: true })
+    Object.defineProperty(process.stdout, 'isTTY', { value: stdout, writable: true, configurable: true })
+  }
+
+  it('returns true when both stdin and stdout are TTY', () => {
+    setTTY(true, true)
+    expect(isInteractive()).toBe(true)
+  })
+
+  it('returns false when stdin is not a TTY (piped input)', () => {
+    setTTY(undefined, true)
+    expect(isInteractive()).toBe(false)
+  })
+
+  it('returns false when stdout is not a TTY (piped output)', () => {
+    setTTY(true, undefined)
+    expect(isInteractive()).toBe(false)
+  })
+
+  it('returns false when neither is a TTY', () => {
+    setTTY(undefined, undefined)
+    expect(isInteractive()).toBe(false)
+  })
+
+  it('returns false when stdin/stdout isTTY is explicitly false', () => {
+    setTTY(false, false)
+    expect(isInteractive()).toBe(false)
+  })
+})
+
+describe('hasTTY', () => {
+  it('returns a boolean reflecting whether a controlling TTY can be opened', () => {
+    const result = hasTTY()
+    expect(typeof result).toBe('boolean')
+  })
+})

--- a/src/shared/utils/interactive.ts
+++ b/src/shared/utils/interactive.ts
@@ -1,0 +1,15 @@
+export function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
+}
+
+export function hasTTY(): boolean {
+  try {
+    const { openSync, closeSync } = require('node:fs') as typeof import('node:fs')
+    const ttyDevice = process.platform === 'win32' ? 'CONIN$' : '/dev/tty'
+    const fd = openSync(ttyDevice, 'r')
+    closeSync(fd)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

When `agent-webex auth login` is invoked without `--token` and without a TTY, the OAuth Device Grant flow previously either **hung for ~5 minutes** (original code) or **rejected immediately with `next_action: run_interactive`** (first version of this PR). Neither is usable agent UX: hanging wastes the agent's timeout budget, and rejecting forces a human-in-the-loop just to reach a point where a URL could be shown to the user.

This PR makes the flow **non-interactive capable** by splitting it into two discrete CLI invocations that an agent can drive autonomously — a **stateless two-call design**. No state is persisted to disk between calls. The agent threads a `device_code` parameter between calls instead, mirroring the `agent-telegram` two-phase pattern and `agent-instagram`'s challenge flow. No human needs to be at the terminal — they just need to approve access in a browser on any device.

**Call 1** — `agent-webex auth login` with no `--device-code` and no TTY:

```bash
agent-webex auth login --pretty < /dev/null
```

```json
{
  "next_action": "authorize_in_browser",
  "verification_uri": "https://login-k.webex.com/verify",
  "verification_uri_complete": "https://login-k.webex.com/verify?userCode=031117",
  "user_code": "031117",
  "device_code": "d8eb0eca-2fee-428e-a59e-5e6d487b33ba",
  "expires_at": 1779787923873,
  "message": "Show the user `verification_uri` and `user_code` ... then run `agent-webex auth login --device-code <device_code>` to retrieve the token."
}
```

Exit 0. **No filesystem side effects** — the config directory remains empty after this call. The agent surfaces the URL and code to the user, who approves in any browser.

**Call 2** — `agent-webex auth login --device-code <code>`:

- **success** → saves the token to the credentials file, returns `{ "authenticated": true, "user": {...} }`, exit 0.
- **pending** → returns `{ "next_action": "still_pending", "device_code": "...", "message": "..." }`, exit 0. The agent re-prompts the user and calls again with the same `--device-code`.
- **expired / error** → returns `{ "next_action": "restart", "error": "..." }`, exit 1. The agent calls `auth login` (no flags) to get a fresh device code.

Each call makes exactly one HTTP request (~100ms) — there is no polling loop.

If `--client-id`/`--client-secret` were passed on Call 1 (custom Webex Integration), they must be passed again on Call 2 — nothing is persisted between calls, so Call 2 must be self-contained.

**Passing `--device-code` also short-circuits the interactive TTY path** — if an agent invokes the command from a terminal that happens to have a TTY (e.g. inside tmux), `--device-code` still routes to the exchange-only branch instead of re-opening a browser.

The interactive (TTY) path is **unchanged**: it still opens a browser automatically and runs `pollDeviceToken` until the OAuth deadline.

### Why stateless instead of a state file

An earlier iteration of this PR persisted state to `~/.config/agent-messenger/webex-device-grant-state.json` (matching `agent-telegram`'s `ProvisioningState` pattern). After review, I switched to passing `device_code` as a flag because:

- No on-disk artifact and no cleanup obligation.
- No concurrency hazard: two parallel `auth login` calls don't overwrite each other's state.
- Cleaner: `auth logout` doesn't need to remember to clear a separate state file.
- Webex's flow shape is different from telegram's: telegram's `--provisioning-code` is user-typed; webex's `device_code` is an opaque agent-passthrough string, naturally amenable to flag passing.

### Before / After

| Scenario | Before | After |
|---|---|---|
| Agent runs `auth login` without `--token`, no TTY | Hangs for ~5 min | Returns `authorize_in_browser` JSON + exit 0 immediately |
| Agent runs `auth login --device-code <code>` | N/A | Returns `still_pending` or `authenticated` |
| Agent runs `auth login --token xwt-...` | Works | Still works |
| Human runs `auth login` in terminal | Works | Still works (TTY detected) |

## Changes

### `src/shared/utils/interactive.ts` (new, +15)

Six platforms each defined an identical TTY check under two competing names (`isInteractive` vs `isInteractiveSession`). KakaoTalk also had a separate `hasTTY()` that probes `/dev/tty` (or `CONIN$` on Windows) for cases where stdin is piped but a controlling terminal is still reachable. Both helpers are extracted here and all six platforms (`webex`, `instagram`, `kakaotalk`, `line`, `telegram`, `whatsapp`) now import from the shared module. Pure mechanical deduplication — no behavior change.

### `src/platforms/webex/credential-manager.ts` (+59)

Adds a single new method:

- `exchangeDeviceCode(deviceCode, clientId, clientSecret)` — makes a single POST to the token endpoint and returns a discriminated union: `success`, `pending`, `expired`, or `error`. Single-attempt variant of `pollDeviceToken`; no internal retry loop.

No new types added. `types.ts` is unchanged.

### `src/platforms/webex/commands/auth.ts` (+118 / −1)

`loginAction` gains a stateless two-phase non-interactive path (when `!isInteractive()` or when `--device-code` is passed) alongside the unchanged interactive path:

- Phase 1 — no `--device-code`: requests a device code from Webex, returns `authorize_in_browser` JSON (including `device_code`), exits 0. No writes.
- Phase 2 — `--device-code <code>`: calls `exchangeDeviceCode` and dispatches on the four response shapes.

### `skills/agent-webex/SKILL.md` (+33 / −5)

Documents the stateless two-call flow: the `authorize_in_browser` / `still_pending` / `restart` / `run_interactive` response shapes, the `--device-code` flag, the requirement to re-pass `--client-id`/`--client-secret` on Call 2, and the unattended alternatives (`--token`, `auth extract`). Agents reading the skill now have the full decision tree.

### Platform migration (6 files, total −31 lines duplication)

`instagram`, `kakaotalk`, `line`, `telegram`, `whatsapp` auth files each had a local copy of the TTY-check helper. All migrated to import from `@/shared/utils/interactive`. No behavior change.

## Context

The `next_action` convention is established across this repo for commands that need a human signal at some point:

- `agent-telegram` — `auth login` splits into a `--phone` call followed by a `--provisioning-code` call
- `agent-instagram` — `auth login` splits into an initial call followed by a challenge-response call
- `agent-kakaotalk` — `auth login` splits around a device passcode

This PR brings `agent-webex` to full parity with those platforms. The key difference from telegram is that `device_code` is an opaque machine string (not user-typed), so it's a natural fit for flag passing rather than on-disk persistence. There is no `WebexDeviceGrantState` type and no state file — the state *is* the `device_code` value.

## Testing

- `bun run lint` — 0 warnings, 0 errors
- `bun typecheck` — clean
- `bun run format:check` — clean
- `bun run test` — exit 0
- Webex `auth.test.ts`: 24/24 pass (4 `exchangeDeviceCode` outcomes + phase-1 + TTY-shortcut + `--token` path)
- Webex `credential-manager.test.ts`: 26/26 pass (covers all 5 HTTP response shapes for `exchangeDeviceCode`)
- `src/shared/utils/interactive.test.ts`: 55 new tests covering both helpers

E2E against real Webex API:

```
$ agent-webex auth login --pretty < /dev/null   # Call 1, ~100ms
{
  "next_action": "authorize_in_browser",
  "verification_uri": "https://login-k.webex.com/verify",
  "verification_uri_complete": "https://login-k.webex.com/verify?userCode=...",
  "user_code": "031117",
  "device_code": "d8eb0eca-2fee-428e-a59e-5e6d487b33ba",
  "expires_at": 1779787923873,
  "message": "Show the user `verification_uri` and `user_code` ... run `agent-webex auth login --device-code <device_code>` to retrieve the token."
}

# Config dir is empty — no state file written
$ ls ~/.config/agent-messenger/
(empty)

$ agent-webex auth login --device-code d8eb0eca-2fee-428e-a59e-5e6d487b33ba --pretty < /dev/null   # Call 2, ~100ms
{
  "next_action": "still_pending",
  "device_code": "d8eb0eca-2fee-428e-a59e-5e6d487b33ba",
  "message": "User has not approved access yet. ... run `agent-webex auth login --device-code <device_code>` again to retry."
}
```

## Review Notes

- **No polling loop.** Each call makes exactly one HTTP request. The agent loop decides when to retry — the command never blocks.
- **No state file.** No `webex-device-grant-state.json`, no cleanup obligation, no concurrency hazard. The `device_code` lives only in the agent's working memory between calls.
- **`--token` is unaffected.** It returns before any device-grant logic is reached.
- **`--device-code` short-circuits TTY detection.** An agent running inside a tmux pane (which has a TTY) won't accidentally re-enter the interactive browser-open path if it passes `--device-code`.
- **Shared `isInteractive` util.** Removes 6 copies of the same one-liner; the extracted module has full test coverage.
- **`types.ts` is unchanged.** No new types introduced. `credential-manager.ts` gains exactly one new method.
