### PR TITLE
Keep plain LINE message text in streamEvents instead of force-decrypting

### DIFF
--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -358,8 +358,11 @@ describe('LineClient', () => {
       return out
     }
 
-    it('decrypts messages and emits event + message', async () => {
-      const op = { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me' } }
+    it('decrypts Letter-Sealing chunk messages and emits event + message', async () => {
+      const op = {
+        type: 'RECEIVE_MESSAGE',
+        message: { id: '1', from: 'u1', to: 'me', chunks: ['a', 'b'], metadata: { e2eeMark: '2', e2eeVersion: '2' } },
+      }
       const client = clientWithStream([op], async () => ({ id: '1', from: 'u1', to: 'me', text: 'hello' }))
 
       const events = await collect(client)
@@ -368,9 +371,29 @@ describe('LineClient', () => {
       expect(msg.message.text).toBe('hello')
     })
 
+    it('keeps a plain message text without decrypting it', async () => {
+      // given: a plain (non-Letter-Sealing) message that already carries text and
+      // has no E2EE chunks — decrypt MUST NOT run, mirroring the history path
+      const op = { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me', text: 'plain hi' } }
+      let decryptCalls = 0
+      const client = clientWithStream([op], async (m) => {
+        decryptCalls++
+        return m
+      })
+
+      const events = await collect(client)
+      const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
+      expect(decryptCalls).toBe(0)
+      expect(msg.message.text).toBe('plain hi')
+      expect(msg.message.decryption_error).toBeUndefined()
+    })
+
     it('keeps streaming when E2EE decryption fails (no reconnect loop)', async () => {
       const ops = [
-        { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me', text: 'plain-on-raw' } },
+        {
+          type: 'RECEIVE_MESSAGE',
+          message: { id: '1', from: 'u1', to: 'me', chunks: ['a', 'b'], metadata: { e2eeMark: '2', e2eeVersion: '2' } },
+        },
         { type: 'NOTIFIED_READ_MESSAGE' },
       ]
       const client = clientWithStream(ops, async () => {
@@ -386,7 +409,10 @@ describe('LineClient', () => {
     })
 
     it('marks missing E2EE key failures explicitly', async () => {
-      const op = { type: 'RECEIVE_MESSAGE', message: { id: '1', from: 'u1', to: 'me' } }
+      const op = {
+        type: 'RECEIVE_MESSAGE',
+        message: { id: '1', from: 'u1', to: 'me', chunks: ['a', 'b'], metadata: { e2eeMark: '2', e2eeVersion: '2' } },
+      }
       const client = clientWithStream([op], async () => {
         throw new Error('NoE2EEKey: E2EE Key has not been saved')
       })

--- a/src/platforms/line/client.test.ts
+++ b/src/platforms/line/client.test.ts
@@ -361,7 +361,13 @@ describe('LineClient', () => {
     it('decrypts Letter-Sealing chunk messages and emits event + message', async () => {
       const op = {
         type: 'RECEIVE_MESSAGE',
-        message: { id: '1', from: 'u1', to: 'me', chunks: ['a', 'b'], metadata: { e2eeMark: '2', e2eeVersion: '2' } },
+        message: {
+          id: '1',
+          from: 'u1',
+          to: 'me',
+          chunks: ['a', 'b'],
+          contentMetadata: { e2eeMark: '2', e2eeVersion: '2' },
+        },
       }
       const client = clientWithStream([op], async () => ({ id: '1', from: 'u1', to: 'me', text: 'hello' }))
 
@@ -369,6 +375,25 @@ describe('LineClient', () => {
       expect(events.map((e) => e.kind)).toEqual(['event', 'message'])
       const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
       expect(msg.message.text).toBe('hello')
+    })
+
+    it('normalizes metadata-only E2EE messages to contentMetadata before decrypting', async () => {
+      // given: an encrypted message whose E2EE metadata lives under `metadata`
+      // (not `contentMetadata`); the vendor decryptor reads contentMetadata
+      // unconditionally, so it must be normalized first — same as the history path
+      const op = {
+        type: 'RECEIVE_MESSAGE',
+        message: { id: '1', from: 'u1', to: 'me', chunks: ['a', 'b'], metadata: { e2eeMark: '2', e2eeVersion: '2' } },
+      }
+      const client = clientWithStream([op], async (m) => {
+        const meta = (m as { contentMetadata?: { e2eeVersion?: string } }).contentMetadata
+        return { id: '1', from: 'u1', to: 'me', text: `v${meta?.e2eeVersion}` }
+      })
+
+      const events = await collect(client)
+      const msg = events[1] as Extract<LineRawEvent, { kind: 'message' }>
+      expect(msg.message.text).toBe('v2')
+      expect(msg.message.decryption_error).toBeUndefined()
     })
 
     it('keeps a plain message text without decrypting it', async () => {

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -548,7 +548,7 @@ export class LineClient {
         let decryptionError: LineDecryptionError | undefined
         if (isEncryptedChunkMessage(op.message)) {
           try {
-            raw = await client.base.e2ee.decryptE2EEMessage(op.message)
+            raw = await client.base.e2ee.decryptE2EEMessage(normalizeE2EEMetadata(op.message))
           } catch (error) {
             raw = op.message
             decrypted = false

--- a/src/platforms/line/client.ts
+++ b/src/platforms/line/client.ts
@@ -533,6 +533,12 @@ export class LineClient {
     })) {
       yield { kind: 'event', op }
       if (op.type === 'SEND_MESSAGE' || op.type === 'RECEIVE_MESSAGE') {
+        // Plain messages already carry their text and must skip decryption, same
+        // as the history path (decryptMessageText). Force-decrypting a plain op
+        // returns an object without `.text`, silently dropping the message to
+        // null text with no decryption_error — indistinguishable from an empty
+        // message downstream.
+        //
         // A single undecryptable message must not kill the stream: the failing
         // op stays in the sync window and would be re-fetched every poll, causing
         // an endless decrypt-fail -> reconnect loop. Fall back to the raw op and
@@ -540,12 +546,14 @@ export class LineClient {
         let raw = op.message
         let decrypted = true
         let decryptionError: LineDecryptionError | undefined
-        try {
-          raw = await client.base.e2ee.decryptE2EEMessage(op.message)
-        } catch (error) {
-          raw = op.message
-          decrypted = false
-          decryptionError = getDecryptionError(error)
+        if (isEncryptedChunkMessage(op.message)) {
+          try {
+            raw = await client.base.e2ee.decryptE2EEMessage(op.message)
+          } catch (error) {
+            raw = op.message
+            decrypted = false
+            decryptionError = getDecryptionError(error)
+          }
         }
         decryptionError ??= getUndecryptableMessageError(raw)
         yield {


### PR DESCRIPTION
## Problem

Inbound LINE messages from real human DMs were surfaced by the real-time listener `streamEvents` with text: null and no decryption error, making them indistinguishable from genuinely empty messages.

Downstream consumers such as typeclaw's LINE channel adapter then dropped these real messages as empty_text. The repeated production symptom was content_type=NONE, text_len=0, attachments=0, with no decryption error.

## Root cause

The live streamEvents path called `decryptE2EEMessage` unconditionally on every SEND_MESSAGE or RECEIVE_MESSAGE op.

The history path already guarded plain messages in `decryptMessageText`, so plain non-Letter-Sealing messages returned their original text directly. The live path lacked that guard.

For a plain text message, force-decryption returns a decrypted-shaped object without a text field. That made the event text null, and because the object was no longer an encrypted chunk, no decryption_error was attached. Result: a real text message silently became empty.

## Fix

Guard the decrypt call in streamEvents with `isEncryptedChunkMessage`, mirroring the history path. Only Letter-Sealing chunk messages are decrypted, and plain messages keep their original text.

This completes the live-path side left after #224 and #219. The history path already guarded plain messages, while the real-time streamEvents path did not.

Encrypted-message decryption and the decrypt-failure or missing-key paths remain unchanged.

## Testing

- Add a regression test proving a plain message with text and no E2EE chunks is not decrypted, keeps its text, and has no decryption_error.
- Fix three existing streamEvents tests whose fixtures lacked the E2EE chunks and metadata needed to actually exercise the decrypt path.
- Full LINE suite passes with 139 tests.
- Full repo suite passes with 3076 tests.
- Lint and typecheck are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes real-time LINE message handling by skipping decryption for plain messages and normalizing E2EE metadata before decrypting. Restores human DM text and avoids spurious decryption errors in `streamEvents`.

- **Bug Fixes**
  - Decrypt only Letter-Sealing chunk messages using `isEncryptedChunkMessage`; plain messages keep their text.
  - Normalize metadata-only E2EE messages to `contentMetadata` before decrypting to match decryptor expectations.
  - Decryption failure handling unchanged; errors are surfaced and streaming continues.
  - Tests: added regressions for plain messages and metadata-only E2EE; updated `streamEvents` tests to include proper chunks/metadata.

- **Migration**
  - No changes. `SKILL.md` and docs remain unchanged.

<sup>Written for commit 7ef009425441f4af9fec744b12f768e5f4c17e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

