### PR TITLE
fix(webex): HTML-escape plain-text edit content to avoid sparkBase artifact

### DIFF
--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -714,6 +714,31 @@ describe('WebexClient', () => {
         expect(body.object.content).toBe('Edited text')
       })
 
+      it('plain text edit HTML-escapes content so bare URLs do not become sparkBase markup', async () => {
+        mockResponse(mockEditActivity('https://example.com/a?x=1&y=2'))
+
+        const client = await createExtractedClient()
+        await client.editMessage('activity-123', TEST_ROOM_ID, 'https://example.com/a?x=1&y=2')
+
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body.object.displayName).toBe('https://example.com/a?x=1&y=2')
+        expect(body.object.content).toBe('https://example.com/a?x=1&amp;y=2')
+        expect(body.object.content).not.toContain('&amp;amp;')
+        expect(body.object.content).not.toContain('<a ')
+        expect(body.object.content).not.toContain('onClick')
+        expect(body.object.content).not.toContain('sparkBase')
+      })
+
+      it('plain text edit escapes angle brackets and quotes in content', async () => {
+        mockResponse(mockEditActivity('a <b> "c" \'d\' & e'))
+
+        const client = await createExtractedClient()
+        await client.editMessage('activity-123', TEST_ROOM_ID, 'a <b> "c" \'d\' & e')
+
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body.object.content).toBe('a &lt;b&gt; &quot;c&quot; &#39;d&#39; &amp; e')
+      })
+
       it('clientTempId uses -edit suffix to match Webex web client format', async () => {
         mockResponse(mockEditActivity('Edited text'))
 

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -1,6 +1,6 @@
 import { WebexCredentialManager } from './credential-manager'
 import { WebexEncryptionService } from './encryption'
-import { markdownToHtml, stripMarkdown } from './markdown-to-html'
+import { escapeHtml, markdownToHtml, stripMarkdown } from './markdown-to-html'
 import type { WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './types'
 import { WebexError } from './types'
 
@@ -276,7 +276,7 @@ export class WebexClient {
     if (options?.markdown) {
       content = markdownToHtml(text)
     } else if (options?.forEdit) {
-      content = text
+      content = escapeHtml(text)
     }
 
     if (this.encryption) {

--- a/src/platforms/webex/markdown-to-html.ts
+++ b/src/platforms/webex/markdown-to-html.ts
@@ -184,7 +184,7 @@ function isSafeUrl(url: string): boolean {
   return SAFE_URL_PATTERN.test(url.trim())
 }
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   return value
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')


### PR DESCRIPTION
## Problem

Editing a Webex message without --markdown over the internal extracted-token API injected raw text into the HTML `object.content` field.

Because the internal API renders the content field as HTML, a bare URL was rewritten by the Webex web client into literal visible markup.

```html
<a ... onClick="sparkBase.clickEventHandler(event)">
```

The unescaped ampersand in a query string also broke HTML-entity rendering.

Repro: `agent-webex message edit <id> <space> "https://example.com/a?x=1&y=2"`.

## Root cause

In `buildEncryptedObject()`, the plain-text edit branch set raw text into an HTML field.

```ts
content = text
```

The send path leaves content undefined, which is fine. The markdown path runs markdownToHtml, which escapes and emits proper HTML, which is also fine. Only the plain-text edit path was wrong.

## Fix

HTML-escape content with the existing `escapeHtml` helper, now exported from markdown-to-html.ts.

```ts
content = escapeHtml(text)
```

## Context

The edit path must keep content non-empty to avoid the server auto-tombstoning the message. That behavior is guarded by the existing test named plain text edit populates both displayName and content to avoid auto-tombstone.

Dropping content would regress that behavior. Escaping keeps content non-empty, renders bare URLs as clean clickable text, and lets Webex apply its own safe URL detection without emitting onClick, alt, or sparkBase markup ourselves.

We deliberately do not pre-emit our own anchor tag for bare URLs. That would add URL-parsing and sanitizer surface for no benefit, because escaped plain text renders correctly.

## Result

Content for the sample URL is now escaped exactly once.

```html
https://example.com/a?x=1&amp;y=2
```

No anchor, onClick, or sparkBase artifact is emitted. Markdown edits, markdown sends, and the public-API path are unchanged.

## Testing

- Add a failing-first regression test asserting the escaped edit payload for a bare URL with query string.
- Add negative assertions against the raw anchor prefix.
- Add negative assertions against `onClick`.
- Add negative assertions against `sparkBase`.
- Add negative assertions against double-escaped `&amp;amp;`.
- Add an angle-bracket and quote escaping test.
- Mutation-verify that reverting the fix from `escapeHtml(text)` to raw text fails exactly these two new tests.
- `bun test` — 3079 pass, 0 fail.
- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.

## Review Notes

Please verify that the fix stays scoped to the internal Webex plain-text edit payload and does not change markdown edit, send, or public-API behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes plain-text Webex edit content so bare URLs don’t become sparkBase anchor markup and ampersands render correctly. Only affects the internal edit path; markdown edits/sends and the public API are unchanged. Docs/SKILL.md: no changes.

- **Bug Fixes**
  - Use `escapeHtml(text)` for plain-text edits (`forEdit`) to keep `content` non-empty and safe.
  - Export `escapeHtml` from `markdown-to-html.ts`; `markdownToHtml` and send/public API paths unchanged.
  - Add regression tests for URL ampersand handling, bracket/quote escaping, and negatives for `<a`, `onClick`, `sparkBase`, and double-escaping.

<sup>Written for commit ce850eddd0a5e3a9a9a3a16462ed99b35856d85f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

