### PR TITLE
feat(webexbot): emit Webex REST IDs from the listener

### DIFF
--- a/docs/content/docs/sdk/webexbot.mdx
+++ b/docs/content/docs/sdk/webexbot.mdx
@@ -177,6 +177,22 @@ const listener = new WebexBotListener(client, {
 | `disconnected`       | `string` (reason)        | Connection dropped; listener will auto-reconnect       |
 | `error`              | `Error`                  | Fatal error (max reconnects exceeded). Listener stops. |
 
+### ID format
+
+Every REST-resource ID on emitted events — person IDs (`personId`, `actorId`, `mentionedPeople`), room IDs (`roomId`), message IDs (`id`, `parentId`, `messageId`), and `AttachmentAction.id` — is in **Webex REST ID format** (`ciscospark://...` base64), directly comparable with IDs returned by `WebexBotClient` (e.g. `getMessage`, `listSpaces`, `listPeople`). The two Mercury-only activity IDs that have no REST resource — `MembershipActivity.id` and `RoomActivity.id` — stay as raw Mercury UUIDs. The original Mercury payload (with raw UUIDs) is preserved under `.raw` on every event except `message_deleted`, whose upstream Mercury event does not include the full activity.
+
+```typescript
+import { WebexBotClient, WebexBotListener, fromRestId } from 'agent-messenger/webexbot'
+
+listener.on('message_created', async (event) => {
+  // event.roomId is a REST ID — compare it directly with REST results
+  const space = await client.getSpace(event.roomId)
+
+  // Recover the raw Mercury UUID when needed
+  const personUuid = fromRestId(event.personId)
+})
+```
+
 ### Reconnection
 
 On transient failures (network drops, 5xx), the listener emits `disconnected` and retries with exponential backoff up to `reconnectBackoffMax`. After `maxReconnectAttempts` consecutive failures, it emits `error` and stops.

--- a/skills/agent-webexbot/SKILL.md
+++ b/skills/agent-webexbot/SKILL.md
@@ -281,6 +281,8 @@ Output is NDJSON — one JSON object per line:
 {"type":"message_created","payload":{"id":"Y2lz...","text":"Hello bot!","personEmail":"alice@example.com","roomId":"Y2lz..."}}
 ```
 
+Event IDs (`id`, `parentId`, `messageId`, `roomId`, `personId`, `actorId`, `mentionedPeople`) are emitted as Webex REST IDs (`ciscospark://...` base64), so they compare directly with IDs returned by other `agent-webexbot` commands (`message get`, `space list`, `user list`). The Mercury-only activity IDs `membership_created.id` and `room_created`/`room_updated.id` stay as raw UUIDs; the raw Mercury payload is preserved under `payload.raw` (except for `message_deleted`, whose Mercury event does not carry the full payload).
+
 ## Output Format
 
 ### JSON (Default)

--- a/src/platforms/webexbot/id-normalizer.test.ts
+++ b/src/platforms/webexbot/id-normalizer.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'bun:test'
+
+import type {
+  AttachmentAction,
+  DecryptedMessage,
+  DeletedMessage,
+  MembershipActivity,
+  MercuryActivity,
+  RoomActivity,
+} from 'webex-message-handler'
+
+import {
+  fromRestId,
+  normalizeAttachmentAction,
+  normalizeDeletedMessage,
+  normalizeMembership,
+  normalizeMessage,
+  normalizeRoomActivity,
+  toRestId,
+} from './id-normalizer'
+
+const RAW: MercuryActivity = {
+  id: 'activity-uuid',
+  verb: 'post',
+  actor: { id: 'person-uuid', objectType: 'person', emailAddress: 'user@example.com' },
+  object: { id: 'object-uuid', objectType: 'comment', displayName: 'hi' },
+  target: { id: 'room-uuid', objectType: 'conversation' },
+  published: '2024-01-01T00:00:00Z',
+}
+
+describe('toRestId / fromRestId', () => {
+  it('encodes a uuid into a ciscospark REST id round-trippable to the uuid', () => {
+    const restId = toRestId('abc-123', 'PEOPLE')
+    expect(Buffer.from(restId, 'base64').toString('utf-8')).toBe('ciscospark://us/PEOPLE/abc-123')
+    expect(fromRestId(restId)).toBe('abc-123')
+  })
+
+  it('supports ATTACHMENT_ACTION which the upstream helper omits', () => {
+    expect(Buffer.from(toRestId('a-1', 'ATTACHMENT_ACTION'), 'base64').toString('utf-8')).toBe(
+      'ciscospark://us/ATTACHMENT_ACTION/a-1',
+    )
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(toRestId('', 'MESSAGE')).toBe('')
+  })
+})
+
+describe('normalizeMessage', () => {
+  const message: DecryptedMessage = {
+    id: 'msg-uuid',
+    parentId: 'parent-uuid',
+    roomId: 'room-uuid',
+    personId: 'person-uuid',
+    personEmail: 'user@example.com',
+    text: 'hello',
+    html: '<p>hello</p>',
+    created: '2024-01-01T00:00:00Z',
+    roomType: 'group',
+    mentionedPeople: ['mention-uuid-1', 'mention-uuid-2'],
+    mentionedGroups: ['all'],
+    files: ['https://files.example.com/a.png'],
+    raw: RAW,
+  }
+
+  it('encodes message, room, person and mention ids to REST form', () => {
+    const result = normalizeMessage(message)
+
+    expect(result.id).toBe(toRestId('msg-uuid', 'MESSAGE'))
+    expect(result.parentId).toBe(toRestId('parent-uuid', 'MESSAGE'))
+    expect(result.roomId).toBe(toRestId('room-uuid', 'ROOM'))
+    expect(result.personId).toBe(toRestId('person-uuid', 'PEOPLE'))
+    expect(result.mentionedPeople).toEqual([toRestId('mention-uuid-1', 'PEOPLE'), toRestId('mention-uuid-2', 'PEOPLE')])
+  })
+
+  it('leaves non-id fields and raw untouched', () => {
+    const result = normalizeMessage(message)
+
+    expect(result.mentionedGroups).toEqual(['all'])
+    expect(result.files).toEqual(['https://files.example.com/a.png'])
+    expect(result.personEmail).toBe('user@example.com')
+    expect(result.text).toBe('hello')
+    expect(result.raw).toBe(RAW)
+  })
+
+  it('returns a new object without mutating the input', () => {
+    const result = normalizeMessage(message)
+
+    expect(result).not.toBe(message)
+    expect(message.personId).toBe('person-uuid')
+  })
+
+  it('preserves an absent parentId', () => {
+    const { parentId: _omit, ...withoutParent } = message
+    const result = normalizeMessage(withoutParent)
+
+    expect(result.parentId).toBeUndefined()
+  })
+})
+
+describe('normalizeDeletedMessage', () => {
+  it('encodes messageId, roomId and personId to REST form', () => {
+    const deleted: DeletedMessage = {
+      messageId: 'msg-uuid',
+      roomId: 'room-uuid',
+      personId: 'person-uuid',
+    }
+
+    expect(normalizeDeletedMessage(deleted)).toEqual({
+      messageId: toRestId('msg-uuid', 'MESSAGE'),
+      roomId: toRestId('room-uuid', 'ROOM'),
+      personId: toRestId('person-uuid', 'PEOPLE'),
+    })
+  })
+})
+
+describe('normalizeMembership', () => {
+  it('encodes person and room ids but leaves the activity id raw', () => {
+    const membership: MembershipActivity = {
+      id: 'activity-uuid',
+      actorId: 'actor-uuid',
+      personId: 'member-uuid',
+      roomId: 'room-uuid',
+      action: 'add',
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    const result = normalizeMembership(membership)
+
+    expect(result.id).toBe('activity-uuid')
+    expect(result.actorId).toBe(toRestId('actor-uuid', 'PEOPLE'))
+    expect(result.personId).toBe(toRestId('member-uuid', 'PEOPLE'))
+    expect(result.roomId).toBe(toRestId('room-uuid', 'ROOM'))
+    expect(result.raw).toBe(RAW)
+  })
+})
+
+describe('normalizeAttachmentAction', () => {
+  it('encodes the action id as ATTACHMENT_ACTION and the resource ids to REST form', () => {
+    const action: AttachmentAction = {
+      id: 'action-uuid',
+      messageId: 'msg-uuid',
+      personId: 'person-uuid',
+      personEmail: 'user@example.com',
+      roomId: 'room-uuid',
+      inputs: { choice: 'yes' },
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    const result = normalizeAttachmentAction(action)
+
+    expect(result.id).toBe(toRestId('action-uuid', 'ATTACHMENT_ACTION'))
+    expect(result.messageId).toBe(toRestId('msg-uuid', 'MESSAGE'))
+    expect(result.personId).toBe(toRestId('person-uuid', 'PEOPLE'))
+    expect(result.roomId).toBe(toRestId('room-uuid', 'ROOM'))
+    expect(result.inputs).toEqual({ choice: 'yes' })
+  })
+
+  it('preserves an empty messageId', () => {
+    const action: AttachmentAction = {
+      id: 'action-uuid',
+      messageId: '',
+      personId: 'person-uuid',
+      personEmail: 'user@example.com',
+      roomId: 'room-uuid',
+      inputs: {},
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    expect(normalizeAttachmentAction(action).messageId).toBe('')
+  })
+})
+
+describe('normalizeRoomActivity', () => {
+  it('encodes room and actor ids but leaves the activity id raw', () => {
+    const room: RoomActivity = {
+      id: 'activity-uuid',
+      roomId: 'room-uuid',
+      actorId: 'actor-uuid',
+      action: 'created',
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    const result = normalizeRoomActivity(room)
+
+    expect(result.id).toBe('activity-uuid')
+    expect(result.roomId).toBe(toRestId('room-uuid', 'ROOM'))
+    expect(result.actorId).toBe(toRestId('actor-uuid', 'PEOPLE'))
+    expect(result.raw).toBe(RAW)
+  })
+})

--- a/src/platforms/webexbot/id-normalizer.ts
+++ b/src/platforms/webexbot/id-normalizer.ts
@@ -1,0 +1,73 @@
+import { fromRestId } from 'webex-message-handler'
+import type {
+  AttachmentAction,
+  DecryptedMessage,
+  DeletedMessage,
+  MembershipActivity,
+  RoomActivity,
+} from 'webex-message-handler'
+
+export { fromRestId }
+
+// Superset of webex-message-handler's toRestId union, which omits ATTACHMENT_ACTION
+// (the resource type behind GET /v1/attachment/actions).
+export type WebexRestIdType = 'MESSAGE' | 'PEOPLE' | 'ROOM' | 'ATTACHMENT_ACTION'
+
+/**
+ * Encode a raw Mercury UUID as a base64 `ciscospark://us/{TYPE}/{uuid}` Webex
+ * REST ID. Empty input is returned unchanged so an absent ID never becomes a
+ * bogus `ciscospark://us/{TYPE}/` value.
+ */
+export function toRestId(uuid: string, type: WebexRestIdType): string {
+  if (!uuid) return uuid
+  return Buffer.from(`ciscospark://us/${type}/${uuid}`).toString('base64')
+}
+
+export function normalizeMessage(message: DecryptedMessage): DecryptedMessage {
+  return {
+    ...message,
+    id: toRestId(message.id, 'MESSAGE'),
+    parentId: message.parentId ? toRestId(message.parentId, 'MESSAGE') : message.parentId,
+    roomId: toRestId(message.roomId, 'ROOM'),
+    personId: toRestId(message.personId, 'PEOPLE'),
+    mentionedPeople: message.mentionedPeople.map((id) => toRestId(id, 'PEOPLE')),
+  }
+}
+
+export function normalizeDeletedMessage(message: DeletedMessage): DeletedMessage {
+  return {
+    messageId: toRestId(message.messageId, 'MESSAGE'),
+    roomId: toRestId(message.roomId, 'ROOM'),
+    personId: toRestId(message.personId, 'PEOPLE'),
+  }
+}
+
+export function normalizeMembership(activity: MembershipActivity): MembershipActivity {
+  // `id` stays raw: it is a Mercury activity UUID, not a REST membership ID.
+  return {
+    ...activity,
+    actorId: toRestId(activity.actorId, 'PEOPLE'),
+    personId: toRestId(activity.personId, 'PEOPLE'),
+    roomId: toRestId(activity.roomId, 'ROOM'),
+  }
+}
+
+export function normalizeAttachmentAction(action: AttachmentAction): AttachmentAction {
+  return {
+    ...action,
+    id: toRestId(action.id, 'ATTACHMENT_ACTION'),
+    messageId: action.messageId ? toRestId(action.messageId, 'MESSAGE') : action.messageId,
+    personId: toRestId(action.personId, 'PEOPLE'),
+    roomId: toRestId(action.roomId, 'ROOM'),
+  }
+}
+
+export function normalizeRoomActivity(activity: RoomActivity): RoomActivity {
+  // `id` stays raw: the Mercury conversation activity UUID has no
+  // consumer-facing REST resource (the comparable REST ID is `roomId`).
+  return {
+    ...activity,
+    roomId: toRestId(activity.roomId, 'ROOM'),
+    actorId: toRestId(activity.actorId, 'PEOPLE'),
+  }
+}

--- a/src/platforms/webexbot/index.ts
+++ b/src/platforms/webexbot/index.ts
@@ -1,5 +1,7 @@
 export { WebexBotClient } from './client'
 export { WebexBotCredentialManager } from './credential-manager'
+export { fromRestId, toRestId } from './id-normalizer'
+export type { WebexRestIdType } from './id-normalizer'
 export { WebexBotListener } from './listener'
 export type { WebexBotListenerOptions } from './listener'
 export type { WebexBotConfig, WebexBotCredentials, WebexBotEntry, WebexBotListenerEventMap } from './types'

--- a/src/platforms/webexbot/listener.test.ts
+++ b/src/platforms/webexbot/listener.test.ts
@@ -9,6 +9,7 @@ import type {
   WebexMessageHandlerEvents,
 } from 'webex-message-handler'
 
+import { toRestId } from './id-normalizer'
 import { WebexBotListener } from './listener'
 
 const STATUS: HandlerStatus = {
@@ -78,8 +79,16 @@ describe('WebexBotListener', () => {
     await listener.start()
     handler.emit('message:created', MESSAGE)
 
-    expect(messageCreated).toHaveBeenCalledWith(MESSAGE)
-    expect(webexEvent).toHaveBeenCalledWith(MESSAGE)
+    const expected = expect.objectContaining({
+      id: toRestId('message-123', 'MESSAGE'),
+      roomId: toRestId('room-123', 'ROOM'),
+      personId: toRestId('person-123', 'PEOPLE'),
+      personEmail: 'user@example.com',
+      text: 'hello',
+      raw: RAW_ACTIVITY,
+    })
+    expect(messageCreated).toHaveBeenCalledWith(expected)
+    expect(webexEvent).toHaveBeenCalledWith(expected)
   })
 
   it('stop calls handler disconnect', async () => {

--- a/src/platforms/webexbot/listener.ts
+++ b/src/platforms/webexbot/listener.ts
@@ -15,6 +15,13 @@ import type {
 import WebSocket from 'ws'
 
 import type { WebexBotClient } from './client'
+import {
+  normalizeAttachmentAction,
+  normalizeDeletedMessage,
+  normalizeMembership,
+  normalizeMessage,
+  normalizeRoomActivity,
+} from './id-normalizer'
 import type { WebexBotListenerEventMap } from './types'
 import { createWdmRewriteFetch, discoverWdmDevicesUrl } from './wdm-discovery'
 
@@ -176,38 +183,45 @@ export class WebexBotListener {
   private wireHandler(handler: WebexMessageHandlerLike, generation: number): () => void {
     const onMessageCreated = (event: DecryptedMessage) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('message_created', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeMessage(event)
+      this.emitter.emit('message_created', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onMessageUpdated = (event: DecryptedMessage) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('message_updated', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeMessage(event)
+      this.emitter.emit('message_updated', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onMessageDeleted = (event: DeletedMessage) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('message_deleted', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeDeletedMessage(event)
+      this.emitter.emit('message_deleted', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onMembershipCreated = (event: MembershipActivity) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('membership_created', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeMembership(event)
+      this.emitter.emit('membership_created', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onAttachmentAction = (event: AttachmentAction) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('attachment_action', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeAttachmentAction(event)
+      this.emitter.emit('attachment_action', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onRoomCreated = (event: RoomActivity) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('room_created', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeRoomActivity(event)
+      this.emitter.emit('room_created', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onRoomUpdated = (event: RoomActivity) => {
       if (!this.isCurrent(handler, generation)) return
-      this.emitter.emit('room_updated', event)
-      this.emitter.emit('webex_event', event)
+      const normalized = normalizeRoomActivity(event)
+      this.emitter.emit('room_updated', normalized)
+      this.emitter.emit('webex_event', normalized)
     }
     const onConnected = () => {
       if (!this.isCurrent(handler, generation)) return

--- a/src/platforms/webexbot/types.ts
+++ b/src/platforms/webexbot/types.ts
@@ -56,6 +56,15 @@ export const WebexBotCredentialsSchema = z.object({
   bot_name: z.string(),
 })
 
+/**
+ * ID contract: every REST-resource ID on these events (person, room, message,
+ * and attachment-action IDs) is emitted in Webex REST ID format, directly
+ * comparable with IDs returned by `WebexBotClient`. Mercury-only activity IDs
+ * (`MembershipActivity.id`, `RoomActivity.id`) stay raw, and the original
+ * Mercury payload is preserved under `.raw` (except `DeletedMessage`, whose
+ * upstream Mercury event omits the full activity). Decode any REST ID with
+ * {@link fromRestId}.
+ */
 export interface WebexBotListenerEventMap {
   message_created: [event: DecryptedMessage]
   message_updated: [event: DecryptedMessage]


### PR DESCRIPTION
## Problem

The Webex bot listener re-emits events from `webex-message-handler`, which carries **raw Mercury UUIDs** (`fb51254f-…`). The Webex REST API — and therefore `WebexBotClient` — returns IDs in **base64 `ciscospark://…` REST form** (`Y2lz…`). So `event.roomId`/`event.personId`/`event.id` from the listener never matched IDs returned by the client, a silent class of wrong-encoding comparison bugs for every consumer.

This contract was already *implied* — the `agent-webexbot` SKILL doc advertises `"id":"Y2lz…","roomId":"Y2lz…"` listener output — but the code emitted raw UUIDs. This PR makes reality match the documented promise.

## What changed

Normalize **every REST-resource ID** to REST form at the listener boundary (covers both the SDK `WebexBotListener` and the `agent-webexbot listen` CLI), keeping Mercury-native UUIDs reachable under `.raw`.

| Event | Field → encoding |
| --- | --- |
| `message_created` / `message_updated` | `id`→MESSAGE, `parentId`→MESSAGE, `roomId`→ROOM, `personId`→PEOPLE, `mentionedPeople[]`→PEOPLE |
| `message_deleted` | `messageId`→MESSAGE, `roomId`→ROOM, `personId`→PEOPLE |
| `membership_created` | `actorId`→PEOPLE, `personId`→PEOPLE, `roomId`→ROOM |
| `attachment_action` | `id`→ATTACHMENT_ACTION, `messageId`→MESSAGE, `personId`→PEOPLE, `roomId`→ROOM |
| `room_created` / `room_updated` | `roomId`→ROOM, `actorId`→PEOPLE |

### Deliberately left raw (encoding them would *create* wrong-encoding bugs)

- `MembershipActivity.id` and `RoomActivity.id` — Mercury **activity** UUIDs with no consumer-facing REST resource (the comparable REST IDs are `roomId`/`personId`). Encoding them as a guessed type would produce plausible-but-wrong IDs.
- `mentionedGroups` (e.g. `"all"`) and `files` (URLs) — not IDs.

### Notes

- `AttachmentAction.id` → `ATTACHMENT_ACTION`. The upstream `toRestId` type union omits this type, so this PR adds a local `toRestId` (a superset) plus re-exports `fromRestId`, both exported from `agent-messenger/webexbot` so the conversion is discoverable rather than tribal knowledge.
- `message_deleted` keeps no `.raw`: the upstream Mercury delete event drops the full activity, so it is unavailable at the boundary. Raw UUIDs remain recoverable via `fromRestId`.

## Contract

> Listener events emit every REST-resource ID in Webex REST format, directly comparable with `WebexBotClient` results; Mercury-only activity IDs stay raw, and the original Mercury payload is preserved under `.raw`.

## Testing

- New `id-normalizer.test.ts`: helper round-trip, `ATTACHMENT_ACTION`, empty-input guard, per-event field mapping, raw/non-id preservation, no input mutation.
- Updated `listener.test.ts` to assert REST-encoded fields.
- `bun typecheck`, `bun lint`, full `bun test` (3165 pass) all green. (A pre-existing, unrelated `format:check` error in `docs/src/app/globals.css` is not touched by this branch.)
<!-- OMO_INTERNAL_INITIATOR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit Webex REST-form IDs from the Webex bot listener so event IDs match `WebexBotClient` results and prevent raw-UUID vs REST-ID mismatches. Mercury-only activity UUIDs remain as-is, and the original Mercury payload stays under `.raw`.

- **New Features**
  - Listener emits REST IDs for person, room, message, and attachment-action fields; works for SDK and `agent-webexbot listen`.
  - Added `toRestId` and re-exported `fromRestId`; exported from `agent-messenger/webexbot` with `WebexRestIdType`. Per-event normalizers applied.
  - Tests added for ID round-trip and event mappings; listener tests updated.
  - Docs updated: `docs/content/docs/sdk/webexbot.mdx` and `skills/agent-webexbot/SKILL.md`.

- **Migration**
  - If you compared listener IDs as raw UUIDs, decode with `fromRestId(event.<id>)` or switch to comparing REST IDs from `WebexBotClient`.
  - No changes needed if you already used REST IDs.

<sup>Written for commit 49e001b9f14d6a9f0db73799bd772ec15cede990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

