### PR TITLE
feat(webex): split auth login into login (email/password) and oauth

### DIFF
--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -42,12 +42,32 @@ This command:
 - Auto-extraction runs when no valid token is stored, so manual extraction is rarely needed
 - Messages are encrypted client-side (JWE/AES-256-GCM). Encryption keys are cached at extract time; for end-to-end encrypted conversations whose key is not cached, the key is fetched on demand (Mercury + KMS) and persisted for reuse. Non-encrypted conversations send as plaintext.
 
+### Email/Password Login
+
+Logs in with a Webex email and password — no browser. Useful for servers and CI/CD that need a real user token (e.g. for the real-time listener, which receives all space messages without an @mention). Run `agent-webex auth login` with no flags in a terminal to be prompted for your email and then your password (read without echoing); for headless use, pipe the password via stdin to keep it out of shell history.
+
+```bash
+# Interactive — prompts for email, then password (hidden)
+agent-webex auth login
+
+# Headless — provide the email and pipe the password from stdin
+printf '%s' "$WEBEX_PASSWORD" | agent-webex auth login --email you@example.com --password-stdin
+
+# Provide the email only — password is prompted securely
+agent-webex auth login --email you@example.com
+```
+
+- Discovers the user's Webex region, performs OAuth2 Authorization Code + PKCE against Cisco IdBroker, and stores access/refresh tokens in `~/.config/agent-messenger/`
+- Produces a KMS-scoped user token (client-side JWE/AES-256-GCM encryption works)
+- `--idbroker-host <host>` overrides region auto-discovery if needed
+- Accounts protected by SSO/IdP or MFA are not supported and fail with a clear error
+
 ### OAuth Device Grant (Fallback)
 
 Uses OAuth Device Grant flow with built-in Integration credentials. No tokens to copy, no developer portal setup needed. Messages show "via agent-messenger".
 
 ```bash
-agent-webex auth login
+agent-webex auth oauth
 ```
 
 This command:
@@ -59,25 +79,13 @@ This command:
 - Stores access and refresh tokens securely in `~/.config/agent-messenger/`
 - Auto-refreshes expired access tokens (14-day access, 90-day refresh)
 
-### Headless Email/Password (Server-side)
-
-Logs in with a Webex email and password — no browser. Useful for servers and CI/CD that need a real user token (e.g. for the real-time listener, which receives all space messages without an @mention). Pipe the password via stdin to keep it out of shell history.
-
-```bash
-printf '%s' "$WEBEX_PASSWORD" | agent-webex auth login --email you@example.com --password-stdin
-```
-
-- Discovers the user's Webex region, performs OAuth2 Authorization Code + PKCE against Cisco IdBroker, and stores access/refresh tokens in `~/.config/agent-messenger/`
-- Produces a KMS-scoped user token (client-side JWE/AES-256-GCM encryption works)
-- `--idbroker-host <host>` overrides region auto-discovery if needed
-- Accounts protected by SSO/IdP or MFA are not supported and fail with a clear error
-
 ### How Login Works
 
-1. Run `agent-webex auth extract` (recommended) or `agent-webex auth login` (fallback)
+1. Run `agent-webex auth extract` (recommended), `agent-webex auth login` (email/password), or `agent-webex auth oauth` (Device Grant)
 2. For extraction: CLI reads your browser's Webex session — no prompts needed
-3. For Device Grant: Browser opens, enter the displayed code, CLI stores tokens
-4. Access tokens are refreshed automatically
+3. For email/password: CLI prompts for any missing credentials, then exchanges them for a token
+4. For Device Grant: Browser opens, enter the displayed code, CLI stores tokens
+5. Access tokens are refreshed automatically
 
 ### Token Types
 
@@ -95,14 +103,15 @@ printf '%s' "$WEBEX_PASSWORD" | agent-webex auth login --email you@example.com -
 # Extract token from browser (recommended)
 agent-webex auth extract
 
-# Log in (Device Grant flow, opens browser)
+# Log in with email/password (prompts when flags are omitted)
 agent-webex auth login
-
-# Log in with custom Integration credentials
-agent-webex auth login --client-id <id> --client-secret <secret>
-
-# Log in headlessly with an email and password (read from stdin)
 printf '%s' "$WEBEX_PASSWORD" | agent-webex auth login --email you@example.com --password-stdin
+
+# Log in via OAuth Device Grant (opens browser)
+agent-webex auth oauth
+
+# Log in via OAuth with custom Integration credentials
+agent-webex auth oauth --client-id <id> --client-secret <secret>
 
 # Log in with a bot token (never expires)
 agent-webex auth login --token <bot-token>
@@ -126,7 +135,7 @@ Override the built-in Integration credentials with your own:
 | `AGENT_WEBEX_CLIENT_ID`     | Webex Integration client ID     |
 | `AGENT_WEBEX_CLIENT_SECRET` | Webex Integration client secret |
 
-Both must be set together. When set, `auth login` (without `--token`) uses these instead of the built-in credentials.
+Both must be set together. When set, `auth oauth` uses these instead of the built-in credentials.
 
 ## Commands
 
@@ -250,10 +259,10 @@ agent-webex auth login
 
 ### Token Expired (401 Unauthorized)
 
-**If using Device Grant (default)**: Tokens auto-refresh. If you still get 401s, the refresh token may have expired (after 90 days). Re-run:
+**If using Device Grant**: Tokens auto-refresh. If you still get 401s, the refresh token may have expired (after 90 days). Re-run:
 
 ```bash
-agent-webex auth login
+agent-webex auth oauth
 ```
 
 **If using a PAT**: Generate a new one at https://developer.webex.com/docs/getting-started
@@ -262,10 +271,10 @@ agent-webex auth login
 
 ### "Device authorization timed out"
 
-You didn't approve the request in the browser before the code expired. Run `auth login` again:
+You didn't approve the request in the browser before the code expired. Run `auth oauth` again:
 
 ```bash
-agent-webex auth login
+agent-webex auth oauth
 ```
 
 ### "Device authorization failed"

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -24,11 +24,12 @@ A TypeScript CLI tool that enables AI agents and humans to interact with Cisco W
 # Extract token from browser (Chrome, Edge, Arc, Brave) — messages appear as you
 agent-webex auth extract
 
-# Or: Headless login with email/password — messages appear as you
+# Or: Log in with email/password — messages appear as you (prompts when flags are omitted)
+agent-webex auth login
 printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
 # Or: Log in via OAuth Device Grant (opens browser, messages show "via agent-messenger")
-agent-webex auth login
+agent-webex auth oauth
 
 # Get workspace snapshot
 agent-webex snapshot
@@ -44,9 +45,9 @@ agent-webex space list
 
 Webex supports three authentication methods:
 
-1. **Browser token extraction** (recommended): Extracts your first-party token from a Chromium browser where you're logged into web.webex.com. Messages appear as you — no "via" label.
-2. **Headless password login**: Exchanges Webex email/password for a first-party web token without opening a browser. Messages appear as you. Not supported for SSO/MFA accounts.
-3. **OAuth Device Grant**: Opens a browser for you to authorize. Messages show "via agent-messenger" label.
+1. **Browser token extraction** (`auth extract`, recommended): Extracts your first-party token from a Chromium browser where you're logged into web.webex.com. Messages appear as you — no "via" label.
+2. **Email/password login** (`auth login`): Exchanges Webex email/password for a first-party web token without opening a browser. Run `auth login` with no flags to be prompted, or pass `--email`/`--password-stdin` for headless use. Messages appear as you. Not supported for SSO/MFA accounts.
+3. **OAuth Device Grant** (`auth oauth`): Opens a browser for you to authorize. Messages show "via agent-messenger" label.
 
 ### Browser Token Extraction (Recommended)
 
@@ -72,25 +73,32 @@ agent-webex auth extract --browser-profile ~/work-profile --browser-profile ~/pe
 
 **When to re-extract**: Browser tokens expire. When your token expires, re-run `agent-webex auth extract` or let auto-extraction handle it (the CLI attempts extraction automatically on each run).
 
-### Headless Password Login
+### Email/Password Login
 
-Use email/password login when no browser profile is available and the account does not require SSO or MFA.
+`agent-webex auth login` logs you in with your Webex email and password. Run it with no flags in a terminal to be prompted for your email and then your password (the password is read without echoing). Use email/password login when no browser profile is available and the account does not require SSO or MFA.
 
 ```bash
+# Interactive — prompts for email, then password (hidden input)
+agent-webex auth login
+
+# Headless — provide the email and pipe the password from stdin (keeps it out of shell history)
 printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
+
+# Provide the email only — the password is prompted securely when omitted
+agent-webex auth login --email <email>
 ```
 
-This stores a refreshable first-party web token locally and supports encrypted messaging through the internal Webex API.
+This stores a refreshable first-party web token locally and supports encrypted messaging through the internal Webex API. Pass `--token <bot-or-personal-access-token>` to log in with a bot token or PAT instead.
 
 ### OAuth Device Grant (Fallback)
 
-`agent-webex auth login` starts the Device Grant flow: it displays a verification URL and user code, then opens the browser. You enter the code at the verification page and approve access. The CLI polls for the token automatically. Access and refresh tokens are stored locally, and the access token auto-refreshes via the refresh token.
+`agent-webex auth oauth` starts the Device Grant flow: it displays a verification URL and user code, then opens the browser. You enter the code at the verification page and approve access. The CLI polls for the token automatically. Access and refresh tokens are stored locally, and the access token auto-refreshes via the refresh token.
 
 Note: Messages sent via OAuth Device Grant show "via agent-messenger" because the token is associated with a third-party Webex Integration.
 
-Optionally, pass `--token <bot-token>` for bot token auth. Or pass `--client-id <id> --client-secret <secret>` to use your own Webex Integration credentials instead of the built-in ones.
+Optionally, pass `--client-id <id> --client-secret <secret>` to use your own Webex Integration credentials instead of the built-in ones.
 
-**For AI agents (non-TTY)**: `agent-webex auth login` exposes the OAuth Device Grant flow as a stateless two-call sequence — no hangs, no polling loops, no on-disk state. Just structured JSON every time.
+**For AI agents (non-TTY)**: `agent-webex auth oauth` exposes the OAuth Device Grant flow as a stateless two-call sequence — no hangs, no polling loops, no on-disk state. Just structured JSON every time.
 
 **Call 1** (no `--device-code` passed): the command requests a device code from Webex and returns immediately:
 
@@ -112,7 +120,7 @@ Show the user `verification_uri_complete` (or `verification_uri` + `user_code`) 
 
 - **Success** — returns `{ "authenticated": true, "user": { ... } }`, exit 0.
 - **Still pending** — returns `{ "next_action": "still_pending", "device_code": "...", ... }`, exit 0. The user has not approved yet; confirm with them and retry with the same `--device-code` value.
-- **Expired / failed** — returns `{ "next_action": "restart", "error": "..." }`, exit 1. The device code is no longer usable; start over with another `agent-webex auth login` (no flags) to get a fresh one.
+- **Expired / failed** — returns `{ "next_action": "restart", "error": "..." }`, exit 1. The device code is no longer usable; start over with another `agent-webex auth oauth` (no flags) to get a fresh one.
 
 If you passed `--client-id` / `--client-secret` (custom Webex Integration) on Call 1, pass them again on Call 2.
 
@@ -125,17 +133,18 @@ Alternatives that skip the Device Grant flow entirely:
 Env vars `AGENT_WEBEX_CLIENT_ID` / `AGENT_WEBEX_CLIENT_SECRET` can also override the built-in credentials.
 
 ```bash
-# Log in (Device Grant flow, opens browser)
+# Log in with email/password (prompts when flags are omitted)
 agent-webex auth login
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
-# Log in with custom Integration credentials
-agent-webex auth login --client-id <id> --client-secret <secret>
+# Log in via OAuth Device Grant (opens browser)
+agent-webex auth oauth
+
+# Log in via OAuth with custom Integration credentials
+agent-webex auth oauth --client-id <id> --client-secret <secret>
 
 # Log in with a bot token
 agent-webex auth login --token <token>
-
-# Headless email/password login
-printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
 # Check auth status
 agent-webex auth status
@@ -152,7 +161,7 @@ agent-webex auth logout
 - **Bot Token**: Pass via `--token` flag. Never expires. Best for CI/CD.
 - **Custom Integration**: Pass `--client-id` + `--client-secret` or set env vars for your own Webex Integration.
 
-**IMPORTANT**: NEVER guide the user to open a web browser, use DevTools, or manually copy tokens from a browser's network inspector. Always use `agent-webex auth extract` or `agent-webex auth login` for authentication.
+**IMPORTANT**: NEVER guide the user to open a web browser, use DevTools, or manually copy tokens from a browser's network inspector. Always use `agent-webex auth extract`, `agent-webex auth login`, or `agent-webex auth oauth` for authentication.
 
 For detailed token management, see [references/authentication.md](references/authentication.md).
 
@@ -228,14 +237,18 @@ If a memorized ID returns an error (space not found, member not found), remove i
 ### Auth Commands
 
 ```bash
-# Log in (Device Grant flow, opens browser)
+# Log in with email/password (prompts when flags are omitted)
 agent-webex auth login
-
-# Log in with custom Integration credentials
-agent-webex auth login --client-id <id> --client-secret <secret>
+printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
 # Log in with a bot token
 agent-webex auth login --token <token>
+
+# Log in via OAuth Device Grant (opens browser)
+agent-webex auth oauth
+
+# Log in via OAuth with custom Integration credentials
+agent-webex auth oauth --client-id <id> --client-secret <secret>
 
 # Check auth status
 agent-webex auth status
@@ -360,7 +373,7 @@ All commands return consistent error format:
 Common errors:
 
 - `Not authenticated`: No valid token. Run `auth login` first
-- `Device authorization timed out`: User didn't complete verification in time. Run `auth login` again.
+- `Device authorization timed out`: User didn't complete verification in time. Run `auth oauth` again.
 - `401 Unauthorized`: Token expired or invalid. Re-run `auth login`
 - `429 Too Many Requests`: Rate limited. Wait and retry (Webex allows ~600 requests per minute)
 - `404 Not Found`: Invalid space ID, message ID, or resource
@@ -429,10 +442,12 @@ See the [Webex SDK documentation](https://agent-messenger.dev/docs/sdk/webex) fo
 
 ### Token refresh failed
 
-OAuth tokens auto-refresh, so expiration is handled automatically. If a refresh fails (revoked access, network issues), re-run:
+OAuth tokens auto-refresh, so expiration is handled automatically. If a refresh fails (revoked access, network issues), re-run the login method you used:
 
 ```bash
-agent-webex auth login
+agent-webex auth oauth     # OAuth Device Grant
+agent-webex auth login     # email/password
+agent-webex auth extract   # browser token
 ```
 
 Bot tokens never expire and don't need refreshing.

--- a/skills/agent-webex/references/authentication.md
+++ b/skills/agent-webex/references/authentication.md
@@ -5,8 +5,8 @@
 agent-webex supports five authentication methods against the Webex REST API (`https://webexapis.com/v1`):
 
 1. **Browser Token Extraction**: Extracts your first-party token and cached encryption keys from a Chromium browser where you're logged into web.webex.com. Supports all operations including encrypted messaging via the internal API. Zero-config.
-2. **Headless Password Login**: Exchanges email/password for a first-party web token without opening a browser. Supports encrypted messaging via the internal API. Not supported for SSO/MFA accounts.
-3. **OAuth Device Grant** (recommended for messaging): Zero-config. Run `auth login`, approve in browser, done. Tokens refresh automatically. Supports all operations including sending messages (shows "via agent-messenger").
+2. **Email/Password Login**: Run `auth login` to exchange email/password for a first-party web token without opening a browser. Prompts for email and password when omitted (the password is read without echoing), or pass `--email`/`--password-stdin` for headless use. Supports encrypted messaging via the internal API. Not supported for SSO/MFA accounts.
+3. **OAuth Device Grant** (recommended for messaging): Zero-config. Run `auth oauth`, approve in browser, done. Tokens refresh automatically. Supports all operations including sending messages (shows "via agent-messenger").
 4. **Bot Token**: Pass via `auth login --token`. Never expires. Best for CI/CD.
 5. **Personal Access Token (PAT)**: Pass via `auth login --token`. Expires in 12 hours. For quick testing.
 
@@ -41,24 +41,31 @@ Use `--browser-profile <path>` for agent-browser profiles, custom Chrome user da
 
 **Limitations**: Direct messages (`message dm`) require an existing conversation with the recipient. The extracted token cannot create new 1:1 conversations — start one from the Webex app first, then use the CLI.
 
-### Headless Password Login
+### Email/Password Login
 
 Use this when a browser profile is unavailable and the Webex account accepts direct email/password login.
 
-- **How it works**: Run `agent-webex auth login --email <email> --password-stdin`. The CLI performs the Webex web OAuth + PKCE flow headlessly, registers a Webex device, and stores refreshable credentials.
+- **How it works**: Run `agent-webex auth login`. With no flags in a terminal, the CLI prompts for your email and then your password (read without echoing). For headless use, pass `--email <email> --password-stdin` (or `--email <email>` alone to be prompted only for the password). The CLI performs the Webex web OAuth + PKCE flow headlessly, registers a Webex device, and stores refreshable credentials.
 - **Auto-refresh**: The CLI refreshes expired access tokens using the stored web refresh token.
 - **End-to-end encryption**: Uses the internal Webex API with KMS key fetching, so messages appear as you without the "via" label.
 - **Limitations**: SSO and MFA accounts are not supported by this headless flow.
 
 ```bash
+# Interactive — prompts for email, then password (hidden)
+agent-webex auth login
+
+# Headless — provide the email and pipe the password from stdin
 printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
+
+# Provide the email only — password is prompted securely
+agent-webex auth login --email <email>
 ```
 
 ### OAuth Device Grant
 
 The fallback authentication method when browser extraction is unavailable. No credentials to copy, no developer portal setup required.
 
-- **How it works**: Run `agent-webex auth login`. The CLI requests a device code from Webex, opens your browser, and waits for you to approve. Once approved, access and refresh tokens are stored automatically.
+- **How it works**: Run `agent-webex auth oauth`. The CLI requests a device code from Webex, opens your browser, and waits for you to approve. Once approved, access and refresh tokens are stored automatically.
 - **Access token lifetime**: 14 days
 - **Refresh token lifetime**: 90 days
 - **Auto-refresh**: The CLI refreshes expired access tokens automatically using the stored refresh token. No manual intervention needed until the refresh token itself expires (90 days).
@@ -66,7 +73,7 @@ The fallback authentication method when browser extraction is unavailable. No cr
 - **Best for**: Interactive use, development, any scenario where a human can approve via browser
 
 ```bash
-agent-webex auth login
+agent-webex auth oauth
 ```
 
 The CLI ships with built-in Integration credentials so this works out of the box. You can override them with your own (see [Environment Variables](#environment-variables)).
@@ -103,14 +110,15 @@ agent-webex auth login --token "YOUR_PAT_HERE"
 # Browser extraction (recommended — messages appear as you)
 agent-webex auth extract
 
-# Headless email/password login (messages appear as you)
+# Email/password login (messages appear as you; prompts when flags are omitted)
+agent-webex auth login
 printf '%s' '<password>' | agent-webex auth login --email <email> --password-stdin
 
 # Device Grant (fallback — messages show "via agent-messenger")
-agent-webex auth login
+agent-webex auth oauth
 
-# With custom Integration credentials
-agent-webex auth login --client-id <id> --client-secret <secret>
+# Device Grant with custom Integration credentials
+agent-webex auth oauth --client-id <id> --client-secret <secret>
 
 # Bot token
 agent-webex auth login --token <bot-token>
@@ -250,7 +258,7 @@ Browser-extracted tokens have no refresh mechanism — when they expire, re-extr
 ### OAuth Device Grant
 
 ```
-auth login -> Device code -> Browser approval -> Access token (14 days) + Refresh token (90 days)
+auth oauth -> Device code -> Browser approval -> Access token (14 days) + Refresh token (90 days)
                                                         |
                                                   Token expires
                                                         |
@@ -258,7 +266,7 @@ auth login -> Device code -> Browser approval -> Access token (14 days) + Refres
                                                         |
                                                   Refresh token expires (90 days)
                                                         |
-                                                  Re-run "auth login"
+                                                  Re-run "auth oauth"
 ```
 
 The CLI checks token expiry before each API call and refreshes automatically when needed. You won't notice this happening.
@@ -288,7 +296,7 @@ Override the built-in Integration credentials with your own:
 | `AGENT_WEBEX_CLIENT_ID` | Webex Integration client ID |
 | `AGENT_WEBEX_CLIENT_SECRET` | Webex Integration client secret |
 
-Both must be set together. When set, `auth login` (without `--token`) uses these instead of the built-in credentials.
+Both must be set together. When set, `auth oauth` uses these instead of the built-in credentials.
 
 Legacy aliases `AGENT_MESSENGER_WEBEX_CLIENT_ID` and `AGENT_MESSENGER_WEBEX_CLIENT_SECRET` are also supported.
 
@@ -306,7 +314,7 @@ agent-webex auth login
 
 Token is expired or invalid.
 
-**If using Device Grant**: The CLI auto-refreshes tokens, so this usually means the refresh token has expired (after 90 days). Run `agent-webex auth login` again.
+**If using Device Grant**: The CLI auto-refreshes tokens, so this usually means the refresh token has expired (after 90 days). Run `agent-webex auth oauth` again.
 
 **If using a PAT**: Generate a new one at https://developer.webex.com/docs/getting-started
 
@@ -326,7 +334,7 @@ The device code request was rejected. Possible causes:
 
 ### "Device authorization timed out"
 
-You didn't approve the request in the browser before the code expired. Run `auth login` again.
+You didn't approve the request in the browser before the code expired. Run `auth oauth` again.
 
 ### "Token validation failed"
 

--- a/skills/agent-webex/references/common-patterns.md
+++ b/skills/agent-webex/references/common-patterns.md
@@ -18,8 +18,11 @@ This guide covers typical workflows for AI agents interacting with Cisco Webex u
 # Recommended: Browser extraction (zero-config, sends as you, no "via" label)
 agent-webex auth extract
 
-# Fallback: Device Grant (zero-config, opens browser, shows "via agent-messenger")
+# Email/password login (messages appear as you; prompts when flags are omitted)
 agent-webex auth login
+
+# Fallback: Device Grant (zero-config, opens browser, shows "via agent-messenger")
+agent-webex auth oauth
 
 # With a bot token (never expires, for CI/CD)
 agent-webex auth login --token "YOUR_BOT_TOKEN_HERE"
@@ -628,7 +631,7 @@ done
 
 ```bash
 # Best: Device Grant (auto-refreshes, no token management)
-agent-webex auth login
+agent-webex auth oauth
 
 # Also good: bot token (never expires)
 agent-webex auth login --token "$BOT_TOKEN"

--- a/src/platforms/webex/cli.test.ts
+++ b/src/platforms/webex/cli.test.ts
@@ -20,6 +20,21 @@ describe('Webex CLI program structure', () => {
     expect(output).toContain('space')
   })
 
+  it('auth --help lists login and oauth subcommands', async () => {
+    const proc = spawn(['bun', 'run', './src/platforms/webex/cli.ts', 'auth', '--help'], {
+      cwd: process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    const output = await new Response(proc.stdout).text()
+
+    expect(output).toContain('login')
+    expect(output).toContain('oauth')
+    expect(output).toContain('extract')
+    expect(output).toContain('status')
+    expect(output).toContain('logout')
+  })
+
   it('--version shows package version', async () => {
     const proc = spawn(['bun', 'run', './src/platforms/webex/cli.ts', '--version'], {
       cwd: process.cwd(),
@@ -30,7 +45,7 @@ describe('Webex CLI program structure', () => {
     expect(output.trim()).toBe(pkg.version)
   })
 
-  it('auth login --help shows Device Grant options', async () => {
+  it('auth login --help shows email/password options', async () => {
     const proc = spawn(['bun', 'run', './src/platforms/webex/cli.ts', 'auth', 'login', '--help'], {
       cwd: process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -38,7 +53,22 @@ describe('Webex CLI program structure', () => {
 
     const output = await new Response(proc.stdout).text()
 
+    expect(output).toContain('--email')
+    expect(output).toContain('--password')
+    expect(output).toContain('--password-stdin')
     expect(output).toContain('--token')
+    expect(output).toContain('--pretty')
+  })
+
+  it('auth oauth --help shows Device Grant options', async () => {
+    const proc = spawn(['bun', 'run', './src/platforms/webex/cli.ts', 'auth', 'oauth', '--help'], {
+      cwd: process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    const output = await new Response(proc.stdout).text()
+
+    expect(output).toContain('--device-code')
     expect(output).toContain('--client-id')
     expect(output).toContain('--client-secret')
     expect(output).toContain('--pretty')

--- a/src/platforms/webex/commands/auth.test.ts
+++ b/src/platforms/webex/commands/auth.test.ts
@@ -1,11 +1,21 @@
-import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:test'
 import * as childProcess from 'node:child_process'
+import * as fs from 'node:fs'
 
 import { WebexClient } from '../client'
 import { WebexCredentialManager } from '../credential-manager'
+import * as passwordLogin from '../password-login'
 import { WebexTokenExtractor } from '../token-extractor'
 import { WebexError } from '../types'
-import { extractAction, loginAction, logoutAction, statusAction } from './auth'
+import { extractAction, loginAction, logoutAction, oauthAction, statusAction } from './auth'
+
+let promptQueue: string[] = []
+mock.module('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: async () => promptQueue.shift() ?? '',
+    close: () => {},
+  }),
+}))
 
 class ProcessExit extends Error {
   constructor(readonly code?: string | number | null) {
@@ -18,6 +28,7 @@ describe('auth commands', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>
   let execSpy: ReturnType<typeof spyOn>
   let stderrWriteSpy: ReturnType<typeof spyOn>
+  let stdoutWriteSpy: ReturnType<typeof spyOn>
   const protoSpies: ReturnType<typeof spyOn>[] = []
   let originalStdinTTY: boolean | undefined
   let originalStdoutTTY: boolean | undefined
@@ -42,10 +53,12 @@ describe('auth commands', () => {
   }
 
   beforeEach(() => {
+    promptQueue = []
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
     execSpy = spyOn(childProcess, 'exec').mockImplementation((() => {}) as any)
     stderrWriteSpy = spyOn(process.stderr, 'write').mockImplementation(() => true)
+    stdoutWriteSpy = spyOn(process.stdout, 'write').mockImplementation(() => true)
     originalStdinTTY = process.stdin.isTTY
     originalStdoutTTY = process.stdout.isTTY
     // Default to interactive TTY for existing tests; non-interactive tests override.
@@ -62,6 +75,7 @@ describe('auth commands', () => {
     consoleErrorSpy.mockRestore()
     execSpy.mockRestore()
     stderrWriteSpy.mockRestore()
+    stdoutWriteSpy.mockRestore()
     for (const s of protoSpies) s.mockRestore()
     protoSpies.length = 0
     setTTY(originalStdinTTY)
@@ -99,9 +113,158 @@ describe('auth commands', () => {
       expect(savedConfig.expiresAt).toBe(0)
       expect(savedConfig.refreshToken).toBe('')
     })
+
+    it('still allows --token login when non-interactive (bot/PAT path)', async () => {
+      setTTY(false)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+
+      await loginAction({ token: 'bot-token-123', pretty: false })
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.authenticated).toBe(true)
+      expect(output.user.displayName).toBe('Test User')
+    })
   })
 
-  describe('loginAction with --client-id and --client-secret', () => {
+  describe('loginAction with --email/--password', () => {
+    const passwordConfig = {
+      accessToken: 'pw-access-token',
+      refreshToken: 'pw-refresh-token',
+      expiresAt: Date.now() + 3_600_000,
+      deviceUrl: 'https://wdm-r.wbx2.com/wdm/api/v1/devices/test-device',
+      userId: 'user-1',
+    }
+
+    it('logs in with email/password and saves the password token type', async () => {
+      const pwSpy = protoSpy(passwordLogin, 'loginWithPassword').mockResolvedValue(passwordConfig)
+      const saveSpy = protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({ email: 'alice@example.com', password: 'hunter2', pretty: false })
+
+      expect(pwSpy).toHaveBeenCalledWith('alice@example.com', 'hunter2', { idbrokerHost: undefined })
+      const savedConfig = saveSpy.mock.calls[0][0] as { tokenType: string; clientId: string }
+      expect(savedConfig.tokenType).toBe('password')
+      expect(savedConfig.clientId).toBe(passwordLogin.WEB_CLIENT_ID)
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.authenticated).toBe(true)
+      expect(output.user.displayName).toBe('Test User')
+    })
+
+    it('forwards --idbroker-host to the password login flow', async () => {
+      const pwSpy = protoSpy(passwordLogin, 'loginWithPassword').mockResolvedValue(passwordConfig)
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({
+        email: 'alice@example.com',
+        password: 'hunter2',
+        idbrokerHost: 'https://idbroker.example.com',
+        pretty: false,
+      })
+
+      expect(pwSpy).toHaveBeenCalledWith('alice@example.com', 'hunter2', {
+        idbrokerHost: 'https://idbroker.example.com',
+      })
+    })
+
+    it('reads the password from stdin with --password-stdin', async () => {
+      const pwSpy = protoSpy(passwordLogin, 'loginWithPassword').mockResolvedValue(passwordConfig)
+      protoSpy(fs, 'readFileSync').mockReturnValue('stdin-secret\n')
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({ email: 'alice@example.com', passwordStdin: true, pretty: false })
+
+      expect(pwSpy).toHaveBeenCalledWith('alice@example.com', 'stdin-secret', { idbrokerHost: undefined })
+    })
+
+    it('rejects passing both --password and --password-stdin', async () => {
+      const exitSpy = protoSpy(process, 'exit').mockImplementation((code?: string | number | null) => {
+        throw new ProcessExit(code)
+      })
+
+      await expect(
+        loginAction({ email: 'alice@example.com', password: 'p', passwordStdin: true, pretty: false }),
+      ).rejects.toThrow(ProcessExit)
+
+      const lastCall = stderrWriteSpy.mock.calls[stderrWriteSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.error).toContain('Use only one of --password or --password-stdin')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('loginAction interactive prompts', () => {
+    const passwordConfig = {
+      accessToken: 'pw-access-token',
+      refreshToken: 'pw-refresh-token',
+      expiresAt: Date.now() + 3_600_000,
+      deviceUrl: 'https://wdm-r.wbx2.com/wdm/api/v1/devices/test-device',
+      userId: 'user-1',
+    }
+
+    it('prompts for email and password when none are provided', async () => {
+      promptQueue = ['alice@example.com', 'prompted-secret']
+      const pwSpy = protoSpy(passwordLogin, 'loginWithPassword').mockResolvedValue(passwordConfig)
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({ pretty: false })
+
+      expect(pwSpy).toHaveBeenCalledWith('alice@example.com', 'prompted-secret', { idbrokerHost: undefined })
+    })
+
+    it('prompts only for the password when --email is provided without a password', async () => {
+      promptQueue = ['prompted-secret']
+      const pwSpy = protoSpy(passwordLogin, 'loginWithPassword').mockResolvedValue(passwordConfig)
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({ email: 'alice@example.com', pretty: false })
+
+      expect(pwSpy).toHaveBeenCalledWith('alice@example.com', 'prompted-secret', { idbrokerHost: undefined })
+    })
+  })
+
+  describe('loginAction non-interactive without credentials', () => {
+    it('errors when no email is provided and points to auth oauth', async () => {
+      setTTY(false)
+      const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ pretty: false })
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.error).toContain('Email required')
+      expect(output.error).toContain('auth oauth')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+
+    it('errors when --email is provided but no password is available', async () => {
+      setTTY(false)
+      const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
+
+      await loginAction({ email: 'alice@example.com', pretty: false })
+
+      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
+      const output = JSON.parse(lastCall)
+      expect(output.error).toContain('Password required')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('oauthAction with --client-id and --client-secret', () => {
     it('uses provided credentials for Device Grant flow', async () => {
       protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode').mockResolvedValue({
         deviceCode: 'd',
@@ -120,7 +283,7 @@ describe('auth commands', () => {
       protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
       protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
 
-      await loginAction({ clientId: 'my-id', clientSecret: 'my-secret', pretty: false })
+      await oauthAction({ clientId: 'my-id', clientSecret: 'my-secret', pretty: false })
 
       expect(WebexCredentialManager.prototype.requestDeviceCode).toHaveBeenCalledWith('my-id')
       expect(WebexCredentialManager.prototype.pollDeviceToken).toHaveBeenCalledWith(
@@ -150,7 +313,7 @@ describe('auth commands', () => {
       protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
       protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
 
-      await loginAction({ clientId: 'my-id', clientSecret: 'my-secret', pretty: false })
+      await oauthAction({ clientId: 'my-id', clientSecret: 'my-secret', pretty: false })
 
       const savedConfig = saveSpy.mock.calls[0][0] as { tokenType: string }
       expect(savedConfig.tokenType).toBe('oauth')
@@ -174,7 +337,7 @@ describe('auth commands', () => {
       protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
       protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
 
-      await loginAction({ clientId: 'my-id', clientSecret: 'my-secret', pretty: false })
+      await oauthAction({ clientId: 'my-id', clientSecret: 'my-secret', pretty: false })
 
       const savedConfig = saveSpy.mock.calls[0][0] as { clientId: string; clientSecret: string }
       expect(savedConfig.clientId).toBe('my-id')
@@ -182,7 +345,7 @@ describe('auth commands', () => {
     })
   })
 
-  describe('loginAction non-interactive (no TTY)', () => {
+  describe('oauthAction non-interactive (no TTY)', () => {
     const device = {
       deviceCode: 'webex-device-code-abc123',
       userCode: 'USER-CODE',
@@ -199,7 +362,7 @@ describe('auth commands', () => {
       const pollSpy = protoSpy(WebexCredentialManager.prototype, 'pollDeviceToken')
       const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
 
-      await loginAction({ pretty: false })
+      await oauthAction({ pretty: false })
 
       expect(requestSpy).toHaveBeenCalled()
       expect(exchangeSpy).not.toHaveBeenCalled()
@@ -212,7 +375,7 @@ describe('auth commands', () => {
       expect(output.verification_uri_complete).toBe(device.verificationUriComplete)
       expect(output.user_code).toBe(device.userCode)
       expect(output.device_code).toBe(device.deviceCode)
-      expect(output.message).toContain('--device-code')
+      expect(output.message).toContain('auth oauth --device-code')
       expect(exitSpy).toHaveBeenCalledWith(0)
     })
 
@@ -221,7 +384,7 @@ describe('auth commands', () => {
       protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode').mockResolvedValue(device)
       protoSpy(process, 'exit').mockImplementation(() => undefined as never)
 
-      await loginAction({ pretty: false })
+      await oauthAction({ pretty: false })
 
       expect(execSpy).not.toHaveBeenCalled()
     })
@@ -232,7 +395,7 @@ describe('auth commands', () => {
       const requestSpy = protoSpy(WebexCredentialManager.prototype, 'requestDeviceCode')
       const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
 
-      await loginAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
+      await oauthAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
 
       expect(requestSpy).not.toHaveBeenCalled()
 
@@ -253,7 +416,7 @@ describe('auth commands', () => {
       protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
       protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
 
-      await loginAction({
+      await oauthAction({
         deviceCode: 'webex-device-code-abc123',
         clientId: 'my-id',
         clientSecret: 'my-secret',
@@ -276,7 +439,7 @@ describe('auth commands', () => {
       protoSpy(WebexCredentialManager.prototype, 'exchangeDeviceCode').mockResolvedValue({ status: 'expired' })
       const exitSpy = protoSpy(process, 'exit').mockImplementation(() => undefined as never)
 
-      await loginAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
+      await oauthAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
 
       const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
       const output = JSON.parse(lastCall)
@@ -297,25 +460,11 @@ describe('auth commands', () => {
       protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
       protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
 
-      await loginAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
+      await oauthAction({ deviceCode: 'webex-device-code-abc123', pretty: false })
 
       expect(exchangeSpy).toHaveBeenCalled()
       expect(requestSpy).not.toHaveBeenCalled()
       expect(pollSpy).not.toHaveBeenCalled()
-    })
-
-    it('still allows --token login when non-interactive (bot/PAT path)', async () => {
-      setTTY(false)
-      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
-      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
-      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
-
-      await loginAction({ token: 'bot-token-123', pretty: false })
-
-      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string
-      const output = JSON.parse(lastCall)
-      expect(output.authenticated).toBe(true)
-      expect(output.user.displayName).toBe('Test User')
     })
   })
 

--- a/src/platforms/webex/commands/auth.test.ts
+++ b/src/platforms/webex/commands/auth.test.ts
@@ -235,6 +235,18 @@ describe('auth commands', () => {
 
       expect(pwSpy).toHaveBeenCalledWith('alice@example.com', 'prompted-secret', { idbrokerHost: undefined })
     })
+
+    it('preserves whitespace in the prompted password', async () => {
+      promptQueue = ['  spaced secret  ']
+      const pwSpy = protoSpy(passwordLogin, 'loginWithPassword').mockResolvedValue(passwordConfig)
+      protoSpy(WebexCredentialManager.prototype, 'saveConfig').mockResolvedValue(undefined)
+      protoSpy(WebexClient.prototype, 'login').mockResolvedValue(new WebexClient())
+      protoSpy(WebexClient.prototype, 'testAuth').mockResolvedValue(mockPerson)
+
+      await loginAction({ email: 'alice@example.com', pretty: false })
+
+      expect(pwSpy).toHaveBeenCalledWith('alice@example.com', '  spaced secret  ', { idbrokerHost: undefined })
+    })
   })
 
   describe('loginAction non-interactive without credentials', () => {

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -58,7 +58,7 @@ async function promptHidden(message: string): Promise<string | undefined> {
     process.stdout.write(`${message}: `)
     const answer = await rl.question('')
     process.stdout.write('\n')
-    return answer.trim() || undefined
+    return answer === '' ? undefined : answer
   } finally {
     hiddenOutput.muted = false
     rl.close()

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { Writable } from 'node:stream'
 
 import { Command } from 'commander'
 
@@ -6,7 +7,7 @@ import { collectBrowserProfileOption } from '@/shared/chromium'
 import { handleError } from '@/shared/utils/error-handler'
 import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
-import { info, debug } from '@/shared/utils/stderr'
+import { info, debug, error as stderrError } from '@/shared/utils/stderr'
 
 import { getWebexAppCredentials } from '../app-config'
 import { WebexClient } from '../client'
@@ -31,6 +32,39 @@ async function openBrowser(url: string): Promise<void> {
   exec(command)
 }
 
+async function promptText(message: string): Promise<string | undefined> {
+  const { createInterface } = await import('node:readline/promises')
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true })
+  try {
+    const answer = await rl.question(`${message}: `)
+    return answer.trim() || undefined
+  } finally {
+    rl.close()
+  }
+}
+
+async function promptHidden(message: string): Promise<string | undefined> {
+  const { createInterface } = await import('node:readline/promises')
+  const hiddenOutput = new (class extends Writable {
+    muted = false
+    _write(chunk: Buffer | string, encoding: BufferEncoding, cb: (error?: Error | null) => void): void {
+      if (!this.muted) process.stdout.write(chunk, encoding)
+      cb()
+    }
+  })()
+  const rl = createInterface({ input: process.stdin, output: hiddenOutput, terminal: true })
+  try {
+    hiddenOutput.muted = true
+    process.stdout.write(`${message}: `)
+    const answer = await rl.question('')
+    process.stdout.write('\n')
+    return answer.trim() || undefined
+  } finally {
+    hiddenOutput.muted = false
+    rl.close()
+  }
+}
+
 async function resolveClientCredentials(options: {
   clientId?: string
   clientSecret?: string
@@ -49,9 +83,6 @@ async function resolveClientCredentials(options: {
 
 interface LoginOptions {
   token?: string
-  deviceCode?: string
-  clientId?: string
-  clientSecret?: string
   email?: string
   password?: string
   passwordStdin?: boolean
@@ -64,33 +95,136 @@ export async function loginAction(options: LoginOptions): Promise<void> {
     const credManager = new WebexCredentialManager()
 
     if (options.token) {
-      const client = await new WebexClient().login({ token: options.token })
-      const person = await client.testAuth()
-      await credManager.saveConfig({
-        accessToken: options.token,
-        refreshToken: '',
-        expiresAt: 0,
-        tokenType: 'manual',
-      })
-      console.log(
-        formatOutput(
-          {
-            user: { id: person.id, displayName: person.displayName, emails: person.emails },
-            authenticated: true,
-          },
-          options.pretty,
-        ),
-      )
+      await loginWithToken(credManager, options.token, options.pretty)
       return
     }
+
+    if (options.password && options.passwordStdin) {
+      throw new Error('Use only one of --password or --password-stdin.')
+    }
+
+    const interactive = isInteractive()
+
+    let email = options.email
+    if (!email) {
+      if (!interactive) {
+        console.log(
+          formatOutput(
+            {
+              error:
+                'Email required. Use --email <email> with --password or --password-stdin, ' +
+                'or run "agent-webex auth oauth" for browser-based login.',
+            },
+            options.pretty,
+          ),
+        )
+        process.exit(1)
+        return
+      }
+      email = await promptText('Webex email')
+      if (!email) {
+        stderrError('Email is required.')
+        process.exit(1)
+        return
+      }
+    }
+
+    let password = options.password
+    if (!password && options.passwordStdin) {
+      password = readFileSync(0, 'utf-8').replace(/\r?\n$/, '')
+    }
+    if (!password) {
+      if (!interactive) {
+        console.log(
+          formatOutput(
+            { error: 'Password required. Use --password or --password-stdin, or run interactively to be prompted.' },
+            options.pretty,
+          ),
+        )
+        process.exit(1)
+        return
+      }
+      password = await promptHidden('Password')
+      if (!password) {
+        stderrError('Password is required.')
+        process.exit(1)
+        return
+      }
+    }
+
+    await loginWithEmailPassword(credManager, email, password, options)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function loginWithToken(credManager: WebexCredentialManager, token: string, pretty?: boolean): Promise<void> {
+  const client = await new WebexClient().login({ token })
+  const person = await client.testAuth()
+  await credManager.saveConfig({
+    accessToken: token,
+    refreshToken: '',
+    expiresAt: 0,
+    tokenType: 'manual',
+  })
+  console.log(
+    formatOutput(
+      {
+        user: { id: person.id, displayName: person.displayName, emails: person.emails },
+        authenticated: true,
+      },
+      pretty,
+    ),
+  )
+}
+
+async function loginWithEmailPassword(
+  credManager: WebexCredentialManager,
+  email: string,
+  password: string,
+  options: LoginOptions,
+): Promise<void> {
+  const config = await loginWithPassword(email, password, { idbrokerHost: options.idbrokerHost })
+
+  await credManager.saveConfig({
+    ...config,
+    tokenType: 'password',
+    clientId: WEB_CLIENT_ID,
+    clientSecret: WEB_CLIENT_SECRET,
+    encryptionKeys: {},
+  })
+
+  const client = await new WebexClient().login({
+    token: config.accessToken,
+    deviceUrl: config.deviceUrl,
+    tokenType: 'password',
+  })
+  const person = await client.testAuth()
+
+  console.log(
+    formatOutput(
+      {
+        authenticated: true,
+        user: { id: person.id, displayName: person.displayName, emails: person.emails },
+      },
+      options.pretty,
+    ),
+  )
+}
+
+interface OAuthOptions {
+  deviceCode?: string
+  clientId?: string
+  clientSecret?: string
+  pretty?: boolean
+}
+
+export async function oauthAction(options: OAuthOptions): Promise<void> {
+  try {
+    const credManager = new WebexCredentialManager()
 
     if (options.deviceCode) {
       await finishDeviceGrant(credManager, options)
-      return
-    }
-
-    if (options.email) {
-      await loginWithEmailPassword(credManager, options)
       return
     }
 
@@ -136,48 +270,9 @@ export async function loginAction(options: LoginOptions): Promise<void> {
   }
 }
 
-async function loginWithEmailPassword(credManager: WebexCredentialManager, options: LoginOptions): Promise<void> {
-  const password = await resolvePassword(options)
-  const config = await loginWithPassword(options.email!, password, { idbrokerHost: options.idbrokerHost })
-
-  await credManager.saveConfig({
-    ...config,
-    tokenType: 'password',
-    clientId: WEB_CLIENT_ID,
-    clientSecret: WEB_CLIENT_SECRET,
-    encryptionKeys: {},
-  })
-
-  const client = await new WebexClient().login({
-    token: config.accessToken,
-    deviceUrl: config.deviceUrl,
-    tokenType: 'password',
-  })
-  const person = await client.testAuth()
-
-  console.log(
-    formatOutput(
-      {
-        authenticated: true,
-        user: { id: person.id, displayName: person.displayName, emails: person.emails },
-      },
-      options.pretty,
-    ),
-  )
-}
-
-async function resolvePassword(options: LoginOptions): Promise<string> {
-  if (options.password && options.passwordStdin) {
-    throw new Error('Use only one of --password or --password-stdin.')
-  }
-  if (options.password) return options.password
-  if (options.passwordStdin) return readFileSync(0, 'utf-8').replace(/\r?\n$/, '')
-  throw new Error('--password or --password-stdin is required with --email.')
-}
-
 async function startNonInteractiveDeviceGrant(
   credManager: WebexCredentialManager,
-  options: LoginOptions,
+  options: OAuthOptions,
 ): Promise<void> {
   const { clientId } = await resolveClientCredentials(options)
   const device = await credManager.requestDeviceCode(clientId)
@@ -193,7 +288,7 @@ async function startNonInteractiveDeviceGrant(
         device_code: device.deviceCode,
         expires_at: expiresAt,
         message:
-          'Show the user `verification_uri` and `user_code` (or just `verification_uri_complete`) and ask them to approve access in any browser. After they approve, run `agent-webex auth login --device-code <device_code>` to retrieve the token. The device code expires at `expires_at`. If you passed `--client-id`/`--client-secret`, pass them again on the second call.',
+          'Show the user `verification_uri` and `user_code` (or just `verification_uri_complete`) and ask them to approve access in any browser. After they approve, run `agent-webex auth oauth --device-code <device_code>` to retrieve the token. The device code expires at `expires_at`. If you passed `--client-id`/`--client-secret`, pass them again on the second call.',
       },
       options.pretty,
     ),
@@ -201,7 +296,7 @@ async function startNonInteractiveDeviceGrant(
   process.exit(0)
 }
 
-async function finishDeviceGrant(credManager: WebexCredentialManager, options: LoginOptions): Promise<void> {
+async function finishDeviceGrant(credManager: WebexCredentialManager, options: OAuthOptions): Promise<void> {
   const { clientId, clientSecret } = await resolveClientCredentials(options)
   const result = await credManager.exchangeDeviceCode(options.deviceCode!, clientId, clientSecret)
 
@@ -228,7 +323,7 @@ async function finishDeviceGrant(credManager: WebexCredentialManager, options: L
           next_action: 'still_pending',
           device_code: options.deviceCode,
           message:
-            'User has not approved access yet. Confirm with the user that they completed authorization in the browser, then run `agent-webex auth login --device-code <device_code>` again to retry.',
+            'User has not approved access yet. Confirm with the user that they completed authorization in the browser, then run `agent-webex auth oauth --device-code <device_code>` again to retry.',
         },
         options.pretty,
       ),
@@ -242,7 +337,7 @@ async function finishDeviceGrant(credManager: WebexCredentialManager, options: L
       {
         next_action: 'restart',
         error: result.status === 'expired' ? 'Device code expired.' : `Device code exchange failed: ${result.message}`,
-        message: 'This device code is no longer valid. Run `agent-webex auth login` to start a new login.',
+        message: 'This device code is no longer valid. Run `agent-webex auth oauth` to start a new login.',
       },
       options.pretty,
     ),
@@ -303,7 +398,7 @@ export async function extractAction(options: {
           {
             error:
               'No Webex token found in any browser. Make sure you are logged in at https://web.webex.com (not webex.com) in Chrome, Edge, Arc, or Brave.',
-            hint: 'Run "auth login" for OAuth Device Grant flow, or --debug for more info.',
+            hint: 'Run "auth oauth" for OAuth Device Grant flow, or --debug for more info.',
           },
           options.pretty,
         ),
@@ -355,7 +450,7 @@ export async function extractAction(options: {
           formatOutput(
             {
               error: 'Extracted browser token is expired and could not be refreshed.',
-              hint: 'Log in at https://web.webex.com (not webex.com) in your browser, then run "auth extract" again. Or use "auth login" for OAuth Device Grant flow.',
+              hint: 'Log in at https://web.webex.com (not webex.com) in your browser, then run "auth extract" again. Or use "auth oauth" for OAuth Device Grant flow.',
             },
             options.pretty,
           ),
@@ -417,25 +512,34 @@ export const authCommand = new Command('auth')
   .addCommand(
     new Command('login')
       .description(
-        'Log in to Webex. In a TTY this opens a browser and waits for approval. ' +
-          'When non-interactive (AI agents, CI/CD): first call starts the OAuth Device Grant flow ' +
-          'and returns a verification URL, user code, and device code. After the user approves in a ' +
-          'browser, call again with --device-code to exchange it for a token. Pass --token for ' +
-          'fully unattended auth.',
+        'Log in to Webex with your email and password (first-party token, messages appear as you). ' +
+          'Run with no flags in a terminal to be prompted for email and password. ' +
+          'Pass --token for a bot or personal access token. For browser-based OAuth, use `auth oauth`.',
       )
+      .option('--email <email>', 'Webex email address (prompted if omitted in a terminal)')
+      .option('--password <password>', 'Password for --email login (prompted securely if omitted in a terminal)')
+      .option('--password-stdin', 'Read the password for --email login from stdin')
+      .option('--idbroker-host <host>', 'Override IdBroker host for email/password login')
       .option('--token <token>', 'Use a bot token or personal access token directly')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(loginAction),
+  )
+  .addCommand(
+    new Command('oauth')
+      .description(
+        'Log in to Webex via OAuth Device Grant. In a TTY this opens a browser and waits for approval. ' +
+          'When non-interactive (AI agents, CI/CD): the first call starts the flow and returns a verification ' +
+          'URL, user code, and device code. After the user approves in a browser, call again with --device-code ' +
+          'to exchange it for a token.',
+      )
       .option(
         '--device-code <code>',
-        'OAuth Device Grant code returned from a previous non-interactive `auth login` call',
+        'OAuth Device Grant code returned from a previous non-interactive `auth oauth` call',
       )
       .option('--client-id <id>', 'Webex Integration client ID')
       .option('--client-secret <secret>', 'Webex Integration client secret')
-      .option('--email <email>', 'Log in headlessly with a Webex email address')
-      .option('--password <password>', 'Password for --email login')
-      .option('--password-stdin', 'Read password for --email login from stdin')
-      .option('--idbroker-host <host>', 'Override IdBroker host for --email login')
       .option('--pretty', 'Pretty print JSON output')
-      .action(loginAction),
+      .action(oauthAction),
   )
   .addCommand(
     new Command('extract')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split Webex auth flows: `agent-webex auth login` now does email/password (with prompts), and the OAuth Device Grant flow moved to `agent-webex auth oauth`. Also fixes the interactive password prompt to preserve whitespace and updates help, tests, and docs.

- **New Features**
  - `auth login`: prompts for email/password; supports `--email`, `--password`, `--password-stdin`, `--idbroker-host`; keeps `--token`; stores KMS‑scoped user token.
  - `auth oauth`: owns Device Grant; supports `--device-code`, `--client-id`, `--client-secret`; non‑interactive two‑call JSON flow with clearer messages.
  - CLI help lists `login` and `oauth`; tests cover help output, interactive prompts, and whitespace handling.

- **Migration**
  - Replace previous Device Grant calls: `agent-webex auth login` → `agent-webex auth oauth`.
  - `AGENT_WEBEX_CLIENT_ID`/`AGENT_WEBEX_CLIENT_SECRET` now apply to `auth oauth`.
  - Error/help references updated (e.g., timeouts and 401s now point to `auth oauth`); `auth login` is for email/password only.
  - Docs updated: `docs/content/docs/cli/webex.mdx`, `skills/agent-webex/SKILL.md`, `skills/agent-webex/references/authentication.md`, and `skills/agent-webex/references/common-patterns.md`.

<sup>Written for commit e09264a7cdb7775cc3f98358727408fa17eb5038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

