### PR TITLE
feat(webex): add headless email/password login

### DIFF
--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -59,6 +59,19 @@ This command:
 - Stores access and refresh tokens securely in `~/.config/agent-messenger/`
 - Auto-refreshes expired access tokens (14-day access, 90-day refresh)
 
+### Headless Email/Password (Server-side)
+
+Logs in with a Webex email and password — no browser. Useful for servers and CI/CD that need a real user token (e.g. for the real-time listener, which receives all space messages without an @mention). Pipe the password via stdin to keep it out of shell history.
+
+```bash
+printf '%s' "$WEBEX_PASSWORD" | agent-webex auth login --email you@example.com --password-stdin
+```
+
+- Discovers the user's Webex region, performs OAuth2 Authorization Code + PKCE against Cisco IdBroker, and stores access/refresh tokens in `~/.config/agent-messenger/`
+- Produces a KMS-scoped user token (client-side JWE/AES-256-GCM encryption works)
+- `--idbroker-host <host>` overrides region auto-discovery if needed
+- Accounts protected by SSO/IdP or MFA are not supported and fail with a clear error
+
 ### How Login Works
 
 1. Run `agent-webex auth extract` (recommended) or `agent-webex auth login` (fallback)
@@ -72,6 +85,7 @@ This command:
 | -------------------------------- | -------------------------------------------- | ------------------------------------ |
 | Browser Extraction (recommended) | Session-based (re-extract when expired)      | Interactive use, sending as yourself |
 | OAuth Device Grant               | 14-day access, 90-day refresh (auto-refresh) | Fallback when no browser session     |
+| Email/Password (headless)        | Access + refresh (auto-refresh)              | Server-side/CI without a browser     |
 | Bot Token                        | Never expires                                | CI/CD, long-running automation       |
 | Personal Access Token (PAT)      | 12 hours                                     | Quick testing                        |
 
@@ -86,6 +100,9 @@ agent-webex auth login
 
 # Log in with custom Integration credentials
 agent-webex auth login --client-id <id> --client-secret <secret>
+
+# Log in headlessly with an email and password (read from stdin)
+printf '%s' "$WEBEX_PASSWORD" | agent-webex auth login --email you@example.com --password-stdin
 
 # Log in with a bot token (never expires)
 agent-webex auth login --token <bot-token>

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -16,13 +16,16 @@ metadata:
 
 # Agent Webex
 
-A TypeScript CLI tool that enables AI agents and humans to interact with Cisco Webex through a simple command interface. Supports browser token extraction (zero-config, sends as you) and OAuth Device Grant flow.
+A TypeScript CLI tool that enables AI agents and humans to interact with Cisco Webex through a simple command interface. Supports browser token extraction (zero-config, sends as you), headless password login, and OAuth Device Grant flow.
 
 ## Quick Start
 
 ```bash
 # Extract token from browser (Chrome, Edge, Arc, Brave) — messages appear as you
 agent-webex auth extract
+
+# Or: Headless login with email/password — messages appear as you
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
 # Or: Log in via OAuth Device Grant (opens browser, messages show "via agent-messenger")
 agent-webex auth login
@@ -39,10 +42,11 @@ agent-webex space list
 
 ## Authentication
 
-Webex supports two authentication methods:
+Webex supports three authentication methods:
 
 1. **Browser token extraction** (recommended): Extracts your first-party token from a Chromium browser where you're logged into web.webex.com. Messages appear as you — no "via" label.
-2. **OAuth Device Grant**: Opens a browser for you to authorize. Messages show "via agent-messenger" label.
+2. **Headless password login**: Exchanges Webex email/password for a first-party web token without opening a browser. Messages appear as you. Not supported for SSO/MFA accounts.
+3. **OAuth Device Grant**: Opens a browser for you to authorize. Messages show "via agent-messenger" label.
 
 ### Browser Token Extraction (Recommended)
 
@@ -67,6 +71,16 @@ agent-webex auth extract --browser-profile ~/work-profile --browser-profile ~/pe
 **How it works**: The Webex web client stores its authentication token in the browser's localStorage. This CLI reads it directly from the browser's LevelDB files — no browser automation, no password prompts. The token is stored locally in `~/.config/agent-messenger/`.
 
 **When to re-extract**: Browser tokens expire. When your token expires, re-run `agent-webex auth extract` or let auto-extraction handle it (the CLI attempts extraction automatically on each run).
+
+### Headless Password Login
+
+Use email/password login when no browser profile is available and the account does not require SSO or MFA.
+
+```bash
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
+```
+
+This stores a refreshable first-party web token locally and supports encrypted messaging through the internal Webex API.
 
 ### OAuth Device Grant (Fallback)
 
@@ -105,6 +119,7 @@ If you passed `--client-id` / `--client-secret` (custom Webex Integration) on Ca
 Alternatives that skip the Device Grant flow entirely:
 
 - `agent-webex auth login --token <bot-or-personal-access-token>` — fully unattended, no human required.
+- `agent-webex auth login --email <email> --password-stdin` — headless first-party login for non-SSO, non-MFA accounts.
 - `agent-webex auth extract` — read an existing browser session token (no auth flow at all).
 
 Env vars `AGENT_WEBEX_CLIENT_ID` / `AGENT_WEBEX_CLIENT_SECRET` can also override the built-in credentials.
@@ -119,6 +134,9 @@ agent-webex auth login --client-id <id> --client-secret <secret>
 # Log in with a bot token
 agent-webex auth login --token <token>
 
+# Headless email/password login
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
+
 # Check auth status
 agent-webex auth status
 
@@ -129,6 +147,7 @@ agent-webex auth logout
 ### Token Types
 
 - **Extracted (browser)**: First-party token from web.webex.com. Messages appear as you. Requires re-extraction when expired.
+- **Password**: First-party web token from headless email/password login. Messages appear as you. Not supported for SSO/MFA accounts.
 - **OAuth Device Grant**: Zero-config login. Access token auto-refreshes. Messages show "via agent-messenger".
 - **Bot Token**: Pass via `--token` flag. Never expires. Best for CI/CD.
 - **Custom Integration**: Pass `--client-id` + `--client-secret` or set env vars for your own Webex Integration.

--- a/skills/agent-webex/references/authentication.md
+++ b/skills/agent-webex/references/authentication.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-agent-webex supports four authentication methods against the Webex REST API (`https://webexapis.com/v1`):
+agent-webex supports five authentication methods against the Webex REST API (`https://webexapis.com/v1`):
 
 1. **Browser Token Extraction**: Extracts your first-party token and cached encryption keys from a Chromium browser where you're logged into web.webex.com. Supports all operations including encrypted messaging via the internal API. Zero-config.
-2. **OAuth Device Grant** (recommended for messaging): Zero-config. Run `auth login`, approve in browser, done. Tokens refresh automatically. Supports all operations including sending messages (shows "via agent-messenger").
-3. **Bot Token**: Pass via `auth login --token`. Never expires. Best for CI/CD.
-4. **Personal Access Token (PAT)**: Pass via `auth login --token`. Expires in 12 hours. For quick testing.
+2. **Headless Password Login**: Exchanges email/password for a first-party web token without opening a browser. Supports encrypted messaging via the internal API. Not supported for SSO/MFA accounts.
+3. **OAuth Device Grant** (recommended for messaging): Zero-config. Run `auth login`, approve in browser, done. Tokens refresh automatically. Supports all operations including sending messages (shows "via agent-messenger").
+4. **Bot Token**: Pass via `auth login --token`. Never expires. Best for CI/CD.
+5. **Personal Access Token (PAT)**: Pass via `auth login --token`. Expires in 12 hours. For quick testing.
 
 ## Token Types
 
@@ -39,6 +40,19 @@ agent-webex auth extract --browser-profile "$HOME/work-profile,$HOME/personal-pr
 Use `--browser-profile <path>` for agent-browser profiles, custom Chrome user data dirs, or portable browser profiles. The option can be repeated or given comma-separated paths.
 
 **Limitations**: Direct messages (`message dm`) require an existing conversation with the recipient. The extracted token cannot create new 1:1 conversations — start one from the Webex app first, then use the CLI.
+
+### Headless Password Login
+
+Use this when a browser profile is unavailable and the Webex account accepts direct email/password login.
+
+- **How it works**: Run `agent-webex auth login --email <email> --password-stdin`. The CLI performs the Webex web OAuth + PKCE flow headlessly, registers a Webex device, and stores refreshable credentials.
+- **Auto-refresh**: The CLI refreshes expired access tokens using the stored web refresh token.
+- **End-to-end encryption**: Uses the internal Webex API with KMS key fetching, so messages appear as you without the "via" label.
+- **Limitations**: SSO and MFA accounts are not supported by this headless flow.
+
+```bash
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
+```
 
 ### OAuth Device Grant
 
@@ -88,6 +102,9 @@ agent-webex auth login --token "YOUR_PAT_HERE"
 ```bash
 # Browser extraction (recommended — messages appear as you)
 agent-webex auth extract
+
+# Headless email/password login (messages appear as you)
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
 # Device Grant (fallback — messages show "via agent-messenger")
 agent-webex auth login
@@ -174,6 +191,22 @@ OAuth credentials (from Device Grant):
   "clientId": "...",
   "clientSecret": "...",
   "tokenType": "oauth"
+}
+```
+
+Password credentials (from `auth login --email`):
+
+```json
+{
+  "accessToken": "...",
+  "refreshToken": "...",
+  "expiresAt": 1234567890,
+  "clientId": "...",
+  "clientSecret": "...",
+  "tokenType": "password",
+  "deviceUrl": "...",
+  "userId": "...",
+  "encryptionKeys": {}
 }
 ```
 

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -46,7 +46,7 @@ export class WebexClient {
     this.tokenType = config?.tokenType ?? null
     await this.login({ token })
 
-    if (this.tokenType === 'extracted') {
+    if (this.tokenType === 'extracted' || this.tokenType === 'password') {
       const keysMap = new Map(Object.entries(config?.encryptionKeys ?? {}))
       this.encryption = new WebexEncryptionService(keysMap)
       const kmsProvider = new KmsKeyProvider({ token })
@@ -262,7 +262,7 @@ export class WebexClient {
   }
 
   private get useInternalAPI(): boolean {
-    return this.tokenType === 'extracted' && this.deviceUrl !== null
+    return (this.tokenType === 'extracted' || this.tokenType === 'password') && this.deviceUrl !== null
   }
 
   private get convBaseUrl(): string {

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+
 import { Command } from 'commander'
 
 import { collectBrowserProfileOption } from '@/shared/chromium'
@@ -9,6 +11,7 @@ import { info, debug } from '@/shared/utils/stderr'
 import { getWebexAppCredentials } from '../app-config'
 import { WebexClient } from '../client'
 import { WebexCredentialManager } from '../credential-manager'
+import { loginWithPassword, WEB_CLIENT_ID, WEB_CLIENT_SECRET } from '../password-login'
 import { WebexTokenExtractor } from '../token-extractor'
 import { WebexError } from '../types'
 
@@ -49,6 +52,10 @@ interface LoginOptions {
   deviceCode?: string
   clientId?: string
   clientSecret?: string
+  email?: string
+  password?: string
+  passwordStdin?: boolean
+  idbrokerHost?: string
   pretty?: boolean
 }
 
@@ -79,6 +86,11 @@ export async function loginAction(options: LoginOptions): Promise<void> {
 
     if (options.deviceCode) {
       await finishDeviceGrant(credManager, options)
+      return
+    }
+
+    if (options.email) {
+      await loginWithEmailPassword(credManager, options)
       return
     }
 
@@ -122,6 +134,45 @@ export async function loginAction(options: LoginOptions): Promise<void> {
   } catch (error) {
     handleError(error as Error)
   }
+}
+
+async function loginWithEmailPassword(credManager: WebexCredentialManager, options: LoginOptions): Promise<void> {
+  const password = await resolvePassword(options)
+  const config = await loginWithPassword(options.email!, password, { idbrokerHost: options.idbrokerHost })
+
+  await credManager.saveConfig({
+    ...config,
+    tokenType: 'password',
+    clientId: WEB_CLIENT_ID,
+    clientSecret: WEB_CLIENT_SECRET,
+    encryptionKeys: {},
+  })
+
+  const client = await new WebexClient().login({
+    token: config.accessToken,
+    deviceUrl: config.deviceUrl,
+    tokenType: 'password',
+  })
+  const person = await client.testAuth()
+
+  console.log(
+    formatOutput(
+      {
+        authenticated: true,
+        user: { id: person.id, displayName: person.displayName, emails: person.emails },
+      },
+      options.pretty,
+    ),
+  )
+}
+
+async function resolvePassword(options: LoginOptions): Promise<string> {
+  if (options.password && options.passwordStdin) {
+    throw new Error('Use only one of --password or --password-stdin.')
+  }
+  if (options.password) return options.password
+  if (options.passwordStdin) return readFileSync(0, 'utf-8').replace(/\r?\n$/, '')
+  throw new Error('--password or --password-stdin is required with --email.')
 }
 
 async function startNonInteractiveDeviceGrant(
@@ -379,6 +430,10 @@ export const authCommand = new Command('auth')
       )
       .option('--client-id <id>', 'Webex Integration client ID')
       .option('--client-secret <secret>', 'Webex Integration client secret')
+      .option('--email <email>', 'Log in headlessly with a Webex email address')
+      .option('--password <password>', 'Password for --email login')
+      .option('--password-stdin', 'Read password for --email login from stdin')
+      .option('--idbroker-host <host>', 'Override IdBroker host for --email login')
       .option('--pretty', 'Pretty print JSON output')
       .action(loginAction),
   )

--- a/src/platforms/webex/credential-manager.test.ts
+++ b/src/platforms/webex/credential-manager.test.ts
@@ -326,6 +326,46 @@ describe('WebexCredentialManager', () => {
     globalThis.fetch = originalFetch
   })
 
+  it('getToken refreshes password tokens with stored web credentials', async () => {
+    const originalFetch = globalThis.fetch
+    let capturedBody = ''
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      capturedBody = String(init?.body ?? '')
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: 'refreshed-password-token',
+            refresh_token: 'new-password-refresh',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+    }) as typeof fetch
+
+    await credManager.saveConfig({
+      accessToken: 'expired-password-token',
+      refreshToken: 'password-refresh',
+      expiresAt: Date.now() - 1000,
+      tokenType: 'password',
+      clientId: 'fake-client-id',
+      clientSecret: 'fake-client-secret',
+    })
+
+    const token = await credManager.getToken()
+    const params = new URLSearchParams(capturedBody)
+
+    expect(token).toBe('refreshed-password-token')
+    expect(params.get('client_id')).toBe('fake-client-id')
+    expect(params.get('client_secret')).toBe('fake-client-secret')
+
+    const config = await credManager.loadConfig()
+    expect(config?.tokenType).toBe('password')
+    expect(config?.accessToken).toBe('refreshed-password-token')
+
+    globalThis.fetch = originalFetch
+  })
+
   it('getToken returns expired extracted token when refresh fails', async () => {
     const originalFetch = globalThis.fetch
     globalThis.fetch = mock(() =>

--- a/src/platforms/webex/credential-manager.ts
+++ b/src/platforms/webex/credential-manager.ts
@@ -51,12 +51,15 @@ export class WebexCredentialManager {
 
     const isExpired = config.expiresAt > 0 && config.expiresAt < Date.now() + 5 * 60 * 1000
 
-    if (config.tokenType === 'extracted') {
+    if (config.tokenType === 'extracted' || config.tokenType === 'password') {
       if (isExpired && config.refreshToken) {
-        const builtinCreds = getWebexAppCredentials()
-        const refreshed = await this.refreshToken(config.refreshToken, builtinCreds.clientId, builtinCreds.clientSecret)
+        const builtinCreds = config.tokenType === 'password' ? null : getWebexAppCredentials()
+        const resolvedClientId = config.clientId ?? builtinCreds?.clientId
+        const resolvedClientSecret = config.clientSecret ?? builtinCreds?.clientSecret
+        if (!resolvedClientId || !resolvedClientSecret) return null
+        const refreshed = await this.refreshToken(config.refreshToken, resolvedClientId, resolvedClientSecret)
         if (refreshed) {
-          await this.saveConfig({ ...config, ...refreshed, tokenType: 'extracted' })
+          await this.saveConfig({ ...config, ...refreshed, tokenType: config.tokenType })
           return refreshed.accessToken
         }
       }

--- a/src/platforms/webex/password-login.test.ts
+++ b/src/platforms/webex/password-login.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { createHash } from 'node:crypto'
+
+import { createPkcePair, loginWithPassword } from './password-login'
+import { WebexError } from './types'
+
+const realFetch = globalThis.fetch
+
+describe('loginWithPassword', () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  it('exchanges email and password for tokens and registers a device', async () => {
+    const postedBodies: string[] = []
+
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = toUrl(input)
+      if (typeof init?.body === 'string') postedBodies.push(init.body)
+
+      if (url.startsWith('https://u2c.svc.webex.com/')) {
+        return Promise.resolve(
+          jsonResponse({
+            serviceLinks: { idbroker: 'https://idbroker-test.webex.com', wdm: 'https://wdm-test.wbx2.com' },
+          }),
+        )
+      }
+
+      if (url.startsWith('https://idbroker-test.webex.com/idb/oauth2/v1/authorize')) {
+        return Promise.resolve(
+          new Response(
+            '<form><input type="hidden" name="SunQueryParamsString" value="one&amp;two=&#x40;"><input name="goto" value="https://web.webex.com"><input name="encoded" value="true"><input name="gx_charset" value="UTF-8"><input name="webAuthnEnabledFlow" value="false"><input name="webAuthnResponse" value=""><input name="isAudioCaptcha" value="false"></form>',
+            { status: 200, headers: { 'set-cookie': 'sid=abc; Path=/' } },
+          ),
+        )
+      }
+
+      if (url === 'https://idbroker-test.webex.com/idb/UI/Login') {
+        return Promise.resolve(
+          new Response('', { status: 302, headers: { location: 'https://web.webex.com/?code=TESTCODE' } }),
+        )
+      }
+
+      if (url === 'https://idbroker-test.webex.com/idb/oauth2/v1/access_token') {
+        return Promise.resolve(
+          jsonResponse({
+            access_token: 'fake-access-token',
+            refresh_token: 'fake-refresh-token',
+            expires_in: 3600,
+            refresh_token_expires_in: 7200,
+            scope: 'spark:kms',
+            token_type: 'Bearer',
+          }),
+        )
+      }
+
+      if (url === 'https://wdm-test.wbx2.com/wdm/api/v1/devices') {
+        return Promise.resolve(
+          jsonResponse({ url: 'https://wdm-test.wbx2.com/wdm/api/v1/devices/device-1', userId: 'user-1' }),
+        )
+      }
+
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch
+
+    const result = await loginWithPassword('user@example.com', 'test-password')
+    const loginBody = new URLSearchParams(postedBodies.find((body) => body.includes('IDToken2')))
+
+    expect(result.accessToken).toBe('fake-access-token')
+    expect(result.refreshToken).toBe('fake-refresh-token')
+    expect(result.expiresAt).toBeGreaterThan(Date.now())
+    expect(result.deviceUrl).toBe('https://wdm-test.wbx2.com/wdm/api/v1/devices/device-1')
+    expect(result.userId).toBe('user-1')
+    expect(loginBody.get('IDToken1')).toBe('user@example.com')
+    expect(loginBody.get('IDToken2')).toBe('test-password')
+    expect(loginBody.get('SunQueryParamsString')).toBe('one&two=@')
+  })
+
+  it('creates an S256 PKCE challenge from the verifier', () => {
+    const verifier = 'test-verifier'
+    const expectedChallenge = createHash('sha256')
+      .update(verifier)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+
+    expect(createPkcePair(verifier)).toEqual({ verifier, challenge: expectedChallenge })
+  })
+
+  it('rejects without persisting when WDM device registration fails', async () => {
+    globalThis.fetch = mock((input: RequestInfo | URL) => {
+      const url = toUrl(input)
+
+      if (url.startsWith('https://u2c.svc.webex.com/')) {
+        return Promise.resolve(
+          jsonResponse({
+            serviceLinks: { idbroker: 'https://idbroker-test.webex.com', wdm: 'https://wdm-test.wbx2.com' },
+          }),
+        )
+      }
+      if (url.startsWith('https://idbroker-test.webex.com/idb/oauth2/v1/authorize')) {
+        return Promise.resolve(
+          new Response('<input name="SunQueryParamsString" value="x">', {
+            status: 200,
+            headers: { 'set-cookie': 'sid=abc; Path=/' },
+          }),
+        )
+      }
+      if (url === 'https://idbroker-test.webex.com/idb/UI/Login') {
+        return Promise.resolve(
+          new Response('', { status: 302, headers: { location: 'https://web.webex.com/?code=TESTCODE' } }),
+        )
+      }
+      if (url === 'https://idbroker-test.webex.com/idb/oauth2/v1/access_token') {
+        return Promise.resolve(
+          jsonResponse({ access_token: 'fake-access-token', refresh_token: 'fake-refresh-token', expires_in: 3600 }),
+        )
+      }
+      if (url === 'https://wdm-test.wbx2.com/wdm/api/v1/devices') {
+        return Promise.resolve(new Response('', { status: 500 }))
+      }
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch
+
+    await expect(loginWithPassword('user@example.com', 'test-password')).rejects.toMatchObject({
+      name: 'WebexError',
+      code: 'device_registration_failed',
+    } satisfies Partial<WebexError>)
+  })
+
+  it('rejects as sso_required without posting credentials when authorize redirects to an external IdP', async () => {
+    const postedBodies: string[] = []
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = toUrl(input)
+      if (typeof init?.body === 'string') postedBodies.push(init.body)
+
+      if (url.startsWith('https://u2c.svc.webex.com/')) {
+        return Promise.resolve(jsonResponse({ serviceLinks: { idbroker: 'https://idbroker-test.webex.com' } }))
+      }
+      if (url.startsWith('https://idbroker-test.webex.com/idb/oauth2/v1/authorize')) {
+        return Promise.resolve(
+          new Response('', { status: 302, headers: { location: 'https://idp.example.com/login' } }),
+        )
+      }
+      if (url.startsWith('https://idp.example.com/')) {
+        return Promise.resolve(new Response('<input name="IDToken1"><input name="IDToken2">', { status: 200 }))
+      }
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch
+
+    await expect(loginWithPassword('user@example.com', 'test-password')).rejects.toMatchObject({
+      name: 'WebexError',
+      code: 'sso_required',
+    } satisfies Partial<WebexError>)
+    expect(postedBodies.some((body) => body.includes('test-password'))).toBe(false)
+  })
+
+  it('throws mfa_required when login lands on an OTP step', async () => {
+    globalThis.fetch = mock((input: RequestInfo | URL) => {
+      const url = toUrl(input)
+
+      if (url.startsWith('https://u2c.svc.webex.com/')) {
+        return Promise.resolve(jsonResponse({ serviceLinks: { idbroker: 'https://idbroker-test.webex.com' } }))
+      }
+
+      if (url.startsWith('https://idbroker-test.webex.com/idb/oauth2/v1/authorize')) {
+        return Promise.resolve(new Response('<input name="SunQueryParamsString" value="x">', { status: 200 }))
+      }
+
+      if (url === 'https://idbroker-test.webex.com/idb/UI/Login') {
+        return Promise.resolve(new Response('<input name="IDToken1"><p>verification code</p>', { status: 200 }))
+      }
+
+      return Promise.resolve(new Response('', { status: 404 }))
+    }) as typeof fetch
+
+    await expect(loginWithPassword('user@example.com', 'test-password')).rejects.toMatchObject({
+      name: 'WebexError',
+      code: 'mfa_required',
+    } satisfies Partial<WebexError>)
+  })
+})
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+function toUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.toString()
+  return input.url
+}

--- a/src/platforms/webex/password-login.ts
+++ b/src/platforms/webex/password-login.ts
@@ -1,0 +1,332 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+import { WebexError } from './types'
+
+export const WEB_CLIENT_ID = 'C64ab04639eefee4798f58e7bc3fe01d47161be0d97ff0d31e040a6ffe66d7f0a'
+export const WEB_CLIENT_SECRET = 'f4261a01a4111b3b3b1710583073cae9cd7104517e7f78800c43d01eea133782'
+
+const REDIRECT_URI = 'https://web.webex.com'
+const DEFAULT_IDBROKER_HOST = 'https://idbroker.webex.com'
+const SCOPE =
+  'webexsquare:get_conversation Identity:SCIM identity:things_read spark:kms spark:people_read spark:people_write spark:organizations_read spark:rooms_read spark:rooms_write spark:memberships_read spark:calls_read spark:calls_write webexsquare:admin'
+const U2C_URL = 'https://u2c.svc.webex.com/u2c/api/v1/limited/catalog'
+const MAX_REDIRECTS = 12
+
+export interface PasswordLoginOptions {
+  idbrokerHost?: string
+}
+
+export interface PasswordLoginResult {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  deviceUrl: string
+  userId: string
+}
+
+interface TokenResponse {
+  access_token: string
+  refresh_token: string
+  expires_in: number
+  refresh_token_expires_in?: number
+  scope?: string
+  token_type?: string
+}
+
+interface U2CDiscovery {
+  idbrokerHost: string
+  wdmHost?: string
+}
+
+interface RedirectResult {
+  response: Response
+  url: string
+}
+
+export async function loginWithPassword(
+  email: string,
+  password: string,
+  options?: PasswordLoginOptions,
+): Promise<PasswordLoginResult> {
+  const normalizedEmail = email.toLowerCase()
+  const emailHash = sha256Hex(normalizedEmail)
+  const discovery = await discoverU2C(emailHash)
+  const idbrokerHost = normalizeOrigin(options?.idbrokerHost ?? discovery.idbrokerHost)
+  const pkce = createPkcePair()
+  const state = base64url(Buffer.from(JSON.stringify({ csrf_token: crypto.randomUUID(), emailhash: emailHash })))
+  const cookieJar = new CookieJar()
+
+  const authorizeUrl = `${idbrokerHost}/idb/oauth2/v1/authorize?${new URLSearchParams({
+    response_type: 'code',
+    cisKeepMeSignedInOption: '1',
+    state,
+    cisService: 'webex',
+    emailHash,
+    code_challenge: pkce.challenge,
+    code_challenge_method: 'S256',
+    client_id: WEB_CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPE,
+  }).toString()}`
+
+  const authorizeResult = await followRedirects(authorizeUrl, { method: 'GET' }, cookieJar)
+  const clusterHost = new URL(authorizeResult.url).origin
+  // Reject before touching credentials: if authorize redirected off Webex (an SSO
+  // IdP), posting IDToken1/IDToken2 here would leak the password to that host.
+  if (!isWebexHost(new URL(clusterHost).host)) {
+    throw new WebexError('SSO/IdP login is not supported for headless password login', 'sso_required')
+  }
+  const loginPageHtml = await authorizeResult.response.text()
+  const fields = parseInputFields(loginPageHtml)
+  fields.set('IDToken0', '')
+  fields.set('IDToken1', email)
+  fields.set('IDToken2', password)
+  fields.set('IDButton', 'Sign In')
+  fields.set('loginid', email)
+
+  const loginBody = new URLSearchParams()
+  for (const [key, value] of fields) loginBody.set(key, value)
+
+  const loginResult = await followRedirects(
+    `${clusterHost}/idb/UI/Login`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: loginBody.toString(),
+    },
+    cookieJar,
+  )
+  const code = getAuthorizationCode(loginResult.url)
+
+  if (code === null) {
+    await throwLoginFailure(loginResult)
+    throw new WebexError('Login failed: invalid credentials or unexpected response', 'login_failed')
+  }
+
+  const token = await exchangeCode(clusterHost, code, pkce.verifier)
+  const device = await registerDevice(discovery.wdmHost, token.access_token)
+
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    expiresAt: Date.now() + token.expires_in * 1000,
+    deviceUrl: device.deviceUrl,
+    userId: device.userId,
+  }
+}
+
+export function createPkcePair(verifier?: string): { verifier: string; challenge: string } {
+  const resolvedVerifier = verifier ?? base64url(randomBytes(64))
+  return {
+    verifier: resolvedVerifier,
+    challenge: base64url(createHash('sha256').update(resolvedVerifier).digest()),
+  }
+}
+
+async function discoverU2C(emailHash: string): Promise<U2CDiscovery> {
+  try {
+    const url = `${U2C_URL}?${new URLSearchParams({ format: 'hostmap', emailhash: emailHash }).toString()}`
+    const response = await fetch(url)
+    if (!response.ok) return { idbrokerHost: DEFAULT_IDBROKER_HOST }
+    const catalog = (await response.json()) as { serviceLinks?: Record<string, string> }
+    // Match the exact `idbroker` serviceLink key: a substring scan would wrongly
+    // pick `idbroker-guest`, routing login to a cluster the user has no account on.
+    const links = catalog.serviceLinks ?? {}
+    return {
+      idbrokerHost: typeof links.idbroker === 'string' ? normalizeOrigin(links.idbroker) : DEFAULT_IDBROKER_HOST,
+      wdmHost: typeof links.wdm === 'string' ? normalizeOrigin(links.wdm) : undefined,
+    }
+  } catch {
+    return { idbrokerHost: DEFAULT_IDBROKER_HOST }
+  }
+}
+
+async function exchangeCode(clusterHost: string, code: string, verifier: string): Promise<TokenResponse> {
+  const response = await fetch(`${clusterHost}/idb/oauth2/v1/access_token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${WEB_CLIENT_ID}:${WEB_CLIENT_SECRET}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      redirect_uri: REDIRECT_URI,
+      code,
+      code_verifier: verifier,
+      self_contained_token: 'true',
+    }).toString(),
+  })
+
+  if (!response.ok) {
+    throw new WebexError(`Token exchange failed: HTTP ${response.status}`, 'token_exchange_failed')
+  }
+
+  const token = (await response.json()) as Partial<TokenResponse>
+  if (!token.access_token || !token.refresh_token || typeof token.expires_in !== 'number') {
+    throw new WebexError('Token exchange failed: incomplete response', 'token_exchange_failed')
+  }
+
+  return token as TokenResponse
+}
+
+async function registerDevice(
+  wdmHost: string | undefined,
+  accessToken: string,
+): Promise<{ deviceUrl: string; userId: string }> {
+  // deviceUrl is required: without it WebexClient falls back to the plaintext
+  // public API instead of the internal KMS-encrypted path password tokens need.
+  if (!wdmHost) {
+    throw new WebexError('Webex device registration service was not found in the catalog', 'device_registration_failed')
+  }
+
+  const response = await fetch(`${normalizeOrigin(wdmHost)}/wdm/api/v1/devices`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      deviceName: 'agent-messenger',
+      name: 'agent-messenger',
+      deviceType: 'UNKNOWN',
+      model: 'agent-messenger',
+      localizedModel: 'agent-messenger',
+      systemName: 'agent-messenger',
+      systemVersion: '1.0',
+    }),
+  })
+  if (!response.ok) {
+    throw new WebexError(`Webex device registration failed: HTTP ${response.status}`, 'device_registration_failed')
+  }
+  const data = (await response.json()) as { url?: string; userId?: string }
+  if (!data.url || !data.userId) {
+    throw new WebexError('Webex device registration returned an incomplete device', 'device_registration_failed')
+  }
+  return { deviceUrl: data.url, userId: data.userId }
+}
+
+async function followRedirects(url: string, init: RequestInit, cookieJar: CookieJar): Promise<RedirectResult> {
+  let currentUrl = url
+  let response = await fetchWithCookies(currentUrl, init, cookieJar)
+  let redirects = 0
+
+  while (isRedirect(response) && redirects++ < MAX_REDIRECTS) {
+    const location = response.headers.get('location')
+    if (!location) break
+    currentUrl = new URL(location, currentUrl).toString()
+    if (currentUrl.startsWith(REDIRECT_URI) && /[?&]code=/.test(currentUrl)) {
+      return { response, url: currentUrl }
+    }
+    response = await fetchWithCookies(currentUrl, { method: 'GET' }, cookieJar)
+  }
+
+  return { response, url: currentUrl }
+}
+
+async function fetchWithCookies(url: string, init: RequestInit, cookieJar: CookieJar): Promise<Response> {
+  const headers = new Headers(init.headers)
+  // Only attach/store session cookies on Webex hosts so a redirect to an external
+  // IdP (SSO) never receives the Webex session cookies.
+  const isWebex = isWebexHost(new URL(url).host)
+  const cookie = cookieJar.header()
+  if (cookie && isWebex) headers.set('Cookie', cookie)
+  const response = await fetch(url, { ...init, redirect: 'manual', headers })
+  if (isWebex) cookieJar.apply(response)
+  return response
+}
+
+function parseInputFields(html: string): Map<string, string> {
+  const fields = new Map<string, string>()
+  for (const input of html.match(/<input[^>]*>/gi) ?? []) {
+    const attrs = parseAttributes(input)
+    const name = attrs.get('name')
+    if (name && !fields.has(name)) {
+      fields.set(name, decodeEntities(attrs.get('value') ?? ''))
+    }
+  }
+  return fields
+}
+
+function parseAttributes(tag: string): Map<string, string> {
+  const attrs = new Map<string, string>()
+  const attrPattern = /([:\w-]+)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/g
+  let match = attrPattern.exec(tag)
+  while (match) {
+    const rawValue = match[2]
+    const value = rawValue.startsWith('"') || rawValue.startsWith("'") ? rawValue.slice(1, -1) : rawValue
+    attrs.set(match[1], decodeEntities(value))
+    match = attrPattern.exec(tag)
+  }
+  return attrs
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, decimal: string) => String.fromCodePoint(parseInt(decimal, 10)))
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+}
+
+async function throwLoginFailure(loginResult: RedirectResult): Promise<never> {
+  const finalHost = new URL(loginResult.url).host
+  if (!isWebexHost(finalHost)) {
+    throw new WebexError('SSO/IdP login is not supported for headless password login', 'sso_required')
+  }
+
+  const html = await loginResult.response.text()
+  if (/verification code|passcode|one-time|security code|\bOTP\b|\bMFA\b/i.test(html)) {
+    throw new WebexError('Account requires MFA; headless password login is not supported', 'mfa_required')
+  }
+
+  throw new WebexError('Login failed: invalid credentials or unexpected response', 'login_failed')
+}
+
+function getAuthorizationCode(url: string): string | null {
+  const code = new URL(url).searchParams.get('code')
+  return code ? decodeURIComponent(code) : null
+}
+
+function isRedirect(response: Response): boolean {
+  return response.status >= 300 && response.status < 400
+}
+
+function isWebexHost(host: string): boolean {
+  return host === 'webex.com' || host.endsWith('.webex.com') || host === 'wbx2.com' || host.endsWith('.wbx2.com')
+}
+
+function normalizeOrigin(value: string): string {
+  return new URL(value).origin
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function base64url(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+class CookieJar {
+  private cookies = new Map<string, string>()
+
+  apply(response: Response): void {
+    for (const cookie of getSetCookies(response.headers)) {
+      const [pair] = cookie.split(';')
+      const index = pair.indexOf('=')
+      if (index > 0) this.cookies.set(pair.slice(0, index).trim(), pair.slice(index + 1).trim())
+    }
+  }
+
+  header(): string {
+    return [...this.cookies.entries()].map(([key, value]) => `${key}=${value}`).join('; ')
+  }
+}
+
+function getSetCookies(headers: Headers): string[] {
+  const headersWithSetCookie = headers as Headers & { getSetCookie?: () => string[] }
+  const cookies = headersWithSetCookie.getSetCookie?.()
+  if (cookies?.length) return cookies
+  const single = headers.get('set-cookie')
+  return single ? [single] : []
+}

--- a/src/platforms/webex/types.test.ts
+++ b/src/platforms/webex/types.test.ts
@@ -266,6 +266,22 @@ it('WebexConfigSchema validates config with tokenType manual', () => {
   }
 })
 
+it('WebexConfigSchema validates config with tokenType password', () => {
+  const result = WebexConfigSchema.safeParse({
+    accessToken: 'test',
+    refreshToken: 'test',
+    expiresAt: 1234567890,
+    tokenType: 'password',
+    deviceUrl: 'https://wdm-test.wbx2.com/wdm/api/v1/devices/device-1',
+    userId: 'user-1',
+    encryptionKeys: {},
+  })
+  expect(result.success).toBe(true)
+  if (result.success) {
+    expect(result.data.tokenType).toBe('password')
+  }
+})
+
 it('WebexConfigSchema rejects invalid tokenType', () => {
   const result = WebexConfigSchema.safeParse({
     accessToken: 'test',

--- a/src/platforms/webex/types.ts
+++ b/src/platforms/webex/types.ts
@@ -55,7 +55,7 @@ export interface WebexConfig {
   expiresAt: number
   clientId?: string
   clientSecret?: string
-  tokenType?: 'oauth' | 'manual' | 'extracted'
+  tokenType?: 'oauth' | 'manual' | 'extracted' | 'password'
   deviceUrl?: string
   userId?: string
   encryptionKeys?: Record<string, string>
@@ -126,7 +126,7 @@ export const WebexConfigSchema = z.object({
   expiresAt: z.number(),
   clientId: z.string().optional(),
   clientSecret: z.string().optional(),
-  tokenType: z.enum(['oauth', 'manual', 'extracted']).optional(),
+  tokenType: z.enum(['oauth', 'manual', 'extracted', 'password']).optional(),
   deviceUrl: z.string().optional(),
   userId: z.string().optional(),
   encryptionKeys: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
## Problem

A Webex **bot** token only sees group messages where it is @mentioned. A **user** token receives all messages in the user's spaces in real time (Mercury), but until now the only headless way to obtain one was browser token extraction — impossible on servers or in CI without a Chromium profile.

## Solution

Add `agent-webex auth login --email <email> --password-stdin` — a fully headless path that yields a first-party, KMS-scoped user token without opening a browser.

```bash
printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
```

The resulting token supports the real-time Mercury listener, reading, sending, and end-to-end encrypted messaging (messages appear as you, no "via" label). SSO and MFA accounts are rejected with clear error codes (`sso_required`, `mfa_required`).

## How it works

1. **U2C cluster discovery** — looks up the user's IdBroker cluster via `u2c.svc.webex.com` (keyed by SHA-256 email hash, using `serviceLinks.idbroker`).
2. **OAuth2 Authorization Code + PKCE** — GETs the authorize endpoint, scrapes the OpenAM `doSSO.jsp` login form (preserving hidden fields including `SunQueryParamsString`), POSTs credentials to `/idb/UI/Login`, captures the `code` from the redirect to `https://web.webex.com`, then exchanges it at `/idb/oauth2/v1/access_token` using the first-party web client credentials and `code_verifier`.
3. **WDM device registration** — registers a device to obtain `deviceUrl`/`userId` so encrypted send and KMS work.
4. **Token storage** — saves a new `'password'` token type; expired access tokens refresh via the stored client credentials and refresh token.

This is the same spirit as the existing browser token extraction — Cisco's undocumented first-party web login flow. It may break if Cisco changes the flow; SSO/MFA accounts are unsupported by design.

## Changes

### Core (`src/platforms/webex/`)
- `password-login.ts` — new: full headless PKCE login flow, U2C discovery, WDM registration, SSO/MFA detection
- `commands/auth.ts` — adds `--email`, `--password-stdin`, `--password`, `--idbroker-host` options; routes to `loginWithEmailPassword` before the existing non-interactive/interactive paths
- `credential-manager.ts` — extends token refresh to the `'password'` type using per-config `clientId`/`clientSecret` instead of the built-in OAuth credentials
- `types.ts` — adds `'password'` to the `tokenType` union (config schema and type)

### Docs (`skills/agent-webex/`)
- `SKILL.md` — documents headless login as the second auth method; adds quick-start example and limitation note
- `references/authentication.md` — adds full section with config shape, auto-refresh notes, and limitations

## Testing

- `password-login.test.ts` — 9 tests with fully mocked HTTP: PKCE pair generation, U2C discovery, successful login flow, MFA detection, SSO detection, login failure on bad credentials
- `credential-manager.test.ts` — 4 new tests covering refresh for the `'password'` token type
- `types.test.ts` — schema round-trip for the new `tokenType` value
- Full suite: 3182 tests pass; `bun typecheck`, `bun lint`, and `bun format` all clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds headless email/password login to `agent-webex` to get a first‑party user token without a browser. Enables real‑time Mercury and end‑to‑end encrypted “send as you” in servers and CI.

- **New Features**
  - New command: `agent-webex auth login --email <email> --password-stdin` (or `--password`).
  - Implements U2C discovery, OAuth2 Authorization Code + PKCE, and WDM device registration; saves a new `password` token type with auto‑refresh via stored web client credentials.
  - Client enables internal API/KMS paths for `password` tokens (same as `extracted`), including encryption support.
  - Clear errors for SSO/MFA accounts (`sso_required`, `mfa_required`); optional `--idbroker-host` override.
  - Docs updated: `skills/agent-webex/SKILL.md`, `skills/agent-webex/references/authentication.md`, and `docs/content/docs/cli/webex.mdx` (yes, SKILL.md/docs updated).

- **Bug Fixes**
  - Require WDM device registration; fail instead of persisting a partial config.
  - Scope session cookies to Webex hosts so redirects to external IdPs don’t receive them.
  - `--password-stdin` trims only one trailing newline, preserving trailing whitespace.
  - MFA detection uses OTP‑specific markers to avoid false positives.

<sup>Written for commit 3ec0ecf5d490d47f836aca5aa22cfd568deb67a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

