### PR TITLE
fix(webex): fetch missing KMS keys on demand to encrypt E2E messages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "qrcode": "^1.5.4",
         "thrift": "^0.20.0",
         "tweetnacl": "^1.0.3",
+        "webex-message-handler": "^0.6.10",
         "ws": "^8.19.0",
         "zod": "^4.3.6",
       },
@@ -525,6 +526,34 @@
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
+    "lodash._arraycopy": ["lodash._arraycopy@3.0.0", "", {}, "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A=="],
+
+    "lodash._arrayeach": ["lodash._arrayeach@3.0.0", "", {}, "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ=="],
+
+    "lodash._baseassign": ["lodash._baseassign@3.2.0", "", { "dependencies": { "lodash._basecopy": "^3.0.0", "lodash.keys": "^3.0.0" } }, "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ=="],
+
+    "lodash._baseclone": ["lodash._baseclone@3.3.0", "", { "dependencies": { "lodash._arraycopy": "^3.0.0", "lodash._arrayeach": "^3.0.0", "lodash._baseassign": "^3.0.0", "lodash._basefor": "^3.0.0", "lodash.isarray": "^3.0.0", "lodash.keys": "^3.0.0" } }, "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q=="],
+
+    "lodash._basecopy": ["lodash._basecopy@3.0.1", "", {}, "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ=="],
+
+    "lodash._basefor": ["lodash._basefor@3.0.3", "", {}, "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A=="],
+
+    "lodash._bindcallback": ["lodash._bindcallback@3.0.1", "", {}, "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ=="],
+
+    "lodash._getnative": ["lodash._getnative@3.9.1", "", {}, "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA=="],
+
+    "lodash._isiterateecall": ["lodash._isiterateecall@3.0.9", "", {}, "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ=="],
+
+    "lodash.clone": ["lodash.clone@3.0.3", "", { "dependencies": { "lodash._baseclone": "^3.0.0", "lodash._bindcallback": "^3.0.0", "lodash._isiterateecall": "^3.0.0" } }, "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A=="],
+
+    "lodash.clonedeep": ["lodash.clonedeep@3.0.2", "", { "dependencies": { "lodash._baseclone": "^3.0.0", "lodash._bindcallback": "^3.0.0" } }, "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
+
+    "lodash.isarray": ["lodash.isarray@3.0.4", "", {}, "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ=="],
+
+    "lodash.keys": ["lodash.keys@3.1.2", "", { "dependencies": { "lodash._getnative": "^3.0.0", "lodash.isarguments": "^3.0.0", "lodash.isarray": "^3.0.0" } }, "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
@@ -572,6 +601,8 @@
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
     "node-jose": ["node-jose@2.2.0", "", { "dependencies": { "base64url": "^3.0.1", "buffer": "^6.0.3", "es6-promise": "^4.2.8", "lodash": "^4.17.21", "long": "^5.2.0", "node-forge": "^1.2.1", "pako": "^2.0.4", "process": "^0.11.10", "uuid": "^9.0.0" } }, "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw=="],
+
+    "node-kms": ["node-kms@0.4.1", "", { "dependencies": { "es6-promise": "^2.0.1", "lodash.clone": "^3.0.2", "lodash.clonedeep": "^3.0.1", "node-jose": "^2.2.0", "uuid": "^2.0.1" } }, "sha512-qhrfrsEPooJCTDPc8yPaLIu8rHGKrSngK/X9eZziM0RUnMY3PtKU8PHmG5JokeNw7wokW8/dKtwEH5I24oW5ew=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -719,11 +750,15 @@
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
+    "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "webex-message-handler": ["webex-message-handler@0.6.10", "", { "dependencies": { "node-jose": "^2.2.0", "node-kms": "^0.4.1", "undici": "^7.24.6", "uuid": "^11.1.0" } }, "sha512-7SO79EagduWMY/8cRViAyz3/Isvd5+l+nDT1+MPIviWbsYmlKF40vaOGuqFquIuwlgAiqw36Dgej3ZUE1y/74w=="],
 
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
@@ -755,6 +790,10 @@
 
     "libsignal/protobufjs": ["protobufjs@6.8.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.0", "@types/node": "^10.1.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw=="],
 
+    "node-kms/es6-promise": ["es6-promise@2.3.0", "", {}, "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="],
+
+    "node-kms/uuid": ["uuid@2.0.3", "", {}, "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg=="],
+
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "qified/hookified": ["hookified@2.1.1", "", {}, "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA=="],
@@ -762,6 +801,8 @@
     "thrift/ws": ["ws@5.2.4", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ=="],
 
     "tsc-alias/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
+    "webex-message-handler/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "@whiskeysockets/baileys/@hapi/boom/@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 

--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -40,7 +40,7 @@ This command:
 - Supported browsers: Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium
 - Supports `--browser-profile <path>` for agent-browser profiles, custom Chrome user data dirs, or portable browser profiles; repeatable and comma-separated values are accepted
 - Auto-extraction runs when no valid token is stored, so manual extraction is rarely needed
-- Messages are encrypted client-side (JWE/AES-256-GCM) when encryption keys are available; falls back to plaintext otherwise. Re-run `auth extract` to refresh keys for new conversations.
+- Messages are encrypted client-side (JWE/AES-256-GCM). Encryption keys are cached at extract time; for end-to-end encrypted conversations whose key is not cached, the key is fetched on demand (Mercury + KMS) and persisted for reuse. Non-encrypted conversations send as plaintext.
 
 ### OAuth Device Grant (Fallback)
 

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "qrcode": "^1.5.4",
     "thrift": "^0.20.0",
     "tweetnacl": "^1.0.3",
+    "webex-message-handler": "^0.6.10",
     "ws": "^8.19.0",
     "zod": "^4.3.6"
   },

--- a/skills/agent-webex/references/authentication.md
+++ b/skills/agent-webex/references/authentication.md
@@ -19,7 +19,7 @@ Extracts your first-party Webex session token from a Chromium-based browser wher
 - **Supported browsers**: Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium
 - **Token lifetime**: Depends on Webex session policy (typically hours to days). Re-extract when expired.
 - **Auto-extraction**: The CLI attempts browser extraction automatically when no valid token is stored, so you often don't need to run `auth extract` manually.
-- **End-to-end encryption**: When encryption keys are found in the browser's cache, messages are encrypted client-side (JWE with AES-256-GCM) before sending via the internal conversation API. This ensures messages appear as encrypted in the Webex client. If no keys are found (e.g., the conversation hasn't been opened in the browser), messages fall back to plaintext.
+- **End-to-end encryption**: Messages are encrypted client-side (JWE with AES-256-GCM) before sending via the internal conversation API, so they appear as encrypted in the Webex client. Keys cached from the browser are used directly; for an end-to-end encrypted conversation whose key was not cached at extract time, the key is fetched on demand over the Mercury websocket + KMS flow and persisted for reuse. Only non-encrypted conversations are sent as plaintext.
 - **Best for**: Interactive use, sending messages as yourself without the "via" label
 
 ```bash

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -1,7 +1,8 @@
 import { WebexCredentialManager } from './credential-manager'
 import { WebexEncryptionService } from './encryption'
+import { KmsKeyProvider } from './kms-key-provider'
 import { escapeHtml, markdownToHtml, stripMarkdown } from './markdown-to-html'
-import type { WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './types'
+import type { WebexConfig, WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './types'
 import { WebexError } from './types'
 
 const BASE_URL = 'https://webexapis.com/v1'
@@ -44,14 +45,38 @@ export class WebexClient {
     this.tokenType = config?.tokenType ?? null
     await this.login({ token })
 
-    if (this.tokenType === 'extracted' && config?.encryptionKeys) {
-      const keysMap = new Map(Object.entries(config.encryptionKeys))
-      if (keysMap.size > 0) {
-        this.encryption = new WebexEncryptionService(keysMap)
-      }
+    if (this.tokenType === 'extracted') {
+      const keysMap = new Map(Object.entries(config?.encryptionKeys ?? {}))
+      this.encryption = new WebexEncryptionService(keysMap)
+      const kmsProvider = new KmsKeyProvider({ token })
+      this.encryption.setKeyProvider({
+        fetchKey: async (keyUri: string) => {
+          const serializedKey = await kmsProvider.fetchKey(keyUri)
+          if (serializedKey) {
+            await this.persistEncryptionKey(credManager, keyUri, serializedKey)
+          }
+          return serializedKey
+        },
+        close: () => kmsProvider.close(),
+      })
     }
 
     return this
+  }
+
+  async dispose(): Promise<void> {
+    await this.encryption?.close()
+  }
+
+  private async persistEncryptionKey(
+    credManager: WebexCredentialManager,
+    keyUri: string,
+    serializedKey: string,
+  ): Promise<void> {
+    const latestConfig = await credManager.loadConfig()
+    if (!latestConfig) return
+    const encryptionKeys = { ...latestConfig.encryptionKeys, [keyUri]: serializedKey }
+    await credManager.saveConfig({ ...latestConfig, encryptionKeys } satisfies WebexConfig)
   }
 
   private ensureAuth(): string {
@@ -287,6 +312,9 @@ export class WebexClient {
       if (keyUri) {
         const encryptedDisplayName = await this.encryption.encryptText(keyUri, displayName)
         const encryptedContent = content ? await this.encryption.encryptText(keyUri, content) : undefined
+        if (content && !encryptedContent) {
+          throw new WebexError('Cannot encrypt message for Webex E2E conversation', 'encryption_failed')
+        }
         if (encryptedDisplayName) {
           const object: Record<string, string> = {
             objectType: 'comment',
@@ -297,6 +325,7 @@ export class WebexClient {
           }
           return { object, encryptionKeyUrl: keyUri }
         }
+        throw new WebexError('Cannot encrypt message for Webex E2E conversation', 'encryption_failed')
       }
     }
 

--- a/src/platforms/webex/commands/message.test.ts
+++ b/src/platforms/webex/commands/message.test.ts
@@ -32,6 +32,7 @@ let mockGetMessage: ReturnType<typeof spyOn>
 let mockDeleteMessage: ReturnType<typeof spyOn>
 let mockEditMessage: ReturnType<typeof spyOn>
 let mockLogin: ReturnType<typeof spyOn>
+let mockDispose: ReturnType<typeof spyOn>
 let consoleLogSpy: ReturnType<typeof spyOn>
 let consoleErrorSpy: ReturnType<typeof spyOn>
 let processExitSpy: ReturnType<typeof spyOn>
@@ -47,6 +48,7 @@ beforeEach(() => {
   mockLogin = protoSpy('login').mockImplementation(async function (this: WebexClient) {
     return this
   })
+  mockDispose = protoSpy('dispose').mockResolvedValue(undefined)
   mockSendMessage = protoSpy('sendMessage').mockResolvedValue(mockMessage)
   mockSendDirectMessage = protoSpy('sendDirectMessage').mockResolvedValue(mockMessage)
   mockListMessages = protoSpy('listMessages').mockResolvedValue([mockMessage, mockMessage2])
@@ -78,12 +80,21 @@ it('calls sendMessage with correct args and outputs result', async () => {
   expect(output).toContain('msg_123')
   expect(output).toContain('space_456')
   expect(output).toContain('user@example.com')
+  expect(mockDispose).toHaveBeenCalled()
 })
 
 it('passes markdown option when --markdown flag is set on send', async () => {
   await sendAction('space_456', '**bold**', { markdown: true, pretty: false })
 
   expect(mockSendMessage).toHaveBeenCalledWith('space_456', '**bold**', { markdown: true })
+})
+
+it('disposes the client when send fails', async () => {
+  mockSendMessage.mockRejectedValue(new WebexError('Send failed', 'send_failed'))
+
+  await sendAction('space_456', 'Hello world', { pretty: false })
+
+  expect(mockDispose).toHaveBeenCalled()
 })
 
 it('exits with code 1 when not authenticated on send', async () => {
@@ -166,6 +177,7 @@ it('calls editMessage with roomId in args and outputs result', async () => {
   const output = consoleLogSpy.mock.calls[0][0]
   expect(output).toContain('msg_123')
   expect(output).toContain('Updated message')
+  expect(mockDispose).toHaveBeenCalled()
 })
 
 it('passes markdown option to editMessage when --markdown flag is set', async () => {

--- a/src/platforms/webex/commands/message.ts
+++ b/src/platforms/webex/commands/message.ts
@@ -123,7 +123,9 @@ export async function dmAction(
   options: { markdown?: boolean; pretty?: boolean },
 ): Promise<void> {
   try {
-    const message = await withWebexClient((client) => client.sendDirectMessage(email, text, { markdown: options.markdown }))
+    const message = await withWebexClient((client) =>
+      client.sendDirectMessage(email, text, { markdown: options.markdown }),
+    )
 
     const output = {
       id: message.id,

--- a/src/platforms/webex/commands/message.ts
+++ b/src/platforms/webex/commands/message.ts
@@ -6,14 +6,23 @@ import { formatOutput } from '@/shared/utils/output'
 import { WebexClient } from '../client'
 import type { WebexMessage } from '../types'
 
+async function withWebexClient<T>(run: (client: WebexClient) => Promise<T>): Promise<T> {
+  const client = new WebexClient()
+  try {
+    await client.login()
+    return await run(client)
+  } finally {
+    await client.dispose()
+  }
+}
+
 export async function sendAction(
   spaceId: string,
   text: string,
   options: { markdown?: boolean; pretty?: boolean },
 ): Promise<void> {
   try {
-    const client = await new WebexClient().login()
-    const message = await client.sendMessage(spaceId, text, { markdown: options.markdown })
+    const message = await withWebexClient((client) => client.sendMessage(spaceId, text, { markdown: options.markdown }))
 
     const output = {
       id: message.id,
@@ -31,9 +40,8 @@ export async function sendAction(
 
 export async function listAction(spaceId: string, options: { limit?: number; pretty?: boolean }): Promise<void> {
   try {
-    const client = await new WebexClient().login()
     const limit = options.limit ?? 50
-    const messages = await client.listMessages(spaceId, { max: limit })
+    const messages = await withWebexClient((client) => client.listMessages(spaceId, { max: limit }))
 
     const output = messages.map((msg: WebexMessage) => ({
       id: msg.id,
@@ -51,8 +59,7 @@ export async function listAction(spaceId: string, options: { limit?: number; pre
 
 export async function getAction(messageId: string, options: { pretty?: boolean }): Promise<void> {
   try {
-    const client = await new WebexClient().login()
-    const message = await client.getMessage(messageId)
+    const message = await withWebexClient((client) => client.getMessage(messageId))
 
     const output = {
       id: message.id,
@@ -75,8 +82,7 @@ export async function deleteAction(messageId: string, options: { force?: boolean
       return process.exit(0)
     }
 
-    const client = await new WebexClient().login()
-    await client.deleteMessage(messageId)
+    await withWebexClient((client) => client.deleteMessage(messageId))
 
     console.log(formatOutput({ deleted: messageId }, options.pretty))
   } catch (error) {
@@ -91,10 +97,11 @@ export async function editAction(
   options: { markdown?: boolean; pretty?: boolean },
 ): Promise<void> {
   try {
-    const client = await new WebexClient().login()
-    const message = await client.editMessage(messageId, spaceId, text, {
-      markdown: options.markdown,
-    })
+    const message = await withWebexClient((client) =>
+      client.editMessage(messageId, spaceId, text, {
+        markdown: options.markdown,
+      }),
+    )
 
     const output = {
       id: message.id,
@@ -116,8 +123,7 @@ export async function dmAction(
   options: { markdown?: boolean; pretty?: boolean },
 ): Promise<void> {
   try {
-    const client = await new WebexClient().login()
-    const message = await client.sendDirectMessage(email, text, { markdown: options.markdown })
+    const message = await withWebexClient((client) => client.sendDirectMessage(email, text, { markdown: options.markdown }))
 
     const output = {
       id: message.id,

--- a/src/platforms/webex/encryption.test.ts
+++ b/src/platforms/webex/encryption.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 
 import * as jose from 'node-jose'
 
@@ -11,12 +11,16 @@ const decodeJweHeader = (jwe: string): Record<string, unknown> => {
   return JSON.parse(json) as Record<string, unknown>
 }
 
-const createKeyring = async (keyUri: string) => {
+const createSerializedKey = async (keyUri: string) => {
   const keystore = jose.JWK.createKeyStore()
   const key = await keystore.generate('oct', 256, { alg: 'A256GCM' })
   const jwk = key.toJSON(true)
+  return JSON.stringify({ uri: keyUri, jwk })
+}
+
+const createKeyring = async (keyUri: string) => {
   const rawKeys = new Map<string, string>()
-  rawKeys.set(keyUri, JSON.stringify({ jwk }))
+  rawKeys.set(keyUri, await createSerializedKey(keyUri))
   return new WebexEncryptionService(rawKeys)
 }
 
@@ -50,5 +54,56 @@ describe('WebexEncryptionService', () => {
     const plaintext = await service.decryptText(keyUri, jwe as string)
 
     expect(plaintext).toBe('round trip')
+  })
+
+  it('getKey returns cached key without calling provider when key is present', async () => {
+    const service = await createKeyring(keyUri)
+    const provider = { fetchKey: mock(async () => null as string | null) }
+    service.setKeyProvider(provider)
+
+    const key = await service.getKey(keyUri)
+
+    expect(key).not.toBeNull()
+    expect(provider.fetchKey).not.toHaveBeenCalled()
+  })
+
+  it('getKey calls provider and returns key when key is missing', async () => {
+    const missingKeyUri = 'kms://kms-aore.wbx2.com/keys/0d7a0dfb-0464-40ce-8f3d-e65a33b61561'
+    const serializedKey = await createSerializedKey(missingKeyUri)
+    const service = new WebexEncryptionService(new Map())
+    const provider = { fetchKey: mock(async () => serializedKey) }
+    service.setKeyProvider(provider)
+
+    const key = await service.getKey(missingKeyUri)
+
+    expect(key).not.toBeNull()
+    expect(provider.fetchKey).toHaveBeenCalledWith(missingKeyUri)
+  })
+
+  it('getKey returns null when provider returns null', async () => {
+    const missingKeyUri = 'kms://kms-aore.wbx2.com/keys/13d6256d-f7f1-4b98-8102-4d3d87b2834a'
+    const service = new WebexEncryptionService(new Map())
+    const provider = { fetchKey: mock(async () => null as string | null) }
+    service.setKeyProvider(provider)
+
+    const key = await service.getKey(missingKeyUri)
+
+    expect(key).toBeNull()
+    expect(provider.fetchKey).toHaveBeenCalledWith(missingKeyUri)
+  })
+
+  it('getKey reuses provider result from raw keys after first fetch', async () => {
+    const missingKeyUri = 'kms://kms-aore.wbx2.com/keys/84afb005-5ba5-49c8-bd46-0c5d7ddf1c30'
+    const serializedKey = await createSerializedKey(missingKeyUri)
+    const service = new WebexEncryptionService(new Map())
+    const provider = { fetchKey: mock(async () => serializedKey) }
+    service.setKeyProvider(provider)
+
+    await service.getKey(missingKeyUri)
+    ;(service as unknown as { keyCache: Map<string, jose.JWK.Key> }).keyCache.clear()
+    const key = await service.getKey(missingKeyUri)
+
+    expect(key).not.toBeNull()
+    expect(provider.fetchKey).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/platforms/webex/encryption.ts
+++ b/src/platforms/webex/encryption.ts
@@ -28,7 +28,7 @@ export class WebexEncryptionService {
 
     let raw = this.rawKeys.get(keyUri)
     if (!raw && this.keyProvider) {
-      raw = await this.keyProvider.fetchKey(keyUri) ?? undefined
+      raw = (await this.keyProvider.fetchKey(keyUri)) ?? undefined
     }
     if (!raw) return null
 

--- a/src/platforms/webex/encryption.ts
+++ b/src/platforms/webex/encryption.ts
@@ -1,23 +1,41 @@
 import * as jose from 'node-jose'
 
+export interface WebexKeyProvider {
+  fetchKey(keyUri: string): Promise<string | null>
+  close?(): Promise<void>
+}
+
 export class WebexEncryptionService {
   private rawKeys: Map<string, string>
   private keyCache: Map<string, jose.JWK.Key> = new Map()
+  private keyProvider: WebexKeyProvider | null = null
 
   constructor(serializedKeys: Map<string, string>) {
     this.rawKeys = serializedKeys
+  }
+
+  setKeyProvider(provider: WebexKeyProvider): void {
+    this.keyProvider = provider
+  }
+
+  async close(): Promise<void> {
+    await this.keyProvider?.close?.()
   }
 
   async getKey(keyUri: string): Promise<jose.JWK.Key | null> {
     const cached = this.keyCache.get(keyUri)
     if (cached) return cached
 
-    const raw = this.rawKeys.get(keyUri)
+    let raw = this.rawKeys.get(keyUri)
+    if (!raw && this.keyProvider) {
+      raw = await this.keyProvider.fetchKey(keyUri) ?? undefined
+    }
     if (!raw) return null
 
     try {
       const parsed = JSON.parse(raw) as { jwk: object }
       const joseKey = await jose.JWK.asKey(parsed.jwk)
+      this.rawKeys.set(keyUri, raw)
       this.keyCache.set(keyUri, joseKey)
       return joseKey
     } catch {

--- a/src/platforms/webex/kms-key-provider.ts
+++ b/src/platforms/webex/kms-key-provider.ts
@@ -1,5 +1,5 @@
-import WebSocket from 'ws'
 import { DeviceManager, KmsClient, MercurySocket, noopLogger } from 'webex-message-handler'
+import WebSocket from 'ws'
 
 interface KmsKeyProviderOptions {
   token: string
@@ -74,7 +74,7 @@ export class KmsKeyProvider {
     }
     const wsFactory = (url: string) => new WebSocket(url) as never
     const dm = new DeviceManager({ logger: noopLogger, httpDo })
-    const reg = await dm.register(this.token) as Registration
+    const reg = (await dm.register(this.token)) as Registration
     const mercury = new MercurySocket({ logger: noopLogger, wsFactory })
     const kms = new KmsClient({
       token: this.token,

--- a/src/platforms/webex/kms-key-provider.ts
+++ b/src/platforms/webex/kms-key-provider.ts
@@ -86,8 +86,14 @@ export class KmsKeyProvider {
     })
     mercury.on('kms:response', (data: unknown) => kms.handleKmsMessage(data))
     await mercury.connect(reg.webSocketUrl, this.token)
-    await kms.initialize()
     this.mercury = mercury
+    try {
+      await kms.initialize()
+    } catch (error) {
+      await mercury.disconnect().catch(() => undefined)
+      this.mercury = null
+      throw error
+    }
     this.kms = kms
   }
 }

--- a/src/platforms/webex/kms-key-provider.ts
+++ b/src/platforms/webex/kms-key-provider.ts
@@ -1,0 +1,93 @@
+import WebSocket from 'ws'
+import { DeviceManager, KmsClient, MercurySocket, noopLogger } from 'webex-message-handler'
+
+interface KmsKeyProviderOptions {
+  token: string
+  logger?: { debug(message: string): void }
+}
+
+interface Registration {
+  webSocketUrl: string
+  deviceUrl: string
+  userId: string
+  encryptionServiceUrl: string
+}
+
+type HttpRequest = {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body?: string
+}
+
+export class KmsKeyProvider {
+  private token: string
+  private logger?: { debug(message: string): void }
+  private mercury: MercurySocket | null = null
+  private kms: KmsClient | null = null
+  private readyPromise: Promise<void> | null = null
+
+  constructor(options: KmsKeyProviderOptions) {
+    this.token = options.token
+    this.logger = options.logger
+  }
+
+  async fetchKey(keyUri: string): Promise<string | null> {
+    try {
+      await this.ensureReady()
+      const key = await this.kms?.getKey(keyUri)
+      if (!key) return null
+      return JSON.stringify({ uri: keyUri, jwk: key.toJSON(true) })
+    } catch (error) {
+      this.logger?.debug(`Webex KMS key fetch failed: ${error instanceof Error ? error.message : String(error)}`)
+      await this.close()
+      this.readyPromise = null
+      return null
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.mercury?.disconnect().catch(() => undefined)
+    this.mercury = null
+    this.kms = null
+    this.readyPromise = null
+  }
+
+  private async ensureReady(): Promise<void> {
+    this.readyPromise ??= this.initialize()
+    await this.readyPromise
+  }
+
+  private async initialize(): Promise<void> {
+    const httpDo = async (req: HttpRequest) => {
+      const res = await fetch(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+      })
+      return {
+        status: res.status,
+        ok: res.ok,
+        json: () => res.json(),
+        text: () => res.text(),
+      }
+    }
+    const wsFactory = (url: string) => new WebSocket(url) as never
+    const dm = new DeviceManager({ logger: noopLogger, httpDo })
+    const reg = await dm.register(this.token) as Registration
+    const mercury = new MercurySocket({ logger: noopLogger, wsFactory })
+    const kms = new KmsClient({
+      token: this.token,
+      deviceUrl: reg.deviceUrl,
+      userId: reg.userId,
+      encryptionServiceUrl: reg.encryptionServiceUrl,
+      logger: noopLogger,
+      httpDo,
+    })
+    mercury.on('kms:response', (data: unknown) => kms.handleKmsMessage(data))
+    await mercury.connect(reg.webSocketUrl, this.token)
+    await kms.initialize()
+    this.mercury = mercury
+    this.kms = kms
+  }
+}

--- a/src/platforms/webex/typings/webex-message-handler.d.ts
+++ b/src/platforms/webex/typings/webex-message-handler.d.ts
@@ -1,0 +1,45 @@
+export {}
+
+declare module 'webex-message-handler' {
+  import type * as jose from 'node-jose'
+
+  type Logger = Record<string, (...args: unknown[]) => void>
+  type HttpRequest = { url: string; method: string; headers: Record<string, string>; body?: string }
+  type HttpResponse = { status: number; ok: boolean; json(): Promise<unknown>; text(): Promise<string> }
+  type HttpDo = (req: HttpRequest) => Promise<HttpResponse>
+
+  export const noopLogger: Logger
+  export const consoleLogger: Logger
+
+  export class DeviceManager {
+    constructor(options: { logger: Logger; httpDo: HttpDo })
+    register(token: string): Promise<{
+      webSocketUrl: string
+      deviceUrl: string
+      userId: string
+      services: unknown
+      encryptionServiceUrl: string
+    }>
+  }
+
+  export class MercurySocket {
+    constructor(options: { logger: Logger; wsFactory: (url: string) => unknown })
+    on(event: 'kms:response', handler: (data: unknown) => void): void
+    connect(webSocketUrl: string, token: string): Promise<void>
+    disconnect(): Promise<void>
+  }
+
+  export class KmsClient {
+    constructor(options: {
+      token: string
+      deviceUrl: string
+      userId: string
+      encryptionServiceUrl: string
+      logger: Logger
+      httpDo: HttpDo
+    })
+    initialize(): Promise<void>
+    getKey(keyUri: string): Promise<jose.JWK.Key | null>
+    handleKmsMessage(data: unknown): void
+  }
+}


### PR DESCRIPTION
## Problem

Sending a message to an end-to-end encrypted Webex conversation whose KMS key was absent from the local cache silently fell back to a plaintext `displayName`/`content` payload. Webex server-side autolinks bare URLs in those plaintext fields, and clients render the result as literal `<a onClick="sparkBase...">` markup instead of a clickable hyperlink.

The root cause: KMS keys are harvested from the browser only at `auth extract` time. Any conversation not open in the browser at extraction time has no cached key, so the CLI could not encrypt and leaked plaintext into the E2E room.

## Fix

Implement on-demand KMS key retrieval — the same device-register → Mercury WebSocket → KMS ECDH → fetch-key-by-URI flow the native Webex web client uses — via the `webex-message-handler` dependency (`KmsClient`, `MercurySocket`, `DeviceManager`).

- **`KmsKeyProvider`** (`kms-key-provider.ts`, new): wraps the device-register + Mercury + KMS flow. Lazy (connects only on first missing-key fetch), single reused connection per message operation, `close()` for clean process exit.
- **`WebexEncryptionService.getKey`**: falls back to the key provider when a key is absent, then caches it in memory and persists it to the credential store so future runs skip the fetch.
- **`WebexClient`**: wires the provider for extracted-token sessions (even when the key cache is empty) and disposes the connection after send/edit completes.
- **`buildEncryptedObject`**: now throws when a conversation has a KMS key URI but encryption cannot be performed, instead of falling through to a plaintext payload. Plaintext is still allowed only for non-E2E conversations.

## Testing

- New/updated unit tests (provider mocked; no network): cached-key path does not call the provider; missing-key path fetches, caches, persists, and reuses on the next call; provider returning null yields null.
- Full Webex suite: 256 tests pass.
- `tsc --noEmit` — clean.
- `oxlint` — 0 warnings, 0 errors.
- Manual end-to-end against a DM whose key was previously absent: message stored as JWE (`displayName` + `content`), renders as a clean clickable link with no `sparkBase` markup; fetched key persisted to the local cache.

## Review Notes

- `kms-key-provider.ts` owns the full device → Mercury → KMS lifecycle and is the main surface to review. In particular: the lazy-connect semantics, the `close()` contract, and error propagation when the key fetch times out or the KMS returns null.
- The hardening in `buildEncryptedObject` changes a silent fallthrough into a thrown error. Verify the throw is caught and surfaced correctly for all callers (send and edit paths).
- `webex-message-handler.d.ts` is a hand-rolled ambient declaration; it should be reviewed against the published types if the package gains its own declarations in future.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch missing Webex KMS keys on demand and enforce E2E encryption to stop plaintext fallbacks and broken autolink rendering. The client now always disposes after each command and disconnects Mercury if KMS initialization fails.

- **Bug Fixes**
  - On-demand KMS key retrieval via `KmsKeyProvider` using `webex-message-handler` (lazy connect, reuse, clean close; disconnects Mercury on KMS init failure).
  - `WebexEncryptionService.getKey` uses the provider when missing, then caches and persists the key; E2E paths throw instead of falling back to plaintext.
  - Added a command helper to always dispose the client on success or failure; tests cover provider paths and disposal.

- **Dependencies**
  - Added `webex-message-handler@^0.6.10`.
  - Docs updated: synced Webex CLI and agent-webex authentication docs to describe on-demand KMS key fetch.

<sup>Written for commit d9f264ba02c87df6fde935be2b2d0effa6b0803a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

