### PR TITLE
fix(webexbot): resolve clustered room IDs on non-default clusters

### DIFF
--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -191,6 +191,53 @@ describe('WebexClient', () => {
     })
   })
 
+  describe('iterateSpaces', () => {
+    it('follows the Link header across pages and yields every room', async () => {
+      // given two pages chained by a rel="next" Link header
+      mockResponse({ items: [{ id: 'room1', title: 'One', type: 'group' }] }, 200, {
+        Link: '<https://webexapis.com/v1/rooms?max=1000&before=cursor1>; rel="next"',
+      })
+      mockResponse({ items: [{ id: 'room2', title: 'Two', type: 'group' }] })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      const ids: string[] = []
+      for await (const room of client.iterateSpaces({ max: 1000 })) {
+        ids.push(room.id)
+      }
+
+      expect(ids).toEqual(['room1', 'room2'])
+      expect(fetchCalls[0].url).toContain('/rooms?max=1000')
+      expect(fetchCalls[1].url).toContain('before=cursor1')
+    })
+
+    it('stops after a single page when no next Link is present', async () => {
+      mockResponse({ items: [{ id: 'room1', title: 'One', type: 'group' }] })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      const ids: string[] = []
+      for await (const room of client.iterateSpaces()) {
+        ids.push(room.id)
+      }
+
+      expect(ids).toEqual(['room1'])
+      expect(fetchCalls).toHaveLength(1)
+    })
+
+    it('stops consuming the generator early without fetching the next page', async () => {
+      mockResponse({ items: [{ id: 'room1', title: 'One', type: 'group' }] }, 200, {
+        Link: '<https://webexapis.com/v1/rooms?max=1000&before=cursor1>; rel="next"',
+      })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      for await (const room of client.iterateSpaces({ max: 1000 })) {
+        expect(room.id).toBe('room1')
+        break
+      }
+
+      expect(fetchCalls).toHaveLength(1)
+    })
+  })
+
   describe('getSpace', () => {
     it('calls GET /rooms/{spaceId}', async () => {
       mockResponse({ id: 'room1', title: 'Test Room', type: 'group' })

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -131,6 +131,14 @@ export class WebexClient {
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    return (await this.requestWithLink<T>(method, path, body)).data
+  }
+
+  private async requestWithLink<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<{ data: T; nextPath: string | null }> {
     const url = `${BASE_URL}${path}`
     const bucketKey = this.getBucketKey(method, path)
 
@@ -179,10 +187,11 @@ export class WebexClient {
       }
 
       if (response.status === 204) {
-        return undefined as T
+        return { data: undefined as T, nextPath: null }
       }
 
-      return response.json() as Promise<T>
+      const data = (await response.json()) as T
+      return { data, nextPath: parseNextPath(response.headers.get('Link')) }
     }
 
     throw new WebexError('Request failed after retries', 'max_retries')
@@ -218,6 +227,18 @@ export class WebexClient {
     const query = params.toString()
     const data = await this.request<{ items: WebexSpace[] }>('GET', `/rooms?${query}`)
     return data.items
+  }
+
+  async *iterateSpaces(options?: { type?: string; max?: number }): AsyncGenerator<WebexSpace> {
+    const params = new URLSearchParams()
+    if (options?.type) params.set('type', options.type)
+    params.set('max', String(options?.max ?? 100))
+    let path: string | null = `/rooms?${params.toString()}`
+    while (path) {
+      const page: { data: { items: WebexSpace[] }; nextPath: string | null } = await this.requestWithLink('GET', path)
+      yield* page.data.items
+      path = page.nextPath
+    }
   }
 
   async getSpace(spaceId: string): Promise<WebexSpace> {
@@ -593,6 +614,16 @@ export class WebexClient {
     }
     return parsed.toString()
   }
+}
+
+// Webex paginates List endpoints via an RFC 5988 `Link` header
+// (`<https://webexapis.com/v1/rooms?...&before=cursor>; rel="next"`). Return the
+// next page as a BASE_URL-relative path, or null when there is no next page.
+function parseNextPath(linkHeader: string | null): string | null {
+  if (!linkHeader) return null
+  const next = linkHeader.match(/<([^>]+)>\s*;\s*rel="next"/i)
+  if (!next) return null
+  return next[1].startsWith(BASE_URL) ? next[1].slice(BASE_URL.length) : null
 }
 
 function sanitizeFilename(name: string | undefined): string | undefined {

--- a/src/platforms/webexbot/client.test.ts
+++ b/src/platforms/webexbot/client.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 
 import { WebexBotClient } from './client'
+import { toRestId } from './id-normalizer'
 
 describe('WebexBotClient', () => {
   const originalFetch = globalThis.fetch
@@ -193,6 +194,129 @@ describe('WebexBotClient', () => {
       const result = await client.downloadContent('https://webexapis.com/v1/contents/c1')
 
       expect(result.filename).toBe('passwd')
+    })
+  })
+
+  describe('room cluster resolution', () => {
+    const roomUuid = '12345678-1234-1234-1234-1234567890ab'
+    const usRoomId = toRestId(roomUuid, 'ROOM')
+    const clusteredRoomId = Buffer.from(`ciscospark://urn:TEAM:us-west-2_r/ROOM/${roomUuid}`).toString('base64url')
+
+    const isRoomsList = (url: string) => new URL(url).pathname === '/v1/rooms'
+
+    const clusteredId = (uuid: string) =>
+      Buffer.from(`ciscospark://urn:TEAM:us-west-2_r/ROOM/${uuid}`).toString('base64url')
+
+    const mockRoomsPage = (items: unknown[], nextCursor?: string) => {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (nextCursor) headers.Link = `<https://webexapis.com/v1/rooms?max=1000&before=${nextCursor}>; rel="next"`
+      fetchResponses.push(new Response(JSON.stringify({ items }), { status: 200, headers }))
+    }
+
+    it('rewrites a us-cluster roomId to the real urn:TEAM id before sending', async () => {
+      // given a non-default-cluster room only reachable via its clustered id
+      mockResponse({ items: [{ id: clusteredRoomId, title: 'Team', type: 'group' }] })
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' })
+
+      // when sending to the us-flattened id the listener emitted
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.sendMessage(usRoomId, 'hello')
+
+      // then the lookup runs and the send targets the corrected clustered id
+      expect(isRoomsList(fetchCalls[0].url)).toBe(true)
+      const body = JSON.parse(fetchCalls[1].options?.body as string)
+      expect(body.roomId).toBe(clusteredRoomId)
+    })
+
+    it('routes listMemberships through the corrected clustered id', async () => {
+      mockResponse({ items: [{ id: clusteredRoomId, type: 'group' }] })
+      mockResponse({ items: [{ id: 'm1', roomId: clusteredRoomId, personId: 'p1' }] })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.listMemberships(usRoomId)
+
+      const membershipsUrl = new URL(fetchCalls[1].url)
+      expect(membershipsUrl.pathname).toBe('/v1/memberships')
+      expect(membershipsUrl.searchParams.get('roomId')).toBe(clusteredRoomId)
+    })
+
+    it('routes listMessages and its space lookup through the corrected clustered id', async () => {
+      mockResponse({ items: [{ id: clusteredRoomId, type: 'group' }] })
+      mockResponse({ id: clusteredRoomId, title: 'Team', type: 'group' })
+      mockResponse({ items: [{ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' }] })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.listMessages(usRoomId, { max: 5 })
+
+      expect(fetchCalls[1].url).toBe(`https://webexapis.com/v1/rooms/${clusteredRoomId}`)
+      const messagesUrl = new URL(fetchCalls[2].url)
+      expect(messagesUrl.searchParams.get('roomId')).toBe(clusteredRoomId)
+    })
+
+    it('passes an already-clustered roomId through without a lookup', async () => {
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.sendMessage(clusteredRoomId, 'hi')
+
+      expect(fetchCalls).toHaveLength(1)
+      expect(new URL(fetchCalls[0].url).pathname).toBe('/v1/messages')
+      expect(JSON.parse(fetchCalls[0].options?.body as string).roomId).toBe(clusteredRoomId)
+    })
+
+    it('caches the resolution so repeated calls trigger one room lookup', async () => {
+      mockResponse({ items: [{ id: clusteredRoomId, type: 'group' }] })
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId })
+      mockResponse({ id: 'msg-2', roomId: clusteredRoomId })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.sendMessage(usRoomId, 'a')
+      await client.sendMessage(usRoomId, 'b')
+
+      expect(fetchCalls.filter((c) => isRoomsList(c.url))).toHaveLength(1)
+    })
+
+    it('follows Link pages until the room is found on a later page', async () => {
+      // given the matching room is only on the second page
+      mockRoomsPage([{ id: clusteredId('00000000-0000-0000-0000-000000000000'), type: 'group' }], 'cursor1')
+      mockRoomsPage([{ id: clusteredRoomId, type: 'group' }])
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' })
+
+      // when sending to a room not present on the first page
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.sendMessage(usRoomId, 'hi')
+
+      // then the second page is fetched via the Link cursor and the send targets the match
+      expect(isRoomsList(fetchCalls[0].url)).toBe(true)
+      expect(isRoomsList(fetchCalls[1].url)).toBe(true)
+      expect(fetchCalls[1].url).toContain('before=cursor1')
+      expect(JSON.parse(fetchCalls[2].options?.body as string).roomId).toBe(clusteredRoomId)
+    })
+
+    it('stops paging once the room is found and does not fetch later pages', async () => {
+      // given a first page that already contains the match but still advertises a next page
+      mockRoomsPage([{ id: clusteredRoomId, type: 'group' }], 'cursor1')
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await client.sendMessage(usRoomId, 'hi')
+
+      // then only the first page is fetched (a second page fetch would hit the unmocked response and throw)
+      expect(fetchCalls.filter((c) => isRoomsList(c.url))).toHaveLength(1)
+      expect(JSON.parse(fetchCalls[1].options?.body as string).roomId).toBe(clusteredRoomId)
+    })
+
+    it('fails open to the un-clustered id and warns when no room matches', async () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      mockResponse({ items: [] })
+      mockResponse({ id: 'msg-1', roomId: usRoomId })
+
+      const client = await new WebexBotClient().login({ token: 'bot-token' })
+      await expect(client.sendMessage(usRoomId, 'x')).resolves.toBeDefined()
+
+      expect(JSON.parse(fetchCalls[1].options?.body as string).roomId).toBe(usRoomId)
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
     })
   })
 })

--- a/src/platforms/webexbot/client.ts
+++ b/src/platforms/webexbot/client.ts
@@ -2,9 +2,32 @@ import { WebexClient } from '../webex/client'
 import type { WebexMembership, WebexMessage, WebexPerson, WebexSpace } from '../webex/types'
 import { WebexBotError } from './types'
 
+interface DecodedWebexId {
+  cluster: string
+  type: string
+  uuid: string
+}
+
+// Webex REST ids are base64(url) of `ciscospark://<cluster>/<TYPE>/<uuid>`; the
+// cluster correction needs all three parts, not just the <uuid> `fromRestId` returns.
+function decodeWebexId(restId: string): DecodedWebexId | null {
+  if (!restId) return null
+  const decoded = Buffer.from(restId, 'base64').toString('utf-8')
+  const match = decoded.match(/^ciscospark:\/\/([^/]+)\/([^/]+)\/(.+)$/)
+  if (!match) return null
+  return { cluster: match[1], type: match[2], uuid: match[3] }
+}
+
 export class WebexBotClient {
   private client = new WebexClient()
   private token: string | null = null
+
+  // The listener flattens room ids to `ciscospark://us/ROOM/<uuid>`, but team/group
+  // rooms live on `ciscospark://urn:TEAM:<cluster>/ROOM/<uuid>` — a cluster the bare
+  // uuid cannot recover. Cache the real clustered id per uuid and dedupe concurrent
+  // lookups so a burst of calls triggers a single `listSpaces`.
+  private clusteredRoomIds = new Map<string, string>()
+  private roomIdLookups = new Map<string, Promise<string>>()
 
   async login(credentials?: { token: string }): Promise<this> {
     if (credentials) {
@@ -41,7 +64,7 @@ export class WebexBotClient {
   }
 
   async getSpace(spaceId: string): Promise<WebexSpace> {
-    return this.client.getSpace(spaceId)
+    return this.client.getSpace(await this.resolveRoomId(spaceId))
   }
 
   async sendMessage(
@@ -49,7 +72,7 @@ export class WebexBotClient {
     text: string,
     options?: { markdown?: boolean; parentId?: string; files?: string[] },
   ): Promise<WebexMessage> {
-    return this.client.sendMessage(roomId, text, options)
+    return this.client.sendMessage(await this.resolveRoomId(roomId), text, options)
   }
 
   async sendDirectMessage(personEmail: string, text: string, options?: { markdown?: boolean }): Promise<WebexMessage> {
@@ -57,16 +80,21 @@ export class WebexBotClient {
   }
 
   async listMessages(roomId: string, options?: { max?: number; parentId?: string }): Promise<WebexMessage[]> {
-    const space = await this.client.getSpace(roomId)
+    const resolvedRoomId = await this.resolveRoomId(roomId)
+    const space = await this.client.getSpace(resolvedRoomId)
     const messageOptions = space.type === 'group' ? { ...options, mentionedPeople: 'me' } : options
-    return this.client.listMessages(roomId, messageOptions)
+    return this.client.listMessages(resolvedRoomId, messageOptions)
   }
 
   async listReplies(roomId: string, parentId: string, options?: { max?: number }): Promise<WebexMessage[]> {
-    return this.client.listMessages(roomId, { ...options, parentId })
+    return this.client.listMessages(await this.resolveRoomId(roomId), { ...options, parentId })
   }
 
   async getMessage(messageId: string): Promise<WebexMessage> {
+    // MESSAGE ids carry their parent room's cluster, which the bare-UUID normalizer
+    // also flattens to `us`. Correcting that needs the room context, which a lone
+    // messageId does not provide; room-keyed calls (the reported failures) are
+    // corrected via resolveRoomId instead.
     return this.client.getMessage(messageId)
   }
 
@@ -80,7 +108,7 @@ export class WebexBotClient {
     text: string,
     options?: { markdown?: boolean },
   ): Promise<WebexMessage> {
-    return this.client.editMessage(messageId, roomId, text, options)
+    return this.client.editMessage(messageId, await this.resolveRoomId(roomId), text, options)
   }
 
   async listPeople(options?: { email?: string; displayName?: string; max?: number }): Promise<WebexPerson[]> {
@@ -96,7 +124,7 @@ export class WebexBotClient {
   }
 
   async listMemberships(roomId: string, options?: { max?: number }): Promise<WebexMembership[]> {
-    return this.client.listMemberships(roomId, options)
+    return this.client.listMemberships(await this.resolveRoomId(roomId), options)
   }
 
   async uploadFile(
@@ -104,10 +132,53 @@ export class WebexBotClient {
     file: { content: Blob; filename: string },
     options?: { text?: string; markdown?: boolean; parentId?: string },
   ): Promise<WebexMessage> {
-    return this.client.uploadFile(roomId, file, options)
+    return this.client.uploadFile(await this.resolveRoomId(roomId), file, options)
   }
 
   async downloadContent(contentRef: string): Promise<{ data: ArrayBuffer; filename: string; contentType: string }> {
     return this.client.downloadContent(contentRef)
+  }
+
+  private async resolveRoomId(roomId: string): Promise<string> {
+    const decoded = decodeWebexId(roomId)
+    // Already cluster-qualified or undecodable: nothing to correct.
+    if (!decoded || decoded.cluster.startsWith('urn:')) return roomId
+
+    const { uuid } = decoded
+    const cached = this.clusteredRoomIds.get(uuid)
+    if (cached) return cached
+
+    const inFlight = this.roomIdLookups.get(uuid)
+    if (inFlight) return inFlight
+
+    const lookup = this.lookupRoomId(uuid, roomId)
+    this.roomIdLookups.set(uuid, lookup)
+    try {
+      return await lookup
+    } finally {
+      this.roomIdLookups.delete(uuid)
+    }
+  }
+
+  private async lookupRoomId(uuid: string, fallback: string): Promise<string> {
+    try {
+      // Page through every room the bot belongs to (largest page size, following
+      // `Link` pages), stopping as soon as the trailing UUID matches.
+      for await (const room of this.client.iterateSpaces({ max: 1000 })) {
+        if (decodeWebexId(room.id)?.uuid === uuid) {
+          this.clusteredRoomIds.set(uuid, room.id)
+          return room.id
+        }
+      }
+    } catch {
+      // Network/auth failure: fail open to the un-corrected id rather than block the call.
+      return fallback
+    }
+
+    console.warn(
+      `[webexbot] Could not resolve clustered room id for ${uuid}; falling back to the un-clustered id. ` +
+        'Room-scoped calls may fail if this room lives on a non-default Webex cluster.',
+    )
+    return fallback
   }
 }


### PR DESCRIPTION
## Problem

The listener normalizes raw Mercury UUIDs into Webex REST IDs via `toRestId(uuid, type)` in `id-normalizer.ts`, which hardcodes the cluster segment as `us`:

```
ciscospark://us/${type}/${uuid}
```

This is correct for `PEOPLE` and `ORGANIZATION` (always `us`), but **wrong for `ROOM` on non-default clusters**. Webex addresses team/group rooms by a cluster-qualified URI:

```
ciscospark://us/ROOM/<uuid>                     ← what the normalizer emits
ciscospark://urn:TEAM:us-west-2_r/ROOM/<uuid>   ← the real, routable ID
```

The cluster is **not recoverable from the bare UUID**. So for team/group rooms, `listMemberships`, `listMessages`/`getSpace`, and `sendMessage`/`uploadFile` all fail with `Could not find a room with provided ID` — **the bot receives the message but cannot reply**. DMs are unaffected, since DM rooms live on the plain `us` cluster.

`GET /v1/rooms` returns rooms with their correctly clustered IDs, so decoding each returned room ID and matching by the trailing UUID suffix recovers the real cluster-qualified ID.

## Fix

A room-ID cluster-correction resolver contained entirely within `WebexBotClient` (`id-normalizer.ts` is untouched; `PEOPLE`/`ORGANIZATION` behavior is unchanged):

- `resolveRoomId(roomId)` decodes the ID (base64 **and** base64url, padded or unpadded).
  - Already cluster-qualified (`urn:TEAM:…`) or undecodable → returned unchanged (no lookup).
  - `us`-flattened → look up the real clustered ID via `listSpaces` (`GET /v1/rooms`), matching by the trailing UUID suffix.
- **Cached** per UUID (a room's cluster is immutable, so no TTL is needed) and **concurrency-safe** — a single in-flight promise per UUID dedupes a burst of calls to one `listSpaces`.
- **Fails open**: an unresolved ID (bot not a member, or pagination miss) falls back to the input with a warning rather than throwing.

Every room-keyed REST call (`sendMessage`, `uploadFile`, `listMessages` + its `getSpace`, `listReplies`, `listMemberships`, `getSpace`, `editMessage`) routes through the resolver. The correction happens **only at the REST-call boundary** — the listener's emitted/normalized IDs (engagement, identity, persistence) are unchanged.

`MESSAGE`-type calls (`getMessage`, `deleteMessage`) are left as-is and documented: a lone message ID carries no room context to recover the cluster from, and room-keyed calls cover the reported failures.

## Testing

Added unit tests (with a fake `listSpaces` returning a room on `urn:TEAM:us-west-2_r`):

- A `us`-cluster room ID is rewritten to the `urn:TEAM` form before `sendMessage`.
- `listMemberships` / `listMessages` (and its `getSpace`) call the underlying client with the corrected clustered ID.
- An already-`urn:TEAM` ID passes through untouched (no `listSpaces` call).
- A cache hit does not trigger a second `listSpaces`.
- No match → returns the input unchanged + warning (fail-open), does not throw.

- `bun lint`, `bun typecheck`, `bun run format:check`, and full `bun test` (3172 pass) all green.
- The `id-normalizer` base64url tests (#236) and `PEOPLE`/`ORG` behavior are not regressed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Webex bot failures on non-default clusters by resolving `ROOM` IDs to their cluster-qualified form before REST calls. Bots can now send messages and list content in team/group spaces across clusters.

- **Bug Fixes**
  - Added a room-ID resolver in `WebexBotClient` that decodes REST IDs and, for `us`-flattened rooms, finds the real `urn:TEAM:<cluster>` by UUID match using `WebexClient.iterateSpaces` (follows `Link` rel="next" pages, `max=1000`; stops early).
  - Routed all room-scoped calls through the resolver; cached per UUID, deduped concurrent lookups, and fail open to the input ID with a warning if unresolved.
  - Introduced `WebexClient.iterateSpaces` and `requestWithLink` to support pagination (no behavior change to existing methods); `id-normalizer.ts` untouched; `PEOPLE`/`ORGANIZATION` unchanged; `MESSAGE` calls left as-is.

Docs: SKILL.md/docs not updated (listener-emitted IDs and public surfaces are unchanged).

<sup>Written for commit e134b5e529b29baa2ba8afafb88abad87fae9609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

