### PR TITLE
fix: green up main CI (test mock pollution + nondeterministic profile order)

### DIFF
--- a/src/platforms/webex/commands/member.test.ts
+++ b/src/platforms/webex/commands/member.test.ts
@@ -1,14 +1,7 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 
+import { WebexClient } from '../client'
 import { WebexError } from '../types'
-
-const mockHandleError = mock((err: Error) => {
-  throw err
-})
-
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: mockHandleError,
-}))
 
 const mockMembers = [
   {
@@ -31,32 +24,39 @@ const mockMembers = [
   },
 ]
 
-const mockListMemberships = mock(() => Promise.resolve(mockMembers))
-const mockLogin = mock(() => Promise.resolve({ listMemberships: mockListMemberships }))
-
-mock.module('../client', () => ({
-  WebexClient: class {
-    login = mockLogin
-  },
-}))
-
 import { listAction } from './member'
 
 describe('member commands', () => {
+  let mockListMemberships: ReturnType<typeof spyOn>
+  let mockLogin: ReturnType<typeof spyOn>
   let consoleSpy: ReturnType<typeof spyOn>
+  let consoleErrorSpy: ReturnType<typeof spyOn>
+  let processExitSpy: ReturnType<typeof spyOn>
+  const protoSpies: ReturnType<typeof spyOn>[] = []
+
+  function protoSpy(method: keyof WebexClient) {
+    const s = spyOn(WebexClient.prototype, method as never)
+    protoSpies.push(s)
+    return s
+  }
 
   beforeEach(() => {
-    mockListMemberships.mockReset().mockImplementation(() => Promise.resolve(mockMembers))
-    mockLogin.mockReset().mockImplementation(() => Promise.resolve({ listMemberships: mockListMemberships }))
-    mockHandleError.mockReset().mockImplementation((err: Error) => {
-      throw err
+    mockLogin = protoSpy('login').mockImplementation(async function (this: WebexClient) {
+      return this
     })
+    mockListMemberships = protoSpy('listMemberships').mockResolvedValue(mockMembers)
 
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
   })
 
   afterEach(() => {
     consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    processExitSpy.mockRestore()
+    for (const s of protoSpies) s.mockRestore()
+    protoSpies.length = 0
   })
 
   it('calls listMemberships with spaceId and outputs mapped members', async () => {
@@ -91,23 +91,19 @@ describe('member commands', () => {
     expect(mockListMemberships).toHaveBeenCalledWith('room-1', { max: 25 })
   })
 
-  it('throws when not authenticated', async () => {
-    mockLogin.mockImplementation(async () => {
-      throw new WebexError('No Webex credentials found.', 'no_credentials')
-    })
+  it('exits with code 1 when not authenticated', async () => {
+    mockLogin.mockRejectedValue(new WebexError('No Webex credentials found.', 'no_credentials'))
 
-    await expect(listAction('room-1', {})).rejects.toThrow('No Webex credentials found.')
+    await listAction('room-1', {})
 
-    expect(mockHandleError).toHaveBeenCalledWith(expect.any(WebexError))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
   })
 
-  it('throws on API error', async () => {
-    mockListMemberships.mockImplementation(async () => {
-      throw new Error('API failure')
-    })
+  it('exits with code 1 on API error', async () => {
+    mockListMemberships.mockRejectedValue(new Error('API failure'))
 
-    await expect(listAction('room-1', {})).rejects.toThrow('API failure')
+    await listAction('room-1', {})
 
-    expect(mockHandleError).toHaveBeenCalledWith(expect.any(Error))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
   })
 })

--- a/src/platforms/webex/commands/message.test.ts
+++ b/src/platforms/webex/commands/message.test.ts
@@ -1,14 +1,7 @@
-import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
+import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
+import { WebexClient } from '../client'
 import { WebexError } from '../types'
-
-const mockHandleError = mock((err: Error) => {
-  throw err
-})
-
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: mockHandleError,
-}))
 
 const mockMessage = {
   id: 'msg_123',
@@ -30,51 +23,48 @@ const mockMessage2 = {
   created: '2025-01-29T10:01:00.000Z',
 }
 
-const mockSendMessage = mock(() => Promise.resolve(mockMessage))
-const mockSendDirectMessage = mock(() => Promise.resolve(mockMessage))
-const mockListMessages = mock(() => Promise.resolve([mockMessage, mockMessage2]))
-const mockGetMessage = mock(() => Promise.resolve(mockMessage))
-const mockDeleteMessage = mock(() => Promise.resolve(undefined))
-const mockEditMessage = mock(() => Promise.resolve({ ...mockMessage, text: 'Updated message' }))
-
-const mockClient = {
-  sendMessage: mockSendMessage,
-  sendDirectMessage: mockSendDirectMessage,
-  listMessages: mockListMessages,
-  getMessage: mockGetMessage,
-  deleteMessage: mockDeleteMessage,
-  editMessage: mockEditMessage,
-}
-
-const mockLogin = mock(() => Promise.resolve(mockClient))
-
-mock.module('../client', () => ({
-  WebexClient: class {
-    login = mockLogin
-  },
-}))
-
 import { deleteAction, dmAction, editAction, getAction, listAction, sendAction } from './message'
 
+let mockSendMessage: ReturnType<typeof spyOn>
+let mockSendDirectMessage: ReturnType<typeof spyOn>
+let mockListMessages: ReturnType<typeof spyOn>
+let mockGetMessage: ReturnType<typeof spyOn>
+let mockDeleteMessage: ReturnType<typeof spyOn>
+let mockEditMessage: ReturnType<typeof spyOn>
+let mockLogin: ReturnType<typeof spyOn>
 let consoleLogSpy: ReturnType<typeof spyOn>
+let consoleErrorSpy: ReturnType<typeof spyOn>
+let processExitSpy: ReturnType<typeof spyOn>
+const protoSpies: ReturnType<typeof spyOn>[] = []
+
+function protoSpy(method: keyof WebexClient) {
+  const s = spyOn(WebexClient.prototype, method as never)
+  protoSpies.push(s)
+  return s
+}
 
 beforeEach(() => {
-  mockSendMessage.mockReset().mockImplementation(() => Promise.resolve(mockMessage))
-  mockSendDirectMessage.mockReset().mockImplementation(() => Promise.resolve(mockMessage))
-  mockListMessages.mockReset().mockImplementation(() => Promise.resolve([mockMessage, mockMessage2]))
-  mockGetMessage.mockReset().mockImplementation(() => Promise.resolve(mockMessage))
-  mockDeleteMessage.mockReset().mockImplementation(() => Promise.resolve(undefined))
-  mockEditMessage.mockReset().mockImplementation(() => Promise.resolve({ ...mockMessage, text: 'Updated message' }))
-  mockLogin.mockReset().mockImplementation(() => Promise.resolve(mockClient))
-  mockHandleError.mockReset().mockImplementation((err: Error) => {
-    throw err
+  mockLogin = protoSpy('login').mockImplementation(async function (this: WebexClient) {
+    return this
   })
+  mockSendMessage = protoSpy('sendMessage').mockResolvedValue(mockMessage)
+  mockSendDirectMessage = protoSpy('sendDirectMessage').mockResolvedValue(mockMessage)
+  mockListMessages = protoSpy('listMessages').mockResolvedValue([mockMessage, mockMessage2])
+  mockGetMessage = protoSpy('getMessage').mockResolvedValue(mockMessage)
+  mockDeleteMessage = protoSpy('deleteMessage').mockResolvedValue(undefined)
+  mockEditMessage = protoSpy('editMessage').mockResolvedValue({ ...mockMessage, text: 'Updated message' })
 
   consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+  consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+  processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
 })
 
 afterEach(() => {
   consoleLogSpy.mockRestore()
+  consoleErrorSpy.mockRestore()
+  processExitSpy.mockRestore()
+  for (const s of protoSpies) s.mockRestore()
+  protoSpies.length = 0
 })
 
 it('calls sendMessage with correct args and outputs result', async () => {
@@ -96,14 +86,13 @@ it('passes markdown option when --markdown flag is set on send', async () => {
   expect(mockSendMessage).toHaveBeenCalledWith('space_456', '**bold**', { markdown: true })
 })
 
-it('throws when not authenticated on send', async () => {
-  mockLogin.mockImplementation(async () => {
-    throw new WebexError('No Webex credentials found.', 'no_credentials')
-  })
+it('exits with code 1 when not authenticated on send', async () => {
+  mockLogin.mockRejectedValue(new WebexError('No Webex credentials found.', 'no_credentials'))
 
-  await expect(sendAction('space_456', 'Hello', { pretty: false })).rejects.toThrow('No Webex credentials found.')
+  await sendAction('space_456', 'Hello', { pretty: false })
 
-  expect(mockHandleError).toHaveBeenCalledWith(expect.any(WebexError))
+  expect(mockSendMessage).not.toHaveBeenCalled()
+  expect(processExitSpy).toHaveBeenCalledWith(1)
 })
 
 it('calls sendDirectMessage with email and text', async () => {

--- a/src/platforms/webex/commands/snapshot.test.ts
+++ b/src/platforms/webex/commands/snapshot.test.ts
@@ -1,14 +1,7 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 
+import { WebexClient } from '../client'
 import { WebexError } from '../types'
-
-const mockHandleError = mock((err: Error) => {
-  throw err
-})
-
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: mockHandleError,
-}))
 
 const mockSpaces = [
   {
@@ -43,40 +36,39 @@ const mockMyMemberships = [
   },
 ]
 
-const mockListSpaces = mock(() => Promise.resolve(mockSpaces as any))
-const mockListMyMemberships = mock(() => Promise.resolve(mockMyMemberships as any))
-
-const mockClient = {
-  listSpaces: mockListSpaces,
-  listMyMemberships: mockListMyMemberships,
-}
-
-const mockLogin = mock(() => Promise.resolve(mockClient))
-
-mock.module('../client', () => ({
-  WebexClient: class {
-    login = mockLogin
-  },
-}))
-
 import { snapshotAction } from './snapshot'
 
 describe('snapshot command', () => {
+  let mockLogin: ReturnType<typeof spyOn>
   let consoleSpy: ReturnType<typeof spyOn>
+  let consoleErrorSpy: ReturnType<typeof spyOn>
+  let processExitSpy: ReturnType<typeof spyOn>
+  const protoSpies: ReturnType<typeof spyOn>[] = []
+
+  function protoSpy(method: keyof WebexClient) {
+    const s = spyOn(WebexClient.prototype, method as never)
+    protoSpies.push(s)
+    return s
+  }
 
   beforeEach(() => {
-    mockListSpaces.mockReset().mockImplementation(() => Promise.resolve(mockSpaces as any))
-    mockListMyMemberships.mockReset().mockImplementation(() => Promise.resolve(mockMyMemberships as any))
-    mockLogin.mockReset().mockImplementation(() => Promise.resolve(mockClient))
-    mockHandleError.mockReset().mockImplementation((err: Error) => {
-      throw err
+    mockLogin = protoSpy('login').mockImplementation(async function (this: WebexClient) {
+      return this
     })
+    protoSpy('listSpaces').mockResolvedValue(mockSpaces as any)
+    protoSpy('listMyMemberships').mockResolvedValue(mockMyMemberships as any)
 
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
   })
 
   afterEach(() => {
     consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    processExitSpy.mockRestore()
+    for (const s of protoSpies) s.mockRestore()
+    protoSpies.length = 0
   })
 
   it('returns spaces with id and title only in brief mode', async () => {
@@ -112,13 +104,11 @@ describe('snapshot command', () => {
     expect(output.spaces[0].id).toBe('space-1')
   })
 
-  it('throws when not authenticated', async () => {
-    mockLogin.mockImplementation(async () => {
-      throw new WebexError('No Webex credentials found.', 'no_credentials')
-    })
+  it('exits with code 1 when not authenticated', async () => {
+    mockLogin.mockRejectedValue(new WebexError('No Webex credentials found.', 'no_credentials'))
 
-    await expect(snapshotAction({})).rejects.toThrow('No Webex credentials found.')
+    await snapshotAction({})
 
-    expect(mockHandleError).toHaveBeenCalledWith(expect.any(WebexError))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
   })
 })

--- a/src/platforms/webex/commands/space.test.ts
+++ b/src/platforms/webex/commands/space.test.ts
@@ -1,14 +1,7 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 
+import { WebexClient } from '../client'
 import { WebexError } from '../types'
-
-const mockHandleError = mock((err: Error) => {
-  throw err
-})
-
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: mockHandleError,
-}))
 
 const mockSpaces = [
   {
@@ -42,35 +35,40 @@ const mockSpace = {
   creatorId: 'person-1',
 }
 
-const mockListSpaces = mock(() => Promise.resolve(mockSpaces))
-const mockGetSpace = mock(() => Promise.resolve(mockSpace))
-const mockLogin = mock(() => Promise.resolve({ listSpaces: mockListSpaces, getSpace: mockGetSpace }))
-
-mock.module('../client', () => ({
-  WebexClient: class {
-    login = mockLogin
-  },
-}))
-
 import { infoAction, listAction } from './space'
 
+let mockListSpaces: ReturnType<typeof spyOn>
+let mockGetSpace: ReturnType<typeof spyOn>
+let mockLogin: ReturnType<typeof spyOn>
 let consoleLogSpy: ReturnType<typeof spyOn>
+let consoleErrorSpy: ReturnType<typeof spyOn>
+let processExitSpy: ReturnType<typeof spyOn>
+const protoSpies: ReturnType<typeof spyOn>[] = []
+
+function protoSpy(method: keyof WebexClient) {
+  const s = spyOn(WebexClient.prototype, method as never)
+  protoSpies.push(s)
+  return s
+}
 
 beforeEach(() => {
-  mockListSpaces.mockReset().mockImplementation(() => Promise.resolve(mockSpaces))
-  mockGetSpace.mockReset().mockImplementation(() => Promise.resolve(mockSpace))
-  mockLogin
-    .mockReset()
-    .mockImplementation(() => Promise.resolve({ listSpaces: mockListSpaces, getSpace: mockGetSpace }))
-  mockHandleError.mockReset().mockImplementation((err: Error) => {
-    throw err
+  mockLogin = protoSpy('login').mockImplementation(async function (this: WebexClient) {
+    return this
   })
+  mockListSpaces = protoSpy('listSpaces').mockResolvedValue(mockSpaces)
+  mockGetSpace = protoSpy('getSpace').mockResolvedValue(mockSpace)
 
   consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+  consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+  processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
 })
 
 afterEach(() => {
   consoleLogSpy.mockRestore()
+  consoleErrorSpy.mockRestore()
+  processExitSpy.mockRestore()
+  for (const s of protoSpies) s.mockRestore()
+  protoSpies.length = 0
 })
 
 describe('listAction', () => {
@@ -137,15 +135,13 @@ describe('listAction', () => {
     )
   })
 
-  it('throws when not authenticated', async () => {
-    mockLogin.mockImplementation(async () => {
-      throw new WebexError('No Webex credentials found.', 'no_credentials')
-    })
+  it('exits with code 1 when not authenticated', async () => {
+    mockLogin.mockRejectedValue(new WebexError('No Webex credentials found.', 'no_credentials'))
 
-    await expect(listAction({})).rejects.toThrow('No Webex credentials found.')
+    await listAction({})
 
     expect(mockListSpaces).not.toHaveBeenCalled()
-    expect(mockHandleError).toHaveBeenCalledWith(expect.any(WebexError))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
   })
 })
 
@@ -200,14 +196,12 @@ describe('infoAction', () => {
     )
   })
 
-  it('throws when not authenticated', async () => {
-    mockLogin.mockImplementation(async () => {
-      throw new WebexError('No Webex credentials found.', 'no_credentials')
-    })
+  it('exits with code 1 when not authenticated', async () => {
+    mockLogin.mockRejectedValue(new WebexError('No Webex credentials found.', 'no_credentials'))
 
-    await expect(infoAction('space-1', {})).rejects.toThrow('No Webex credentials found.')
+    await infoAction('space-1', {})
 
     expect(mockGetSpace).not.toHaveBeenCalled()
-    expect(mockHandleError).toHaveBeenCalledWith(expect.any(WebexError))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
   })
 })

--- a/src/platforms/webex/commands/whoami.test.ts
+++ b/src/platforms/webex/commands/whoami.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
-import * as clientModule from '../client'
+import { WebexClient } from '../client'
 import { WebexError } from '../types'
 import { whoamiCommand } from './whoami'
 
@@ -17,27 +17,23 @@ const mockUser = {
   created: '2024-01-01T00:00:00.000Z',
 }
 
-const makeFakeClient = () => ({
-  login: async function (this: unknown) {
-    return this
-  },
-  testAuth: async () => mockUser,
-})
-
-let webexClientSpy: ReturnType<typeof spyOn>
+let loginSpy: ReturnType<typeof spyOn>
+let testAuthSpy: ReturnType<typeof spyOn>
 let consoleLogSpy: ReturnType<typeof spyOn>
 let processExitSpy: ReturnType<typeof spyOn>
 
 beforeEach(() => {
-  webexClientSpy = spyOn(clientModule, 'WebexClient').mockImplementation(
-    makeFakeClient as unknown as typeof clientModule.WebexClient,
-  )
+  loginSpy = spyOn(WebexClient.prototype, 'login').mockImplementation(async function (this: WebexClient) {
+    return this
+  })
+  testAuthSpy = spyOn(WebexClient.prototype, 'testAuth').mockResolvedValue(mockUser)
   consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
   processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
 })
 
 afterEach(() => {
-  webexClientSpy?.mockRestore()
+  loginSpy?.mockRestore()
+  testAuthSpy?.mockRestore()
   consoleLogSpy?.mockRestore()
   processExitSpy?.mockRestore()
 })
@@ -102,15 +98,7 @@ it('whoami outputs pretty-printed JSON when --pretty flag is passed', async () =
 
 it('whoami exits with code 1 when not authenticated', async () => {
   // given: no credentials
-  webexClientSpy.mockImplementation(
-    () =>
-      ({
-        login: async () => {
-          throw new WebexError('No Webex credentials found.', 'no_credentials')
-        },
-        testAuth: async () => mockUser,
-      }) as unknown as clientModule.WebexClient,
-  )
+  loginSpy.mockRejectedValue(new WebexError('No Webex credentials found.', 'no_credentials'))
 
   // when: running whoami
   await whoamiCommand.parseAsync([], { from: 'user' })

--- a/src/platforms/whatsapp/commands/auth.test.ts
+++ b/src/platforms/whatsapp/commands/auth.test.ts
@@ -2,12 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:te
 
 const originalConsoleLog = console.log
 
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: (err: Error) => {
-    throw err
-  },
-}))
-
 const mockGetAccount = mock(() => Promise.resolve(null))
 const mockListAccounts = mock(() => Promise.resolve([]))
 const mockSetCurrent = mock(() => Promise.resolve(false))
@@ -46,6 +40,7 @@ import { authCommand } from './auth'
 
 describe('auth commands', () => {
   let consoleLogSpy: ReturnType<typeof mock>
+  let consoleErrorSpy: ReturnType<typeof spyOn>
   let processExitSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
@@ -73,14 +68,14 @@ describe('auth commands', () => {
 
     consoleLogSpy = mock((..._args: unknown[]) => {})
     console.log = consoleLogSpy
-    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => {
-      throw new Error(`process.exit(${_code})`)
-    })
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
     processExitSpy.mockClear()
   })
 
   afterEach(() => {
     console.log = originalConsoleLog
+    consoleErrorSpy.mockRestore()
     processExitSpy.mockRestore()
   })
 
@@ -153,7 +148,7 @@ describe('auth commands', () => {
     it('outputs error and exits when account not found', async () => {
       mockSetCurrent.mockImplementation(() => Promise.resolve(false))
 
-      await expect(authCommand.parseAsync(['use', 'nonexistent'], { from: 'user' })).rejects.toThrow('process.exit(1)')
+      await authCommand.parseAsync(['use', 'nonexistent'], { from: 'user' })
 
       expect(processExitSpy).toHaveBeenCalledWith(1)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
@@ -185,7 +180,7 @@ describe('auth commands', () => {
     it('outputs error and exits when no account configured', async () => {
       mockGetAccount.mockImplementation(() => Promise.resolve(null))
 
-      await expect(authCommand.parseAsync(['status'], { from: 'user' })).rejects.toThrow('process.exit(1)')
+      await authCommand.parseAsync(['status'], { from: 'user' })
 
       expect(processExitSpy).toHaveBeenCalledWith(1)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
@@ -217,9 +212,7 @@ describe('auth commands', () => {
     it('outputs error for specific missing account', async () => {
       mockGetAccount.mockImplementation(() => Promise.resolve(null))
 
-      await expect(authCommand.parseAsync(['status', '--account', 'missing-id'], { from: 'user' })).rejects.toThrow(
-        'process.exit(1)',
-      )
+      await authCommand.parseAsync(['status', '--account', 'missing-id'], { from: 'user' })
 
       expect(processExitSpy).toHaveBeenCalledWith(1)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
@@ -241,8 +234,9 @@ describe('auth commands', () => {
       )
       mockRemoveAccount.mockImplementation(() => Promise.resolve(true))
 
-      await expect(authCommand.parseAsync(['logout'], { from: 'user' })).rejects.toThrow('process.exit(0)')
+      await authCommand.parseAsync(['logout'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockRemoveAccount).toHaveBeenCalledWith('plus-12025551234')
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output.success).toBe(true)
@@ -253,7 +247,7 @@ describe('auth commands', () => {
     it('outputs error and exits when no account configured', async () => {
       mockGetAccount.mockImplementation(() => Promise.resolve(null))
 
-      await expect(authCommand.parseAsync(['logout'], { from: 'user' })).rejects.toThrow('process.exit(1)')
+      await authCommand.parseAsync(['logout'], { from: 'user' })
 
       expect(processExitSpy).toHaveBeenCalledWith(1)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
@@ -273,8 +267,9 @@ describe('auth commands', () => {
       mockConnect.mockImplementation(() => Promise.reject(new Error('Connection failed')))
       mockRemoveAccount.mockImplementation(() => Promise.resolve(true))
 
-      await expect(authCommand.parseAsync(['logout'], { from: 'user' })).rejects.toThrow('process.exit(0)')
+      await authCommand.parseAsync(['logout'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockRemoveAccount).toHaveBeenCalledWith('plus-12025551234')
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output.success).toBe(true)
@@ -295,10 +290,9 @@ describe('auth commands', () => {
       })
       mockRemoveAccount.mockImplementation(() => Promise.resolve(true))
 
-      await expect(
-        authCommand.parseAsync(['logout', '--account', 'plus-19995551234'], { from: 'user' }),
-      ).rejects.toThrow('process.exit(0)')
+      await authCommand.parseAsync(['logout', '--account', 'plus-19995551234'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockRemoveAccount).toHaveBeenCalledWith('plus-19995551234')
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output.success).toBe(true)

--- a/src/platforms/whatsapp/commands/auth.ts
+++ b/src/platforms/whatsapp/commands/auth.ts
@@ -82,7 +82,7 @@ async function loginWithPairingCode(options: LoginOptions & { phone: string }): 
       options.pretty,
     ),
   )
-  process.exit(0)
+  return process.exit(0)
 }
 
 async function loginWithQR(options: LoginOptions): Promise<void> {
@@ -145,7 +145,7 @@ async function loginWithQR(options: LoginOptions): Promise<void> {
       options.pretty,
     ),
   )
-  process.exit(0)
+  return process.exit(0)
 }
 
 async function loginAction(options: LoginOptions): Promise<void> {
@@ -156,7 +156,7 @@ async function loginAction(options: LoginOptions): Promise<void> {
       await loginWithPairingCode(options as LoginOptions & { phone: string })
     } else {
       console.error('Error: Either --phone or --qr is required')
-      process.exit(1)
+      return process.exit(1)
     }
   } catch (error) {
     handleError(error as Error)
@@ -179,7 +179,7 @@ async function statusAction(options: StatusOptions): Promise<void> {
           options.pretty,
         ),
       )
-      process.exit(1)
+      return process.exit(1)
     }
 
     console.log(
@@ -229,7 +229,7 @@ async function useAction(accountId: string, options: { pretty?: boolean }): Prom
 
     if (!found) {
       console.log(formatOutput({ error: `WhatsApp account "${accountId}" not found.` }, options.pretty))
-      process.exit(1)
+      return process.exit(1)
     }
 
     const current = await manager.getAccount()
@@ -246,7 +246,7 @@ async function logoutAction(options: { account?: string; pretty?: boolean }): Pr
 
     if (!account && !options.account) {
       console.log(formatOutput({ error: 'No WhatsApp account configured.' }, options.pretty))
-      process.exit(1)
+      return process.exit(1)
     }
 
     const accountId = account?.account_id ?? options.account!
@@ -267,7 +267,7 @@ async function logoutAction(options: { account?: string; pretty?: boolean }): Pr
 
     await manager.removeAccount(accountId)
     console.log(formatOutput({ success: true, account_id: accountId, logged_out: true }, options.pretty))
-    process.exit(0)
+    return process.exit(0)
   } catch (error) {
     handleError(error as Error)
   }

--- a/src/platforms/whatsapp/commands/chat.test.ts
+++ b/src/platforms/whatsapp/commands/chat.test.ts
@@ -2,12 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:te
 
 const originalConsoleLog = console.log
 
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: (err: Error) => {
-    throw err
-  },
-}))
-
 const mockGetAccount = mock(() =>
   Promise.resolve({
     account_id: 'plus-12025551234',
@@ -69,6 +63,7 @@ import { chatCommand } from './chat'
 
 describe('chat commands', () => {
   let consoleLogSpy: ReturnType<typeof mock>
+  let consoleErrorSpy: ReturnType<typeof spyOn>
   let processExitSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
@@ -118,21 +113,22 @@ describe('chat commands', () => {
 
     consoleLogSpy = mock((..._args: unknown[]) => {})
     console.log = consoleLogSpy
-    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => {
-      throw new Error(`process.exit(${_code})`)
-    })
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
     processExitSpy.mockClear()
   })
 
   afterEach(() => {
     console.log = originalConsoleLog
+    consoleErrorSpy.mockRestore()
     processExitSpy.mockRestore()
   })
 
   describe('list', () => {
     it('lists chats with default limit', async () => {
-      await expect(chatCommand.parseAsync(['list'], { from: 'user' })).rejects.toThrow('process.exit(0)')
+      await chatCommand.parseAsync(['list'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockListChats).toHaveBeenCalledWith(20)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output).toHaveLength(1)
@@ -141,25 +137,23 @@ describe('chat commands', () => {
     })
 
     it('respects --limit option', async () => {
-      await expect(chatCommand.parseAsync(['list', '--limit', '5'], { from: 'user' })).rejects.toThrow(
-        'process.exit(0)',
-      )
+      await chatCommand.parseAsync(['list', '--limit', '5'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockListChats).toHaveBeenCalledWith(5)
     })
 
     it('passes account option to credential manager', async () => {
-      await expect(chatCommand.parseAsync(['list', '--account', 'my-account'], { from: 'user' })).rejects.toThrow(
-        'process.exit(0)',
-      )
+      await chatCommand.parseAsync(['list', '--account', 'my-account'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetAccount).toHaveBeenCalledWith('my-account')
     })
 
     it('exits with error when no account configured', async () => {
       mockGetAccount.mockImplementation(() => Promise.resolve(null))
 
-      await expect(chatCommand.parseAsync(['list'], { from: 'user' })).rejects.toThrow('process.exit(1)')
+      await chatCommand.parseAsync(['list'], { from: 'user' })
 
       expect(processExitSpy).toHaveBeenCalledWith(1)
     })
@@ -167,8 +161,9 @@ describe('chat commands', () => {
 
   describe('search', () => {
     it('searches chats by query', async () => {
-      await expect(chatCommand.parseAsync(['search', 'Bob'], { from: 'user' })).rejects.toThrow('process.exit(0)')
+      await chatCommand.parseAsync(['search', 'Bob'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockSearchChats).toHaveBeenCalledWith('Bob', 20)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output).toHaveLength(1)
@@ -177,18 +172,16 @@ describe('chat commands', () => {
     })
 
     it('respects --limit option', async () => {
-      await expect(chatCommand.parseAsync(['search', 'Alice', '--limit', '3'], { from: 'user' })).rejects.toThrow(
-        'process.exit(0)',
-      )
+      await chatCommand.parseAsync(['search', 'Alice', '--limit', '3'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockSearchChats).toHaveBeenCalledWith('Alice', 3)
     })
 
     it('passes account option to credential manager', async () => {
-      await expect(
-        chatCommand.parseAsync(['search', 'test', '--account', 'my-account'], { from: 'user' }),
-      ).rejects.toThrow('process.exit(0)')
+      await chatCommand.parseAsync(['search', 'test', '--account', 'my-account'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetAccount).toHaveBeenCalledWith('my-account')
     })
   })

--- a/src/platforms/whatsapp/commands/message.test.ts
+++ b/src/platforms/whatsapp/commands/message.test.ts
@@ -2,12 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:te
 
 const originalConsoleLog = console.log
 
-mock.module('@/shared/utils/error-handler', () => ({
-  handleError: (err: Error) => {
-    throw err
-  },
-}))
-
 const mockGetAccount = mock(() =>
   Promise.resolve({
     account_id: 'plus-12025551234',
@@ -69,6 +63,7 @@ import { messageCommand } from './message'
 
 describe('message commands', () => {
   let consoleLogSpy: ReturnType<typeof mock>
+  let consoleErrorSpy: ReturnType<typeof spyOn>
   let processExitSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
@@ -118,23 +113,22 @@ describe('message commands', () => {
 
     consoleLogSpy = mock((..._args: unknown[]) => {})
     console.log = consoleLogSpy
-    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => {
-      throw new Error(`process.exit(${_code})`)
-    })
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never)
     processExitSpy.mockClear()
   })
 
   afterEach(() => {
     console.log = originalConsoleLog
+    consoleErrorSpy.mockRestore()
     processExitSpy.mockRestore()
   })
 
   describe('list', () => {
     it('fetches messages for a chat', async () => {
-      await expect(messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net'], { from: 'user' })).rejects.toThrow(
-        'process.exit(0)',
-      )
+      await messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetMessages).toHaveBeenCalledWith('12025551234@s.whatsapp.net', 25)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output).toHaveLength(1)
@@ -143,27 +137,25 @@ describe('message commands', () => {
     })
 
     it('respects --limit option', async () => {
-      await expect(
-        messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net', '--limit', '10'], { from: 'user' }),
-      ).rejects.toThrow('process.exit(0)')
+      await messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net', '--limit', '10'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetMessages).toHaveBeenCalledWith('12025551234@s.whatsapp.net', 10)
     })
 
     it('passes account option to credential manager', async () => {
-      await expect(
-        messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net', '--account', 'my-account'], { from: 'user' }),
-      ).rejects.toThrow('process.exit(0)')
+      await messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net', '--account', 'my-account'], {
+        from: 'user',
+      })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetAccount).toHaveBeenCalledWith('my-account')
     })
 
     it('exits with error when no account configured', async () => {
       mockGetAccount.mockImplementation(() => Promise.resolve(null))
 
-      await expect(messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net'], { from: 'user' })).rejects.toThrow(
-        'process.exit(1)',
-      )
+      await messageCommand.parseAsync(['list', '12025551234@s.whatsapp.net'], { from: 'user' })
 
       expect(processExitSpy).toHaveBeenCalledWith(1)
     })
@@ -171,10 +163,9 @@ describe('message commands', () => {
 
   describe('send', () => {
     it('sends a message to a chat', async () => {
-      await expect(
-        messageCommand.parseAsync(['send', '12025551234@s.whatsapp.net', 'Hello world'], { from: 'user' }),
-      ).rejects.toThrow('process.exit(0)')
+      await messageCommand.parseAsync(['send', '12025551234@s.whatsapp.net', 'Hello world'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockSendMessage).toHaveBeenCalledWith('12025551234@s.whatsapp.net', 'Hello world')
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output.id).toBe('msg-2')
@@ -182,22 +173,20 @@ describe('message commands', () => {
     })
 
     it('passes account option to credential manager', async () => {
-      await expect(
-        messageCommand.parseAsync(['send', '12025551234@s.whatsapp.net', 'Hi', '--account', 'my-account'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit(0)')
+      await messageCommand.parseAsync(['send', '12025551234@s.whatsapp.net', 'Hi', '--account', 'my-account'], {
+        from: 'user',
+      })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetAccount).toHaveBeenCalledWith('my-account')
     })
   })
 
   describe('react', () => {
     it('sends a reaction to a message', async () => {
-      await expect(
-        messageCommand.parseAsync(['react', '12025551234@s.whatsapp.net', 'msg-1', '👍'], { from: 'user' }),
-      ).rejects.toThrow('process.exit(0)')
+      await messageCommand.parseAsync(['react', '12025551234@s.whatsapp.net', 'msg-1', '👍'], { from: 'user' })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockSendReaction).toHaveBeenCalledWith('12025551234@s.whatsapp.net', 'msg-1', '👍', undefined)
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output.success).toBe(true)
@@ -207,22 +196,23 @@ describe('message commands', () => {
     })
 
     it('passes --from-me flag to sendReaction', async () => {
-      await expect(
-        messageCommand.parseAsync(['react', '12025551234@s.whatsapp.net', 'msg-1', '❤️', '--from-me'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit(0)')
+      await messageCommand.parseAsync(['react', '12025551234@s.whatsapp.net', 'msg-1', '❤️', '--from-me'], {
+        from: 'user',
+      })
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockSendReaction).toHaveBeenCalledWith('12025551234@s.whatsapp.net', 'msg-1', '❤️', true)
     })
 
     it('passes account option to credential manager', async () => {
-      await expect(
-        messageCommand.parseAsync(['react', '12025551234@s.whatsapp.net', 'msg-1', '👍', '--account', 'my-account'], {
+      await messageCommand.parseAsync(
+        ['react', '12025551234@s.whatsapp.net', 'msg-1', '👍', '--account', 'my-account'],
+        {
           from: 'user',
-        }),
-      ).rejects.toThrow('process.exit(0)')
+        },
+      )
 
+      expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetAccount).toHaveBeenCalledWith('my-account')
     })
   })

--- a/src/shared/chromium/browsers.ts
+++ b/src/shared/chromium/browsers.ts
@@ -75,11 +75,13 @@ export function discoverBrowserProfileDirs(browserBase: string): string[] {
   dirs.push(join(browserBase, 'Default'))
   if (!existsSync(browserBase)) return dirs
   try {
-    const entries = readdirSync(browserBase, { withFileTypes: true })
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue
-      if (!/^Profile \d+$/i.test(entry.name)) continue
-      dirs.push(join(browserBase, entry.name))
+    // readdirSync order is filesystem-dependent (e.g. Linux returns unsorted),
+    // so sort numbered profiles by their numeric index for deterministic output.
+    const profiles = readdirSync(browserBase, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && /^Profile \d+$/i.test(entry.name))
+      .sort((a, b) => parseInt(a.name.slice('Profile '.length), 10) - parseInt(b.name.slice('Profile '.length), 10))
+    for (const profile of profiles) {
+      dirs.push(join(browserBase, profile.name))
     }
   } catch {
     return dirs


### PR DESCRIPTION
## Summary

CI on `main` was failing (run #26444855239). There were **two independent root causes**, both of which only surface in the full `bun test src/` run — every affected test passes in isolation, which is the classic signature of cross-file pollution + filesystem-order dependence.

## Root cause 1 — Bun mock pollution across test files

The Webex command tests (`message`, `space`, `snapshot`, `member`) used `mock.module('../client', ...)`, and `whoami` used a module-export constructor spy `spyOn(clientModule, 'WebexClient')`.

Bun's `mock.module` is **process-global and persistent** — it is not undone between files. Once any of these files ran, every later file that imported `../client` got the mocked `WebexClient` (which lacks a real `testAuth`/`login` on its prototype). On the CI runner's file ordering this broke:

- `webex auth ... testAuth is not a function`
- `webex whoami exits with code 1 when not authenticated` → `No Webex credentials found.`
- `discord dm listAction/createAction handles authentication error` → `Token is required`
- `discord reaction add: handles missing token gracefully` → `Token is required`

**Fix:** replace the global module mocks with restorable `spyOn(WebexClient.prototype, ...)` spies (tracked and `mockRestore()`d in `afterEach`), and drop the global `@/shared/utils/error-handler` module mock in favor of a `process.exit` spy. Each file now cleans up fully after itself, so it can no longer poison sibling files.

## Root cause 2 — nondeterministic browser-profile ordering

`discoverBrowserProfileDirs` pushed numbered profiles in raw `readdirSync` order, which is unsorted on Linux. CI produced `[Default, Profile 2, Profile 1]`, failing the order-sensitive assertion (passes on macOS where readdir happens to be sorted).

**Fix:** sort numbered profiles by their parsed numeric index (so `Profile 2` < `Profile 10`), keeping `Default` first. Applied inside `discoverBrowserProfileDirs` so all callers benefit.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun run format:check` — changed files correctly formatted
- Reproductions confirmed fixed in both file orderings; all webex commands together; webex → discord cross-check
- Full `bun test src/` — all previously-failing webex/discord/browsers tests now pass

> Note: a handful of `slack TokenExtractor` tests fail locally because they read real Slack/browser data on the dev machine; they are pre-existing (identical on `main`), environment-specific, and pass on CI's clean runner. They are untouched by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI failures on main by removing test mock pollution (Webex + WhatsApp) and making browser profile discovery deterministic. The full `bun test src/` run now passes consistently on CI.

- **Bug Fixes**
  - Webex tests: replaced global module mocks with restorable `spyOn(WebexClient.prototype, ...)`; mocked `process.exit`; added per-file cleanup to prevent cross-file leaks.
  - WhatsApp: removed global error-handler test mock; tests now spy on `process.exit`; updated `src/platforms/whatsapp/commands/auth.ts` to return `process.exit(...)` for clean test control flow.
  - Browser profiles: `discoverBrowserProfileDirs` now sorts numbered profiles by numeric index, keeping `Default` first, to avoid filesystem-order flakiness.
  - Docs: SKILL.md/docs not updated (no user-facing changes).

<sup>Written for commit f1f846b3936e344e1f31c3801e267ff44e24b0e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/207?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

