### PR TITLE
Add message reply support to Discord bot

### DIFF
--- a/docs/content/docs/cli/discordbot.mdx
+++ b/docs/content/docs/cli/discordbot.mdx
@@ -159,6 +159,9 @@ agent-discordbot message send general "Hello world"
 # Reply to a message
 agent-discordbot message send general "On it!" --reply 9876543210987654321
 
+# Send a message into a thread
+agent-discordbot message send general "Hello world" --thread 9876543210987654321
+
 # List messages
 agent-discordbot message list <channel>
 agent-discordbot message list general --limit 50

--- a/docs/content/docs/cli/discordbot.mdx
+++ b/docs/content/docs/cli/discordbot.mdx
@@ -156,6 +156,9 @@ agent-discordbot server info <server-id>
 agent-discordbot message send <channel> <text>
 agent-discordbot message send general "Hello world"
 
+# Reply to a message
+agent-discordbot message send general "On it!" --reply 9876543210987654321
+
 # List messages
 agent-discordbot message list <channel>
 agent-discordbot message list general --limit 50

--- a/docs/content/docs/sdk/discordbot.mdx
+++ b/docs/content/docs/sdk/discordbot.mdx
@@ -80,6 +80,10 @@ const msg = await client.sendMessage(channelId, 'Hello world')
 const reply = await client.sendMessage(channelId, 'Reply', { thread_id: threadId })
 // → DiscordMessage { id, channel_id, author, content, timestamp }
 
+// Reply to a specific message
+const replyToMsg = await client.sendMessage(channelId, 'On it!', { reply_to: messageId })
+// → DiscordMessage { id, channel_id, author, content, timestamp }
+
 // Get recent messages from a channel (default limit: 50)
 const messages = await client.getMessages(channelId)
 const limited = await client.getMessages(channelId, 25)

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -205,6 +205,10 @@ agent-discordbot message send 1234567890123456789 "Hello world"
 agent-discordbot message send <channel-id> <content> --reply <message-id>
 agent-discordbot message send 1234567890123456789 "On it!" --reply 9876543210987654321
 
+# Send a message into a thread
+agent-discordbot message send <channel-id> <content> --thread <thread-id>
+agent-discordbot message send 1234567890123456789 "Hello world" --thread 9876543210987654321
+
 # List messages
 agent-discordbot message list <channel-id>
 agent-discordbot message list 1234567890123456789 --limit 50

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -201,6 +201,10 @@ agent-discordbot server info <server-id>
 agent-discordbot message send <channel-id> <content>
 agent-discordbot message send 1234567890123456789 "Hello world"
 
+# Reply to a message
+agent-discordbot message send <channel-id> <content> --reply <message-id>
+agent-discordbot message send 1234567890123456789 "On it!" --reply 9876543210987654321
+
 # List messages
 agent-discordbot message list <channel-id>
 agent-discordbot message list 1234567890123456789 --limit 50

--- a/src/platforms/discordbot/client.test.ts
+++ b/src/platforms/discordbot/client.test.ts
@@ -167,6 +167,23 @@ describe('DiscordBotClient', () => {
 
       expect(fetchCalls[0].options?.body).toBe(JSON.stringify({ content: 'Thread reply', thread_id: 'thread123' }))
     })
+
+    it('includes message_reference when reply_to is provided', async () => {
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: 'Reply text',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      })
+
+      const client = await new DiscordBotClient().login({ token: 'bot-token' })
+      await client.sendMessage('ch1', 'Reply text', { reply_to: 'parent123' })
+
+      expect(fetchCalls[0].options?.body).toBe(
+        JSON.stringify({ content: 'Reply text', message_reference: { message_id: 'parent123' } }),
+      )
+    })
   })
 
   describe('editMessage', () => {

--- a/src/platforms/discordbot/client.ts
+++ b/src/platforms/discordbot/client.ts
@@ -249,10 +249,17 @@ export class DiscordBotClient {
     return this.request<DiscordChannel>('GET', `/channels/${channelId}`)
   }
 
-  async sendMessage(channelId: string, content: string, options?: { thread_id?: string }): Promise<DiscordMessage> {
-    const body: Record<string, string> = { content }
+  async sendMessage(
+    channelId: string,
+    content: string,
+    options?: { thread_id?: string; reply_to?: string },
+  ): Promise<DiscordMessage> {
+    const body: Record<string, unknown> = { content }
     if (options?.thread_id) {
       body.thread_id = options.thread_id
+    }
+    if (options?.reply_to) {
+      body.message_reference = { message_id: options.reply_to }
     }
     return this.request<DiscordMessage>('POST', `/channels/${channelId}/messages`, body)
   }

--- a/src/platforms/discordbot/commands/message.test.ts
+++ b/src/platforms/discordbot/commands/message.test.ts
@@ -4,14 +4,15 @@ import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const mockSendMessage = mock((_channelId: string, content: string, _options?: { thread_id?: string }) =>
-  Promise.resolve({
-    id: 'msg1',
-    channel_id: 'ch1',
-    content,
-    author: { id: 'bot1', username: 'testbot' },
-    timestamp: '2025-01-01T00:00:00.000Z',
-  }),
+const mockSendMessage = mock(
+  (_channelId: string, content: string, _options?: { thread_id?: string; reply_to?: string }) =>
+    Promise.resolve({
+      id: 'msg1',
+      channel_id: 'ch1',
+      content,
+      author: { id: 'bot1', username: 'testbot' },
+      timestamp: '2025-01-01T00:00:00.000Z',
+    }),
 )
 
 const mockGetMessages = mock((_channelId: string, _limit?: number) =>
@@ -127,7 +128,7 @@ describe('message commands', () => {
       expect(result.content).toBe('hello world')
       expect(result.author).toBe('testbot')
       expect(mockResolveChannel).toHaveBeenCalledWith('guild1', 'general')
-      expect(mockSendMessage).toHaveBeenCalledWith('ch1', 'hello world', { thread_id: undefined })
+      expect(mockSendMessage).toHaveBeenCalledWith('ch1', 'hello world', { thread_id: undefined, reply_to: undefined })
     })
 
     it('sends message to channel by ID', async () => {
@@ -135,7 +136,7 @@ describe('message commands', () => {
 
       expect(result.id).toBe('msg1')
       expect(mockResolveChannel).toHaveBeenCalledWith('guild1', '123456')
-      expect(mockSendMessage).toHaveBeenCalledWith('123456', 'hi', { thread_id: undefined })
+      expect(mockSendMessage).toHaveBeenCalledWith('123456', 'hi', { thread_id: undefined, reply_to: undefined })
     })
 
     it('sends message to thread', async () => {
@@ -145,7 +146,23 @@ describe('message commands', () => {
       })
 
       expect(result.id).toBe('msg1')
-      expect(mockSendMessage).toHaveBeenCalledWith('ch1', 'thread reply', { thread_id: 'thread123' })
+      expect(mockSendMessage).toHaveBeenCalledWith('ch1', 'thread reply', {
+        thread_id: 'thread123',
+        reply_to: undefined,
+      })
+    })
+
+    it('replies to a message', async () => {
+      const result = await sendAction('general', 'reply text', {
+        _credManager: manager,
+        reply: 'parent123',
+      })
+
+      expect(result.id).toBe('msg1')
+      expect(mockSendMessage).toHaveBeenCalledWith('ch1', 'reply text', {
+        thread_id: undefined,
+        reply_to: 'parent123',
+      })
     })
 
     it('returns error on channel not found', async () => {

--- a/src/platforms/discordbot/commands/message.ts
+++ b/src/platforms/discordbot/commands/message.ts
@@ -28,7 +28,7 @@ interface MessageResult {
 export async function sendAction(
   channel: string,
   text: string,
-  options: BotOption & { thread?: string },
+  options: BotOption & { thread?: string; reply?: string },
 ): Promise<MessageResult> {
   try {
     const client = await getClient(options)
@@ -36,6 +36,7 @@ export async function sendAction(
     const channelId = await client.resolveChannel(serverId, channel)
     const message = await client.sendMessage(channelId, text, {
       thread_id: options.thread,
+      reply_to: options.reply,
     })
 
     return {
@@ -173,10 +174,11 @@ export const messageCommand = new Command('message')
       .argument('<channel>', 'Channel ID or name')
       .argument('<text>', 'Message text')
       .option('--thread <id>', 'Thread ID for replies')
+      .option('--reply <message-id>', 'Reply to a message by ID')
       .option('--bot <id>', 'Use specific bot')
       .option('--server <id>', 'Server ID')
       .option('--pretty', 'Pretty print JSON output')
-      .action(async (channel: string, text: string, opts: BotOption & { thread?: string }) => {
+      .action(async (channel: string, text: string, opts: BotOption & { thread?: string; reply?: string }) => {
         cliOutput(await sendAction(channel, text, opts), opts.pretty)
       }),
   )


### PR DESCRIPTION
## Summary

The Discord bot CLI/SDK previously had no way to reply to a specific message — `message send` only supported `--thread` (posting *into* a thread channel), which is distinct from Discord's inline reply (a message that references a parent via `message_reference`).

This PR adds first-class reply support, mirroring the existing `--thread` option pattern.

## Changes

- **SDK** (client.ts): `DiscordBotClient.sendMessage` now accepts a `reply_to` option and includes `message_reference: { message_id }` in the POST body when provided.
- **CLI** (commands/message.ts): added a `--reply <message-id>` flag to `message send`, wired through `sendAction`.
- **Tests**: added coverage for the SDK request body (`message_reference`) and the CLI flag (`reply_to` passthrough).
- **Docs**: documented the flag/option in `SKILL.md`, the CLI docs, and the SDK docs.

## Usage

```bash
# CLI
agent-discordbot message send general "On it!" --reply 9876543210987654321
```

```typescript
// SDK
await client.sendMessage(channelId, 'On it!', { reply_to: messageId })
```

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun test src/platforms/discordbot/` — 253 pass, 0 fail
- `oxfmt --check` on changed files — clean

Note: pre-existing, environment-dependent failures in unrelated platforms (Slack token extraction requiring a local browser profile; Telegram network auth) are untouched by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline message reply support to the Discord bot in both CLI and SDK. Use --reply or reply_to; replies send Discord’s message_reference so they render inline.

- **New Features**
  - SDK: `DiscordBotClient.sendMessage` accepts `reply_to` and sends `message_reference`.
  - CLI: `message send` adds `--reply <message-id>` and passes it through `sendAction`.
  - Tests cover the SDK request body and CLI flag passthrough.

Docs updated: `skills/agent-discordbot/SKILL.md`, CLI docs, and SDK docs (added `--reply` and documented `--thread` examples).

<sup>Written for commit d55493ae0ddf0becaa16e634b464c74f4e33335d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/205?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

