### PR TITLE
Forward LINE contentMetadata on real-time message events

### DIFF
--- a/src/platforms/line/listener.test.ts
+++ b/src/platforms/line/listener.test.ts
@@ -172,6 +172,64 @@ describe('LineListener', () => {
       expect(messages[0].author_id).toBe('u456')
       expect(messages[0].text).toBe('hello world')
       expect(messages[0].content_type).toBe('NONE')
+      expect(messages[0].content_metadata).toEqual({})
+    })
+
+    it('forwards contentMetadata for non-text messages', async () => {
+      const client = createMockLineClient()
+      listener = new LineListener(client)
+
+      const messages: LinePushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      mockInternalClientInstance.simulateMessage({
+        isMyMessage: false,
+        from: { type: 'USER', id: 'u456' },
+        to: { type: 'USER', id: 'u123' },
+        text: null,
+        raw: {
+          id: 'msg010',
+          contentType: 'STICKER',
+          createdTime: 1700000007000,
+          contentMetadata: { STKID: '123', STKPKGID: '456', STKVER: '1' },
+        },
+      })
+      await flush()
+
+      expect(messages.length).toBe(1)
+      expect(messages[0].text).toBeNull()
+      expect(messages[0].content_type).toBe('STICKER')
+      expect(messages[0].content_metadata).toEqual({ STKID: '123', STKPKGID: '456', STKVER: '1' })
+    })
+
+    it('coerces non-string contentMetadata values to strings', async () => {
+      const client = createMockLineClient()
+      listener = new LineListener(client)
+
+      const messages: LinePushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      mockInternalClientInstance.simulateMessage({
+        isMyMessage: false,
+        from: { type: 'USER', id: 'u456' },
+        to: { type: 'USER', id: 'u123' },
+        text: null,
+        raw: {
+          id: 'msg011',
+          contentType: 'IMAGE',
+          createdTime: 1700000008000,
+          contentMetadata: { FILE_SIZE: 2048, PREVIEW_URL: 'https://example.com/p.jpg', EMPTY: null },
+        },
+      })
+      await flush()
+
+      expect(messages.length).toBe(1)
+      expect(messages[0].content_metadata).toEqual({
+        FILE_SIZE: '2048',
+        PREVIEW_URL: 'https://example.com/p.jpg',
+      })
     })
 
     it('uses to.id as chat_id for own messages', async () => {

--- a/src/platforms/line/listener.ts
+++ b/src/platforms/line/listener.ts
@@ -107,6 +107,7 @@ export class LineListener {
         author_id: msg.from.id,
         text: msg.text ?? null,
         content_type: String(msg.raw.contentType ?? 'NONE'),
+        content_metadata: normalizeContentMetadata(msg.raw.contentMetadata),
         sent_at: new Date(Number(msg.raw.createdTime)).toISOString(),
       }
       this.emitter.emit('message', event)
@@ -140,4 +141,13 @@ export class LineListener {
       this.reconnectTimer = null
     }
   }
+}
+
+function normalizeContentMetadata(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object') return {}
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (value !== null && value !== undefined) result[key] = String(value)
+  }
+  return result
 }

--- a/src/platforms/line/types.ts
+++ b/src/platforms/line/types.ts
@@ -138,6 +138,8 @@ export interface LinePushMessageEvent {
   author_id: string
   text: string | null
   content_type: string
+  // Raw LINE contentMetadata (sticker IDs, file name/size, media URLs); empty for plain text.
+  content_metadata: Record<string, string>
   sent_at: string
 }
 


### PR DESCRIPTION
## Summary

Fixes #214. The LINE real-time listener (`LineListener`) built `LinePushMessageEvent` from only `text` and `content_type`, **dropping `msg.raw.contentMetadata` entirely**. For any non-text message (sticker, image, video, audio, file, contact, location) `text` is `null`, so consumers received an effectively empty event with no way to identify or fetch the media.

This change surfaces the raw metadata so downstream consumers can distinguish a sticker from an image, render informative placeholders (`[LINE sticker STKID=123]`), and fetch media via the URLs LINE provides.

## Changes

- **`types.ts`** — Add a `content_metadata: Record<string, string>` field to `LinePushMessageEvent` (part of the exported SDK surface).
- **`listener.ts`** — Forward `msg.raw.contentMetadata` via a `normalizeContentMetadata` helper that coerces values to strings, skips `null`/`undefined`, and defaults to `{}` for plain-text messages or when upstream omits it.
- **`listener.test.ts`** — Add coverage for sticker metadata forwarding, non-string value coercion, and the empty-object default on text messages.

## Compatibility

Additive and backward-compatible — the field is always present (empty object for text), so existing consumers keying off `text`/`content_type` are unaffected, while new consumers gain access to sticker IDs, file name/size, and media URLs.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun test src/platforms/line/` — **110/110 pass**

> Note: 9 pre-existing `TokenExtractor` (Slack) failures exist on `main`; they are environment-dependent and unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward LINE contentMetadata on message events so consumers can distinguish stickers, images, and files and fetch media URLs. Adds content_metadata to LinePushMessageEvent with string values; empty for text.

- **Bug Fixes**
  - Forward `msg.raw.contentMetadata` via a normalizer (stringifies values, drops nulls; defaults to `{}`).
  - Add `content_metadata: Record<string, string>` to `LinePushMessageEvent`.
  - Tests cover stickers, non-string coercion, and empty default.

- **Migration**
  - Additive; no breaking changes.
  - SKILL.md/docs: no updates required.

<sup>Written for commit 80f13da844e475b536717b6a052a57d036e4aec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

