### PR TITLE
Fix LINE E2EE key isolation, restoration, and message decryption

### DIFF
--- a/docs/content/docs/cli/line.mdx
+++ b/docs/content/docs/cli/line.mdx
@@ -9,14 +9,14 @@ description: Complete reference for the agent-line CLI.
 
 Before diving in, a few things about LINE's architecture:
 
-| Term                      | Description                                                                                                                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **MID**                   | LINE's unique identifier for users, chats, and rooms. Prefixed with `u` (user), `c` (group chat), or `r` (room).                                                                           |
-| **QR code login**         | The primary authentication method. Scan a QR code with the LINE mobile app to authorize the CLI.                                                                                           |
-| **ANDROIDSECONDARY**      | The default device type. Registers as a secondary Android device so your phone and desktop sessions stay active.                                                                           |
-| **E2EE (Letter Sealing)** | LINE's end-to-end encryption. The CLI attempts E2EE first and falls back to plaintext if keys aren't available. Chats that require E2EE reject the fallback and fail with `e2ee_required`. |
-| **Device types**          | Controls which device slot the CLI occupies. Secondary devices coexist with your other sessions.                                                                                           |
-| **PIN verification**      | During login, LINE may display a PIN that you confirm on your phone to authorize the new device.                                                                                           |
+| Term                      | Description                                                                                                                                                                                                                                                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MID**                   | LINE's unique identifier for users, chats, and rooms. Prefixed with `u` (user), `c` (group chat), or `r` (room).                                                                                                                                                                                                                   |
+| **QR code login**         | The primary authentication method. Scan a QR code with the LINE mobile app to authorize the CLI.                                                                                                                                                                                                                                   |
+| **ANDROIDSECONDARY**      | The default device type. Registers as a secondary Android device so your phone and desktop sessions stay active.                                                                                                                                                                                                                   |
+| **E2EE (Letter Sealing)** | LINE's end-to-end encryption. The CLI encrypts and decrypts E2EE messages when key material is available, restoring keys saved by a prior QR/email login. It attempts E2EE first and falls back to plaintext otherwise. Chats that require E2EE reject the fallback and fail with `e2ee_required` when no key material is present. |
+| **Device types**          | Controls which device slot the CLI occupies. Secondary devices coexist with your other sessions.                                                                                                                                                                                                                                   |
+| **PIN verification**      | During login, LINE may display a PIN that you confirm on your phone to authorize the new device.                                                                                                                                                                                                                                   |
 
 ## Quick Start
 
@@ -192,7 +192,9 @@ Each message includes:
 - `message_id` — unique message identifier
 - `chat_id` — which chat the message belongs to
 - `author_id` — sender's MID
-- `text` — message text content (null for non-text messages)
+- `author_name` — sender's display name, resolved from contacts (omitted when it can't be resolved)
+- `text` — message text content (null for non-text or undecryptable messages). Letter Sealing (E2EE) messages are decrypted automatically when key material is available
+- `decryption_error` — present only when an E2EE message couldn't be decrypted; `{ code, message }` where `code` is `missing_e2ee_key` or `decrypt_failed`
 - `content_type` — message type (NONE = text, IMAGE, VIDEO, etc.)
 - `sent_at` — ISO 8601 timestamp
 
@@ -230,7 +232,7 @@ agent-line message list c7a8b9c0d1e2f3a4b5c6d7e8 -n 200
 - No message editing or deletion
 - No search across chats
 - Plain text messages only (no photos, videos, or rich content)
-- Sending to chats that **require** E2EE (Letter Sealing) is not supported on auth-token sessions; such sends fail with `e2ee_required`
+- Sending to chats that **require** E2EE (Letter Sealing) needs E2EE key material from a prior QR/email login; without it such sends fail with `e2ee_required`
 - Chat IDs are MID strings, not human-readable — use `chat list` to discover them
 
 ## Troubleshooting
@@ -267,7 +269,7 @@ If the QR code doesn't open in your browser:
 
 ### E2EE errors
 
-The CLI tries E2EE (Letter Sealing) first and falls back to plaintext when possible, so most messages still send. Chats that **require** E2EE reject the plaintext fallback, and the send fails with `e2ee_required` — auth-token sessions have no local E2EE key and cannot encrypt for those chats.
+The CLI tries E2EE (Letter Sealing) first and falls back to plaintext when possible, so most messages still send. When E2EE key material is available — restored from a prior QR/email login — the CLI encrypts and decrypts those messages. Chats that **require** E2EE reject the plaintext fallback, so if no key material is present the send fails with `e2ee_required`. Re-run `agent-line auth login` (QR) to provision E2EE keys.
 
 ### PIN verification timeout
 

--- a/skills/agent-line/SKILL.md
+++ b/skills/agent-line/SKILL.md
@@ -298,7 +298,9 @@ Each message includes:
 - `message_id` - unique message identifier
 - `type` - message type (text, image, sticker, etc.)
 - `author_id` - sender's MID
-- `text` - message text content
+- `author_name` - sender's display name, resolved from contacts (omitted when unresolved)
+- `text` - message text content (E2EE messages are decrypted automatically when key material is available; null when undecryptable)
+- `decryption_error` - present only for E2EE messages that couldn't be decrypted (`code`: `missing_e2ee_key` or `decrypt_failed`)
 - `sent_at` - Unix timestamp (milliseconds)
 
 ## Output Format
@@ -428,8 +430,8 @@ See the [LINE SDK documentation](https://agent-messenger.dev/docs/sdk/line) for 
 ## Limitations
 
 - No auto-extraction of credentials (requires interactive login via QR code or email/password)
-- E2EE (Letter Sealing) may prevent reading some message content
-- Sending to chats that **require** E2EE (Letter Sealing) is not supported on auth-token sessions; such sends fail with `e2ee_required`
+- E2EE (Letter Sealing) messages are decrypted automatically when key material is available (restored from a prior QR/email login); without keys, content may be unreadable
+- Sending to chats that **require** E2EE (Letter Sealing) needs E2EE key material from a prior QR/email login; without it such sends fail with `e2ee_required`
 - No file upload support yet
 - No sticker or rich message sending (text only)
 - No group creation or management
@@ -479,7 +481,7 @@ If commands start failing with `not_authenticated` or `invalid_token`:
 
 ### E2EE messages unreadable
 
-Some chats with Letter Sealing enabled may return empty or encrypted message content. This is a known limitation. The CLI cannot decrypt E2EE messages.
+The CLI decrypts Letter Sealing (E2EE) messages when E2EE key material is available. Keys are provisioned by a QR or email/password login and reused on later sessions. If a message comes back with `text: null` and a `decryption_error` of `missing_e2ee_key`, the session has no usable key — re-run `agent-line auth login` (QR) to provision E2EE keys.
 
 ## References
 

--- a/skills/agent-line/references/common-patterns.md
+++ b/skills/agent-line/references/common-patterns.md
@@ -71,11 +71,14 @@ MESSAGES=$(agent-line message list "$CHAT_ID" -n 50)
 MSG_COUNT=$(echo "$MESSAGES" | jq 'length')
 echo "Found $MSG_COUNT messages"
 
-# Show messages; encrypted Letter Sealing messages may include decryption_error.
-echo "$MESSAGES" | jq -r '.[] | "\(.author_id): \(.text // .decryption_error.message // "[non-text]")"'
+# Show messages by display name; Letter Sealing messages are decrypted when E2EE
+# key material is available, otherwise decryption_error explains why text is null.
+echo "$MESSAGES" | jq -r '.[] | "\(.author_name // .author_id): \(.text // .decryption_error.message // "[non-text]")"'
 ```
 
 **When to use**: Context gathering, summarizing conversations, catching up on missed messages.
+
+**E2EE note**: `message list` decrypts Letter Sealing (E2EE) messages when key material is available — restored from a prior QR/email login. When keys are missing, `text` is `null` and `decryption_error.code` is `missing_e2ee_key`; re-run `agent-line auth login` (QR) to provision keys.
 
 ## Pattern 4: Monitor for New Messages
 

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -200,6 +200,38 @@ describe('LineClient', () => {
       expect(result[0].decryption_error).toBeUndefined()
     })
 
+    it('normalizes metadata-shaped history messages to contentMetadata before decrypting', async () => {
+      let received: { contentMetadata?: unknown } | undefined
+      const client = clientWithTalk(
+        {
+          getServerTime: async () => 1700000000000,
+          getPreviousMessagesV2WithRequest: async () => [
+            {
+              id: '40',
+              from: 'u1',
+              text: null,
+              contentType: 'NONE',
+              createdTime: 1700000004000,
+              chunks: ['a', 'b'],
+              metadata: { e2eeMark: '2', e2eeVersion: '2' },
+            },
+          ],
+        },
+        {
+          decryptE2EEMessage: async (m: { contentMetadata?: unknown }) => {
+            received = m
+            // mirror the vendor decryptor: it reads contentMetadata.e2eeVersion
+            const meta = m.contentMetadata as { e2eeVersion?: string }
+            return { text: `v${meta.e2eeVersion}` }
+          },
+        },
+      )
+
+      const result = await client.getMessages('chat1', { count: 1 })
+      expect((received?.contentMetadata as { e2eeVersion?: string })?.e2eeVersion).toBe('2')
+      expect(result[0].text).toBe('v2')
+    })
+
     it('surfaces missing_e2ee_key when decryption fails for lack of keys', async () => {
       const client = clientWithTalk(
         {

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -56,9 +56,10 @@ describe('LineClient', () => {
   })
 
   describe('getMessages()', () => {
-    function clientWithTalk(talk: Record<string, unknown>): LineClient {
+    function clientWithTalk(talk: Record<string, unknown>, e2ee?: Record<string, unknown>): LineClient {
       const client = new LineClient()
-      ;(client as any).client = { base: { talk } }
+      const { profile, ...talkMethods } = talk
+      ;(client as any).client = { base: { talk: talkMethods, profile, e2ee: e2ee ?? {} } }
       return client
     }
 
@@ -106,28 +107,147 @@ describe('LineClient', () => {
       expect(result.map((m) => m.text)).toEqual(['c', 'b'])
     })
 
-    it('marks encrypted chunk messages without text as missing E2EE keys', async () => {
+    it('resolves author MIDs to display names via getContacts', async () => {
       const client = clientWithTalk({
+        profile: { mid: 'me' },
         getServerTime: async () => 1700000000000,
         getPreviousMessagesV2WithRequest: async () => [
-          {
-            id: '40',
-            from: 'u1',
-            text: null,
-            contentType: 'NONE',
-            createdTime: 1700000004000,
-            chunks: ['a', 'b'],
-            metadata: { e2eeMark: '2', e2eeVersion: '2' },
-          },
+          { id: '10', from: 'u1', text: 'hi', contentType: 'NONE', createdTime: 1700000001000 },
+          { id: '11', from: 'u2', text: 'yo', contentType: 'NONE', createdTime: 1700000002000 },
         ],
+        getContacts: async ({ mids }: { mids: string[] }) =>
+          mids.map((mid) => ({ mid, displayName: mid === 'u1' ? 'Alice' : 'Bob' })),
+      })
+
+      const result = await client.getMessages('chat1', { count: 2 })
+      expect(result.map((m) => m.author_name)).toEqual(['Alice', 'Bob'])
+    })
+
+    it('batch-resolves unique authors in a single getContacts call', async () => {
+      let contactCalls = 0
+      const client = clientWithTalk({
+        profile: { mid: 'me' },
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async () => [
+          { id: '10', from: 'u1', text: 'a', contentType: 'NONE', createdTime: 1700000001000 },
+          { id: '11', from: 'u1', text: 'b', contentType: 'NONE', createdTime: 1700000002000 },
+          { id: '12', from: 'u2', text: 'c', contentType: 'NONE', createdTime: 1700000003000 },
+        ],
+        getContacts: async ({ mids }: { mids: string[] }) => {
+          contactCalls++
+          expect([...mids].sort()).toEqual(['u1', 'u2'])
+          return mids.map((mid) => ({ mid, displayName: mid.toUpperCase() }))
+        },
+      })
+
+      const result = await client.getMessages('chat1', { count: 3 })
+      expect(contactCalls).toBe(1)
+      expect(result.map((m) => m.author_name)).toEqual(['U1', 'U1', 'U2'])
+    })
+
+    it('resolves the current user via getProfile since getContacts omits self', async () => {
+      const client = clientWithTalk({
+        profile: { mid: 'me' },
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async () => [
+          { id: '10', from: 'me', text: 'mine', contentType: 'NONE', createdTime: 1700000001000 },
+        ],
+        getContacts: async () => [],
+        getProfile: async () => ({ mid: 'me', displayName: 'My Name' }),
       })
 
       const result = await client.getMessages('chat1', { count: 1 })
-      expect(result[0].text).toBeNull()
-      expect(result[0].decryption_error).toEqual({
-        code: 'missing_e2ee_key',
-        message: 'LINE message is encrypted with Letter Sealing, but this session has no saved E2EE key material.',
+      expect(result[0].author_name).toBe('My Name')
+    })
+
+    it('falls back to bare author_id when name resolution fails', async () => {
+      const client = clientWithTalk({
+        profile: { mid: 'me' },
+        getServerTime: async () => 1700000000000,
+        getPreviousMessagesV2WithRequest: async () => [
+          { id: '10', from: 'u1', text: 'hi', contentType: 'NONE', createdTime: 1700000001000 },
+        ],
+        getContacts: async () => {
+          throw new Error('network down')
+        },
       })
+
+      const result = await client.getMessages('chat1', { count: 1 })
+      expect(result[0].author_name).toBeUndefined()
+      expect(result[0].author_id).toBe('u1')
+    })
+
+    it('decrypts Letter-Sealing chunk messages via decryptE2EEMessage', async () => {
+      const encrypted = {
+        id: '40',
+        from: 'u1',
+        text: null,
+        contentType: 'NONE',
+        createdTime: 1700000004000,
+        chunks: ['a', 'b'],
+        metadata: { e2eeMark: '2', e2eeVersion: '2' },
+      }
+      const client = clientWithTalk(
+        {
+          getServerTime: async () => 1700000000000,
+          getPreviousMessagesV2WithRequest: async () => [encrypted],
+        },
+        { decryptE2EEMessage: async (m: { id: string }) => ({ ...m, text: 'decrypted secret' }) },
+      )
+
+      const result = await client.getMessages('chat1', { count: 1 })
+      expect(result[0].text).toBe('decrypted secret')
+      expect(result[0].decryption_error).toBeUndefined()
+    })
+
+    it('surfaces missing_e2ee_key when decryption fails for lack of keys', async () => {
+      const client = clientWithTalk(
+        {
+          getServerTime: async () => 1700000000000,
+          getPreviousMessagesV2WithRequest: async () => [
+            {
+              id: '40',
+              from: 'u1',
+              text: null,
+              contentType: 'NONE',
+              createdTime: 1700000004000,
+              chunks: ['a', 'b'],
+              metadata: { e2eeMark: '2', e2eeVersion: '2' },
+            },
+          ],
+        },
+        {
+          decryptE2EEMessage: async () => {
+            throw new Error('NoE2EEKey: E2EE Key has not been saved')
+          },
+        },
+      )
+
+      const result = await client.getMessages('chat1', { count: 1 })
+      expect(result[0].text).toBeNull()
+      expect(result[0].decryption_error?.code).toBe('missing_e2ee_key')
+    })
+
+    it('does not decrypt plain messages that already carry text', async () => {
+      let decryptCalls = 0
+      const client = clientWithTalk(
+        {
+          getServerTime: async () => 1700000000000,
+          getPreviousMessagesV2WithRequest: async () => [
+            { id: '50', from: 'u1', text: 'plain hello', contentType: 'NONE', createdTime: 1700000005000 },
+          ],
+        },
+        {
+          decryptE2EEMessage: async () => {
+            decryptCalls++
+            return { text: 'should-not-run' }
+          },
+        },
+      )
+
+      const result = await client.getMessages('chat1', { count: 1 })
+      expect(result[0].text).toBe('plain hello')
+      expect(decryptCalls).toBe(0)
     })
   })
 

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 import type { Operation as LineOperation } from '@jsr/evex__linejs-types'
@@ -13,6 +13,7 @@ import {
 } from '@/vendor/linejs/client/mod.js'
 
 import { LineCredentialManager } from './credential-manager'
+import { ensureSelfKeyForMid, migrateOwnE2EEKeys } from './e2ee-storage'
 import type {
   LineAccountCredentials,
   LineChat,
@@ -47,6 +48,8 @@ export interface LineRawMessage {
 }
 
 export type LineRawEvent = { kind: 'message'; message: LineRawMessage } | { kind: 'event'; op: LineOperation }
+
+type VendorMessage = Parameters<Client['base']['e2ee']['decryptE2EEMessage']>[0]
 
 const MAX_MESSAGE_ID = 9223372036854775807n
 
@@ -89,17 +92,19 @@ function getDefaultDevice(): LineDevice {
   return 'ANDROIDSECONDARY'
 }
 
-function createStorage(accountId?: string): FileStorage {
+function lineStorageDir(): string {
   const dir = join(getConfigDir(), 'line-storage')
   mkdirSync(dir, { recursive: true })
-  const defaultPath = join(dir, 'default.json')
-  if (!accountId) return new FileStorage(defaultPath)
+  return dir
+}
 
-  const accountPath = join(dir, `${accountId}.json`)
-  if (!existsSync(accountPath) && existsSync(defaultPath)) {
-    copyFileSync(defaultPath, accountPath)
-  }
-  return new FileStorage(accountPath)
+// Per-account stores stay isolated: blindly cloning default.json would copy another
+// account's E2EE private keys into this account's file. E2EE key material is migrated
+// explicitly via migrateOwnE2EEKeys after login resolves the account MID.
+function createStorage(accountId?: string): FileStorage {
+  const dir = lineStorageDir()
+  const fileName = accountId ? `${accountId}.json` : 'default.json'
+  return new FileStorage(join(dir, fileName))
 }
 
 export class LineClient {
@@ -130,7 +135,7 @@ export class LineClient {
       this.client = client
 
       const profile = await client.base.talk.getProfile()
-      createStorage(profile.mid)
+      await this.persistAccountE2EEKeys(client, profile.mid)
       const now = new Date().toISOString()
 
       await this.credManager.setAccount({
@@ -176,7 +181,7 @@ export class LineClient {
       this.client = client
 
       const profile = await client.base.talk.getProfile()
-      createStorage(profile.mid)
+      await this.persistAccountE2EEKeys(client, profile.mid)
       const now = new Date().toISOString()
 
       await this.credManager.setAccount({
@@ -214,9 +219,35 @@ export class LineClient {
       const storage = createStorage(creds.account_id)
 
       this.client = await linejsLoginWithAuthToken(creds.auth_token, { device, storage })
+      await this.repairSelfE2EEKey(this.client, creds.account_id)
       return this
     } catch (error) {
       throw wrapError(error, 'login_failed')
+    }
+  }
+
+  // A fresh QR/email login writes E2EE keys into the shared default store. Copy only
+  // this account's verified key material into its isolated per-account store so token
+  // logins (which read the per-account store) can later encrypt for E2EE chats.
+  private async persistAccountE2EEKeys(client: Client, mid: string): Promise<void> {
+    try {
+      const advertised = await client.base.talk.getE2EEPublicKeys().catch(() => undefined)
+      const target = createStorage(mid)
+      await migrateOwnE2EEKeys(client.base.storage, target, mid, advertised)
+    } catch (error) {
+      warnDegraded('persist account E2EE keys', error)
+    }
+  }
+
+  // Token sessions don't perform an E2EE handshake, so getE2EESelfKeyData can't find
+  // a key under the account MID even when the keyId-addressed key already exists in
+  // storage. Promote it to the MID address, trusting only server-advertised keyIds.
+  private async repairSelfE2EEKey(client: Client, mid: string): Promise<void> {
+    try {
+      const advertised = await client.base.talk.getE2EEPublicKeys().catch(() => undefined)
+      await ensureSelfKeyForMid(client.base.storage, mid, advertised)
+    } catch (error) {
+      warnDegraded('repair self E2EE key', error)
     }
   }
 
@@ -360,21 +391,84 @@ export class LineClient {
         },
       })
 
-      return (rawMessages ?? []).map((msg) => {
-        const decryptionError = getUndecryptableMessageError(msg)
-        return {
-          message_id: String(msg.id),
-          chat_id: chatId,
-          author_id: String(msg.from ?? ''),
-          text: msg.text || null,
-          ...(decryptionError && { decryption_error: decryptionError }),
-          content_type: String(msg.contentType ?? 'NONE'),
-          sent_at: new Date(Number(msg.createdTime)).toISOString(),
-        }
-      })
+      const messages = rawMessages ?? []
+      const authorNames = await this.resolveAuthorNames(client, messages)
+
+      return await Promise.all(
+        messages.map(async (msg) => {
+          const { text, decryptionError } = await this.decryptMessageText(client, msg)
+          const authorId = String(msg.from ?? '')
+          const authorName = authorNames.get(authorId)
+          return {
+            message_id: String(msg.id),
+            chat_id: chatId,
+            author_id: authorId,
+            ...(authorName && { author_name: authorName }),
+            text,
+            ...(decryptionError && { decryption_error: decryptionError }),
+            content_type: String(msg.contentType ?? 'NONE'),
+            sent_at: new Date(Number(msg.createdTime)).toISOString(),
+          }
+        }),
+      )
     } catch (error) {
       throw wrapError(error, 'get_messages_failed')
     }
+  }
+
+  // getPreviousMessagesV2WithRequest returns Letter-Sealing messages as encrypted
+  // chunks with null text, so they must be decrypted with the same path streamEvents
+  // uses. Plain messages already carry text and skip decryption.
+  private async decryptMessageText(
+    client: Client,
+    msg: VendorMessage,
+  ): Promise<{ text: string | null; decryptionError?: LineDecryptionError }> {
+    if (!isEncryptedChunkMessage(msg)) {
+      return { text: msg.text || null }
+    }
+
+    try {
+      const decrypted = await client.base.e2ee.decryptE2EEMessage(msg)
+      return { text: decrypted.text ?? null }
+    } catch (error) {
+      return { text: null, decryptionError: getDecryptionError(error) }
+    }
+  }
+
+  // getContacts doesn't return the current user, so self-authored messages need
+  // getProfile separately. Lookups degrade to bare MIDs rather than failing.
+  private async resolveAuthorNames(
+    client: Client,
+    messages: ReadonlyArray<{ from?: unknown }>,
+  ): Promise<Map<string, string>> {
+    const names = new Map<string, string>()
+    const authorMids = [...new Set(messages.map((m) => String(m.from ?? '')).filter((mid) => mid.length > 0))]
+    if (authorMids.length === 0) return names
+
+    const selfMid = client.base.profile?.mid
+    const contactMids = authorMids.filter((mid) => mid !== selfMid)
+
+    if (contactMids.length > 0) {
+      try {
+        const contacts = await client.base.talk.getContacts({ mids: contactMids })
+        for (const contact of contacts ?? []) {
+          if (contact.displayName) names.set(contact.mid, contact.displayName)
+        }
+      } catch (error) {
+        warnDegraded('resolve message author names', error)
+      }
+    }
+
+    if (selfMid && authorMids.includes(selfMid) && !names.has(selfMid)) {
+      try {
+        const profile = await client.base.talk.getProfile()
+        if (profile.displayName) names.set(selfMid, profile.displayName)
+      } catch (error) {
+        warnDegraded('resolve own display name', error)
+      }
+    }
+
+    return names
   }
 
   async sendMessage(chatId: string, text: string): Promise<LineSendResult> {

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -428,7 +428,7 @@ export class LineClient {
     }
 
     try {
-      const decrypted = await client.base.e2ee.decryptE2EEMessage(msg)
+      const decrypted = await client.base.e2ee.decryptE2EEMessage(normalizeE2EEMetadata(msg))
       return { text: decrypted.text ?? null }
     } catch (error) {
       return { text: null, decryptionError: getDecryptionError(error) }
@@ -602,6 +602,16 @@ function isEncryptedChunkMessage(raw: unknown): boolean {
   const message = raw as { chunks?: unknown; contentMetadata?: unknown; metadata?: unknown }
   if (!Array.isArray(message.chunks) || message.chunks.length === 0) return false
   return hasE2EEMetadata(message.contentMetadata) || hasE2EEMetadata(message.metadata)
+}
+
+// decryptE2EEMessage reads messageObj.contentMetadata.e2eeVersion unconditionally.
+// History messages from getPreviousMessagesV2WithRequest may carry E2EE metadata
+// only under `metadata`, which would crash the decryptor on undefined.e2eeVersion.
+function normalizeE2EEMetadata<T extends VendorMessage>(msg: T): T {
+  const m = msg as { contentMetadata?: unknown; metadata?: unknown }
+  if (hasE2EEMetadata(m.contentMetadata)) return msg
+  if (!hasE2EEMetadata(m.metadata)) return msg
+  return { ...msg, contentMetadata: m.metadata }
 }
 
 function hasE2EEMetadata(raw: unknown): boolean {

--- a/src/platforms/line/e2ee-storage.test.ts
+++ b/src/platforms/line/e2ee-storage.test.ts
@@ -69,6 +69,17 @@ describe('ensureSelfKeyForMid', () => {
     expect(store.data['e2eeKeys:midA']).toBeUndefined()
   })
 
+  it('rejects a payload whose own keyId does not match the advertised slot', async () => {
+    // given: the slot e2eeKeys:100 holds a payload that claims keyId 999
+    const mislabeled = { keyId: 999, privKey: 'privX', pubKey: 'pubX', e2eeVersion: 2 }
+    const store = memStore({ 'e2eeKeys:100': JSON.stringify(mislabeled) })
+
+    const ok = await ensureSelfKeyForMid(store, 'midA', [{ keyId: 100 }])
+
+    expect(ok).toBe(false)
+    expect(store.data['e2eeKeys:midA']).toBeUndefined()
+  })
+
   it('returns false when no keys exist', async () => {
     const store = memStore()
     expect(await ensureSelfKeyForMid(store, 'midA', [{ keyId: 100 }])).toBe(false)
@@ -118,6 +129,18 @@ describe('migrateOwnE2EEKeys', () => {
 
     expect(count).toBe(0)
     expect(Object.keys(target.data)).toHaveLength(0)
+  })
+
+  it('skips a payload whose own keyId does not match the advertised slot', async () => {
+    const mislabeled = { keyId: 999, privKey: 'privX', pubKey: 'pubX', e2eeVersion: 2 }
+    const source = memStore({ 'e2eeKeys:100': JSON.stringify(mislabeled), 'e2eePublicKeys:100': 'blob' })
+    const target = memStore()
+
+    const count = await migrateOwnE2EEKeys(source, target, 'midA', [{ keyId: 100 }])
+
+    expect(count).toBe(0)
+    expect(target.data['e2eeKeys:100']).toBeUndefined()
+    expect(target.data['e2eePublicKeys:100']).toBeUndefined()
   })
 
   it('ignores malformed key entries', async () => {

--- a/src/platforms/line/e2ee-storage.test.ts
+++ b/src/platforms/line/e2ee-storage.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'bun:test'
+
+import { ensureSelfKeyForMid, migrateOwnE2EEKeys } from './e2ee-storage'
+
+function memStore(initial: Record<string, string> = {}) {
+  const data: Record<string, string> = { ...initial }
+  return {
+    data,
+    async get(key: string) {
+      return data[key]
+    },
+    async set(key: string, value: string) {
+      data[key] = value
+    },
+    async getAll() {
+      return { ...data }
+    },
+  }
+}
+
+const SELF_A = { keyId: 100, privKey: 'privA', pubKey: 'pubA', e2eeVersion: 2 }
+const SELF_B = { keyId: 200, privKey: 'privB', pubKey: 'pubB', e2eeVersion: 2 }
+
+describe('ensureSelfKeyForMid', () => {
+  it('keeps an existing MID-addressed self-key', async () => {
+    const store = memStore({ 'e2eeKeys:midA': JSON.stringify(SELF_A) })
+
+    const ok = await ensureSelfKeyForMid(store, 'midA', [{ keyId: 100 }])
+
+    expect(ok).toBe(true)
+    expect(JSON.parse(store.data['e2eeKeys:midA'])).toMatchObject({ privKey: 'privA' })
+  })
+
+  it('promotes a keyId-addressed self-key when the server advertises that keyId', async () => {
+    const store = memStore({ 'e2eeKeys:100': JSON.stringify(SELF_A) })
+
+    const ok = await ensureSelfKeyForMid(store, 'midA', [{ keyId: 100 }])
+
+    expect(ok).toBe(true)
+    expect(JSON.parse(store.data['e2eeKeys:midA'])).toMatchObject({ privKey: 'privA' })
+  })
+
+  it('supports the array-shaped public key (keyId at index 2)', async () => {
+    const store = memStore({ 'e2eeKeys:100': JSON.stringify(SELF_A) })
+
+    const ok = await ensureSelfKeyForMid(store, 'midA', [[undefined, undefined, 100] as never])
+
+    expect(ok).toBe(true)
+  })
+
+  it('never promotes a foreign-MID-addressed key (no advertised match)', async () => {
+    // given: storage contaminated with another account's self-key under its MID
+    const store = memStore({ 'e2eeKeys:midB': JSON.stringify(SELF_B) })
+
+    // when: account A has no advertised keyId matching any stored key
+    const ok = await ensureSelfKeyForMid(store, 'midA', [{ keyId: 999 }])
+
+    // then: A's MID key is not created from B's material
+    expect(ok).toBe(false)
+    expect(store.data['e2eeKeys:midA']).toBeUndefined()
+  })
+
+  it('never promotes a keyId key the server did not advertise for this account', async () => {
+    const store = memStore({ 'e2eeKeys:200': JSON.stringify(SELF_B) })
+
+    const ok = await ensureSelfKeyForMid(store, 'midA', [{ keyId: 100 }])
+
+    expect(ok).toBe(false)
+    expect(store.data['e2eeKeys:midA']).toBeUndefined()
+  })
+
+  it('returns false when no keys exist', async () => {
+    const store = memStore()
+    expect(await ensureSelfKeyForMid(store, 'midA', [{ keyId: 100 }])).toBe(false)
+  })
+
+  it('returns false for an empty mid', async () => {
+    const store = memStore({ 'e2eeKeys:100': JSON.stringify(SELF_A) })
+    expect(await ensureSelfKeyForMid(store, '', [{ keyId: 100 }])).toBe(false)
+  })
+})
+
+describe('migrateOwnE2EEKeys', () => {
+  it('copies only the advertised keyId material into the target', async () => {
+    const source = memStore({
+      'e2eeKeys:100': JSON.stringify(SELF_A),
+      'e2eePublicKeys:100': 'pubkey-blob-A',
+      'e2eeKeys:200': JSON.stringify(SELF_B),
+      'e2eePublicKeys:200': 'pubkey-blob-B',
+    })
+    const target = memStore()
+
+    const count = await migrateOwnE2EEKeys(source, target, 'midA', [{ keyId: 100 }])
+
+    expect(count).toBe(1)
+    expect(JSON.parse(target.data['e2eeKeys:100'])).toMatchObject({ privKey: 'privA' })
+    expect(target.data['e2eePublicKeys:100']).toBe('pubkey-blob-A')
+    // foreign account B keys must not leak across
+    expect(target.data['e2eeKeys:200']).toBeUndefined()
+    expect(target.data['e2eePublicKeys:200']).toBeUndefined()
+  })
+
+  it('copies the MID-addressed self-key when present', async () => {
+    const source = memStore({ 'e2eeKeys:midA': JSON.stringify(SELF_A) })
+    const target = memStore()
+
+    const count = await migrateOwnE2EEKeys(source, target, 'midA', [])
+
+    expect(count).toBe(1)
+    expect(JSON.parse(target.data['e2eeKeys:midA'])).toMatchObject({ privKey: 'privA' })
+  })
+
+  it('migrates nothing when only foreign keys are present', async () => {
+    const source = memStore({ 'e2eeKeys:midB': JSON.stringify(SELF_B), 'e2eeKeys:200': JSON.stringify(SELF_B) })
+    const target = memStore()
+
+    const count = await migrateOwnE2EEKeys(source, target, 'midA', [{ keyId: 100 }])
+
+    expect(count).toBe(0)
+    expect(Object.keys(target.data)).toHaveLength(0)
+  })
+
+  it('ignores malformed key entries', async () => {
+    const source = memStore({ 'e2eeKeys:100': 'not-json', 'e2eeKeys:midA': '{"keyId":1}' })
+    const target = memStore()
+
+    const count = await migrateOwnE2EEKeys(source, target, 'midA', [{ keyId: 100 }])
+
+    expect(count).toBe(0)
+  })
+})

--- a/src/platforms/line/e2ee-storage.ts
+++ b/src/platforms/line/e2ee-storage.ts
@@ -1,0 +1,112 @@
+export interface E2EEKeyStore {
+  get(key: string): Promise<unknown> | unknown
+  set(key: string, value: string): Promise<void> | void
+}
+
+export interface E2EEKeyData {
+  keyId: number | string
+  privKey: string
+  pubKey: string
+  e2eeVersion?: number
+}
+
+export type E2EEPublicKey = { keyId?: number | string } | ReadonlyArray<unknown>
+
+const SELF_KEY_PREFIX = 'e2eeKeys:'
+
+function selfKey(id: number | string): string {
+  return `${SELF_KEY_PREFIX}${id}`
+}
+
+function isE2EEKeyData(value: unknown): value is E2EEKeyData {
+  if (!value || typeof value !== 'object') return false
+  const data = value as Partial<E2EEKeyData>
+  return typeof data.privKey === 'string' && typeof data.pubKey === 'string'
+}
+
+function parseKeyData(raw: unknown): E2EEKeyData | null {
+  if (typeof raw !== 'string') return isE2EEKeyData(raw) ? raw : null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return isE2EEKeyData(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function keyIdOf(key: E2EEPublicKey): number | string | undefined {
+  if (Array.isArray(key)) {
+    const id = key[2]
+    return typeof id === 'number' || typeof id === 'string' ? id : undefined
+  }
+  const id = (key as { keyId?: number | string }).keyId
+  return typeof id === 'number' || typeof id === 'string' ? id : undefined
+}
+
+function advertisedKeyIds(keys: ReadonlyArray<E2EEPublicKey> | undefined): Array<number | string> {
+  if (!keys) return []
+  const ids: Array<number | string> = []
+  for (const key of keys) {
+    const id = keyIdOf(key)
+    if (id !== undefined) ids.push(id)
+  }
+  return ids
+}
+
+// Ensures the account's own self-key is addressable by MID for getE2EESelfKeyData,
+// which checks `e2eeKeys:<mid>` before falling back to a live Thrift channel. The
+// keyId-addressed entry is only trusted when the server advertises that exact keyId
+// for this account, so a contaminated store (another account's key copied in) can
+// never promote a foreign private key to this MID. Returns true when a self-key
+// becomes available under the MID.
+export async function ensureSelfKeyForMid(
+  storage: E2EEKeyStore,
+  mid: string,
+  advertisedKeys: ReadonlyArray<E2EEPublicKey> | undefined,
+): Promise<boolean> {
+  if (!mid) return false
+
+  const existing = parseKeyData(await storage.get(selfKey(mid)))
+  if (existing) return true
+
+  for (const keyId of advertisedKeyIds(advertisedKeys)) {
+    const candidate = parseKeyData(await storage.get(selfKey(keyId)))
+    if (candidate) {
+      await storage.set(selfKey(mid), JSON.stringify(candidate))
+      return true
+    }
+  }
+
+  return false
+}
+
+// Copies only this account's E2EE key material out of a shared (default) store into
+// an isolated per-account store. Trust is anchored to the server-advertised keyIds
+// for `mid`, so foreign-account keys present in the shared store are never carried
+// over. Used right after a fresh login resolves the account MID.
+export async function migrateOwnE2EEKeys(
+  source: E2EEKeyStore,
+  target: E2EEKeyStore,
+  mid: string,
+  advertisedKeys: ReadonlyArray<E2EEPublicKey> | undefined,
+): Promise<number> {
+  if (!mid) return 0
+
+  let migrated = 0
+  const own = parseKeyData(await source.get(selfKey(mid)))
+  if (own) {
+    await target.set(selfKey(mid), JSON.stringify(own))
+    migrated++
+  }
+
+  for (const keyId of advertisedKeyIds(advertisedKeys)) {
+    const data = parseKeyData(await source.get(selfKey(keyId)))
+    if (!data) continue
+    await target.set(selfKey(keyId), JSON.stringify(data))
+    migrated++
+    const publicKey = await source.get(`e2eePublicKeys:${keyId}`)
+    if (typeof publicKey === 'string') await target.set(`e2eePublicKeys:${keyId}`, publicKey)
+  }
+
+  return migrated
+}

--- a/src/platforms/line/e2ee-storage.ts
+++ b/src/platforms/line/e2ee-storage.ts
@@ -34,6 +34,13 @@ function parseKeyData(raw: unknown): E2EEKeyData | null {
   }
 }
 
+// The stored payload carries its own keyId. Requiring it to equal the slot it was
+// read from rejects entries mislabeled under an advertised keyId, so only a payload
+// genuinely belonging to that keyId is ever trusted.
+function keyDataMatchesSlot(data: E2EEKeyData, keyId: number | string): boolean {
+  return String(data.keyId) === String(keyId)
+}
+
 function keyIdOf(key: E2EEPublicKey): number | string | undefined {
   if (Array.isArray(key)) {
     const id = key[2]
@@ -71,7 +78,7 @@ export async function ensureSelfKeyForMid(
 
   for (const keyId of advertisedKeyIds(advertisedKeys)) {
     const candidate = parseKeyData(await storage.get(selfKey(keyId)))
-    if (candidate) {
+    if (candidate && keyDataMatchesSlot(candidate, keyId)) {
       await storage.set(selfKey(mid), JSON.stringify(candidate))
       return true
     }
@@ -101,7 +108,7 @@ export async function migrateOwnE2EEKeys(
 
   for (const keyId of advertisedKeyIds(advertisedKeys)) {
     const data = parseKeyData(await source.get(selfKey(keyId)))
-    if (!data) continue
+    if (!data || !keyDataMatchesSlot(data, keyId)) continue
     await target.set(selfKey(keyId), JSON.stringify(data))
     migrated++
     const publicKey = await source.get(`e2eePublicKeys:${keyId}`)

--- a/src/tui/adapters/line-adapter.ts
+++ b/src/tui/adapters/line-adapter.ts
@@ -37,7 +37,7 @@ export class LineAdapter implements PlatformAdapter {
     return messages.map((msg) => ({
       id: msg.message_id,
       channelId,
-      author: msg.author_id ?? 'unknown',
+      author: msg.author_name ?? msg.author_id ?? 'unknown',
       content: msg.text ?? '',
       timestamp: msg.sent_at,
     }))


### PR DESCRIPTION
## Summary

LINE Letter-Sealing (E2EE) chats were broken in two directions: messages **failed to send** with `E2EE Key has not been saved`, and when they did arrive they **rendered blank** in the TUI/CLI. This PR fixes the full round trip and also resolves author display names.

The symptom was telling: sends to the **LINE official account worked** (not E2EE) but sends to a **real human failed** (E2EE-required). Three distinct root causes, all in the LINE platform layer.

## Root Causes & Fixes

### 1. Storage cross-contamination (key isolation)

`createStorage()` blind-copied `default.json` — which holds **another account's E2EE private keys** — into each per-account store. A token session then couldn't locate its own self-key, and worse, a foreign private key sat in the file.

**Fix:** Stop the blind copy. After a fresh QR/email login resolves the account MID, migrate **only this account's** key material, trust-anchored to the `keyId`s the server advertises via `getE2EEPublicKeys()`. A foreign private key can never be promoted.

### 2. Token sessions never provisioned E2EE keys (restoration)

`loginWithAuthToken` performs no E2EE handshake, so `getE2EESelfKeyData` couldn't find a key under the account MID even when the `keyId`-addressed key already existed in storage.

**Fix:** A repair step on token login promotes the `keyId`-addressed self-key to the MID address — again trusting **only** server-advertised `keyId`s, so contaminated storage can't leak another account's key.

### 3. Read path never decrypted Letter-Sealing messages (blank messages)

`getMessages()` returned encrypted chunks with `null` text because it never decrypted them — unlike `streamEvents`, which did.

**Fix:** `getMessages()` now decrypts E2EE messages through the same path `streamEvents` uses, falling back to `missing_e2ee_key` only when keys are genuinely absent. Plain messages skip decryption.

### Bonus: author display names

`getMessages()` now resolves author MIDs to display names (batch `getContacts`, plus `getProfile` for the current user since `getContacts` omits self), so the TUI and CLI show names instead of raw `u<32hex>` IDs.

## Security Notes

The key-isolation and key-restoration logic lives in a new, dedicated `e2ee-storage.ts` module with a hard invariant: **a private key is trusted only when the server advertises its `keyId` for this account.** Arbitrary stored `e2eeKeys:*` entries are never enumerated or trusted. This was reviewed against the cross-account leak failure mode and is covered by explicit tests.

## Changes

- `src/platforms/line/e2ee-storage.ts` *(new)* — `migrateOwnE2EEKeys`, `ensureSelfKeyForMid`
- `src/platforms/line/e2ee-storage.test.ts` *(new)* — account-isolation & leak-prevention invariants
- `src/platforms/line/client.ts` — isolated `createStorage`, post-login key migration, token-login repair, `getMessages` decryption + author-name resolution
- `src/platforms/line/client.test.ts` — decryption + author-name tests
- `src/tui/adapters/line-adapter.ts` — render `author_name` (fallback to MID)

## Testing

- `bun run lint` — 0 warnings/errors
- `bun run format:check` — clean
- `bun typecheck` — clean
- `bun run test` — **3065 passed**, 0 failed
- Manual end-to-end (local account): send to E2EE human chat succeeds; `getMessages` returns decrypted text with resolved author names; no `missing_e2ee_key`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LINE Letter-Sealing E2EE: sending to human chats works again, message history decrypts (including history chunks), and author names show in the TUI/CLI.

- **Bug Fixes**
  - Isolated per-account storage; stopped copying `default.json`; migrate only this account’s keys based on server‑advertised keyIds to prevent cross‑account leaks.
  - On token login, restore the self‑key by promoting the keyId entry to the MID when advertised; validates that the payload’s own keyId matches the slot to prevent mislabeled keys.
  - `getMessages()` decrypts Letter‑Sealing messages, normalizes history metadata to `contentMetadata` before decrypting, and only surfaces `missing_e2ee_key` when keys are truly absent.
  - Resolves author names via batched `getContacts` and `getProfile` for self; TUI shows names instead of raw MIDs.

- **Migration**
  - No manual steps. Fresh logins migrate keys; token sessions auto‑repair on next run.
  - Docs updated: `docs/cli/line.mdx`, `skills/agent-line/SKILL.md`, and `skills/agent-line/references/common-patterns.md` now document E2EE decryption, `author_name`, and `decryption_error`.

<sup>Written for commit c594a0da3f8adb04f07334a5d4184ff4fe67f28a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

