### PR TITLE
Add KakaoTalk quoted reply support

### DIFF
--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -335,6 +335,9 @@ agent-kakaotalk message list <chat-id> --pretty
 agent-kakaotalk message send <chat-id> "Hello world"
 agent-kakaotalk message send <chat-id> "Hello world" --pretty
 
+# Send a quoted reply to a specific message (use a log_id from `message list`)
+agent-kakaotalk message send <chat-id> "Replying to this" --reply-to <log-id>
+
 # Send a file (auto-routes by MIME: photo / video / audio / generic file)
 agent-kakaotalk message upload <chat-id> ./photo.jpg
 agent-kakaotalk message upload <chat-id> ./clip.mp4
@@ -360,6 +363,20 @@ agent-kakaotalk message send <chat-id> "Hello" --account <account-id>
 agent-kakaotalk message upload <chat-id> ./photo.jpg --account <account-id>
 agent-kakaotalk message mark-read <chat-id> <log-id> --account <account-id>
 ```
+
+#### Replying to a Message
+
+`--reply-to <log-id>` sends the text as a quoted reply that references an existing message. Get the `log_id` from `message list` output. The CLI looks up the target in the chat's recent history (latest 100 messages) to build the quote, so the target must be reasonably recent.
+
+```bash
+# Find the message you want to reply to
+agent-kakaotalk message list <chat-id> -n 50
+
+# Reply to it by its log_id
+agent-kakaotalk message send <chat-id> "Good point!" --reply-to 1234567890
+```
+
+If the `log_id` is not found in the latest 100 messages, the command errors out without sending.
 
 #### Sending Attachments
 
@@ -587,6 +604,12 @@ try {
 
   // Read messages
   const messages = await client.getMessages(chatId, { count: 50 })
+
+  // Reply to a message by quoting it
+  const target = messages[messages.length - 1]
+  await client.sendMessage(chatId, 'Replying to your last message', {
+    replyTo: { log_id: target.log_id, author_id: target.author_id, message: target.message, type: target.type },
+  })
 } finally {
   // Always close when done (LOCO TCP connection)
   client.close()

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -13,6 +13,7 @@ const mockGetAllMembers = mock(() => Promise.resolve({}))
 const mockGetMembersByIds = mock(() => Promise.resolve({}))
 const mockSyncMessages = mock(() => Promise.resolve({}))
 const mockSendMessage = mock(() => Promise.resolve({}))
+const mockSendReply = mock(() => Promise.resolve({}))
 const mockMarkRead = mock(() => Promise.resolve({}))
 const mockClose = mock(() => {})
 const mockOnClose = mock((_handler: () => void) => {})
@@ -30,6 +31,7 @@ mock.module('./protocol/session', () => ({
     getMembersByIds = mockGetMembersByIds
     syncMessages = mockSyncMessages
     sendMessage = mockSendMessage
+    sendReply = mockSendReply
     markRead = mockMarkRead
     close = mockClose
     onClose = mockOnClose
@@ -52,6 +54,7 @@ function resetAllMocks() {
   mockGetMembersByIds.mockReset()
   mockSyncMessages.mockReset()
   mockSendMessage.mockReset()
+  mockSendReply.mockReset()
   mockMarkRead.mockReset()
   mockClose.mockReset()
   mockOnClose.mockReset()
@@ -969,6 +972,60 @@ describe('KakaoTalkClient', () => {
       } catch (e) {
         expect((e as KakaoTalkError).code).toBe('send_message_failed')
       }
+
+      client.close()
+    })
+
+    it('routes to sendReply with a built reply extra when replyTo is given', async () => {
+      // given
+      mockSendReply.mockResolvedValueOnce({ statusCode: 0, body: { logId: makeLong(50), sendAt: 1700000100 } })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const result = await client.sendMessage('100', 'replying', {
+        replyTo: { log_id: '42', author_id: 7, message: 'original', type: 1 },
+      })
+
+      // then
+      expect(mockSendMessage).not.toHaveBeenCalled()
+      expect(mockSendReply).toHaveBeenCalledTimes(1)
+      const [, text, extra] = mockSendReply.mock.calls[0] as [unknown, string, Record<string, unknown>]
+      expect(text).toBe('replying')
+      expect(extra).toEqual({
+        attach_only: false,
+        attach_type: 1,
+        src_logId: '42',
+        src_userId: 7,
+        src_message: 'original',
+        src_type: 1,
+        src_mentions: [],
+        mentions: [],
+      })
+      expect(result).toEqual({
+        success: true,
+        status_code: 0,
+        chat_id: '100',
+        log_id: '50',
+        sent_at: 1700000100,
+      })
+
+      client.close()
+    })
+
+    it('mirrors the source message type into attach_type/src_type', async () => {
+      // given
+      mockSendReply.mockResolvedValueOnce({ statusCode: 0, body: { logId: makeLong(51), sendAt: 1700000101 } })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when — replying to a photo (type 2)
+      await client.sendMessage('100', 'nice pic', {
+        replyTo: { log_id: '99', author_id: 3, message: 'photo', type: 2 },
+      })
+
+      // then
+      const [, , extra] = mockSendReply.mock.calls[0] as [unknown, string, Record<string, unknown>]
+      expect(extra.attach_type).toBe(2)
+      expect(extra.src_type).toBe(2)
 
       client.close()
     })

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -23,6 +23,8 @@ import {
   type KakaoMessage,
   type KakaoMultiPhotoExtra,
   type KakaoProfile,
+  type KakaoReplyExtra,
+  type KakaoReplyTarget,
   type KakaoSendResult,
 } from './types'
 
@@ -443,6 +445,19 @@ function formatMessages(
     attachment: parseAttachmentJson(log.attachment),
     sent_at: log.sendAt as number,
   }))
+}
+
+function buildReplyExtra(target: KakaoReplyTarget): KakaoReplyExtra {
+  return {
+    attach_only: false,
+    attach_type: target.type,
+    src_logId: target.log_id,
+    src_userId: target.author_id,
+    src_message: target.message,
+    src_type: target.type,
+    src_mentions: [],
+    mentions: [],
+  }
 }
 
 export class KakaoTalkClient {
@@ -883,10 +898,16 @@ export class KakaoTalkClient {
     })
   }
 
-  async sendMessage(chatId: string, text: string): Promise<KakaoSendResult> {
+  async sendMessage(chatId: string, text: string, options?: { replyTo?: KakaoReplyTarget }): Promise<KakaoSendResult> {
     return this.executeWithReconnect(async ({ session }) => {
       try {
-        const response = await session.sendMessage(parseLong(chatId), text)
+        const response = options?.replyTo
+          ? await session.sendReply(
+              parseLong(chatId),
+              text,
+              buildReplyExtra(options.replyTo) as unknown as Record<string, unknown>,
+            )
+          : await session.sendMessage(parseLong(chatId), text)
 
         return {
           success: response.statusCode === 0,

--- a/src/platforms/kakaotalk/commands/message.test.ts
+++ b/src/platforms/kakaotalk/commands/message.test.ts
@@ -112,6 +112,48 @@ describe('message commands', () => {
         expect.any(Function),
       )
     })
+
+    it('resolves --reply-to from chat history and sends a quoted reply', async () => {
+      // given
+      mockGetMessages.mockImplementation(() =>
+        Promise.resolve([
+          { log_id: '10', type: 1, author_id: 5, author_name: null, message: 'earlier', attachment: null, sent_at: 1 },
+          { log_id: '42', type: 2, author_id: 7, author_name: null, message: 'target', attachment: null, sent_at: 2 },
+        ]),
+      )
+
+      // when
+      await messageCommand.parseAsync(['send', 'chat-123', 'replying', '--reply-to', '42'], { from: 'user' })
+
+      // then
+      expect(mockGetMessages).toHaveBeenCalledWith('chat-123', { count: 100 })
+      expect(mockSendMessage).toHaveBeenCalledWith('chat-123', 'replying', {
+        replyTo: { log_id: '42', author_id: 7, message: 'target', type: 2 },
+      })
+    })
+
+    it('errors when --reply-to log-id is not found in recent history', async () => {
+      // given
+      mockGetMessages.mockImplementation(() =>
+        Promise.resolve([
+          { log_id: '10', type: 1, author_id: 5, author_name: null, message: 'earlier', attachment: null, sent_at: 1 },
+        ]),
+      )
+      const exitSpy = mock((_code?: number): never => {
+        throw new Error('process.exit called')
+      })
+      process.exit = exitSpy as unknown as typeof process.exit
+
+      // when / then
+      try {
+        await messageCommand.parseAsync(['send', 'chat-123', 'replying', '--reply-to', '999'], { from: 'user' })
+      } catch {
+        // process.exit stub throws to abort the action
+      }
+
+      expect(mockSendMessage).not.toHaveBeenCalled()
+      expect(exitSpy).toHaveBeenCalled()
+    })
   })
 
   describe('mark-read', () => {

--- a/src/platforms/kakaotalk/commands/message.ts
+++ b/src/platforms/kakaotalk/commands/message.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander'
 import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
+import type { KakaoMessage, KakaoReplyTarget } from '../types'
 import { withKakaoClient } from './shared'
 
 async function listAction(
@@ -26,13 +27,42 @@ async function listAction(
 async function sendAction(
   chatId: string,
   text: string,
-  options: { account?: string; pretty?: boolean },
+  options: { account?: string; pretty?: boolean; replyTo?: string },
 ): Promise<void> {
   try {
-    const result = await withKakaoClient(options, (client) => client.sendMessage(chatId, text))
+    const result = await withKakaoClient(options, async (client) => {
+      if (options.replyTo === undefined) {
+        return client.sendMessage(chatId, text)
+      }
+
+      const target = await resolveReplyTarget(client, chatId, options.replyTo)
+      return client.sendMessage(chatId, text, { replyTo: target })
+    })
     console.log(formatOutput(result, options.pretty))
   } catch (error) {
     handleError(error as Error)
+  }
+}
+
+// A reply attachment needs the source message's author, text, and type — not
+// just its log_id — so we look it up in the chat's recent history.
+async function resolveReplyTarget(
+  client: {
+    getMessages: (chatId: string, opts: { count: number }) => Promise<KakaoMessage[]>
+  },
+  chatId: string,
+  logId: string,
+): Promise<KakaoReplyTarget> {
+  const messages = await client.getMessages(chatId, { count: 100 })
+  const source = messages.find((m) => m.log_id === logId)
+  if (!source) {
+    throw new Error(`Reply target log-id ${logId} not found in the latest 100 messages of chat ${chatId}`)
+  }
+  return {
+    log_id: source.log_id,
+    author_id: source.author_id,
+    message: source.message,
+    type: source.type,
   }
 }
 
@@ -122,6 +152,7 @@ export const messageCommand = new Command('message')
       .argument('<chat-id>', 'Chat room ID')
       .argument('<text>', 'Message text')
       .option('--account <id>', 'Use a specific KakaoTalk account')
+      .option('--reply-to <log-id>', 'Send as a quoted reply to this message log ID')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
   )

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -20,6 +20,8 @@ export type {
   KakaoMultiPhotoExtra,
   KakaoPhotoExtra,
   KakaoProfile,
+  KakaoReplyExtra,
+  KakaoReplyTarget,
   KakaoSendResult,
   KakaoTalkListenerEventMap,
   KakaoTalkPushEmoticonEvent,

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -1,6 +1,6 @@
 import { Binary, Long } from 'bson'
 
-import type { KakaoDeviceType } from '../types'
+import { KAKAO_MESSAGE_TYPE, type KakaoDeviceType } from '../types'
 import {
   BOOKING_HOST,
   BOOKING_PORT,
@@ -123,6 +123,20 @@ export class LocoSession {
       msg: text,
       type: 1,
       noSeen: false,
+    })
+  }
+
+  // Quoted reply — a WRITE with message_type 26 (REPLY) whose `extra` JSON
+  // carries the source-message reference. The reply semantics ride entirely on
+  // `type` + `extra`; no extra top-level WRITE fields are needed.
+  async sendReply(chatId: Long, text: string, extra: Record<string, unknown>): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return this.connection.sendPacket('WRITE', {
+      chatId,
+      msg: text,
+      type: KAKAO_MESSAGE_TYPE.REPLY,
+      noSeen: false,
+      extra: JSON.stringify(extra),
     })
   }
 

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -126,6 +126,7 @@ export const KAKAO_MESSAGE_TYPE = {
   VIDEO: 3,
   AUDIO: 5,
   FILE: 18,
+  REPLY: 26,
   MULTIPHOTO: 27,
 } as const
 
@@ -174,6 +175,29 @@ export interface KakaoMultiPhotoExtra {
   thumbnailWidths?: number[]
   thumbnailHeights?: number[]
   expire?: number
+}
+
+// REPLY (type 26) extra. Field names verified against storycraft/node-kakao
+// (src/chat/attachment/reply.ts) and jhleekr/kakao.py: `Id` fields are
+// camelCase (src_logId, NOT src_log_id), and src_mentions/mentions are
+// required even when empty.
+export interface KakaoReplyExtra {
+  attach_only: boolean
+  attach_type: number
+  src_logId: string
+  src_userId: number
+  src_message: string
+  src_type: number
+  src_mentions: unknown[]
+  mentions: unknown[]
+  src_linkId?: string
+}
+
+export interface KakaoReplyTarget {
+  log_id: string
+  author_id: number
+  message: string
+  type: number
 }
 
 export interface KakaoMarkReadResult {


### PR DESCRIPTION
## Summary

Adds quoted-reply support to KakaoTalk, which previously only supported plain-text sends. You can now reply to a specific message from both the CLI and the SDK.

- **CLI**: `agent-kakaotalk message send <chat-id> "..." --reply-to <log-id>`
- **SDK**: `client.sendMessage(chatId, text, { replyTo })`

## How it works

A KakaoTalk quoted reply is a `WRITE` packet with **message_type 26 (REPLY)** whose `extra` JSON references the source message. The reply semantics ride entirely on `type` + `extra` — no extra top-level WRITE fields are needed.

The `extra` payload shape was verified against two open-source LOCO implementations:

- [`storycraft/node-kakao`](https://github.com/storycraft/node-kakao) — `src/chat/attachment/reply.ts`, `src/chat/chat-type.ts`
- [`jhleekr/kakao.py`](https://github.com/jhleekr/kakao.py) — `kakao/chat.py`

Required fields: `attach_only`, `attach_type`, `src_logId`, `src_userId`, `src_message`, `src_type`, `src_mentions`, `mentions`. Note the `Id` fields are **camelCase** (`src_logId`), not snake_case — a subtle correctness trap.

Because the reply attachment needs the source message's **author, text, and type** — not just its `log_id` — the CLI resolves the target from the chat's recent history (latest 100 messages via `getMessages`) and errors clearly if the target isn't found.

## Commits

1. **Add KakaoTalk reply types and REPLY message type** — `KakaoReplyExtra`, `KakaoReplyTarget`, `KAKAO_MESSAGE_TYPE.REPLY`, barrel exports.
2. **Send quoted replies from KakaoTalkClient.sendMessage** — `LocoSession.sendReply` plus the `replyTo` option on `sendMessage` (SDK layer).
3. **Add --reply-to flag to KakaoTalk message send** — CLI flag, target resolution from history, and SKILL.md docs.

## Testing

- `bun typecheck` — clean
- `bun lint` — 0 warnings/errors
- `bun test src/platforms/kakaotalk/` — **218 pass / 0 fail**
- New tests cover: client routing to `sendReply`, reply-extra construction, source-type mirroring, CLI `--reply-to` resolution, and the not-found error path.

> **Caveats (honest):**
> - These are unit tests with a **mocked LOCO session** — the wire format is validated by structure and against reference implementations, not a real KakaoTalk round-trip. A maintainer with an account should smoke-test one real reply.
> - The full-repo `format:check` and `bun run test` have **pre-existing, environment-dependent failures unrelated to this change** (a `docs/` fumadocs CSS import resolution error in the worktree, and Teams/Telegram tests that perform real network auth). Both are clean/absent on a fully-installed `main` checkout; all files changed here pass format, lint, typecheck, and tests.

## Usage

```bash
# Find the message to reply to
agent-kakaotalk message list <chat-id> -n 50

# Reply to it by its log_id
agent-kakaotalk message send <chat-id> "Good point!" --reply-to 1234567890
```
