### PR TITLE
fix(webexbot): scope group history to mentions

### DIFF
--- a/docs/content/docs/cli/webexbot.mdx
+++ b/docs/content/docs/cli/webexbot.mdx
@@ -109,6 +109,8 @@ agent-webexbot message dm alice@example.com "Hey, quick question"
 agent-webexbot message dm alice@example.com "**Build failed**" --markdown
 
 # List messages in a space
+# In group spaces, Webex only returns messages that mention the bot.
+# Direct-space history is returned normally.
 agent-webexbot message list <space-id>
 agent-webexbot message list <space-id> --max 50
 

--- a/docs/content/docs/sdk/webexbot.mdx
+++ b/docs/content/docs/sdk/webexbot.mdx
@@ -65,6 +65,8 @@ const dm = await client.sendDirectMessage('alice@example.com', 'Hey!')
 await client.sendDirectMessage('alice@example.com', '**Important**', { markdown: true })
 
 // List messages in a space (default limit: 50)
+// In group spaces, Webex only returns messages that mention the bot.
+// Direct-space history is returned normally.
 const messages = await client.listMessages(roomId)
 const limited = await client.listMessages(roomId, { max: 25 })
 // → WebexMessage[]

--- a/skills/agent-webexbot/SKILL.md
+++ b/skills/agent-webexbot/SKILL.md
@@ -177,6 +177,8 @@ agent-webexbot message dm alice@example.com "Hey, quick question"
 agent-webexbot message dm alice@example.com "**Build failed**" --markdown
 
 # List messages in a space
+# In group spaces, Webex only returns messages that mention the bot.
+# Direct-space history is returned normally.
 agent-webexbot message list <space-id>
 agent-webexbot message list <space-id> --max 50
 

--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -274,6 +274,16 @@ describe('WebexClient', () => {
 
       expect(fetchCalls[0].url).toContain('max=10')
     })
+
+    it('passes mentionedPeople when requested', async () => {
+      mockResponse({ items: [] })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      await client.listMessages('room1', { max: 10, mentionedPeople: 'me' })
+
+      const url = new URL(fetchCalls[0].url)
+      expect(url.searchParams.get('mentionedPeople')).toBe('me')
+    })
   })
 
   describe('getMessage', () => {

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -387,7 +387,7 @@ export class WebexClient {
     return null
   }
 
-  async listMessages(roomId: string, options?: { max?: number }): Promise<WebexMessage[]> {
+  async listMessages(roomId: string, options?: { max?: number; mentionedPeople?: string }): Promise<WebexMessage[]> {
     if (this.useInternalAPI) {
       const convUuid = this.decodeConvUuid(roomId)
       const max = options?.max ?? 50
@@ -400,6 +400,7 @@ export class WebexClient {
     const params = new URLSearchParams()
     params.set('roomId', roomId)
     params.set('max', String(options?.max ?? 50))
+    if (options?.mentionedPeople) params.set('mentionedPeople', options.mentionedPeople)
     const data = await this.request<{ items: WebexMessage[] }>('GET', `/messages?${params}`)
     return data.items
   }

--- a/src/platforms/webexbot/client.test.ts
+++ b/src/platforms/webexbot/client.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { WebexBotClient } from './client'
+
+describe('WebexBotClient', () => {
+  const originalFetch = globalThis.fetch
+  let fetchCalls: Array<{ url: string; options?: RequestInit }> = []
+  let fetchResponses: Response[] = []
+  let fetchIndex = 0
+
+  beforeEach(() => {
+    fetchCalls = []
+    fetchResponses = []
+    fetchIndex = 0
+    ;(globalThis as { fetch: unknown }).fetch = async (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      fetchCalls.push({ url: url.toString(), options })
+      const response = fetchResponses[fetchIndex]
+      fetchIndex++
+      if (!response) {
+        throw new Error('No mock response configured')
+      }
+      return response
+    }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const mockResponse = (body: unknown, status = 200) => {
+    fetchResponses.push(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  }
+
+  describe('listMessages', () => {
+    it('limits group-space history to messages that mention the bot', async () => {
+      mockResponse({ id: 'group-room', title: 'Team', type: 'group' })
+      mockResponse({ items: [{ id: 'msg-1', roomId: 'group-room', roomType: 'group' }] })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      const messages = await client.listMessages('group-room', { max: 5 })
+
+      expect(messages).toHaveLength(1)
+      expect(fetchCalls[0].url).toBe('https://webexapis.com/v1/rooms/group-room')
+
+      const messagesUrl = new URL(fetchCalls[1].url)
+      expect(messagesUrl.origin + messagesUrl.pathname).toBe('https://webexapis.com/v1/messages')
+      expect(messagesUrl.searchParams.get('roomId')).toBe('group-room')
+      expect(messagesUrl.searchParams.get('max')).toBe('5')
+      expect(messagesUrl.searchParams.get('mentionedPeople')).toBe('me')
+    })
+
+    it('does not add mentionedPeople for direct spaces', async () => {
+      mockResponse({ id: 'direct-room', title: 'DM', type: 'direct' })
+      mockResponse({ items: [{ id: 'msg-1', roomId: 'direct-room', roomType: 'direct' }] })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.listMessages('direct-room', { max: 5 })
+
+      const messagesUrl = new URL(fetchCalls[1].url)
+      expect(messagesUrl.searchParams.get('roomId')).toBe('direct-room')
+      expect(messagesUrl.searchParams.get('mentionedPeople')).toBeNull()
+    })
+  })
+})

--- a/src/platforms/webexbot/client.ts
+++ b/src/platforms/webexbot/client.ts
@@ -53,7 +53,9 @@ export class WebexBotClient {
   }
 
   async listMessages(roomId: string, options?: { max?: number }): Promise<WebexMessage[]> {
-    return this.client.listMessages(roomId, options)
+    const space = await this.client.getSpace(roomId)
+    const messageOptions = space.type === 'group' ? { ...options, mentionedPeople: 'me' } : options
+    return this.client.listMessages(roomId, messageOptions)
   }
 
   async getMessage(messageId: string): Promise<WebexMessage> {


### PR DESCRIPTION
## Summary
- add support for `mentionedPeople=me` when `agent-webexbot` lists messages in group spaces
- preserve direct-space history behavior without the mention filter
- add focused coverage for Webex client query params and Webex bot group/direct history behavior

## Root cause
Webex bot tokens cannot read arbitrary message history in group spaces. The Webex API only exposes group messages to bots when the bot is mentioned, so calling `GET /v1/messages?roomId=<group>&max=N` with a bot token returns `403 Failed to get activity.`

For group spaces, Webex documents the bot-accessible list form as `GET /messages?mentionedPeople=me&roomId=<room>`. `agent-webexbot` was reusing the user-token Webex message list path, which omitted `mentionedPeople=me`.

## Tests
- `bun test src/platforms/webex/client.test.ts src/platforms/webexbot/client.test.ts`
- `bun run typecheck`
- `bun run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Webex bot message history in group spaces to mentions to avoid 403s and follow Webex API rules. Direct-space history stays unchanged.

- **Bug Fixes**
  - WebexBotClient: for group rooms, list messages with mentionedPeople=me; for direct rooms, no filter.
  - WebexClient: added mentionedPeople option and passed it through to /messages.
  - Added focused tests for query params and bot group/direct behavior.
  - Docs: Updated CLI and SDK docs and SKILL.md to note group history is limited to mentions.

<sup>Written for commit 8ba97460380eb4a2a6416fc7f92f3136f812ab2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

