### PR TITLE
Fix LINE message list always returning empty

### DIFF
--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -54,6 +54,68 @@ describe('LineClient', () => {
     })
   })
 
+  describe('getMessages()', () => {
+    function clientWithTalk(talk: Record<string, unknown>): LineClient {
+      const client = new LineClient()
+      ;(client as any).client = { base: { talk } }
+      return client
+    }
+
+    it('returns empty when the message box has no messages', async () => {
+      const client = clientWithTalk({
+        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'chat1', lastMessages: [] }] }),
+      })
+      expect(await client.getMessages('chat1')).toEqual([])
+    })
+
+    it('returns empty when the chat is not in any message box', async () => {
+      const client = clientWithTalk({
+        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'other', lastMessages: [{ id: '5' }] }] }),
+      })
+      expect(await client.getMessages('chat1')).toEqual([])
+    })
+
+    it('anchors on the latest message and returns newest-first, deduplicated', async () => {
+      const latest = {
+        id: '30',
+        from: 'u1',
+        text: 'c',
+        contentType: 'NONE',
+        createdTime: 1700000003000,
+        deliveredTime: 1700000003000,
+      }
+      const older = [
+        { id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 1700000003000 },
+        { id: '10', from: 'u1', text: 'a', contentType: 'NONE', createdTime: 1700000001000 },
+        { id: '20', from: 'u1', text: 'b', contentType: 'NONE', createdTime: 1700000002000 },
+      ]
+      const client = clientWithTalk({
+        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'chat1', lastMessages: [latest] }] }),
+        getPreviousMessagesV2WithRequest: async () => older,
+      })
+
+      const result = await client.getMessages('chat1', { count: 10 })
+      expect(result.map((m) => m.message_id)).toEqual(['30', '20', '10'])
+      expect(result.map((m) => m.text)).toEqual(['c', 'b', 'a'])
+    })
+
+    it('respects the count limit', async () => {
+      const latest = { id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 3 }
+      const older = [
+        { id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 3 },
+        { id: '20', from: 'u1', text: 'b', contentType: 'NONE', createdTime: 2 },
+        { id: '10', from: 'u1', text: 'a', contentType: 'NONE', createdTime: 1 },
+      ]
+      const client = clientWithTalk({
+        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'chat1', lastMessages: [latest] }] }),
+        getPreviousMessagesV2WithRequest: async () => older,
+      })
+
+      const result = await client.getMessages('chat1', { count: 2 })
+      expect(result.map((m) => m.message_id)).toEqual(['30', '20'])
+    })
+  })
+
   describe('login() without credentials', () => {
     it('throws LineError when no saved credentials exist', async () => {
       const { LineCredentialManager } = require('./credential-manager')

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -61,58 +61,48 @@ describe('LineClient', () => {
       return client
     }
 
-    it('returns empty when the message box has no messages', async () => {
+    it('returns empty when the chat has no messages', async () => {
       const client = clientWithTalk({
-        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'chat1', lastMessages: [] }] }),
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async () => [],
       })
       expect(await client.getMessages('chat1')).toEqual([])
     })
 
-    it('returns empty when the chat is not in any message box', async () => {
+    it('queries from the latest message regardless of message-box position', async () => {
+      let request: any
       const client = clientWithTalk({
-        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'other', lastMessages: [{ id: '5' }] }] }),
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async (args: any) => {
+          request = args.request
+          return [{ id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 3 }]
+        },
       })
-      expect(await client.getMessages('chat1')).toEqual([])
+
+      const result = await client.getMessages('chat-not-in-top-boxes', { count: 10 })
+      expect(request.messageBoxId).toBe('chat-not-in-top-boxes')
+      expect(request.endMessageId.messageId).toBe(9223372036854775807n)
+      expect(result.map((m) => m.message_id)).toEqual(['30'])
     })
 
-    it('anchors on the latest message and returns newest-first, deduplicated', async () => {
-      const latest = {
-        id: '30',
-        from: 'u1',
-        text: 'c',
-        contentType: 'NONE',
-        createdTime: 1700000003000,
-        deliveredTime: 1700000003000,
-      }
-      const older = [
+    it('maps vendor fields and preserves order/count from the request', async () => {
+      const raw = [
         { id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 1700000003000 },
-        { id: '10', from: 'u1', text: 'a', contentType: 'NONE', createdTime: 1700000001000 },
         { id: '20', from: 'u1', text: 'b', contentType: 'NONE', createdTime: 1700000002000 },
       ]
+      let requestedCount: number | undefined
       const client = clientWithTalk({
-        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'chat1', lastMessages: [latest] }] }),
-        getPreviousMessagesV2WithRequest: async () => older,
-      })
-
-      const result = await client.getMessages('chat1', { count: 10 })
-      expect(result.map((m) => m.message_id)).toEqual(['30', '20', '10'])
-      expect(result.map((m) => m.text)).toEqual(['c', 'b', 'a'])
-    })
-
-    it('respects the count limit', async () => {
-      const latest = { id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 3 }
-      const older = [
-        { id: '30', from: 'u1', text: 'c', contentType: 'NONE', createdTime: 3 },
-        { id: '20', from: 'u1', text: 'b', contentType: 'NONE', createdTime: 2 },
-        { id: '10', from: 'u1', text: 'a', contentType: 'NONE', createdTime: 1 },
-      ]
-      const client = clientWithTalk({
-        getMessageBoxes: async () => ({ messageBoxes: [{ id: 'chat1', lastMessages: [latest] }] }),
-        getPreviousMessagesV2WithRequest: async () => older,
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async (args: any) => {
+          requestedCount = args.request.messagesCount
+          return raw
+        },
       })
 
       const result = await client.getMessages('chat1', { count: 2 })
+      expect(requestedCount).toBe(2)
       expect(result.map((m) => m.message_id)).toEqual(['30', '20'])
+      expect(result.map((m) => m.text)).toEqual(['c', 'b'])
     })
   })
 

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
-import type { Operation as LineOperation } from '@jsr/evex__linejs-types'
+import type { Message as LineRawMessageData, Operation as LineOperation } from '@jsr/evex__linejs-types'
 
 import { getConfigDir } from '@/shared/utils/config-dir'
 import { FileStorage } from '@/vendor/linejs/base/storage/mod.js'
@@ -291,19 +291,28 @@ export class LineClient {
       const client = this.ensureClient()
       const count = options?.count ?? 20
 
-      const serverTime = await client.base.talk.getServerTime()
-      const rawMessages = await client.base.talk.getPreviousMessagesV2WithRequest({
+      const latest = await this.getLatestMessage(chatId)
+      if (!latest) return []
+
+      // getPreviousMessagesV2WithRequest pages backward from a real endMessageId.
+      // A messageId:0 sentinel returns nothing, so anchor on the latest message
+      // and include it in the result.
+      const older = await client.base.talk.getPreviousMessagesV2WithRequest({
         request: {
           messageBoxId: chatId,
           endMessageId: {
-            deliveredTime: BigInt(serverTime),
-            messageId: BigInt(0),
+            deliveredTime: BigInt(latest.deliveredTime ?? latest.createdTime ?? 0),
+            messageId: BigInt(latest.id),
           },
           messagesCount: count,
         },
       })
 
-      return (rawMessages ?? []).map((msg) => ({
+      const byId = new Map<string, (typeof older)[number]>()
+      for (const msg of [latest, ...(older ?? [])]) byId.set(String(msg.id), msg)
+      const merged = [...byId.values()].sort((a, b) => Number(BigInt(b.id) - BigInt(a.id))).slice(0, count)
+
+      return merged.map((msg) => ({
         message_id: String(msg.id),
         chat_id: chatId,
         author_id: String(msg.from ?? ''),
@@ -314,6 +323,18 @@ export class LineClient {
     } catch (error) {
       throw wrapError(error, 'get_messages_failed')
     }
+  }
+
+  private async getLatestMessage(chatId: string): Promise<LineRawMessageData | null> {
+    const client = this.ensureClient()
+    const boxes = await client.base.talk.getMessageBoxes({
+      messageBoxListRequest: { messageBoxCountLimit: 50, lastMessagesPerMessageBoxCount: 1 },
+      syncReason: 'INTERNAL',
+    })
+    const box = (boxes?.messageBoxes ?? []).find((b) => b.id === chatId)
+    const messages = box?.lastMessages ?? []
+    if (messages.length === 0) return null
+    return messages.reduce((latest, msg) => (BigInt(msg.id) > BigInt(latest.id) ? msg : latest))
   }
 
   async sendMessage(chatId: string, text: string): Promise<LineSendResult> {

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
-import type { Message as LineRawMessageData, Operation as LineOperation } from '@jsr/evex__linejs-types'
+import type { Operation as LineOperation } from '@jsr/evex__linejs-types'
 
 import { getConfigDir } from '@/shared/utils/config-dir'
 import { FileStorage } from '@/vendor/linejs/base/storage/mod.js'
@@ -34,6 +34,8 @@ export interface LineRawMessage {
 }
 
 export type LineRawEvent = { kind: 'message'; message: LineRawMessage } | { kind: 'event'; op: LineOperation }
+
+const MAX_MESSAGE_ID = 9223372036854775807n
 
 function wrapError(error: unknown, code: string): LineError {
   if (error instanceof LineError) return error
@@ -291,28 +293,22 @@ export class LineClient {
       const client = this.ensureClient()
       const count = options?.count ?? 20
 
-      const latest = await this.getLatestMessage(chatId)
-      if (!latest) return []
-
-      // getPreviousMessagesV2WithRequest pages backward from a real endMessageId.
-      // A messageId:0 sentinel returns nothing, so anchor on the latest message
-      // and include it in the result.
-      const older = await client.base.talk.getPreviousMessagesV2WithRequest({
+      // getPreviousMessagesV2WithRequest pages backward from endMessageId. A
+      // messageId:0 sentinel returns nothing; the max int64 id acts as "from the
+      // latest message" and works for any chat regardless of message-box position.
+      const serverTime = await client.base.talk.getServerTime()
+      const rawMessages = await client.base.talk.getPreviousMessagesV2WithRequest({
         request: {
           messageBoxId: chatId,
           endMessageId: {
-            deliveredTime: BigInt(latest.deliveredTime ?? latest.createdTime ?? 0),
-            messageId: BigInt(latest.id),
+            deliveredTime: BigInt(serverTime),
+            messageId: MAX_MESSAGE_ID,
           },
           messagesCount: count,
         },
       })
 
-      const byId = new Map<string, (typeof older)[number]>()
-      for (const msg of [latest, ...(older ?? [])]) byId.set(String(msg.id), msg)
-      const merged = [...byId.values()].sort((a, b) => Number(BigInt(b.id) - BigInt(a.id))).slice(0, count)
-
-      return merged.map((msg) => ({
+      return (rawMessages ?? []).map((msg) => ({
         message_id: String(msg.id),
         chat_id: chatId,
         author_id: String(msg.from ?? ''),
@@ -323,18 +319,6 @@ export class LineClient {
     } catch (error) {
       throw wrapError(error, 'get_messages_failed')
     }
-  }
-
-  private async getLatestMessage(chatId: string): Promise<LineRawMessageData | null> {
-    const client = this.ensureClient()
-    const boxes = await client.base.talk.getMessageBoxes({
-      messageBoxListRequest: { messageBoxCountLimit: 50, lastMessagesPerMessageBoxCount: 1 },
-      syncReason: 'INTERNAL',
-    })
-    const box = (boxes?.messageBoxes ?? []).find((b) => b.id === chatId)
-    const messages = box?.lastMessages ?? []
-    if (messages.length === 0) return null
-    return messages.reduce((latest, msg) => (BigInt(msg.id) > BigInt(latest.id) ? msg : latest))
   }
 
   async sendMessage(chatId: string, text: string): Promise<LineSendResult> {


### PR DESCRIPTION
## Summary

`agent-line message list <chat>` (and `LineClient.getMessages()`) **always returned an empty array**, even for chats with history.

## Root cause

`getMessages()` called `getPreviousMessagesV2WithRequest` with a sentinel cursor:

```ts
endMessageId: { deliveredTime: BigInt(serverTime), messageId: BigInt(0) }
```

The `messageId: 0` sentinel makes the vendor return **nothing**. Confirmed live: `getMessageBoxes` reported unread counts and contained the messages, while `getMessages` returned 0 for the same chats.

## Fix

Anchor on the chat's latest message (read from `getMessageBoxes`, which already returns recent messages), then page backward from its real message id. Results are merged with the anchor, de-duplicated by id, sorted newest-first, and capped at `count`.

- Returns `[]` cleanly when the box has no messages or the chat isn't found.
- No transport change; same `getPreviousMessagesV2WithRequest` call, correct cursor.

## Verification

- Live: chats that previously returned 0 now return their messages in newest-first order (e.g. 9 and 7 messages).
- Added unit tests for `getMessages`: empty box, chat-not-found, newest-first dedup/order, and count limit.
- `bun typecheck` clean, `bun lint` clean, `bun test src/platforms/line/` passes.

> Note: 9 unrelated pre-existing Slack `TokenExtractor` test failures exist on `main`; not affected by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed LINE message list returning empty. `agent-line message list <chat>` and `LineClient.getMessages()` now return real messages in newest-first order for any chat.

- **Bug Fixes**
  - Query from the latest message by passing `endMessageId.messageId = 9223372036854775807n` (max int64) to `getPreviousMessagesV2WithRequest`, replacing the `messageId: 0` sentinel and removing the `getMessageBoxes` anchor (no top-50 limit).
  - De-duplicates, sorts newest-first, honors `count`, and returns `[]` when the chat is missing or empty.

- **Docs**
  - `SKILL.md` and docs not updated.

<sup>Written for commit 7b84bf14c86606899cf4059bf4cb912f87dd52d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

