### PR TITLE
fix(kakaotalk): pin bson to Bun-compatible v6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^12.0.0",
         "blessed": "^0.1.81",
-        "bson": "^7.2.0",
+        "bson": "^6.10.4",
         "classic-level": "^3.0.0",
         "commander": "^11.1.0",
         "crypto-js": "^4.2.0",
@@ -366,7 +366,7 @@
 
     "browser-or-node": ["browser-or-node@1.3.0", "", {}, "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="],
 
-    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
+    "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^12.0.0",
     "blessed": "^0.1.81",
-    "bson": "^7.2.0",
+    "bson": "^6.10.4",
     "classic-level": "^3.0.0",
     "commander": "^11.1.0",
     "crypto-js": "^4.2.0",


### PR DESCRIPTION
## Summary

- pin `bson` to `^6.10.4` instead of `^7.2.0`
- refresh `bun.lock` so installs resolve the Bun-compatible v6 line

## Why

`bson@7.x` touches `node:v8.startupSnapshot.isBuildingSnapshot()` during module initialization. Bun currently exposes `node:v8` without implementing that API, so simply importing `bson@7` can terminate a Bun process before application code runs.

Agent Messenger uses `bson` for KakaoTalk LOCO packet serialization/deserialization (`BSON`, `Long`, `Binary`). Those APIs are available in `bson@6.10.4`, and v6 does not make the Bun-incompatible startup snapshot call at import time.

## When it became problematic

- `bson` was introduced to this repo in commit `1911dae9` (`Add LOCO protocol foundation...`) on 2026-03-20 with the range `^7.2.0`.
- The first published `agent-messenger` release containing that commit is `2.0.0`, published 2026-03-30.
- So source builds have had the risk since 2026-03-20; registry consumers have been affected since `agent-messenger@2.0.0`.

## Validation

- `bun install --ignore-scripts`
- `bun -e "import { BSON, Long, Binary } from 'bson'; console.log(BSON.serialize({ ok: true }).length, Long.fromNumber(1).toString(), Binary.SUBTYPE_DEFAULT)"`
- `bun run typecheck`
- `bun test src/platforms/kakaotalk/protocol src/platforms/kakaotalk/client.test.ts`
- `bun test src/` passes 3083 tests; one existing unrelated Node-specific test fails in this container: `TokenExtractor works in Node.js`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `bson` to `^6.10.4` to restore Bun compatibility for KakaoTalk LOCO. This prevents the import-time crash seen with `bson@7` using the `node:v8` startup snapshot API.

- **Dependencies**
  - Set `bson` to `^6.10.4` in `package.json` and refreshed `bun.lock` so installs resolve v6.

No platform source code changed; SKILL.md/docs not updated.

<sup>Written for commit 95832fa0ec298cbd8e1d8f333828ff1b3e1b0e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

