### PR TITLE
Surface a clear error when a LINE chat requires E2EE

### DIFF
--- a/docs/content/docs/cli/line.mdx
+++ b/docs/content/docs/cli/line.mdx
@@ -14,7 +14,7 @@ Before diving in, a few things about LINE's architecture:
 | **MID**                   | LINE's unique identifier for users, chats, and rooms. Prefixed with `u` (user), `c` (group chat), or `r` (room). |
 | **QR code login**         | The primary authentication method. Scan a QR code with the LINE mobile app to authorize the CLI.                 |
 | **ANDROIDSECONDARY**      | The default device type. Registers as a secondary Android device so your phone and desktop sessions stay active. |
-| **E2EE (Letter Sealing)** | LINE's end-to-end encryption. The CLI attempts E2EE first and falls back to plaintext if keys aren't available.  |
+| **E2EE (Letter Sealing)** | LINE's end-to-end encryption. The CLI attempts E2EE first and falls back to plaintext if keys aren't available. Chats that require E2EE reject the fallback and fail with `e2ee_required`.  |
 | **Device types**          | Controls which device slot the CLI occupies. Secondary devices coexist with your other sessions.                 |
 | **PIN verification**      | During login, LINE may display a PIN that you confirm on your phone to authorize the new device.                 |
 
@@ -230,6 +230,7 @@ agent-line message list c7a8b9c0d1e2f3a4b5c6d7e8 -n 200
 - No message editing or deletion
 - No search across chats
 - Plain text messages only (no photos, videos, or rich content)
+- Sending to chats that **require** E2EE (Letter Sealing) is not supported on auth-token sessions; such sends fail with `e2ee_required`
 - Chat IDs are MID strings, not human-readable — use `chat list` to discover them
 
 ## Troubleshooting
@@ -266,7 +267,7 @@ If the QR code doesn't open in your browser:
 
 ### E2EE errors
 
-The CLI tries E2EE (Letter Sealing) first and falls back automatically. If you see E2EE-related warnings, messages are still sent successfully without encryption.
+The CLI tries E2EE (Letter Sealing) first and falls back to plaintext when possible, so most messages still send. Chats that **require** E2EE reject the plaintext fallback, and the send fails with `e2ee_required` — auth-token sessions have no local E2EE key and cannot encrypt for those chats.
 
 ### PIN verification timeout
 

--- a/docs/content/docs/cli/line.mdx
+++ b/docs/content/docs/cli/line.mdx
@@ -9,14 +9,14 @@ description: Complete reference for the agent-line CLI.
 
 Before diving in, a few things about LINE's architecture:
 
-| Term                      | Description                                                                                                      |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **MID**                   | LINE's unique identifier for users, chats, and rooms. Prefixed with `u` (user), `c` (group chat), or `r` (room). |
-| **QR code login**         | The primary authentication method. Scan a QR code with the LINE mobile app to authorize the CLI.                 |
-| **ANDROIDSECONDARY**      | The default device type. Registers as a secondary Android device so your phone and desktop sessions stay active. |
-| **E2EE (Letter Sealing)** | LINE's end-to-end encryption. The CLI attempts E2EE first and falls back to plaintext if keys aren't available. Chats that require E2EE reject the fallback and fail with `e2ee_required`.  |
-| **Device types**          | Controls which device slot the CLI occupies. Secondary devices coexist with your other sessions.                 |
-| **PIN verification**      | During login, LINE may display a PIN that you confirm on your phone to authorize the new device.                 |
+| Term                      | Description                                                                                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **MID**                   | LINE's unique identifier for users, chats, and rooms. Prefixed with `u` (user), `c` (group chat), or `r` (room).                                                                           |
+| **QR code login**         | The primary authentication method. Scan a QR code with the LINE mobile app to authorize the CLI.                                                                                           |
+| **ANDROIDSECONDARY**      | The default device type. Registers as a secondary Android device so your phone and desktop sessions stay active.                                                                           |
+| **E2EE (Letter Sealing)** | LINE's end-to-end encryption. The CLI attempts E2EE first and falls back to plaintext if keys aren't available. Chats that require E2EE reject the fallback and fail with `e2ee_required`. |
+| **Device types**          | Controls which device slot the CLI occupies. Secondary devices coexist with your other sessions.                                                                                           |
+| **PIN verification**      | During login, LINE may display a PIN that you confirm on your phone to authorize the new device.                                                                                           |
 
 ## Quick Start
 

--- a/skills/agent-line/SKILL.md
+++ b/skills/agent-line/SKILL.md
@@ -429,6 +429,7 @@ See the [LINE SDK documentation](https://agent-messenger.dev/docs/sdk/line) for 
 
 - No auto-extraction of credentials (requires interactive login via QR code or email/password)
 - E2EE (Letter Sealing) may prevent reading some message content
+- Sending to chats that **require** E2EE (Letter Sealing) is not supported on auth-token sessions; such sends fail with `e2ee_required`
 - No file upload support yet
 - No sticker or rich message sending (text only)
 - No group creation or management

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 
 import { LineClient } from './client'
 import { LineError } from './types'
@@ -103,6 +103,57 @@ describe('LineClient', () => {
       expect(requestedCount).toBe(2)
       expect(result.map((m) => m.message_id)).toEqual(['30', '20'])
       expect(result.map((m) => m.text)).toEqual(['c', 'b'])
+    })
+  })
+
+  describe('sendMessage()', () => {
+    function clientWithTalk(talk: Record<string, unknown>): LineClient {
+      const client = new LineClient()
+      ;(client as any).client = { base: { talk } }
+      return client
+    }
+
+    it('sends with E2EE when available', async () => {
+      const sendMessage = mock(async () => ({ id: '1', createdTime: 1700000000000 }))
+      const client = clientWithTalk({ sendMessage })
+      const result = await client.sendMessage('chat1', 'hi')
+
+      expect(result.success).toBe(true)
+      expect(result.message_id).toBe('1')
+      expect(sendMessage.mock.calls[0][0]).toMatchObject({ e2ee: true })
+    })
+
+    it('falls back to plain text when E2EE key is unavailable', async () => {
+      let call = 0
+      const sendMessage = mock(async () => {
+        call++
+        if (call === 1) throw new Error('E2EE Key has not been saved')
+        return { id: '2', createdTime: 1700000001000 }
+      })
+      const client = clientWithTalk({ sendMessage })
+      const result = await client.sendMessage('chat1', 'hi')
+
+      expect(result.message_id).toBe('2')
+      expect(sendMessage.mock.calls[1][0]).toMatchObject({ e2ee: false })
+    })
+
+    it('throws e2ee_required when the chat mandates encryption and plain is rejected', async () => {
+      const sendMessage = mock(async (args: { e2ee: boolean }) => {
+        if (args.e2ee) throw new Error('E2EE Key has not been saved')
+        throw new Error('{"code":"E2EE_RETRY_ENCRYPT","reason":"can not send using plain mode"}')
+      })
+      const client = clientWithTalk({ sendMessage })
+
+      await expect(client.sendMessage('chat1', 'hi')).rejects.toMatchObject({ code: 'e2ee_required' })
+    })
+
+    it('rethrows non-E2EE send errors unchanged', async () => {
+      const sendMessage = mock(async () => {
+        throw new Error('rate limited')
+      })
+      const client = clientWithTalk({ sendMessage })
+
+      await expect(client.sendMessage('chat1', 'hi')).rejects.toMatchObject({ code: 'send_message_failed' })
     })
   })
 

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -43,6 +43,14 @@ function wrapError(error: unknown, code: string): LineError {
   return new LineError(code, message)
 }
 
+function isE2EEUnavailableError(message: string): boolean {
+  return /E2EE|e2ee|KeyNotFound|saveE2EE/.test(message)
+}
+
+function requiresEncryption(message: string): boolean {
+  return /RETRY_ENCRYPT|can not send using plain mode|cannot send using plain mode/i.test(message)
+}
+
 function mapChatType(rawType: unknown): 'user' | 'group' | 'room' | 'square' {
   if (rawType === 'GROUP' || rawType === 0) return 'group'
   if (rawType === 'ROOM' || rawType === 1) return 'room'
@@ -330,10 +338,22 @@ export class LineClient {
         sent = await client.base.talk.sendMessage({ to: chatId, text, e2ee: true })
       } catch (e2eeError) {
         const msg = e2eeError instanceof Error ? e2eeError.message : String(e2eeError)
-        if (msg.includes('E2EE') || msg.includes('e2ee') || msg.includes('KeyNotFound') || msg.includes('saveE2EE')) {
+        if (!isE2EEUnavailableError(msg)) throw e2eeError
+
+        try {
           sent = await client.base.talk.sendMessage({ to: chatId, text, e2ee: false })
-        } else {
-          throw e2eeError
+        } catch (plainError) {
+          const plainMsg = plainError instanceof Error ? plainError.message : String(plainError)
+          // Some chats force Letter Sealing and reject plain mode. This session
+          // authenticated via auth token and has no local E2EE private key, so it
+          // cannot encrypt. Surface a clear error and keep the original cause.
+          if (requiresEncryption(plainMsg)) {
+            throw new LineError(
+              'e2ee_required',
+              `This chat requires end-to-end encryption (Letter Sealing), which this auth-token session cannot provide. Original error: ${msg}`,
+            )
+          }
+          throw plainError
         }
       }
 


### PR DESCRIPTION
## Summary

Sending to a LINE chat that **mandates** end-to-end encryption (Letter Sealing) failed with a confusing low-level error and discarded the real cause.

## Root cause

`sendMessage()` tried `e2ee: true` first, then on any E2EE-related error fell back to plain mode (`e2ee: false`). For chats that require Letter Sealing, the server rejects plain mode:

```
{"code":"E2EE_RETRY_ENCRYPT","reason":"can not send using plain mode"}
```

That surfaced as an opaque `send_message_failed` and threw away the original E2EE error. Auth-token sessions have **no local E2EE private key**, so they cannot encrypt — these sends genuinely can't succeed.

## Fix

Detect the "plain mode rejected because encryption is required" case and throw a clear, actionable `LineError` with code `e2ee_required` that names the original cause, instead of a cryptic failure. Other (non-E2EE) send errors are rethrown unchanged. Plain-capable chats (e.g. the LINE official account) still work as before.

Documented the limitation in the LINE skill.

## Verification

- Live: sending to a plain-capable chat succeeds; sending to an E2EE-mandatory chat now fails with a `e2ee_required` error and a descriptive message instead of `send_message_failed: E2EE_RETRY_ENCRYPT`.
- Added unit tests: E2EE send success, plain-text fallback, `e2ee_required` on mandatory chats, and pass-through of unrelated errors.
- `bun typecheck` and `bun lint` clean; `bun test src/platforms/line/` passes.

## Scope note

This does NOT enable encrypted sending to E2EE-mandatory chats — that needs the full LINE E2EE login key-exchange flow (the auth-token session lacks the device private key). This PR makes the failure clear and honest; enabling E2EE sends is a larger, separate effort.

> Note: 9 unrelated pre-existing Slack `TokenExtractor` test failures exist on `main`; not affected by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced a clear `e2ee_required` error when sending to LINE chats that require Letter Sealing. No behavior changes for chats that allow plaintext; other errors are unchanged.

- **Bug Fixes**
  - Detects plain-mode rejection in E2EE-mandatory chats and throws `LineError` with code `e2ee_required`, preserving the original cause.
  - Keeps E2EE-first send and plaintext fallback when allowed; passthrough of non-E2EE send errors.
  - Added unit tests for E2EE send, plain fallback, `e2ee_required`, and error passthrough.
  - Docs updated: `skills/agent-line/SKILL.md` and `docs/content/docs/cli/line.mdx` document the E2EE-required send limitation for auth-token sessions; CLI table formatted to satisfy `oxfmt`.

<sup>Written for commit 0c3d72c238dec7cedf18adb7722c6d0b317b7a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

