### PR TITLE
Restore LINE raw text for listener events

### DIFF
--- a/src/platforms/line/listener.test.ts
+++ b/src/platforms/line/listener.test.ts
@@ -203,6 +203,33 @@ describe('LineListener', () => {
       expect(messages[0].content_metadata).toEqual({ STKID: '123', STKPKGID: '456', STKVER: '1' })
     })
 
+    it('falls back to raw text when text is empty for contentType NONE messages', async () => {
+      const client = createMockLineClient()
+      listener = new LineListener(client)
+
+      const messages: LinePushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      mockInternalClientInstance.simulateMessage({
+        isMyMessage: false,
+        from: { type: 'USER', id: 'u456' },
+        to: { type: 'USER', id: 'u123' },
+        text: '',
+        raw: {
+          id: 'msg012',
+          contentType: 'NONE',
+          text: 'actual text from raw',
+          createdTime: 1700000009000,
+        },
+      })
+      await flush()
+
+      expect(messages.length).toBe(1)
+      expect(messages[0].text).toBe('actual text from raw')
+      expect(messages[0].content_type).toBe('NONE')
+    })
+
     it('coerces non-string contentMetadata values to strings', async () => {
       const client = createMockLineClient()
       listener = new LineListener(client)

--- a/src/platforms/line/listener.ts
+++ b/src/platforms/line/listener.ts
@@ -100,13 +100,14 @@ export class LineListener {
       const isGroupOrRoom = toType === 'GROUP' || toType === 'ROOM' || toType === 0 || toType === 1
       const chatId = isGroupOrRoom ? msg.to.id : msg.isMyMessage ? msg.to.id : msg.from.id
 
+      const contentType = String(msg.raw.contentType ?? 'NONE')
       const event: LinePushMessageEvent = {
         type: 'message',
         chat_id: chatId,
         message_id: String(msg.raw.id),
         author_id: msg.from.id,
-        text: msg.text ?? null,
-        content_type: String(msg.raw.contentType ?? 'NONE'),
+        text: getMessageText(msg.text, msg.raw, contentType),
+        content_type: contentType,
         content_metadata: normalizeContentMetadata(msg.raw.contentMetadata),
         sent_at: new Date(Number(msg.raw.createdTime)).toISOString(),
       }
@@ -150,4 +151,22 @@ function normalizeContentMetadata(raw: unknown): Record<string, string> {
     if (value !== null && value !== undefined) result[key] = String(value)
   }
   return result
+}
+
+function getMessageText(text: unknown, raw: unknown, contentType: string): string | null {
+  const direct = normalizeText(text)
+  if (direct !== null) return direct
+  if (!isTextContentType(contentType)) return null
+
+  if (!raw || typeof raw !== 'object') return null
+  return normalizeText((raw as Record<string, unknown>).text)
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  return value.length > 0 ? value : null
+}
+
+function isTextContentType(contentType: string): boolean {
+  return contentType === 'NONE' || contentType === '0'
 }


### PR DESCRIPTION
## Summary

Fixes #218. LINE real-time listener events could emit null text when LINE delivered a text message with content type `NONE` or 0 and an empty normalized message text value. This restores the raw LINE text as a scoped fallback for those text content types so listener consumers receive the actual message body without changing non-text message handling.

## Changes

- Reuse a computed LINE content type when building listener message events.
- Add a text normalization helper that treats empty strings as missing values.
- Fall back to `raw.text` only for LINE text content types, so stickers, images, and other non-text messages still surface with null text.
- Add a regression test for a content type `NONE` listener event where the normalized text is empty but the raw text contains the message body.

## Verification

- LSP diagnostics are clean for `src/platforms/line/listener.ts`.
- LSP diagnostics are clean for `src/platforms/line/listener.test.ts`.
- `bun run lint` passed.
- `bun run format:check` passed.
- `bun typecheck` passed.
- `bun test src/platforms/line/listener.test.ts` passed.
- `bun test src/platforms/line` passed.
- An initial full `bun run test` without an isolated HOME failed because existing Slack auth extraction tests discovered local browser credentials. No token values, workspace names, local paths, or secret-looking strings from that output are included here.
- Rerunning the full test suite with HOME set to an empty temporary home passed with 3042 pass / 0 fail.
- `bun run build` passed.

## Review Notes

- Please verify that the fallback remains limited to LINE text content types and does not reclassify media or attachment events as text messages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores raw LINE message text when a text message has `contentType` NONE/0 and the normalized text is empty. This ensures listeners receive the actual message body without changing non-text handling.

- **Bug Fixes**
  - Compute `content_type` once and reuse when building events.
  - Add text normalization that treats empty strings as missing; fall back to `raw.text` only for text content types (NONE/0).
  - Add a regression test for a NONE event with empty normalized text but present `raw.text`.

- **Docs**
  - No changes to SKILL.md or docs.

<sup>Written for commit bc1cebacf8d841b34dcf2780f914234ed964ff70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

