### PR TITLE
fix(webexbot): emit REST IDs as unpadded base64url

### DIFF
--- a/src/platforms/webexbot/id-normalizer.test.ts
+++ b/src/platforms/webexbot/id-normalizer.test.ts
@@ -41,6 +41,18 @@ describe('toRestId / fromRestId', () => {
     )
   })
 
+  it('emits unpadded base64url ids matching the Webex REST API', () => {
+    // 36-char UUID -> 59-byte URI, which exposes the padding bug; a URI length
+    // that is a multiple of 3 produces no padding and would hide the regression.
+    const uuid = '12345678-1234-1234-1234-1234567890ab'
+    const restId = toRestId(uuid, 'PEOPLE')
+
+    expect(restId).toBe(Buffer.from(`ciscospark://us/PEOPLE/${uuid}`).toString('base64url'))
+    expect(restId).not.toContain('=')
+    expect(restId).not.toMatch(/[+/]/)
+    expect(fromRestId(restId)).toBe(uuid)
+  })
+
   it('returns empty input unchanged', () => {
     expect(toRestId('', 'MESSAGE')).toBe('')
   })

--- a/src/platforms/webexbot/id-normalizer.ts
+++ b/src/platforms/webexbot/id-normalizer.ts
@@ -14,13 +14,16 @@ export { fromRestId }
 export type WebexRestIdType = 'MESSAGE' | 'PEOPLE' | 'ROOM' | 'ATTACHMENT_ACTION'
 
 /**
- * Encode a raw Mercury UUID as a base64 `ciscospark://us/{TYPE}/{uuid}` Webex
- * REST ID. Empty input is returned unchanged so an absent ID never becomes a
- * bogus `ciscospark://us/{TYPE}/` value.
+ * Encode a raw Mercury UUID as a Webex REST ID. Empty input is returned unchanged
+ * so an absent ID never becomes a bogus `ciscospark://us/{TYPE}/` value.
+ *
+ * Webex REST IDs are unpadded base64url. Padded base64 (trailing `=`) would not
+ * equal the ID the REST API returns for the same resource (e.g. the bot's own
+ * `/people/me` id), silently breaking equality checks such as mention detection.
  */
 export function toRestId(uuid: string, type: WebexRestIdType): string {
   if (!uuid) return uuid
-  return Buffer.from(`ciscospark://us/${type}/${uuid}`).toString('base64')
+  return Buffer.from(`ciscospark://us/${type}/${uuid}`).toString('base64url')
 }
 
 export function normalizeMessage(message: DecryptedMessage): DecryptedMessage {


### PR DESCRIPTION
## Problem

#235 normalizes listener IDs to Webex REST form via a local `toRestId`, but it encodes with **padded base64** (`.toString('base64')`). Webex REST IDs are **unpadded base64url**.

For any resource whose `ciscospark://…` URI length isn't a multiple of 3 — e.g. a real 36-char person UUID → a 59-byte URI — padded base64 appends a trailing `=` that the REST API never returns:

```
ciscospark://us/PEOPLE/12345678-1234-1234-1234-1234567890ab   (59 bytes)
base64     Y2lz…Nzg5MGFi=    ← what #235 emits
base64url  Y2lz…Nzg5MGFi     ← what /people/me actually returns
```

So a normalized `mentionedPeople` entry never equals the bot's own `/people/me` id. Mention detection silently fails and the bot stays quiet when it is @-mentioned — the exact class of comparison bug #235 set out to fix.

(The upstream `webex-message-handler` `toRestId` has the same padded-base64 bug, which is why #235 re-implemented it locally — and inherited it.)

## Fix

One line in `id-normalizer.ts`: `.toString('base64')` → `.toString('base64url')`.

`fromRestId` decodes with the lenient `Buffer.from(id, 'base64')` (which accepts unpadded base64url), so round-tripping is unaffected.

## Testing

Added a regression test using a realistic 36-char UUID, since a `ciscospark` URI whose length is a multiple of 3 produces no padding and would hide the bug. It asserts the encoded id is unpadded, base64url-only, and round-trips back to the UUID.

- `bun lint`, `bun typecheck`, `bun run format:check`, and full `bun test` (3166 pass) all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Webex mention detection by emitting unpadded base64url REST IDs so normalized IDs match what the Webex API returns. Prevents false mismatches with the bot’s own `/people/me` id.

- **Bug Fixes**
  - Use `.toString('base64url')` in `toRestId` for `ciscospark://us/{TYPE}/{uuid}`.
  - Add regression test with a 36-char UUID to verify no `=`, URL-safe chars, and round-trip.

- **Docs**
  - No changes to SKILL.md or docs.

<sup>Written for commit a1333068ee78753e1fcf81076c0d169206cf68ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

