### PR TITLE
Enable LINE E2EE key provisioning

### DIFF
--- a/skills/agent-line/references/common-patterns.md
+++ b/skills/agent-line/references/common-patterns.md
@@ -71,8 +71,8 @@ MESSAGES=$(agent-line message list "$CHAT_ID" -n 50)
 MSG_COUNT=$(echo "$MESSAGES" | jq 'length')
 echo "Found $MSG_COUNT messages"
 
-# Show messages
-echo "$MESSAGES" | jq -r '.[] | "\(.author_id): \(.text // "[non-text]")"'
+# Show messages; encrypted Letter Sealing messages may include decryption_error.
+echo "$MESSAGES" | jq -r '.[] | "\(.author_id): \(.text // .decryption_error.message // "[non-text]")"'
 ```
 
 **When to use**: Context gathering, summarizing conversations, catching up on missed messages.
@@ -130,7 +130,8 @@ listener.on('connected', (info) => {
 })
 
 listener.on('message', (event) => {
-  console.log(`[${event.chat_id}] ${event.author_id}: ${event.text}`)
+  const content = event.text ?? event.decryption_error?.message ?? '[non-text]'
+  console.log(`[${event.chat_id}] ${event.author_id}: ${content}`)
 })
 
 listener.on('error', (error) => {
@@ -151,6 +152,8 @@ await listener.start()
 **When to use**: Building bots, automations, or real-time integrations that need instant message delivery.
 
 **Features**: Auto-reconnects with exponential backoff, typed events, AbortController-based clean shutdown.
+
+**E2EE note**: For LINE Letter Sealing messages that cannot be decrypted in the current session, `text` stays `null` and `decryption_error` explains whether E2EE key material is missing or decryption failed.
 
 ## Pattern 5: Get User Profile
 

--- a/skills/agent-line/references/common-patterns.md
+++ b/skills/agent-line/references/common-patterns.md
@@ -130,6 +130,7 @@ listener.on('connected', (info) => {
 })
 
 listener.on('message', (event) => {
+  // event.decryption_error?: { code: 'missing_e2ee_key' | 'decrypt_failed'; message: string }
   const content = event.text ?? event.decryption_error?.message ?? '[non-text]'
   console.log(`[${event.chat_id}] ${event.author_id}: ${content}`)
 })
@@ -154,6 +155,8 @@ await listener.start()
 **Features**: Auto-reconnects with exponential backoff, typed events, AbortController-based clean shutdown.
 
 **E2EE note**: For LINE Letter Sealing messages that cannot be decrypted in the current session, `text` stays `null` and `decryption_error` explains whether E2EE key material is missing or decryption failed.
+
+Message listener payloads include `decryption_error` when encrypted content is present but unavailable. Check `event.decryption_error.code` for `missing_e2ee_key` or `decrypt_failed` before treating `text: null` as a non-text message.
 
 ## Pattern 5: Get User Profile
 

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -105,6 +105,30 @@ describe('LineClient', () => {
       expect(result.map((m) => m.message_id)).toEqual(['30', '20'])
       expect(result.map((m) => m.text)).toEqual(['c', 'b'])
     })
+
+    it('marks encrypted chunk messages without text as missing E2EE keys', async () => {
+      const client = clientWithTalk({
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async () => [
+          {
+            id: '40',
+            from: 'u1',
+            text: null,
+            contentType: 'NONE',
+            createdTime: 1700000004000,
+            chunks: ['a', 'b'],
+            metadata: { e2eeMark: '2', e2eeVersion: '2' },
+          },
+        ],
+      })
+
+      const result = await client.getMessages('chat1', { count: 1 })
+      expect(result[0].text).toBeNull()
+      expect(result[0].decryption_error).toEqual({
+        code: 'missing_e2ee_key',
+        message: 'LINE message is encrypted with Letter Sealing, but this session has no saved E2EE key material.',
+      })
+    })
   })
 
   describe('sendMessage()', () => {
@@ -206,6 +230,18 @@ describe('LineClient', () => {
       const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
       expect(msg.message.from.id).toBe('u1')
       expect(msg.message.text).toBeNull()
+      expect(msg.message.decryption_error).toEqual({ code: 'decrypt_failed', message: 'E2EE decrypt failed' })
+    })
+
+    it('marks missing E2EE key failures explicitly', async () => {
+      const op = { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me' } }
+      const client = clientWithStream([op], async () => {
+        throw new Error('NoE2EEKey: E2EE Key has not been saved')
+      })
+
+      const events = await collect(client)
+      const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
+      expect(msg.message.decryption_error?.code).toBe('missing_e2ee_key')
     })
 
     it('propagates polling errors so the listener can reconnect', async () => {

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -17,6 +17,7 @@ import type {
   LineAccountCredentials,
   LineChat,
   LineDevice,
+  LineDecryptionError,
   LineFriend,
   LineLoginResult,
   LineMessage,
@@ -26,11 +27,23 @@ import type {
 import { LineError } from './types'
 
 export interface LineRawMessage {
-  raw: { id: unknown; contentType?: unknown; createdTime?: unknown; toType?: unknown; to?: unknown; from?: unknown }
+  raw: {
+    id: unknown
+    contentType?: unknown
+    contentMetadata?: unknown
+    createdTime?: unknown
+    toType?: unknown
+    to?: unknown
+    from?: unknown
+    text?: unknown
+    chunks?: unknown
+    metadata?: unknown
+  }
   to: { id: unknown }
   from: { id: unknown }
   isMyMessage: boolean
   text: string | null
+  decryption_error?: LineDecryptionError
 }
 
 export type LineRawEvent = { kind: 'message'; message: LineRawMessage } | { kind: 'event'; op: LineOperation }
@@ -337,14 +350,18 @@ export class LineClient {
         },
       })
 
-      return (rawMessages ?? []).map((msg) => ({
-        message_id: String(msg.id),
-        chat_id: chatId,
-        author_id: String(msg.from ?? ''),
-        text: msg.text || null,
-        content_type: String(msg.contentType ?? 'NONE'),
-        sent_at: new Date(Number(msg.createdTime)).toISOString(),
-      }))
+      return (rawMessages ?? []).map((msg) => {
+        const decryptionError = getUndecryptableMessageError(msg)
+        return {
+          message_id: String(msg.id),
+          chat_id: chatId,
+          author_id: String(msg.from ?? ''),
+          text: msg.text || null,
+          ...(decryptionError && { decryption_error: decryptionError }),
+          content_type: String(msg.contentType ?? 'NONE'),
+          sent_at: new Date(Number(msg.createdTime)).toISOString(),
+        }
+      })
     } catch (error) {
       throw wrapError(error, 'get_messages_failed')
     }
@@ -418,12 +435,15 @@ export class LineClient {
         // surface the message with null text, since its text is unreadable.
         let raw = op.message
         let decrypted = true
+        let decryptionError: LineDecryptionError | undefined
         try {
           raw = await client.base.e2ee.decryptE2EEMessage(op.message)
-        } catch {
+        } catch (error) {
           raw = op.message
           decrypted = false
+          decryptionError = getDecryptionError(error)
         }
+        decryptionError ??= getUndecryptableMessageError(raw)
         yield {
           kind: 'message',
           message: {
@@ -432,6 +452,7 @@ export class LineClient {
             from: { id: raw.from },
             isMyMessage: selfMid === raw.from,
             text: decrypted ? (raw.text ?? null) : null,
+            ...(decryptionError && { decryption_error: decryptionError }),
           },
         }
       }
@@ -448,4 +469,39 @@ export class LineClient {
     }
     return this.client
   }
+}
+
+function getUndecryptableMessageError(raw: unknown): LineDecryptionError | undefined {
+  if (!isEncryptedChunkMessage(raw) || hasPlainText(raw)) return undefined
+  return {
+    code: 'missing_e2ee_key',
+    message: 'LINE message is encrypted with Letter Sealing, but this session has no saved E2EE key material.',
+  }
+}
+
+function getDecryptionError(error: unknown): LineDecryptionError {
+  const message = error instanceof Error ? error.message : String(error)
+  return {
+    code: /NoE2EEKey|E2EE Key has not been saved|saveE2EE/i.test(message) ? 'missing_e2ee_key' : 'decrypt_failed',
+    message,
+  }
+}
+
+function hasPlainText(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false
+  const text = (raw as { text?: unknown }).text
+  return typeof text === 'string' && text.length > 0
+}
+
+function isEncryptedChunkMessage(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false
+  const message = raw as { chunks?: unknown; contentMetadata?: unknown; metadata?: unknown }
+  if (!Array.isArray(message.chunks) || message.chunks.length === 0) return false
+  return hasE2EEMetadata(message.contentMetadata) || hasE2EEMetadata(message.metadata)
+}
+
+function hasE2EEMetadata(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false
+  const metadata = raw as { e2eeMark?: unknown; e2eeVersion?: unknown }
+  return metadata.e2eeMark !== undefined || metadata.e2eeVersion !== undefined
 }

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 import type { Operation as LineOperation } from '@jsr/evex__linejs-types'
@@ -92,7 +92,14 @@ function getDefaultDevice(): LineDevice {
 function createStorage(accountId?: string): FileStorage {
   const dir = join(getConfigDir(), 'line-storage')
   mkdirSync(dir, { recursive: true })
-  return new FileStorage(join(dir, `${accountId ?? 'default'}.json`))
+  const defaultPath = join(dir, 'default.json')
+  if (!accountId) return new FileStorage(defaultPath)
+
+  const accountPath = join(dir, `${accountId}.json`)
+  if (!existsSync(accountPath) && existsSync(defaultPath)) {
+    copyFileSync(defaultPath, accountPath)
+  }
+  return new FileStorage(accountPath)
 }
 
 export class LineClient {
@@ -123,6 +130,7 @@ export class LineClient {
       this.client = client
 
       const profile = await client.base.talk.getProfile()
+      createStorage(profile.mid)
       const now = new Date().toISOString()
 
       await this.credManager.setAccount({
@@ -159,6 +167,7 @@ export class LineClient {
         {
           email: options.email,
           password: options.password,
+          e2ee: true,
           onPincodeRequest: (pin) => options.onPincode(pin),
         },
         { device, storage },
@@ -167,6 +176,7 @@ export class LineClient {
       this.client = client
 
       const profile = await client.base.talk.getProfile()
+      createStorage(profile.mid)
       const now = new Date().toISOString()
 
       await this.credManager.setAccount({
@@ -201,7 +211,7 @@ export class LineClient {
       }
 
       const device: LineDevice = creds.device ?? getDefaultDevice()
-      const storage = createStorage()
+      const storage = createStorage(creds.account_id)
 
       this.client = await linejsLoginWithAuthToken(creds.auth_token, { device, storage })
       return this

--- a/src/platforms/line/index.test.ts
+++ b/src/platforms/line/index.test.ts
@@ -11,6 +11,12 @@ import {
   LineMessageSchema,
   LineSendResultSchema,
 } from '@/platforms/line/index'
+import type { LineDecryptionError } from '@/platforms/line/index'
+
+const lineDecryptionError: LineDecryptionError = {
+  code: 'missing_e2ee_key',
+  message: 'E2EE key material is missing',
+}
 
 it('LineClient is exported from barrel', () => {
   expect(typeof LineClient).toBe('function')
@@ -46,4 +52,8 @@ it('LineAccountCredentialsSchema is exported from barrel', () => {
 
 it('LineConfigSchema is exported from barrel', () => {
   expect(typeof LineConfigSchema.parse).toBe('function')
+})
+
+it('LineDecryptionError type is exported from barrel', () => {
+  expect(lineDecryptionError.code).toBe('missing_e2ee_key')
 })

--- a/src/platforms/line/index.ts
+++ b/src/platforms/line/index.ts
@@ -6,6 +6,7 @@ export type {
   LineAccountCredentials,
   LineChat,
   LineConfig,
+  LineDecryptionError,
   LineDevice,
   LineFriend,
   LineListenerEventMap,

--- a/src/platforms/line/listener.test.ts
+++ b/src/platforms/line/listener.test.ts
@@ -230,6 +230,38 @@ describe('LineListener', () => {
       expect(messages[0].content_type).toBe('NONE')
     })
 
+    it('forwards LINE decryption errors on message events', async () => {
+      const client = createMockLineClient()
+      listener = new LineListener(client)
+
+      const messages: LinePushMessageEvent[] = []
+      listener.on('message', (event) => messages.push(event))
+
+      await listener.start()
+      mockInternalClientInstance.simulateMessage({
+        isMyMessage: false,
+        from: { type: 'USER', id: 'u456' },
+        to: { type: 'USER', id: 'u123' },
+        text: null,
+        decryption_error: {
+          code: 'missing_e2ee_key',
+          message: 'LINE message is encrypted with Letter Sealing, but this session has no saved E2EE key material.',
+        },
+        raw: {
+          id: 'msg013',
+          contentType: 'NONE',
+          createdTime: 1700000010000,
+          chunks: ['a', 'b'],
+          metadata: { e2eeMark: '2', e2eeVersion: '2' },
+        },
+      })
+      await flush()
+
+      expect(messages.length).toBe(1)
+      expect(messages[0].text).toBeNull()
+      expect(messages[0].decryption_error?.code).toBe('missing_e2ee_key')
+    })
+
     it('coerces non-string contentMetadata values to strings', async () => {
       const client = createMockLineClient()
       listener = new LineListener(client)

--- a/src/platforms/line/listener.ts
+++ b/src/platforms/line/listener.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 
-import type { LineClient } from './client'
+import type { LineClient, LineRawMessage } from './client'
 import type { LineListenerEventMap, LinePushGenericEvent, LinePushMessageEvent } from './types'
 
 const RECONNECT_BASE_DELAY = 1_000
@@ -94,19 +94,20 @@ export class LineListener {
     }
   }
 
-  private emitMessage(msg: any): void {
+  private emitMessage(msg: LineRawMessage): void {
     try {
       const toType = msg.raw.toType
       const isGroupOrRoom = toType === 'GROUP' || toType === 'ROOM' || toType === 0 || toType === 1
-      const chatId = isGroupOrRoom ? msg.to.id : msg.isMyMessage ? msg.to.id : msg.from.id
+      const chatId = String(isGroupOrRoom ? msg.to.id : msg.isMyMessage ? msg.to.id : msg.from.id)
 
       const contentType = String(msg.raw.contentType ?? 'NONE')
       const event: LinePushMessageEvent = {
         type: 'message',
         chat_id: chatId,
         message_id: String(msg.raw.id),
-        author_id: msg.from.id,
+        author_id: String(msg.from.id),
         text: getMessageText(msg.text, msg.raw, contentType),
+        ...(msg.decryption_error && { decryption_error: msg.decryption_error }),
         content_type: contentType,
         content_metadata: normalizeContentMetadata(msg.raw.contentMetadata),
         sent_at: new Date(Number(msg.raw.createdTime)).toISOString(),

--- a/src/platforms/line/types.test.ts
+++ b/src/platforms/line/types.test.ts
@@ -87,6 +87,23 @@ describe('LineMessageSchema', () => {
     expect(result.text).toBeNull()
   })
 
+  it('parses message with decryption error', () => {
+    const data = {
+      message_id: 'msg789',
+      chat_id: 'u1234567890abcdef',
+      author_id: 'u9876543210fedcba',
+      text: null,
+      decryption_error: {
+        code: 'missing_e2ee_key',
+        message: 'LINE message is encrypted with Letter Sealing, but this session has no saved E2EE key material.',
+      },
+      content_type: 'NONE',
+      sent_at: '2026-03-29T00:00:00.000Z',
+    }
+    const result = LineMessageSchema.parse(data)
+    expect(result.decryption_error?.code).toBe('missing_e2ee_key')
+  })
+
   it('rejects missing required fields', () => {
     expect(() => LineMessageSchema.parse({ message_id: 'msg123' })).toThrow()
   })

--- a/src/platforms/line/types.ts
+++ b/src/platforms/line/types.ts
@@ -43,8 +43,14 @@ export interface LineMessage {
   author_id: string
   author_name?: string
   text: string | null
+  decryption_error?: LineDecryptionError
   content_type: string
   sent_at: string
+}
+
+export interface LineDecryptionError {
+  code: 'missing_e2ee_key' | 'decrypt_failed'
+  message: string
 }
 
 export interface LineSendResult {
@@ -106,6 +112,12 @@ export const LineMessageSchema = z.object({
   author_id: z.string(),
   author_name: z.string().optional(),
   text: z.string().nullable(),
+  decryption_error: z
+    .object({
+      code: z.enum(['missing_e2ee_key', 'decrypt_failed']),
+      message: z.string(),
+    })
+    .optional(),
   content_type: z.string(),
   sent_at: z.string(),
 })
@@ -137,6 +149,7 @@ export interface LinePushMessageEvent {
   message_id: string
   author_id: string
   text: string | null
+  decryption_error?: LineDecryptionError
   content_type: string
   // Raw LINE contentMetadata (sticker IDs, file name/size, media URLs); empty for plain text.
   content_metadata: Record<string, string>

--- a/src/vendor/linejs/_dist/client/login.d.ts
+++ b/src/vendor/linejs/_dist/client/login.d.ts
@@ -34,6 +34,7 @@ export interface WithPasswordOptions {
   email: string;
   password: string;
   /** @default 114514 */ pincode?: string;
+  /** @default true */ e2ee?: boolean;
   onPincodeRequest(pin: string): void | Promise<void>;
 }
 export declare const loginWithPassword: (opts: WithPasswordOptions, init: InitOptions) => Promise<Client>;

--- a/src/vendor/linejs/client/login.js
+++ b/src/vendor/linejs/client/login.js
@@ -22,7 +22,8 @@ export const loginWithPassword = async (opts, init)=>{
   await base.loginProcess.withPassword({
     email: opts.email,
     password: opts.password,
-    pincode: opts.pincode
+    pincode: opts.pincode,
+    e2ee: opts.e2ee
   });
   await base.loginProcess.ready();
   return new Client(base);

--- a/src/vendor/linejs/client/login.test.ts
+++ b/src/vendor/linejs/client/login.test.ts
@@ -1,0 +1,11 @@
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'bun:test'
+
+describe('linejs login wrappers', () => {
+  it('passes E2EE option through password login', async () => {
+    const source = await readFile(new URL('./login.js', import.meta.url), 'utf8')
+
+    expect(source).toContain('e2ee: opts.e2ee')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #220. The previous approach only made LINE Letter Sealing failures visible, but it did not address why decryptable sessions were missing saved E2EE key material in the first place.

This updates the LINE credential login path so supported email credential sessions request E2EE key provisioning during sign-in, then stores those keys in account-scoped LINE storage. The optional decryption error metadata remains as a fallback for sessions that still cannot obtain private E2EE keys.

## Root Cause

The vendored LINE login wrapper accepted an E2EE option in the outer API, but it did not forward that option into the underlying login process. As a result, email credential login could complete without provisioning and saving Letter Sealing keys, leaving later message history and stream reads unable to decrypt encrypted chunks.

The storage path also used a shared default file for reconnects. That made key reuse unreliable across accounts and meant later reconnects could miss keys that were provisioned during an earlier account login.

## Fix

### E2EE key provisioning

- Forward the vendored login E2EE option into the underlying LINE login process.
- Expose the optional E2EE flag in the vendored declaration for password-style LINE login.
- Pass E2EE enabled from `LineClient.loginWithEmail` so supported sign-ins provision and save Letter Sealing key material.

### Account-scoped LINE storage

- Store LINE session data in an account-specific storage file after login identifies the account.
- Use the account-specific storage file for reconnects so provisioned E2EE keys can be reused later.
- Migrate the legacy default storage file into the account-specific file when the account file does not exist yet.

### Decryption fallback

- Keep optional `decryption_error` metadata on history and real-time message payloads.
- Mark encrypted chunk-only messages with missing-key metadata when plaintext is absent.
- Forward decrypt failure metadata through `LineListener` while preserving null-text compatibility.

## Context

Email credential login can participate in the LINE E2EE login flow when linejs receives the E2EE option. Existing non-password reconnect flows cannot download private E2EE keys by themselves, so they rely on keys saved by a prior provisioning login. That is why this PR fixes both provisioning and account-specific storage, while keeping machine-readable fallback metadata for sessions that legitimately have no saved keys.

## Testing

- `bun run lint` passed.
- `bun typecheck` passed.
- `bun run format:check` passed.
- `bun run build` passed.
- `bun run test` passed with 3047 tests.
- Focused vendored LINE and LINE platform suite passed with 118 tests.

## Review Notes

- Please verify the vendored wrapper change stays limited to forwarding the E2EE option and updating its declaration.
- Please verify account-scoped storage migration keeps existing single-account installations working while preventing cross-account key reuse.
- Please verify decryption error metadata remains a fallback path, not the primary fix for email credential sessions.