### PR TITLE
fix(webex): include html in message output

### DIFF
--- a/src/platforms/webex/commands/message.test.ts
+++ b/src/platforms/webex/commands/message.test.ts
@@ -8,6 +8,7 @@ const mockMessage = {
   roomId: 'space_456',
   roomType: 'group' as const,
   text: 'Hello world',
+  html: '<p>Hello <a href="https://example.com">world</a></p>',
   personId: 'person_789',
   personEmail: 'user@example.com',
   created: '2025-01-29T10:00:00.000Z',
@@ -18,6 +19,7 @@ const mockMessage2 = {
   roomId: 'space_456',
   roomType: 'group' as const,
   text: 'Second message',
+  html: '<p>Second message</p>',
   personId: 'person_789',
   personEmail: 'user@example.com',
   created: '2025-01-29T10:01:00.000Z',
@@ -133,6 +135,7 @@ it('calls listMessages with limit and outputs array', async () => {
   const output = consoleLogSpy.mock.calls[0][0]
   expect(output).toContain('msg_123')
   expect(output).toContain('msg_124')
+  expect(output).toContain('https://example.com')
 })
 
 it('calls getMessage with correct id and outputs result', async () => {
@@ -143,6 +146,7 @@ it('calls getMessage with correct id and outputs result', async () => {
   const output = consoleLogSpy.mock.calls[0][0]
   expect(output).toContain('msg_123')
   expect(output).toContain('user@example.com')
+  expect(output).toContain('https://example.com')
 })
 
 it('calls deleteMessage and outputs deleted id when --force flag is set', async () => {

--- a/src/platforms/webex/commands/message.ts
+++ b/src/platforms/webex/commands/message.ts
@@ -6,6 +6,17 @@ import { formatOutput } from '@/shared/utils/output'
 import { WebexClient } from '../client'
 import type { WebexMessage } from '../types'
 
+function formatMessageOutput(message: WebexMessage) {
+  return {
+    id: message.id,
+    roomId: message.roomId,
+    text: message.text,
+    html: message.html,
+    personEmail: message.personEmail,
+    created: message.created,
+  }
+}
+
 async function withWebexClient<T>(run: (client: WebexClient) => Promise<T>): Promise<T> {
   const client = new WebexClient()
   try {
@@ -24,15 +35,7 @@ export async function sendAction(
   try {
     const message = await withWebexClient((client) => client.sendMessage(spaceId, text, { markdown: options.markdown }))
 
-    const output = {
-      id: message.id,
-      roomId: message.roomId,
-      text: message.text,
-      personEmail: message.personEmail,
-      created: message.created,
-    }
-
-    console.log(formatOutput(output, options.pretty))
+    console.log(formatOutput(formatMessageOutput(message), options.pretty))
   } catch (error) {
     handleError(error as Error)
   }
@@ -43,13 +46,7 @@ export async function listAction(spaceId: string, options: { limit?: number; pre
     const limit = options.limit ?? 50
     const messages = await withWebexClient((client) => client.listMessages(spaceId, { max: limit }))
 
-    const output = messages.map((msg: WebexMessage) => ({
-      id: msg.id,
-      roomId: msg.roomId,
-      text: msg.text,
-      personEmail: msg.personEmail,
-      created: msg.created,
-    }))
+    const output = messages.map(formatMessageOutput)
 
     console.log(formatOutput(output, options.pretty))
   } catch (error) {
@@ -61,15 +58,7 @@ export async function getAction(messageId: string, options: { pretty?: boolean }
   try {
     const message = await withWebexClient((client) => client.getMessage(messageId))
 
-    const output = {
-      id: message.id,
-      roomId: message.roomId,
-      text: message.text,
-      personEmail: message.personEmail,
-      created: message.created,
-    }
-
-    console.log(formatOutput(output, options.pretty))
+    console.log(formatOutput(formatMessageOutput(message), options.pretty))
   } catch (error) {
     handleError(error as Error)
   }
@@ -103,15 +92,7 @@ export async function editAction(
       }),
     )
 
-    const output = {
-      id: message.id,
-      roomId: message.roomId,
-      text: message.text,
-      personEmail: message.personEmail,
-      created: message.created,
-    }
-
-    console.log(formatOutput(output, options.pretty))
+    console.log(formatOutput(formatMessageOutput(message), options.pretty))
   } catch (error) {
     handleError(error as Error)
   }
@@ -127,15 +108,7 @@ export async function dmAction(
       client.sendDirectMessage(email, text, { markdown: options.markdown }),
     )
 
-    const output = {
-      id: message.id,
-      roomId: message.roomId,
-      text: message.text,
-      personEmail: message.personEmail,
-      created: message.created,
-    }
-
-    console.log(formatOutput(output, options.pretty))
+    console.log(formatOutput(formatMessageOutput(message), options.pretty))
   } catch (error) {
     handleError(error as Error)
   }


### PR DESCRIPTION
## Summary
- include Webex message `html` in CLI output for send/dm/list/get/edit commands
- centralize Webex message output shaping in one helper
- add coverage that Webex message HTML links are preserved in list/get output

## Test plan
- `bun test ./src/platforms/webex/commands/message.test.ts`
- `bun run typecheck`
- `bun run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Webex message html in CLI output so links are preserved, and centralize message output shaping in a single helper. No SKILL.md or docs changes.

- **Bug Fixes**
  - Include html in output for send, dm, list, get, and edit commands.
  - Add tests to ensure HTML links appear in list/get output.

<sup>Written for commit f6c88a8ca2801e581d1b73f3c3e924760d6ccac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

