### PR TITLE
Stream realtime LINE messages in the TUI

### DIFF
--- a/src/tui/adapters/line-adapter.ts
+++ b/src/tui/adapters/line-adapter.ts
@@ -1,5 +1,7 @@
 import { LineClient } from '@/platforms/line/client'
 import { LineCredentialManager } from '@/platforms/line/credential-manager'
+import { LineListener } from '@/platforms/line/listener'
+import type { LinePushMessageEvent } from '@/platforms/line/types'
 
 import type { AuthHint, AuthIO, PlatformAdapter, UnifiedChannel, UnifiedMessage, Workspace } from './types'
 
@@ -7,6 +9,7 @@ export class LineAdapter implements PlatformAdapter {
   readonly name = 'LINE'
 
   private client: LineClient | null = null
+  private listener: LineListener | null = null
   private credManager = new LineCredentialManager()
   private currentAccount: Workspace | null = null
 
@@ -48,6 +51,28 @@ export class LineAdapter implements PlatformAdapter {
     await client.sendMessage(channelId, text)
   }
 
+  async startListening(onMessage: (msg: UnifiedMessage) => void): Promise<void> {
+    const client = this.ensureClient()
+    const listener = new LineListener(client)
+    await listener.start()
+    listener.on('message', (event: LinePushMessageEvent) => {
+      if (event.text === null) return
+      onMessage({
+        id: event.message_id,
+        channelId: event.chat_id,
+        author: event.author_id || 'unknown',
+        content: event.text,
+        timestamp: event.sent_at,
+      })
+    })
+    this.listener = listener
+  }
+
+  stopListening(): void {
+    this.listener?.stop()
+    this.listener = null
+  }
+
   async getWorkspaces(): Promise<Workspace[]> {
     const accounts = await this.credManager.listAccounts()
     return accounts.map((acct) => ({
@@ -57,6 +82,7 @@ export class LineAdapter implements PlatformAdapter {
   }
 
   async switchWorkspace(accountId: string): Promise<void> {
+    this.stopListening()
     const creds = await this.credManager.getAccount(accountId)
     if (!creds) throw new Error(`Account ${accountId} not found`)
 

--- a/src/tui/adapters/line-adapter.ts
+++ b/src/tui/adapters/line-adapter.ts
@@ -82,12 +82,14 @@ export class LineAdapter implements PlatformAdapter {
   }
 
   async switchWorkspace(accountId: string): Promise<void> {
-    this.stopListening()
     const creds = await this.credManager.getAccount(accountId)
     if (!creds) throw new Error(`Account ${accountId} not found`)
 
     const client = new LineClient()
     await client.login(creds)
+    // Persist the selected account so the listener's credential-less reconnects
+    // resolve this account instead of a stale current_account.
+    await this.credManager.setCurrentAccount(accountId)
     this.client = client
     this.currentAccount = { id: creds.account_id, name: creds.display_name ?? creds.account_id }
   }

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -647,6 +647,10 @@ export async function createApp(): Promise<void> {
         const ws = p.workspaces[selectedIndex]
         try {
           await p.adapter.switchWorkspace?.(ws.id)
+          if (p.listening) {
+            p.adapter.stopListening?.()
+            p.listening = false
+          }
           p.channels = null
           renderHeader()
         } catch {}

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -748,6 +748,10 @@ export async function createApp(): Promise<void> {
           p.adapter
             .switchWorkspace(workspace.id)
             .then(() => {
+              if (p.listening) {
+                p.adapter.stopListening?.()
+                p.listening = false
+              }
               p.channels = null
               p.workspaces = null
               renderHeader()


### PR DESCRIPTION
## Problem

LINE messages in `agent-messenger tui` did not update in realtime, while Slack and Discord already streamed live updates. Users had to refresh or reload before new LINE messages appeared.

## Root cause

The TUI realtime path is opt-in through the optional `startListening` method on a platform adapter. LineAdapter did not implement that method, so the guard in src/tui/app.ts skipped listener startup without error even though the LINE platform already had a reconnecting listener.

## Fix

Implement realtime listener lifecycle methods in `src/tui/adapters/line-adapter.ts`.

- Start a LINE listener from the logged-in client and subscribe to message events.
- Convert LINE push message events into unified TUI messages for rendering.
- Ignore events with null text so stickers and media do not appear as empty text messages.
- Stop the listener on explicit teardown and workspace switches to avoid keeping a stream open for the previous account.

## Testing

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun test` — 3077 pass, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable realtime LINE messages in the TUI by adding listener lifecycle support and syncing it on workspace switches. Users now see new LINE messages live without refreshing.

- **Bug Fixes**
  - Implemented `startListening`/`stopListening` in `LineAdapter` using `LineListener`.
  - Mapped `LinePushMessageEvent` to `UnifiedMessage`; ignored null-text events.
  - Persisted selected account in `switchWorkspace()` via `setCurrentAccount()` so reconnects authenticate to the correct account.
  - On workspace switch, `app.ts` now stops the listener and resets `p.listening` in both selection-mode and Ctrl+W picker paths; prevents leaks and dead realtime after switching.
  - SKILL.md/docs: no updates needed.

<sup>Written for commit 7ecb8bd376eee12b95c772dd811b71a558cbf18d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

