### PR TITLE
Add chat commands for personal Teams accounts

### DIFF
--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -209,10 +209,10 @@ agent-teams channel history <team-id> <channel-id> --limit 100
 
 ### Chat Commands
 
-For personal accounts (`@outlook.com` / `teams.live.com`) that have no teams or channels — only 1:1 and group chat threads. Work accounts can use these too for their 1:1 and group chats.
+For personal Microsoft accounts (`@outlook.com` / `@live.com`) that have no teams or channels — only 1:1, group, and self chat threads. Work accounts can use these too for their 1:1 and group chats.
 
 ```bash
-# List 1:1 and group chats
+# List 1:1, group, and self chats
 agent-teams chat list
 
 # Get chat message history

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -207,6 +207,23 @@ agent-teams channel info <team-id> 19:abc123@thread.tacv2
 agent-teams channel history <team-id> <channel-id> --limit 100
 ```
 
+### Chat Commands
+
+For personal accounts (`@outlook.com` / `teams.live.com`) that have no teams or channels — only 1:1 and group chat threads. Work accounts can use these too for their 1:1 and group chats.
+
+```bash
+# List 1:1 and group chats
+agent-teams chat list
+
+# Get chat message history
+agent-teams chat history <chat-id> --limit 100
+
+# Send a message to a chat
+agent-teams chat send <chat-id> "Hello"
+```
+
+Chat IDs look like `19:guid1_guid2@unq.gbl.spaces` (1:1) or `19:guid@thread.tacv2` (group). Get them from `chat list`.
+
 ### Team Commands
 
 ```bash
@@ -357,7 +374,7 @@ Common errors:
 
 - `Not authenticated`: No valid token (auto-extraction failed — see Troubleshooting)
 - `Token expired`: Token has expired and auto-refresh failed — see Troubleshooting
-- `No current team set`: Run `team switch <id>` first
+- `No current team set`: Run `team switch <id>` first. Personal accounts have no teams — use `chat list` / `chat history` / `chat send` instead
 - `Message not found`: Invalid message ID
 - `Channel not found`: Invalid channel ID
 - `401 Unauthorized`: Token expired and auto-refresh failed — see Troubleshooting
@@ -419,6 +436,7 @@ See the [Teams SDK documentation](https://agent-messenger.dev/docs/sdk/teams) fo
 - No real-time events / WebSocket connection
 - No voice/video channel support
 - No team management (create/delete channels, roles)
+- Personal accounts: chats only (no teams/channels); use the `chat` commands
 - No meeting support
 - No webhook support
 - Plain text messages only (no adaptive cards in v1)

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -222,7 +222,7 @@ agent-teams chat history <chat-id> --limit 100
 agent-teams chat send <chat-id> "Hello"
 ```
 
-Chat IDs look like `19:guid1_guid2@unq.gbl.spaces` (1:1) or `19:guid@thread.tacv2` (group). Get them from `chat list`.
+Chat IDs look like `19:guid1_guid2@unq.gbl.spaces` (1:1) or `19:guid@thread.tacv2` (group). Get them from `chat list`. The `48:notes` chat (`type: self`) is your personal "to me" notes thread.
 
 ### Team Commands
 

--- a/skills/agent-teams/references/common-patterns.md
+++ b/skills/agent-teams/references/common-patterns.md
@@ -438,6 +438,34 @@ SNAPSHOT=$(teams_cmd agent-teams snapshot)
 
 **When to use**: Any script that runs for more than a few minutes.
 
+## Pattern 12: Personal Account Chats (No Teams)
+
+**Use case**: Message from a personal Microsoft account (`@outlook.com` / `@live.com`), which has no teams or channels — only 1:1, group, and self ("to me") chats
+
+```bash
+#!/bin/bash
+
+# Personal accounts have no teams, so `team list` is empty and team/channel
+# commands fail with "No current team set". Use the `chat` commands instead.
+
+agent-teams auth extract 2>/dev/null || true
+
+# List chats (type is oneOnOne, group, or self)
+CHATS=$(agent-teams chat list)
+echo "$CHATS" | jq -r '.[] | "  \(.type): \(.id) — \(.topic // .last_message // "")"'
+
+# Pick a chat ID (here: the self "to me" notes thread)
+CHAT_ID=$(echo "$CHATS" | jq -r '.[] | select(.type=="self") | .id')
+
+# Read history and send a message
+agent-teams chat history "$CHAT_ID" --limit 20
+agent-teams chat send "$CHAT_ID" "Reminder: stand-up at 10am"
+```
+
+**When to use**: Any workflow on a personal/consumer Teams account. Get chat IDs from `chat list` — they look like `19:guid1_guid2@unq.gbl.spaces` (1:1), `19:guid@thread.tacv2` (group), or `48:notes` (self).
+
+**Note**: Work accounts also have 1:1 and group chats and can use these same `chat` commands.
+
 ## Best Practices
 
 ### 1. Always Handle Token Expiry

--- a/src/platforms/teams/cli.ts
+++ b/src/platforms/teams/cli.ts
@@ -7,6 +7,7 @@ import pkg from '../../../package.json' with { type: 'json' }
 import {
   authCommand,
   channelCommand,
+  chatCommand,
   fileCommand,
   messageCommand,
   reactionCommand,
@@ -49,6 +50,7 @@ program.hook('preAction', async (_thisCommand, actionCommand) => {
 program.addCommand(authCommand)
 program.addCommand(teamCommand)
 program.addCommand(channelCommand)
+program.addCommand(chatCommand)
 program.addCommand(fileCommand)
 program.addCommand(messageCommand)
 program.addCommand(reactionCommand)

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -170,12 +170,17 @@ describe('TeamsClient', () => {
   })
 
   describe('listChats', () => {
-    it('returns only chat conversations, excluding teams', async () => {
+    it('classifies chats and excludes teams', async () => {
       mockResponse({
         conversations: [
           {
             id: '19:team@thread.tacv2',
             threadProperties: { groupId: '111', spaceThreadTopic: 'Team One', threadType: 'space' },
+          },
+          {
+            id: '48:notes',
+            threadProperties: { threadType: 'streamofnotes', productThreadType: 'StreamOfNotes' },
+            lastMessage: { content: 'Hi', composetime: '2024-01-03T00:00:00.000Z' },
           },
           {
             id: '19:1on1@unq.gbl.spaces',
@@ -192,13 +197,10 @@ describe('TeamsClient', () => {
       const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
       const chats = await client.listChats()
 
-      expect(chats).toHaveLength(2)
-      expect(chats[0].id).toBe('19:1on1@unq.gbl.spaces')
-      expect(chats[0].type).toBe('oneOnOne')
-      expect(chats[0].last_message).toBe('Hi there')
-      expect(chats[1].id).toBe('19:group@thread.tacv2')
-      expect(chats[1].type).toBe('group')
-      expect(chats[1].topic).toBe('Group Chat')
+      expect(chats).toHaveLength(3)
+      expect(chats[0]).toMatchObject({ id: '48:notes', type: 'self', last_message: 'Hi' })
+      expect(chats[1]).toMatchObject({ id: '19:1on1@unq.gbl.spaces', type: 'oneOnOne', last_message: 'Hi there' })
+      expect(chats[2]).toMatchObject({ id: '19:group@thread.tacv2', type: 'group', topic: 'Group Chat' })
       expect(fetchCalls[0].url).toBe(
         'https://msgapi.teams.live.com/v1/users/ME/conversations?view=msnp24Equivalent&pageSize=500',
       )

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -169,6 +169,100 @@ describe('TeamsClient', () => {
     })
   })
 
+  describe('listChats', () => {
+    it('returns only chat conversations, excluding teams', async () => {
+      mockResponse({
+        conversations: [
+          {
+            id: '19:team@thread.tacv2',
+            threadProperties: { groupId: '111', spaceThreadTopic: 'Team One', threadType: 'space' },
+          },
+          {
+            id: '19:1on1@unq.gbl.spaces',
+            lastMessage: { content: '<p>Hi there</p>', composetime: '2024-01-01T00:00:00.000Z' },
+          },
+          {
+            id: '19:group@thread.tacv2',
+            threadProperties: { topic: 'Group Chat', threadType: 'chat' },
+            lastMessage: { content: 'Hello group', composetime: '2024-01-02T00:00:00.000Z' },
+          },
+        ],
+      })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const chats = await client.listChats()
+
+      expect(chats).toHaveLength(2)
+      expect(chats[0].id).toBe('19:1on1@unq.gbl.spaces')
+      expect(chats[0].type).toBe('oneOnOne')
+      expect(chats[0].last_message).toBe('Hi there')
+      expect(chats[1].id).toBe('19:group@thread.tacv2')
+      expect(chats[1].type).toBe('group')
+      expect(chats[1].topic).toBe('Group Chat')
+      expect(fetchCalls[0].url).toBe(
+        'https://msgapi.teams.live.com/v1/users/ME/conversations?view=msnp24Equivalent&pageSize=500',
+      )
+    })
+  })
+
+  describe('getChatMessages', () => {
+    it('returns user messages and filters system events', async () => {
+      mockResponse({
+        messages: [
+          {
+            id: 'm1',
+            content: '<p>Hello</p>',
+            from: 'host/users/ME/contacts/8:alice',
+            imdisplayname: 'Alice',
+            composetime: '2024-01-01T00:00:00.000Z',
+            messagetype: 'RichText/Html',
+          },
+          {
+            id: 'm2',
+            content: 'Bob joined',
+            imdisplayname: 'System',
+            composetime: '2024-01-01T00:01:00.000Z',
+            messagetype: 'ThreadActivity/AddMember',
+          },
+        ],
+      })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const messages = await client.getChatMessages('19:1on1@unq.gbl.spaces', 30)
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0].id).toBe('m1')
+      expect(messages[0].content).toBe('Hello')
+      expect(messages[0].author.displayName).toBe('Alice')
+      expect(messages[0].channel_id).toBe('19:1on1@unq.gbl.spaces')
+      expect(fetchCalls[0].url).toBe(
+        'https://msgapi.teams.live.com/v1/users/ME/conversations/19%3A1on1%40unq.gbl.spaces/messages?startTime=0&view=msnp24Equivalent&pageSize=30',
+      )
+    })
+  })
+
+  describe('sendChatMessage', () => {
+    it('sends an HTML-escaped message to a chat', async () => {
+      mockResponse({ OriginalArrivalTime: 1704067200000 })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const message = await client.sendChatMessage('19:1on1@unq.gbl.spaces', 'a <b> & c')
+
+      expect(message.content).toBe('a <b> & c')
+      expect(fetchCalls[0].url).toBe(
+        'https://msgapi.teams.live.com/v1/users/ME/conversations/19%3A1on1%40unq.gbl.spaces/messages',
+      )
+      expect(fetchCalls[0].options?.method).toBe('POST')
+      expect(fetchCalls[0].options?.body).toBe(
+        JSON.stringify({
+          content: 'a &lt;b&gt; &amp; c',
+          messagetype: 'RichText/Html',
+          contenttype: 'text',
+        }),
+      )
+    })
+  })
+
   describe('getTeam', () => {
     it('returns team info', async () => {
       mockResponse({ id: '111', name: 'Test Team', description: 'A test team' })

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -6,6 +6,7 @@ import type {
   TeamsAccountType,
   TeamsChannel,
   TeamsChat,
+  TeamsChatType,
   TeamsFile,
   TeamsMessage,
   TeamsRegion,
@@ -46,6 +47,19 @@ function escapeHtml(value: string): string {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;')
+}
+
+// groupId => Teams/channel thread (handled by listTeams). "48:notes"/
+// streamofnotes => the user's self ("to me") chat. Anything else without a
+// non-chat threadType is a normal 1:1 (no topic) or group (has topic) chat.
+function classifyChat(
+  id: string,
+  tp?: { topic?: string; threadType?: string; groupId?: string },
+): TeamsChatType | null {
+  if (tp?.groupId) return null
+  if (id === '48:notes' || tp?.threadType === 'streamofnotes') return 'self'
+  if (tp?.threadType && tp.threadType !== 'chat') return null
+  return tp?.topic ? 'group' : 'oneOnOne'
 }
 
 export class TeamsClient {
@@ -372,17 +386,13 @@ export class TeamsClient {
 
     const chats: TeamsChat[] = []
     for (const conv of data.conversations ?? []) {
-      const tp = conv.threadProperties
-      // The conversations endpoint mixes Teams/channel threads (which carry a
-      // groupId) with personal chats; skip the former so they stay in listTeams().
-      if (tp?.groupId) continue
-      if (tp?.threadType && tp.threadType !== 'chat') continue
+      const type = classifyChat(conv.id, conv.threadProperties)
+      if (!type) continue
 
-      const isGroup = Boolean(tp?.topic)
       chats.push({
         id: conv.id,
-        type: isGroup ? 'group' : 'oneOnOne',
-        topic: tp?.topic,
+        type,
+        topic: conv.threadProperties?.topic,
         last_message: stripHtml(conv.lastMessage?.content),
         last_message_at: conv.lastMessage?.composetime ?? conv.lastMessage?.originalarrivaltime,
       })

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -5,6 +5,7 @@ import { TeamsCredentialManager } from './credential-manager'
 import type {
   TeamsAccountType,
   TeamsChannel,
+  TeamsChat,
   TeamsFile,
   TeamsMessage,
   TeamsRegion,
@@ -24,6 +25,28 @@ const MAX_RETRIES = 3
 const BASE_BACKOFF_MS = 100
 const DEFAULT_REGION: TeamsRegion = 'amer'
 const REGIONS: TeamsRegion[] = ['amer', 'emea', 'apac']
+
+function stripHtml(content: string | undefined): string | undefined {
+  if (content === undefined) return undefined
+  const stripped = content.replace(/<[^>]*>/g, '')
+  return stripped
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
 
 export class TeamsClient {
   private token: string | null = null
@@ -322,6 +345,106 @@ export class TeamsClient {
     }
 
     return Array.from(teamsMap.values())
+  }
+
+  async listChats(): Promise<TeamsChat[]> {
+    interface ConversationMessage {
+      content?: string
+      composetime?: string
+      originalarrivaltime?: string
+    }
+    interface Conversation {
+      id: string
+      threadProperties?: {
+        topic?: string
+        threadType?: string
+        groupId?: string
+      }
+      lastMessage?: ConversationMessage
+    }
+    interface ConversationsResponse {
+      conversations: Conversation[]
+    }
+    const data = await this.request<ConversationsResponse>(
+      'GET',
+      '/users/ME/conversations?view=msnp24Equivalent&pageSize=500',
+    )
+
+    const chats: TeamsChat[] = []
+    for (const conv of data.conversations ?? []) {
+      const tp = conv.threadProperties
+      // The conversations endpoint mixes Teams/channel threads (which carry a
+      // groupId) with personal chats; skip the former so they stay in listTeams().
+      if (tp?.groupId) continue
+      if (tp?.threadType && tp.threadType !== 'chat') continue
+
+      const isGroup = Boolean(tp?.topic)
+      chats.push({
+        id: conv.id,
+        type: isGroup ? 'group' : 'oneOnOne',
+        topic: tp?.topic,
+        last_message: stripHtml(conv.lastMessage?.content),
+        last_message_at: conv.lastMessage?.composetime ?? conv.lastMessage?.originalarrivaltime,
+      })
+    }
+
+    return chats
+  }
+
+  async getChatMessages(chatId: string, limit: number = 50): Promise<TeamsMessage[]> {
+    interface ChatMessage {
+      id: string
+      content?: string
+      from?: string
+      imdisplayname?: string
+      composetime?: string
+      originalarrivaltime?: string
+      messagetype?: string
+    }
+    interface MessagesResponse {
+      messages: ChatMessage[]
+    }
+    const encodedChatId = encodeURIComponent(chatId)
+    const data = await this.request<MessagesResponse>(
+      'GET',
+      `/users/ME/conversations/${encodedChatId}/messages?startTime=0&view=msnp24Equivalent&pageSize=${limit}`,
+    )
+
+    const userMessageTypes = new Set(['Text', 'RichText/Html', 'RichText/Media_CallRecording'])
+    return (data.messages ?? [])
+      .filter((msg) => !msg.messagetype || userMessageTypes.has(msg.messagetype))
+      .slice(0, limit)
+      .map((msg) => ({
+        id: msg.id,
+        channel_id: chatId,
+        author: {
+          id: msg.from ?? '',
+          displayName: msg.imdisplayname ?? 'Unknown',
+        },
+        content: stripHtml(msg.content) ?? '',
+        timestamp: msg.composetime ?? msg.originalarrivaltime ?? '',
+      }))
+  }
+
+  async sendChatMessage(chatId: string, content: string): Promise<TeamsMessage> {
+    interface SendResponse {
+      OriginalArrivalTime?: number
+    }
+    const encodedChatId = encodeURIComponent(chatId)
+    const response = await this.request<SendResponse>('POST', `/users/ME/conversations/${encodedChatId}/messages`, {
+      content: escapeHtml(content),
+      messagetype: 'RichText/Html',
+      contenttype: 'text',
+    })
+
+    const arrivalTime = response?.OriginalArrivalTime
+    return {
+      id: arrivalTime ? String(arrivalTime) : '',
+      channel_id: chatId,
+      author: { id: 'ME', displayName: 'Me' },
+      content,
+      timestamp: arrivalTime ? new Date(arrivalTime).toISOString() : new Date().toISOString(),
+    }
   }
 
   async getTeam(teamId: string): Promise<TeamsTeam> {

--- a/src/platforms/teams/commands/chat.test.ts
+++ b/src/platforms/teams/commands/chat.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
+
+import { TeamsClient } from '../client'
+import { TeamsCredentialManager } from '../credential-manager'
+import { historyAction, listAction, sendAction } from './chat'
+
+let clientListChatsSpy: ReturnType<typeof spyOn>
+let clientGetChatMessagesSpy: ReturnType<typeof spyOn>
+let clientSendChatMessageSpy: ReturnType<typeof spyOn>
+let credManagerLoadSpy: ReturnType<typeof spyOn>
+const originalConsoleLog = console.log
+
+beforeEach(() => {
+  clientListChatsSpy = spyOn(TeamsClient.prototype, 'listChats').mockResolvedValue([
+    { id: '19:1on1@unq.gbl.spaces', type: 'oneOnOne', last_message: 'Hi', last_message_at: '2025-01-29T10:00:00Z' },
+    { id: '19:group@thread.tacv2', type: 'group', topic: 'Group Chat' },
+  ])
+
+  clientGetChatMessagesSpy = spyOn(TeamsClient.prototype, 'getChatMessages').mockResolvedValue([
+    {
+      id: 'msg_123',
+      channel_id: '19:1on1@unq.gbl.spaces',
+      author: { id: 'user_789', displayName: 'Alice' },
+      content: 'Hello world',
+      timestamp: '2025-01-29T10:00:00Z',
+    },
+  ])
+
+  clientSendChatMessageSpy = spyOn(TeamsClient.prototype, 'sendChatMessage').mockResolvedValue({
+    id: '1704067200000',
+    channel_id: '19:1on1@unq.gbl.spaces',
+    author: { id: 'ME', displayName: 'Me' },
+    content: 'Hello world',
+    timestamp: '2025-01-29T10:00:00Z',
+  })
+
+  credManagerLoadSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue({
+    current_account: 'personal',
+    accounts: {
+      personal: {
+        token: 'test_token',
+        account_type: 'personal' as const,
+        current_team: null,
+        teams: {},
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  clientListChatsSpy?.mockRestore()
+  clientGetChatMessagesSpy?.mockRestore()
+  clientSendChatMessageSpy?.mockRestore()
+  credManagerLoadSpy?.mockRestore()
+  console.log = originalConsoleLog
+})
+
+it('list: returns array of chats', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await listAction({ pretty: false })
+
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('19:1on1@unq.gbl.spaces')
+  expect(output).toContain('19:group@thread.tacv2')
+})
+
+it('history: returns array of messages', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await historyAction('19:1on1@unq.gbl.spaces', { limit: 50, pretty: false })
+
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('msg_123')
+  expect(output).toContain('Alice')
+})
+
+it('send: returns sent message', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await sendAction('19:1on1@unq.gbl.spaces', 'Hello world', { pretty: false })
+
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('Hello world')
+})

--- a/src/platforms/teams/commands/chat.test.ts
+++ b/src/platforms/teams/commands/chat.test.ts
@@ -79,6 +79,15 @@ it('history: returns array of messages', async () => {
   expect(output).toContain('Alice')
 })
 
+it('history: falls back to default limit when given a non-positive value', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await historyAction('19:1on1@unq.gbl.spaces', { limit: -5, pretty: false })
+
+  expect(clientGetChatMessagesSpy).toHaveBeenCalledWith('19:1on1@unq.gbl.spaces', 50)
+})
+
 it('send: returns sent message', async () => {
   const consoleSpy = mock((_msg: string) => {})
   console.log = consoleSpy

--- a/src/platforms/teams/commands/chat.ts
+++ b/src/platforms/teams/commands/chat.ts
@@ -1,0 +1,130 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { TeamsClient } from '../client'
+import { TeamsCredentialManager } from '../credential-manager'
+
+export async function listAction(options: { pretty?: boolean }): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const chats = await client.listChats()
+
+    const output = chats.map((chat) => ({
+      id: chat.id,
+      type: chat.type,
+      topic: chat.topic,
+      last_message: chat.last_message,
+      last_message_at: chat.last_message_at,
+    }))
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export async function historyAction(chatId: string, options: { limit?: number; pretty?: boolean }): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const messages = await client.getChatMessages(chatId, options.limit || 50)
+
+    const output = messages.map((msg) => ({
+      id: msg.id,
+      author: msg.author.displayName,
+      content: msg.content,
+      timestamp: msg.timestamp,
+    }))
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export async function sendAction(chatId: string, content: string, options: { pretty?: boolean }): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const message = await client.sendChatMessage(chatId, content)
+
+    const output = {
+      id: message.id,
+      content: message.content,
+      timestamp: message.timestamp,
+    }
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const chatCommand = new Command('chat')
+  .description('Personal chat commands (1:1 and group chats)')
+  .addCommand(
+    new Command('list')
+      .description('List 1:1 and group chats')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(listAction),
+  )
+  .addCommand(
+    new Command('history')
+      .description('Get chat message history')
+      .argument('<chat-id>', 'Chat ID')
+      .option('--limit <n>', 'Number of messages to fetch', '50')
+      .option('--pretty', 'Pretty print JSON output')
+      .action((chatId, options) => {
+        return historyAction(chatId, {
+          limit: parseInt(options.limit, 10),
+          pretty: options.pretty,
+        })
+      }),
+  )
+  .addCommand(
+    new Command('send')
+      .description('Send a message to a chat')
+      .argument('<chat-id>', 'Chat ID')
+      .argument('<content>', 'Message content')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(sendAction),
+  )

--- a/src/platforms/teams/commands/chat.ts
+++ b/src/platforms/teams/commands/chat.ts
@@ -54,7 +54,8 @@ export async function historyAction(chatId: string, options: { limit?: number; p
       accountType: cred.accountType,
       region: cred.region,
     })
-    const messages = await client.getChatMessages(chatId, options.limit || 50)
+    const limit = options.limit && options.limit > 0 ? options.limit : 50
+    const messages = await client.getChatMessages(chatId, limit)
 
     const output = messages.map((msg) => ({
       id: msg.id,
@@ -100,10 +101,10 @@ export async function sendAction(chatId: string, content: string, options: { pre
 }
 
 export const chatCommand = new Command('chat')
-  .description('Personal chat commands (1:1 and group chats)')
+  .description('Chat commands (1:1, group, and self chats)')
   .addCommand(
     new Command('list')
-      .description('List 1:1 and group chats')
+      .description('List 1:1, group, and self chats')
       .option('--pretty', 'Pretty print JSON output')
       .action(listAction),
   )

--- a/src/platforms/teams/commands/index.ts
+++ b/src/platforms/teams/commands/index.ts
@@ -4,6 +4,7 @@
 
 export { authCommand } from './auth'
 export { channelCommand } from './channel'
+export { chatCommand } from './chat'
 export { fileCommand } from './file'
 export { messageCommand } from './message'
 export { reactionCommand } from './reaction'

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -35,6 +35,16 @@ export interface TeamsUser {
   userPrincipalName?: string
 }
 
+export type TeamsChatType = 'oneOnOne' | 'group'
+
+export interface TeamsChat {
+  id: string
+  type: TeamsChatType
+  topic?: string
+  last_message?: string
+  last_message_at?: string
+}
+
 export interface TeamsReaction {
   emoji: string
   count: number
@@ -122,6 +132,16 @@ export const TeamsUserSchema = z.object({
   displayName: z.string(),
   email: z.string().optional(),
   userPrincipalName: z.string().optional(),
+})
+
+export const TeamsChatTypeSchema = z.enum(['oneOnOne', 'group'])
+
+export const TeamsChatSchema = z.object({
+  id: z.string(),
+  type: TeamsChatTypeSchema,
+  topic: z.string().optional(),
+  last_message: z.string().optional(),
+  last_message_at: z.string().optional(),
 })
 
 export const TeamsReactionSchema = z.object({

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -35,7 +35,7 @@ export interface TeamsUser {
   userPrincipalName?: string
 }
 
-export type TeamsChatType = 'oneOnOne' | 'group'
+export type TeamsChatType = 'oneOnOne' | 'group' | 'self'
 
 export interface TeamsChat {
   id: string
@@ -134,7 +134,7 @@ export const TeamsUserSchema = z.object({
   userPrincipalName: z.string().optional(),
 })
 
-export const TeamsChatTypeSchema = z.enum(['oneOnOne', 'group'])
+export const TeamsChatTypeSchema = z.enum(['oneOnOne', 'group', 'self'])
 
 export const TeamsChatSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary

Personal Microsoft accounts (`@outlook.com` / `teams.live.com`) have **no teams or channels** — only 1:1, group, and self ("to me") chat threads. Because every `agent-teams` command required a `team-id`, these accounts could authenticate but never message, failing with `No current team set` (#222).

This PR adds a `chat` command group backed by the Skype-based consumer messaging API (`msgapi.teams.live.com/v1`), which was already wired into the client but unused for messaging.

```bash
agent-teams chat list                          # list 1:1, group, and self chats
agent-teams chat history <chat-id> --limit 100 # read a chat's history
agent-teams chat send <chat-id> "Hello"        # send a message to a chat
```

## How it works

- `GET /users/ME/conversations` already returned chat threads, but `listTeams()` discarded everything without a `groupId`. A `classifyChat` helper now sorts each conversation:
  - `groupId` present → Teams/channel thread, skipped (stays in `listTeams()`)
  - `48:notes` / `threadType: streamofnotes` → the user's **self ("to me") chat** (`type: self`)
  - otherwise → `oneOnOne` (no topic) or `group` (has topic)
- `getChatMessages()` / `sendChatMessage()` hit `/users/ME/conversations/{chatId}/messages`. All three methods use the client's **default base URL**, so work accounts transparently hit the regional endpoint and personal accounts hit the consumer endpoint.

## Live verification (real personal account)

Tested end-to-end against a real `@outlook.com` account whose only conversation was the self-chat:

| Command | Result |
| --- | --- |
| `auth extract` | ✅ personal account detected, `teams: []` (reproduces #222) |
| `chat list` | ✅ returns the `48:notes` self-chat as `type: self` |
| `chat history 48:notes` | ✅ reads real messages from the live API |
| `chat send 48:notes "…"` | ✅ message sent; confirmed present on re-reading history |

The empty-`[]` → working result also confirmed the self-chat classification fix below.

## Changes

**SDK layer** (`ca27914`)
- `types.ts`: add `TeamsChat` type + Zod schema
- `client.ts`: add `listChats`, `getChatMessages`, `sendChatMessage`
- `client.test.ts`: cover chat listing, message filtering of system events, HTML-escaped sending

**CLI layer + docs** (`2a5149b`)
- `commands/chat.ts`: `chat list` / `history` / `send` (mirrors `message.ts` / `channel.ts`)
- register `chatCommand` in `commands/index.ts` and `cli.ts` (unconditional — work accounts have chats too)
- `commands/chat.test.ts`: command-level tests
- `skills/agent-teams/SKILL.md`: document the commands

**Self-chat fix** (`f8983ac`)
- recognize the `48:notes` / `streamofnotes` self ("to me") thread as a `self` chat instead of filtering it out — without this, `chat list` was empty for accounts whose only conversation is the self-chat
- extracted `classifyChat` helper; added test coverage

## Hardening

- Outgoing content is **HTML-escaped** before being sent as `RichText/Html`.
- Chat IDs are **URL-encoded** in request paths (they contain `:` and `@`).
- System message types (member-add, topic-update, etc.) are filtered out of history.
- `pageSize` is treated as best-effort and sliced client-side.

## Testing

- `bun test` — **3054 pass, 0 fail**
- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun format` — touched files correctly formatted

## Notes / Follow-ups

- `snapshot` still requires a team and remains team-only; for personal accounts the new error guidance directs users to `chat list`. Making `snapshot` chat-aware is a reasonable follow-up, out of scope here.
- No persistent "current chat" selection yet — commands take an explicit `<chat-id>`.
- Minor: when you send to yourself, history shows an empty `author` (the API omits `imdisplayname` on your own messages). Cosmetic; a follow-up could fall back to the account name.

Closes #222
