### PR TITLE
Stop LINE reconnect churn on empty long-poll responses

### DIFF
--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -225,6 +225,44 @@ describe('LineClient', () => {
 
       await expect(collect(client)).rejects.toThrow('sync failed')
     })
+
+    it('swallows empty long-poll errors so the connection is not torn down', async () => {
+      const client = new LineClient()
+      ;(client as any).client = {
+        base: {
+          profile: { mid: 'me' },
+          createPolling: () => ({
+            async *_listenTalkEvents(opts: { onError?: (e: unknown) => void }) {
+              // given: an idle long-poll returns an empty body, then a real op arrives
+              opts.onError?.(new Error('Request internal failed: Invalid response buffer <>'))
+              yield { type: 'NOTIFIED_READ_MESSAGE' }
+            },
+          }),
+          e2ee: { decryptE2EEMessage: async (m: unknown) => m },
+        },
+      }
+
+      const events = await collect(client)
+      expect(events.map((e) => e.kind)).toEqual(['event'])
+    })
+
+    it('propagates non-empty malformed buffer errors', async () => {
+      const client = new LineClient()
+      ;(client as any).client = {
+        base: {
+          profile: { mid: 'me' },
+          createPolling: () => ({
+            async *_listenTalkEvents(opts: { onError?: (e: unknown) => void }) {
+              opts.onError?.(new Error('Request internal failed: Invalid response buffer <de ad be ef>'))
+              yield undefined as never
+            },
+          }),
+          e2ee: { decryptE2EEMessage: async (m: unknown) => m },
+        },
+      }
+
+      await expect(collect(client)).rejects.toThrow('Invalid response buffer <de ad be ef>')
+    })
   })
 
   describe('login() without credentials', () => {

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -51,6 +51,13 @@ function requiresEncryption(message: string): boolean {
   return /RETRY_ENCRYPT|can not send using plain mode|cannot send using plain mode/i.test(message)
 }
 
+// An idle long-poll returning zero bytes is normal, but the vendored Thrift reader
+// throws "Invalid response buffer <>" (empty brackets = empty body). Match only that
+// empty case so the poll loop continues; a non-empty malformed buffer still propagates.
+function isEmptyLongPollError(message: string): boolean {
+  return /Invalid response buffer <>/.test(message)
+}
+
 // Writes to stderr so partial-result degradation stays visible without
 // corrupting the JSON the CLI prints to stdout.
 function warnDegraded(action: string, error: unknown): void {
@@ -398,7 +405,9 @@ export class LineClient {
     for await (const op of polling._listenTalkEvents({
       signal,
       onError: (error) => {
-        throw error instanceof Error ? error : new Error(String(error))
+        const message = error instanceof Error ? error.message : String(error)
+        if (isEmptyLongPollError(message)) return
+        throw error instanceof Error ? error : new Error(message)
       },
     })) {
       yield { kind: 'event', op }


### PR DESCRIPTION
## Summary

Fixes #215. The LINE real-time listener repeatedly emitted:

```
[line] listener error: Request internal failed: Invalid response buffer <>
[line] disconnected; SDK will reconnect with backoff
```

on an otherwise-healthy session, at a cadence matching the long-poll timeout. The `<>` is the tell: the long-poll (`/SYNC4`) response body had **zero bytes** — a normal outcome for an idle poll. The vendored `linejs` Thrift reader can't parse an empty buffer and throws `Invalid response buffer <>`. The `streamEvents` `onError` callback rethrew it, which broke the polling loop and forced `LineListener` to emit `error` + `disconnected` and reconnect with backoff — steady connect/disconnect churn even though nothing was wrong.

## Fix

Swallow **only** the empty-buffer case in `streamEvents`'s `onError`. The vendored polling loop (`_listenTalkEvents`) already re-polls after `onError` returns normally, so the connection stays alive and re-polls on the same revision — exactly the "no new ops, loop again" behavior the long-poll should have.

A non-empty but malformed buffer keeps its hex dump (e.g. `<de ad be ef>`) and still propagates, so genuine protocol errors continue to trigger reconnect.

### Why fix at the project seam (not the vendored `requestCore`)

`requestCore` is shared by 50+ TalkService/SquareService/etc. methods. An empty body on a non-poll call (e.g. `sendMessage`) may genuinely indicate a problem, and patching vendored code adds maintenance burden across upstream updates. Matching the empty-buffer error string in `streamEvents` scopes the fix precisely to the polling path with zero vendor changes.

## Changes

- **`client.ts`** — Add an `isEmptyLongPollError` predicate and update `streamEvents`'s `onError` to return (swallow) on the empty-buffer case while still rethrowing everything else.
- **`client.test.ts`** — Add coverage: empty-buffer error is swallowed and the loop keeps yielding subsequent ops; a non-empty malformed buffer still propagates.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun test src/platforms/line/` — **110/110 pass** (28 client tests incl. 2 new)

> Note: 9 pre-existing `TokenExtractor` (Slack) failures exist on `main`; they are environment-dependent and unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reconnect churn in the LINE listener by treating zero-byte long-poll (/SYNC4) responses as normal. Only the "Invalid response buffer <>" case is swallowed; malformed non-empty buffers still surface as errors.

- **Bug Fixes**
  - In `streamEvents` `onError`, return on the empty-buffer case so polling continues; all other errors still throw.
  - Added tests for empty vs non-empty buffer behavior.
  - Docs: No changes to SKILL.md or docs.

<sup>Written for commit ecd437def081daeeff07c48ab4be87120afb95d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

