### PR TITLE
Fix LINE event listener never receiving events under Bun

### DIFF
--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -346,8 +346,11 @@ export class LineClient {
   // Drives the vendor polling generator (talk.sync()) instead of Client.listen().
   // Client.listen() uses a LEGY HTTP/2 push connection (duplex:'half' streaming
   // fetch) that yields zero bytes under Bun and dies immediately, so no events
-  // ever arrive (oven-sh/bun#7206, evex-dev/linejs#117). Polling works on any
-  // runtime. Messages are decrypted and normalized like Client.listen() does.
+  // ever arrive (evex-dev/linejs#117). The upstream "fix" (linejs#134, v2.7.0+)
+  // only adds an undici+allowH2 path for Node.js and explicitly skips Bun
+  // ("Bun" in globalThis -> return false), falling back to Bun's native fetch,
+  // which still can't stream duplex:'half' HTTP/2 (oven-sh/bun#30342, #31881).
+  // Polling works on every runtime. Messages are normalized like Client.listen().
   async *streamEvents(signal: AbortSignal): AsyncGenerator<LineRawEvent, void, unknown> {
     const client = this.ensureClient()
     const polling = client.base.createPolling()

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -1,6 +1,8 @@
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import type { Operation as LineOperation } from '@jsr/evex__linejs-types'
+
 import { getConfigDir } from '@/shared/utils/config-dir'
 import { FileStorage } from '@/vendor/linejs/base/storage/mod.js'
 import {
@@ -22,6 +24,16 @@ import type {
   LineSendResult,
 } from './types'
 import { LineError } from './types'
+
+export interface LineRawMessage {
+  raw: { id: unknown; contentType?: unknown; createdTime?: unknown; toType?: unknown; to?: unknown; from?: unknown }
+  to: { id: unknown }
+  from: { id: unknown }
+  isMyMessage: boolean
+  text: string | null
+}
+
+export type LineRawEvent = { kind: 'message'; message: LineRawMessage } | { kind: 'event'; op: LineOperation }
 
 function wrapError(error: unknown, code: string): LineError {
   if (error instanceof LineError) return error
@@ -328,6 +340,34 @@ export class LineClient {
       }
     } catch (error) {
       throw wrapError(error, 'send_message_failed')
+    }
+  }
+
+  // Drives the vendor polling generator (talk.sync()) instead of Client.listen().
+  // Client.listen() uses a LEGY HTTP/2 push connection (duplex:'half' streaming
+  // fetch) that yields zero bytes under Bun and dies immediately, so no events
+  // ever arrive (oven-sh/bun#7206, evex-dev/linejs#117). Polling works on any
+  // runtime. Messages are decrypted and normalized like Client.listen() does.
+  async *streamEvents(signal: AbortSignal): AsyncGenerator<LineRawEvent, void, unknown> {
+    const client = this.ensureClient()
+    const polling = client.base.createPolling()
+    const selfMid = client.base.profile?.mid
+
+    for await (const op of polling._listenTalkEvents({ signal })) {
+      yield { kind: 'event', op }
+      if (op.type === 'SEND_MESSAGE' || op.type === 'RECEIVE_MESSAGE') {
+        const raw = await client.base.e2ee.decryptE2EEMessage(op.message)
+        yield {
+          kind: 'message',
+          message: {
+            raw,
+            to: { id: raw.to },
+            from: { id: raw.from },
+            isMyMessage: selfMid === raw.from,
+            text: raw.text ?? null,
+          },
+        }
+      }
     }
   }
 

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -353,7 +353,12 @@ export class LineClient {
     const polling = client.base.createPolling()
     const selfMid = client.base.profile?.mid
 
-    for await (const op of polling._listenTalkEvents({ signal })) {
+    for await (const op of polling._listenTalkEvents({
+      signal,
+      onError: (error) => {
+        throw error instanceof Error ? error : new Error(String(error))
+      },
+    })) {
       yield { kind: 'event', op }
       if (op.type === 'SEND_MESSAGE' || op.type === 'RECEIVE_MESSAGE') {
         const raw = await client.base.e2ee.decryptE2EEMessage(op.message)

--- a/src/platforms/line/listener.test.ts
+++ b/src/platforms/line/listener.test.ts
@@ -1,60 +1,95 @@
 import { afterEach, describe, expect, mock, it } from 'bun:test'
 
+import type { LineRawEvent } from '@/platforms/line/client'
 import { LineListener } from '@/platforms/line/listener'
 import type { LinePushGenericEvent, LinePushMessageEvent } from '@/platforms/line/types'
 
-const mockGetProfile = mock(() => Promise.resolve({ mid: 'u123', displayName: 'Test User' }))
+const mockGetProfile = mock(() => Promise.resolve({ mid: 'u123', display_name: 'Test User' }))
 
-let mockInternalClientInstance: MockInternalClient
+let mockInternalClientInstance: MockEventSource
 
-class MockInternalClient {
-  handlers: Record<string, ((...args: any[]) => void)[]> = {}
-  private listenReject: ((e: Error) => void) | null = null
+class MockEventSource {
+  private queue: LineRawEvent[] = []
+  private resolveNext: ((value: IteratorResult<LineRawEvent>) => void) | null = null
+  private streamError: Error | null = null
+  private done = false
 
-  on(event: string, handler: (...args: any[]) => void): void {
-    if (!this.handlers[event]) this.handlers[event] = []
-    this.handlers[event].push(handler)
-  }
-
-  listen(opts: { signal?: AbortSignal } = {}): Promise<void> {
-    return new Promise((_resolve, reject) => {
-      this.listenReject = reject
-      opts.signal?.addEventListener('abort', () => {
-        const err = new Error('The operation was aborted')
-        err.name = 'AbortError'
-        reject(err)
-      })
+  async *streamEvents(signal: AbortSignal): AsyncGenerator<LineRawEvent, void, unknown> {
+    signal.addEventListener('abort', () => {
+      const err = new Error('The operation was aborted')
+      err.name = 'AbortError'
+      this.fail(err)
     })
+
+    while (!this.done) {
+      if (this.streamError) {
+        const err = this.streamError
+        this.streamError = null
+        throw err
+      }
+      if (this.queue.length > 0) {
+        yield this.queue.shift()!
+        continue
+      }
+      const next = await new Promise<IteratorResult<LineRawEvent>>((resolve) => {
+        this.resolveNext = resolve
+      })
+      if (next.done) return
+      if (this.streamError) {
+        const err = this.streamError
+        this.streamError = null
+        throw err
+      }
+      yield next.value
+    }
   }
 
-  simulateMessage(msg: unknown): void {
-    this.handlers['message']?.forEach((h) => h(msg))
+  private push(event: LineRawEvent): void {
+    if (this.resolveNext) {
+      const resolve = this.resolveNext
+      this.resolveNext = null
+      resolve({ value: event, done: false })
+    } else {
+      this.queue.push(event)
+    }
+  }
+
+  private fail(error: Error): void {
+    this.streamError = error
+    if (this.resolveNext) {
+      const resolve = this.resolveNext
+      this.resolveNext = null
+      resolve({ value: undefined as never, done: false })
+    }
+  }
+
+  simulateMessage(message: unknown): void {
+    this.push({ kind: 'message', message: message as never })
   }
 
   simulateEvent(op: unknown): void {
-    this.handlers['event']?.forEach((h) => h(op))
+    this.push({ kind: 'event', op: op as never })
   }
 
   simulateListenError(error: Error): void {
-    this.listenReject?.(error)
-  }
-
-  base = {
-    talk: { getProfile: mockGetProfile },
+    this.fail(error)
   }
 }
 
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 const mockLogin = mock((): Promise<void> => {
-  mockInternalClientInstance = new MockInternalClient()
+  mockInternalClientInstance = new MockEventSource()
   return Promise.resolve()
 })
 
 function createMockLineClient() {
   return {
     login: mockLogin,
-    get client() {
-      return mockInternalClientInstance
-    },
+    getProfile: mockGetProfile,
+    streamEvents: (signal: AbortSignal) => mockInternalClientInstance.streamEvents(signal),
   } as any
 }
 
@@ -65,11 +100,11 @@ describe('LineListener', () => {
     listener?.stop()
     mockLogin.mockReset()
     mockLogin.mockImplementation((): Promise<void> => {
-      mockInternalClientInstance = new MockInternalClient()
+      mockInternalClientInstance = new MockEventSource()
       return Promise.resolve()
     })
     mockGetProfile.mockReset()
-    mockGetProfile.mockResolvedValue({ mid: 'u123', displayName: 'Test User' })
+    mockGetProfile.mockResolvedValue({ mid: 'u123', display_name: 'Test User' })
   })
 
   describe('start', () => {
@@ -128,6 +163,7 @@ describe('LineListener', () => {
           createdTime: 1700000000000,
         },
       })
+      await flush()
 
       expect(messages.length).toBe(1)
       expect(messages[0].type).toBe('message')
@@ -153,6 +189,7 @@ describe('LineListener', () => {
         text: 'sent by me',
         raw: { id: 'msg002', contentType: 'NONE', createdTime: 1700000001000 },
       })
+      await flush()
 
       expect(messages.length).toBe(1)
       expect(messages[0].chat_id).toBe('u456')
@@ -175,6 +212,7 @@ describe('LineListener', () => {
         text: 'hi',
         raw: { id: 'msg003', contentType: 'NONE', createdTime: 1700000002000 },
       })
+      await flush()
 
       expect(events.length).toBe(1)
       expect(events[0].type).toBe('message')
@@ -189,6 +227,7 @@ describe('LineListener', () => {
 
       await listener.start()
       mockInternalClientInstance.simulateEvent({ type: 'NOTIFIED_READ_MESSAGE', revision: 42 })
+      await flush()
 
       expect(events.length).toBe(1)
       expect(events[0].type).toBe('NOTIFIED_READ_MESSAGE')
@@ -233,7 +272,7 @@ describe('LineListener', () => {
       mockLogin.mockImplementation((): Promise<void> => {
         callCount++
         if (callCount === 1) return Promise.reject(new Error('network_error'))
-        mockInternalClientInstance = new MockInternalClient()
+        mockInternalClientInstance = new MockEventSource()
         return Promise.resolve()
       })
 
@@ -283,6 +322,7 @@ describe('LineListener', () => {
         text: 'first',
         raw: { id: 'msg004', contentType: 'NONE', createdTime: 1700000003000 },
       })
+      await flush()
 
       listener.off('message', handler)
       mockInternalClientInstance.simulateMessage({
@@ -292,6 +332,7 @@ describe('LineListener', () => {
         text: 'second',
         raw: { id: 'msg005', contentType: 'NONE', createdTime: 1700000004000 },
       })
+      await flush()
 
       expect(messages.length).toBe(1)
       expect(messages[0].text).toBe('first')
@@ -319,6 +360,7 @@ describe('LineListener', () => {
         text: 'second',
         raw: { id: 'msg007', contentType: 'NONE', createdTime: 1700000006000 },
       })
+      await flush()
 
       expect(messages.length).toBe(1)
       expect(messages[0].text).toBe('first')
@@ -336,6 +378,39 @@ describe('LineListener', () => {
 
       await listener.start()
       expect((listener as any).reconnectAttempts).toBe(0)
+    })
+  })
+
+  describe('event source consumption', () => {
+    it('consumes streamEvents and stops pumping after abort', async () => {
+      const streamCalls: AbortSignal[] = []
+      const client = {
+        login: mockLogin,
+        getProfile: mockGetProfile,
+        streamEvents: (signal: AbortSignal) => {
+          streamCalls.push(signal)
+          return mockInternalClientInstance.streamEvents(signal)
+        },
+      } as any
+      listener = new LineListener(client)
+
+      const messages: LinePushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      expect(streamCalls.length).toBe(1)
+
+      listener.stop()
+      mockInternalClientInstance.simulateMessage({
+        isMyMessage: false,
+        from: { type: 'USER', id: 'u456' },
+        to: { type: 'USER', id: 'u123' },
+        text: 'after stop',
+        raw: { id: 'msg100', contentType: 'NONE', createdTime: 1700000010000 },
+      })
+      await flush()
+
+      expect(messages.length).toBe(0)
     })
   })
 })

--- a/src/platforms/line/listener.ts
+++ b/src/platforms/line/listener.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from 'events'
 
 import type { LineClient } from './client'
 import type { LineListenerEventMap, LinePushGenericEvent, LinePushMessageEvent } from './types'
-import { LineError } from './types'
 
 const RECONNECT_BASE_DELAY = 1_000
 const RECONNECT_MAX_DELAY = 30_000
@@ -61,65 +60,70 @@ export class LineListener {
       await this.lineClient.login()
       if (!this.running) return
 
-      const internalClient = (this.lineClient as any).client
-      if (!internalClient) {
-        throw new LineError('not_connected', 'Failed to get internal LINE client')
-      }
-
+      const profile = await this.lineClient.getProfile()
       this.abortController = new AbortController()
-
-      internalClient.on('message', (msg: any) => {
-        try {
-          const toType = msg.raw.toType
-          const isGroupOrRoom = toType === 'GROUP' || toType === 'ROOM' || toType === 0 || toType === 1
-          const chatId = isGroupOrRoom ? msg.to.id : msg.isMyMessage ? msg.to.id : msg.from.id
-
-          const event: LinePushMessageEvent = {
-            type: 'message',
-            chat_id: chatId,
-            message_id: String(msg.raw.id),
-            author_id: msg.from.id,
-            text: msg.text ?? null,
-            content_type: String(msg.raw.contentType ?? 'NONE'),
-            sent_at: new Date(Number(msg.raw.createdTime)).toISOString(),
-          }
-          this.emitter.emit('message', event)
-          this.emitter.emit('line_event', { ...event })
-        } catch (error) {
-          this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
-        }
-      })
-
-      internalClient.on('event', (op: any) => {
-        const event: LinePushGenericEvent = {
-          type: String(op.type ?? 'unknown'),
-          ...(op.revision !== undefined && { revision: String(op.revision) }),
-          ...(op.createdTime !== undefined && {
-            created_time: new Date(Number(op.createdTime)).toISOString(),
-          }),
-        }
-        this.emitter.emit('line_event', event)
-      })
-
-      internalClient.listen({ signal: this.abortController.signal })?.catch((error: unknown) => {
-        if (!this.running) return
-        const err = error instanceof Error ? error : new Error(String(error))
-        if (err.name === 'AbortError') return
-        this.emitter.emit('error', err)
-        this.emitter.emit('disconnected')
-        this.scheduleReconnect()
-      })
-
       this.reconnectAttempts = 0
-
-      const profile = await internalClient.base.talk.getProfile()
       this.emitter.emit('connected', { account_id: profile.mid })
+
+      void this.pump(this.abortController.signal)
     } catch (error) {
       this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
       if (this.running) {
         this.scheduleReconnect()
       }
     }
+  }
+
+  private async pump(signal: AbortSignal): Promise<void> {
+    try {
+      for await (const event of this.lineClient.streamEvents(signal)) {
+        if (event.kind === 'message') {
+          this.emitMessage(event.message)
+        } else {
+          this.emitOperation(event.op)
+        }
+      }
+    } catch (error) {
+      if (!this.running || signal.aborted) return
+      const err = error instanceof Error ? error : new Error(String(error))
+      if (err.name === 'AbortError') return
+      this.emitter.emit('error', err)
+      this.emitter.emit('disconnected')
+      this.scheduleReconnect()
+    }
+  }
+
+  private emitMessage(msg: any): void {
+    try {
+      const toType = msg.raw.toType
+      const isGroupOrRoom = toType === 'GROUP' || toType === 'ROOM' || toType === 0 || toType === 1
+      const chatId = isGroupOrRoom ? msg.to.id : msg.isMyMessage ? msg.to.id : msg.from.id
+
+      const event: LinePushMessageEvent = {
+        type: 'message',
+        chat_id: chatId,
+        message_id: String(msg.raw.id),
+        author_id: msg.from.id,
+        text: msg.text ?? null,
+        content_type: String(msg.raw.contentType ?? 'NONE'),
+        sent_at: new Date(Number(msg.raw.createdTime)).toISOString(),
+      }
+      this.emitter.emit('message', event)
+      this.emitter.emit('line_event', { ...event })
+    } catch (error) {
+      this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+    }
+  }
+
+  private emitOperation(op: any): void {
+    const event: LinePushGenericEvent = {
+      type: String(op.type ?? 'unknown'),
+      ...(op.revision !== undefined && { revision: String(op.revision) }),
+      ...(op.createdTime !== undefined && {
+        created_time: new Date(Number(op.createdTime)).toISOString(),
+      }),
+    }
+    this.emitter.emit('line_event', event)
   }
 
   private scheduleReconnect(): void {

--- a/src/platforms/line/listener.ts
+++ b/src/platforms/line/listener.ts
@@ -61,6 +61,7 @@ export class LineListener {
       if (!this.running) return
 
       const profile = await this.lineClient.getProfile()
+      if (!this.running) return
       this.abortController = new AbortController()
       this.reconnectAttempts = 0
       this.emitter.emit('connected', { account_id: profile.mid })


### PR DESCRIPTION
## Summary

The LINE real-time event listener (`LineListener`) connected successfully but **delivered zero events** — `message`/`line_event` never fired. Investigation found **two layered bugs**, both confirmed with live testing against a real LINE account under Bun.

## Root cause

### Bug 1 — listener options silently disabled both event streams
`LineListener` called the vendor client as `client.listen({ signal })`. But the vendor signature is:

```js
listen(opts = { talk: true, square: true }) { ... }
```

A default parameter only applies when the argument is **omitted**. Passing `{ signal }` replaces the whole object, so `opts.talk` and `opts.square` are both `undefined` and **neither event stream is ever started** — not even the underlying push connection initializes.

### Bug 2 — LEGY HTTP/2 push transport yields zero bytes under Bun
Even when started, the vendor's modern transport opens a long-lived HTTP/2 `POST /PUSH/1/subs` using a `duplex: 'half'` streaming-fetch request body. **Bun does not implement full-duplex streaming `fetch()`** ([oven-sh/bun#7206](https://github.com/oven-sh/bun/issues/7206), [#6017](https://github.com/oven-sh/bun/issues/6017)), so the response body produces **0 bytes** and the connection dies immediately, looping forever on retry. This is a known linejs-on-Bun problem ([evex-dev/linejs#117](https://github.com/evex-dev/linejs/issues/117)).

Observed directly: `readBytes=0`, repeated `CONN died on PingId=0`.

## Fix

Route the listener through the vendor's **polling generator** (`_listenTalkEvents`, backed by `talk.sync()`), which works on any runtime. Exposed via a new `LineClient.streamEvents(signal)` that decrypts E2EE messages and normalizes them exactly as `Client.listen()` does.

- `LineListener` no longer reaches into `(client as any).client` or calls the broken `listen()`.
- Message/operation → event mapping is **unchanged**.
- Reconnect and error semantics are preserved (the polling generator throwing now drives reconnect, replacing the dead `?.catch()` that could never fire because `listen()` returns `void`).

## Verification

Tested live against a real LINE account under Bun — sending a message and confirming the listener receives it in real time. The listener emitted a fully-parsed `message` event (chat_id, message_id, author_id, text, content_type, sent_at).

- `bun typecheck` — clean
- `bun lint` — clean
- `bun test src/platforms/line/` — 98 pass / 0 fail

The previous test mock's `listen()` returned a `Promise`, which masked Bug 1 (real vendor `listen()` returns `void`). Tests now drive delivery through `streamEvents` to match the real contract, plus a regression test that the listener stops pumping after `stop()`/abort.

> Note: 9 unrelated, pre-existing Slack `TokenExtractor` test failures exist on `main` (environment-dependent browser/installation tests); they are not affected by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LINE real-time listener on Bun by switching to a polling-backed stream and improving error propagation, restoring reliable event delivery and reconnects. Event shapes and reconnect behavior remain the same.

- **Bug Fixes**
  - Listener received no events under Bun due to two issues: passing `{ signal }` disabled vendor streams, and Bun’s half-duplex fetch broke the push transport.
  - Added `LineClient.streamEvents(signal)` using the vendor polling generator; decrypts messages and preserves the existing message/event mapping.
  - `LineListener` now consumes `streamEvents`, propagates polling errors to trigger reconnects, guards a `stop()` race, and clarifies in-code why the upstream push fix does not enable Bun; tests updated.

- **Migration**
  - No breaking changes; no action needed.
  - SKILL.md/docs: no updates required.

<sup>Written for commit 62302791965c48b3a60a3e893f054557bc8b0077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

