### PR TITLE
Harden LINE event stream against decryption failures

### DIFF
--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test'
 
 import { LineClient } from './client'
+import type { LineRawEvent } from './client'
 import { LineError } from './types'
 import type { LineChat, LineDevice, LineLoginResult, LineMessage, LineSendResult } from './types'
 
@@ -154,6 +155,75 @@ describe('LineClient', () => {
       const client = clientWithTalk({ sendMessage })
 
       await expect(client.sendMessage('chat1', 'hi')).rejects.toMatchObject({ code: 'send_message_failed' })
+    })
+  })
+
+  describe('streamEvents()', () => {
+    function clientWithStream(ops: unknown[], decrypt: (m: unknown) => Promise<unknown>): LineClient {
+      const client = new LineClient()
+      ;(client as any).client = {
+        base: {
+          profile: { mid: 'me' },
+          createPolling: () => ({
+            // eslint-disable-next-line require-yield
+            async *_listenTalkEvents() {
+              for (const op of ops) yield op
+            },
+          }),
+          e2ee: { decryptE2EEMessage: decrypt },
+        },
+      }
+      return client
+    }
+
+    async function collect(client: LineClient): Promise<LineRawEvent[]> {
+      const out: LineRawEvent[] = []
+      for await (const e of client.streamEvents(new AbortController().signal)) out.push(e)
+      return out
+    }
+
+    it('decrypts messages and emits event + message', async () => {
+      const op = { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me' } }
+      const client = clientWithStream([op], async () => ({ id: '1', from: 'u1', to: 'me', text: 'hello' }))
+
+      const events = await collect(client)
+      expect(events.map((e) => e.kind)).toEqual(['event', 'message'])
+      const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
+      expect(msg.message.text).toBe('hello')
+    })
+
+    it('keeps streaming when E2EE decryption fails (no reconnect loop)', async () => {
+      const ops = [
+        { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me', text: 'plain-on-raw' } },
+        { type: 'NOTIFIED_READ_MESSAGE' },
+      ]
+      const client = clientWithStream(ops, async () => {
+        throw new Error('E2EE decrypt failed')
+      })
+
+      const events = await collect(client)
+      expect(events.map((e) => e.kind)).toEqual(['event', 'message', 'event'])
+      const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
+      expect(msg.message.from.id).toBe('u1')
+      expect(msg.message.text).toBe('plain-on-raw')
+    })
+
+    it('propagates polling errors so the listener can reconnect', async () => {
+      const client = new LineClient()
+      ;(client as any).client = {
+        base: {
+          profile: { mid: 'me' },
+          createPolling: () => ({
+            async *_listenTalkEvents(opts: { onError?: (e: unknown) => void }) {
+              opts.onError?.(new Error('sync failed'))
+              yield undefined as never
+            },
+          }),
+          e2ee: { decryptE2EEMessage: async (m: unknown) => m },
+        },
+      }
+
+      await expect(collect(client)).rejects.toThrow('sync failed')
     })
   })
 

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -205,7 +205,7 @@ describe('LineClient', () => {
       expect(events.map((e) => e.kind)).toEqual(['event', 'message', 'event'])
       const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
       expect(msg.message.from.id).toBe('u1')
-      expect(msg.message.text).toBe('plain-on-raw')
+      expect(msg.message.text).toBeNull()
     })
 
     it('propagates polling errors so the listener can reconnect', async () => {

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -406,12 +406,14 @@ export class LineClient {
         // A single undecryptable message must not kill the stream: the failing
         // op stays in the sync window and would be re-fetched every poll, causing
         // an endless decrypt-fail -> reconnect loop. Fall back to the raw op and
-        // surface the message with null text instead.
+        // surface the message with null text, since its text is unreadable.
         let raw = op.message
+        let decrypted = true
         try {
           raw = await client.base.e2ee.decryptE2EEMessage(op.message)
         } catch {
           raw = op.message
+          decrypted = false
         }
         yield {
           kind: 'message',
@@ -420,7 +422,7 @@ export class LineClient {
             to: { id: raw.to },
             from: { id: raw.from },
             isMyMessage: selfMid === raw.from,
-            text: raw.text ?? null,
+            text: decrypted ? (raw.text ?? null) : null,
           },
         }
       }

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -51,6 +51,13 @@ function requiresEncryption(message: string): boolean {
   return /RETRY_ENCRYPT|can not send using plain mode|cannot send using plain mode/i.test(message)
 }
 
+// Writes to stderr so partial-result degradation stays visible without
+// corrupting the JSON the CLI prints to stdout.
+function warnDegraded(action: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error)
+  console.warn(`[line] could not ${action}: ${message}`)
+}
+
 function mapChatType(rawType: unknown): 'user' | 'group' | 'room' | 'square' {
   if (rawType === 'GROUP' || rawType === 0) return 'group'
   if (rawType === 'ROOM' || rawType === 1) return 'room'
@@ -231,7 +238,10 @@ export class LineClient {
           },
           syncReason: 'INTERNAL',
         }),
-        client.fetchJoinedChats().catch(() => []),
+        client.fetchJoinedChats().catch((error: unknown) => {
+          warnDegraded('fetch joined group/room chats', error)
+          return []
+        }),
       ])
 
       for (const chat of joinedChats) {
@@ -261,7 +271,9 @@ export class LineClient {
           for (const c of contacts ?? []) {
             nameMap.set(c.mid, { name: c.displayName, type: 'user' })
           }
-        } catch {}
+        } catch (error) {
+          warnDegraded('resolve user display names', error)
+        }
       }
 
       if (groupMids.length > 0) {
@@ -275,7 +287,9 @@ export class LineClient {
               memberCount: memberMids ? Object.keys(memberMids).length : undefined,
             })
           }
-        } catch {}
+        } catch (error) {
+          warnDegraded('resolve group/room names', error)
+        }
       }
 
       for (const box of messageBoxes) {
@@ -389,7 +403,16 @@ export class LineClient {
     })) {
       yield { kind: 'event', op }
       if (op.type === 'SEND_MESSAGE' || op.type === 'RECEIVE_MESSAGE') {
-        const raw = await client.base.e2ee.decryptE2EEMessage(op.message)
+        // A single undecryptable message must not kill the stream: the failing
+        // op stays in the sync window and would be re-fetched every poll, causing
+        // an endless decrypt-fail -> reconnect loop. Fall back to the raw op and
+        // surface the message with null text instead.
+        let raw = op.message
+        try {
+          raw = await client.base.e2ee.decryptE2EEMessage(op.message)
+        } catch {
+          raw = op.message
+        }
         yield {
           kind: 'message',
           message: {


### PR DESCRIPTION
> **📚 Stacked on #212.** This PR targets `fix/line-send-e2ee-required` (PR #212), not `main`. Merge #212 first; this PR's diff shows only its own commit once #212 lands. The shared `client.ts` / `client.test.ts` edits are coordinated across the stack to avoid conflicts.

## Summary

Two resilience fixes in `LineClient` for the real-time event path and chat listing.

## 1. E2EE decryption failure no longer kills the listener

`streamEvents()` called `decryptE2EEMessage(op.message)` with no error handling. If a single incoming message failed to decrypt (missing/mismatched key, corrupt payload), the error propagated out of the generator, the listener emitted `error`/`disconnected` and reconnected — but the failing op **stays in the sync window** and is re-fetched on the next poll, so it throws again. Result: an **endless decrypt-fail → reconnect loop** that blocks all subsequent messages.

Fix: wrap the decrypt in try/catch. On failure, fall back to the raw op and emit the message with `text: null` (undecryptable) so the stream keeps flowing.

## 2. `getChats()` degradation is now observable

Joined-chat fetch and name resolution used `.catch(() => [])` and empty `catch {}`, so failures silently dropped group chats or left raw MIDs as names with zero indication. Replaced with warnings on **stderr** (stdout still carries clean JSON for the CLI), so partial-result degradation is visible.

## Verification

- Unit tests added for `streamEvents`: normal decrypt + emit, decrypt-failure resilience (stream continues, message surfaces with raw fields), and polling-error propagation (still reconnects on real sync failures).
- Live: the listener still receives sent messages end-to-end.
- `bun typecheck`, `bun lint`, `bun format:check` clean; `bun test src/platforms/line/` passes.

> Note: 9 unrelated pre-existing Slack `TokenExtractor` test failures exist on `main`; not affected by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes LINE streaming resilient to E2EE decrypt failures and surfaces chat-list degradation with stderr warnings.

- **Bug Fixes**
  - `streamEvents()`: wrap decrypt in try/catch; on failure, keep streaming and emit the message with `text: null` (forced null to avoid stale plaintext).
  - `getChats()`: warn to stderr when joined-chat fetch or name resolution fails; stdout JSON is unchanged.

- **Migration**
  - No migration. Docs and `SKILL.md`: no changes.

<sup>Written for commit c4f205264a592b08c8c8699ee08468085686722d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

