### PR TITLE
Fix partial KakaoTalk member lists

### DIFF
--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -1265,6 +1265,45 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('merges CHATONROOM members when GETMEM returns a partial member list', async () => {
+      mockGetAllMembers.mockResolvedValueOnce({
+        statusCode: 0,
+        body: {
+          members: [
+            {
+              userId: makeLong(42),
+              nickName: 'Alice',
+              type: 100,
+              profileImageUrl: 'https://kakao.com/p/alice.jpg',
+            },
+          ],
+          token: 0,
+        },
+      })
+      mockGetChatInfo.mockResolvedValueOnce({
+        statusCode: 0,
+        body: {
+          status: 0,
+          m: [
+            { userId: makeLong(42), nickName: 'Alice From Room', type: 100 },
+            { userId: makeLong(43), nickName: 'Bob', type: 100 },
+            { userId: makeLong(44), nickName: 'Carol', type: 100 },
+          ],
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const members = await client.getMembers('100')
+
+      expect(members.map((member) => member.user_id)).toEqual(['42', '43', '44'])
+      expect(members[0].nickname).toBe('Alice')
+      expect(members[0].profile_image_url).toBe('https://kakao.com/p/alice.jpg')
+      expect(members[1].nickname).toBe('Bob')
+      expect(members[2].nickname).toBe('Carol')
+
+      client.close()
+    })
+
     it('returns empty array when GETMEM returns no members', async () => {
       mockGetAllMembers.mockResolvedValueOnce({ statusCode: 0, body: {} })
 

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -428,6 +428,54 @@ function formatMember(member: Record<string, unknown>): KakaoMember {
   }
 }
 
+function memberIdKey(member: Record<string, unknown>): string | null {
+  if (member.userId === undefined || member.userId === null) return null
+  const key = longToString(member.userId)
+  return key === '0' ? null : key
+}
+
+function mergeMemberRecords(
+  primaryMembers: Array<Record<string, unknown>>,
+  fallbackMembers: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const merged: Array<Record<string, unknown>> = []
+  const indexByUserId = new Map<string, number>()
+
+  const upsert = (member: Record<string, unknown>) => {
+    const userId = memberIdKey(member)
+    if (!userId) return
+
+    const existingIndex = indexByUserId.get(userId)
+    if (existingIndex === undefined) {
+      indexByUserId.set(userId, merged.length)
+      merged.push(member)
+      return
+    }
+
+    merged[existingIndex] = { ...member, ...merged[existingIndex] }
+  }
+
+  for (const member of primaryMembers) upsert(member)
+  for (const member of fallbackMembers) upsert(member)
+
+  return merged
+}
+
+function extractChatInfoMembers(body: unknown): Array<Record<string, unknown>> {
+  if (!body || typeof body !== 'object') return []
+
+  const record = body as Record<string, unknown>
+  if (Array.isArray(record.m)) {
+    return record.m as Array<Record<string, unknown>>
+  }
+
+  const chatInfo = record.chatInfo
+  if (!chatInfo || typeof chatInfo !== 'object') return []
+
+  const displayMembers = (chatInfo as Record<string, unknown>).displayMembers
+  return Array.isArray(displayMembers) ? (displayMembers as Array<Record<string, unknown>>) : []
+}
+
 function formatMessages(
   logs: Array<Record<string, unknown>>,
   count: number,
@@ -875,7 +923,17 @@ export class KakaoTalkClient {
         const response = await session.getAllMembers(parsedChatId)
         assertLocoOk(response, 'GETMEM')
         const members = (response.body.members ?? []) as Array<Record<string, unknown>>
-        return members.map(formatMember)
+        let fallbackMembers: Array<Record<string, unknown>> = []
+        try {
+          // Some KakaoTalk rooms return only a subset from GETMEM even though
+          // CHATONROOM carries the full active member list in `m`.
+          const chatInfo = await session.getChatInfo(parsedChatId)
+          fallbackMembers = extractChatInfoMembers(chatInfo.body)
+        } catch {
+          fallbackMembers = []
+        }
+
+        return mergeMemberRecords(members, fallbackMembers).map(formatMember)
       } catch (error) {
         throw wrapError(error, 'get_members_failed')
       }


### PR DESCRIPTION
## Summary
- merge CHATONROOM member data into getMembers() so rooms where GETMEM returns a subset still expose all active members
- preserve richer GETMEM fields when duplicate user IDs appear
- add regression coverage for partial GETMEM responses

## Validation
- bun test src/platforms/kakaotalk/client.test.ts
- bunx tsc --noEmit --pretty false
- bun run build
- verified agent-kakaotalk member list returns 20/20 members in the affected room

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incomplete KakaoTalk member lists by merging `GETMEM` results with the room’s `CHATONROOM` roster so all active members are returned. Keeps richer `GETMEM` fields when duplicates appear.

- **Bug Fixes**
  - Merge `getAllMembers` with `getChatInfo` members when `GETMEM` returns a subset.
  - Prefer `GETMEM` fields; use room list as fallback for missing data.
  - Add regression test covering partial `GETMEM` responses.

Docs: No changes to SKILL.md or docs.

<sup>Written for commit d28d9a7906f39f3adcbc0334e714d516b04c3acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

