### PR TITLE
feat(webex): surface and accept friendly `ref` ids

### DIFF
--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -217,12 +217,12 @@ agent-webex snapshot --full
 
 Default returns brief JSON with:
 
-- Spaces (id, title) — only spaces you're a member of
+- Spaces (id, ref, title) — only spaces you're a member of
 - Hint for next commands
 
 With `--full`, returns:
 
-- Spaces (id, title, type, lastActivity)
+- Spaces (id, ref, title, type, lastActivity)
 
 For messages or members, use `message list <space-id>` or `member list <space-id>`.
 

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -328,12 +328,12 @@ agent-webex snapshot --full
 
 Default returns brief JSON with:
 
-- Spaces (id, title) — only spaces you're a member of
+- Spaces (id, ref, title) — only spaces you're a member of
 - Hint for next commands
 
 With `--full`, returns:
 
-- Spaces (id, title, type, lastActivity)
+- Spaces (id, ref, title, type, lastActivity)
 
 For messages or members, use `message list <space-id>` or `member list <space-id>`.
 

--- a/skills/agent-webexbot/SKILL.md
+++ b/skills/agent-webexbot/SKILL.md
@@ -246,7 +246,7 @@ agent-webexbot file download <content-url-or-id> ./downloaded-report.pdf
 Get a workspace overview for AI agents.
 
 ```bash
-# Brief snapshot (bot identity + space IDs/titles)
+# Brief snapshot (bot identity + space ids/refs/titles)
 agent-webexbot snapshot
 
 # Full snapshot (includes space type and last activity)

--- a/skills/agent-webexbot/references/common-patterns.md
+++ b/skills/agent-webexbot/references/common-patterns.md
@@ -331,7 +331,7 @@ agent-webexbot user info "$PERSON_ID" | jq '{displayName, emails, type}'
 ```bash
 #!/bin/bash
 
-# Brief: bot identity + space IDs/titles
+# Brief: bot identity + space ids/refs/titles
 agent-webexbot snapshot
 
 # Full: includes space type and last activity

--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 
 import * as jose from 'node-jose'
 
 import { WebexClient } from './client'
 import { WebexEncryptionService } from './encryption'
+import { toRestId } from './id-normalizer'
 import { WebexError } from './types'
 
 describe('WebexClient', () => {
@@ -444,6 +445,92 @@ describe('WebexClient', () => {
     })
   })
 
+  describe('id ref resolution', () => {
+    const roomUuid = '12345678-1234-1234-1234-1234567890ab'
+    const personUuid = '22222222-2222-2222-2222-222222222222'
+    const messageUuid = '33333333-3333-3333-3333-333333333333'
+    const usRoomId = toRestId(roomUuid, 'ROOM')
+    const clusteredRoomId = Buffer.from(`ciscospark://urn:TEAM:us-west-2_r/ROOM/${roomUuid}`).toString('base64url')
+
+    const isRoomsList = (url: string) => new URL(url).pathname === '/v1/rooms'
+
+    it('resolves a bare room uuid to the real clustered id before sending', async () => {
+      mockResponse({ items: [{ id: clusteredRoomId, title: 'Team', type: 'group' }] })
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      await client.sendMessage(roomUuid, 'hello')
+
+      expect(isRoomsList(fetchCalls[0].url)).toBe(true)
+      expect(JSON.parse(fetchCalls[1].options?.body as string).roomId).toBe(clusteredRoomId)
+    })
+
+    it('rewrites a us-cluster room id to the real clustered id for memberships', async () => {
+      mockResponse({ items: [{ id: clusteredRoomId, title: 'Team', type: 'group' }] })
+      mockResponse({ items: [{ id: 'm1', roomId: clusteredRoomId, personId: 'p1' }] })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      await client.listMemberships(usRoomId)
+
+      const membershipsUrl = new URL(fetchCalls[1].url)
+      expect(membershipsUrl.pathname).toBe('/v1/memberships')
+      expect(membershipsUrl.searchParams.get('roomId')).toBe(clusteredRoomId)
+    })
+
+    it('passes an already-clustered room id through without a lookup', async () => {
+      mockResponse({ id: 'msg-1', roomId: clusteredRoomId, roomType: 'group' })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      await client.sendMessage(clusteredRoomId, 'hello')
+
+      expect(fetchCalls).toHaveLength(1)
+      expect(JSON.parse(fetchCalls[0].options?.body as string).roomId).toBe(clusteredRoomId)
+    })
+
+    it('fails open to the reconstructed room id and warns when no room matches', async () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        mockResponse({ items: [] })
+        mockResponse({ id: 'msg-1', roomId: usRoomId, roomType: 'group' })
+
+        const client = await new WebexClient().login({ token: 'test-token' })
+        await client.sendMessage(roomUuid, 'hello')
+
+        expect(JSON.parse(fetchCalls[1].options?.body as string).roomId).toBe(usRoomId)
+        expect(warnSpy).toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('resolves a person email through the people search endpoint', async () => {
+      const personId = toRestId(personUuid, 'PEOPLE')
+      mockResponse({ items: [{ id: personId, emails: ['alice@example.com'], displayName: 'Alice', type: 'person' }] })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      const person = await client.getPerson('alice@example.com')
+
+      expect(person.id).toBe(personId)
+      const url = new URL(fetchCalls[0].url)
+      expect(url.pathname).toBe('/v1/people')
+      expect(url.searchParams.get('email')).toBe('alice@example.com')
+    })
+
+    it('reconstructs bare person and message uuids for REST calls', async () => {
+      const personId = toRestId(personUuid, 'PEOPLE')
+      const messageId = toRestId(messageUuid, 'MESSAGE')
+      mockResponse({ id: personId, emails: ['alice@example.com'], displayName: 'Alice', type: 'person' })
+      mockResponse({ id: messageId, roomId: usRoomId, text: 'hi' })
+
+      const client = await new WebexClient().login({ token: 'test-token' })
+      await client.getPerson(personUuid)
+      await client.getMessage(messageUuid)
+
+      expect(fetchCalls[0].url).toBe(`https://webexapis.com/v1/people/${personId}`)
+      expect(fetchCalls[1].url).toBe(`https://webexapis.com/v1/messages/${messageId}`)
+    })
+  })
+
   describe('rate limiting', () => {
     it('retries on 429 with Retry-After header', async () => {
       mockResponse({ message: 'Rate limited' }, 429, { 'Retry-After': '0.1' })
@@ -519,6 +606,7 @@ describe('WebexClient', () => {
     const CONV_BASE = 'https://conv-r.wbx2.com/conversation/api/v1'
     const TEST_ROOM_ID = Buffer.from('ciscospark://urn:TEAM:us-west-2_r/ROOM/abc123-def456').toString('base64')
     const TEST_CONV_UUID = 'abc123-def456'
+    const TEST_ACTIVITY_ID = toRestId('activity-123', 'MESSAGE')
 
     const mockActivity = (text: string, overrides?: Partial<Record<string, unknown>>) => ({
       id: 'activity-123',
@@ -605,7 +693,7 @@ describe('WebexClient', () => {
         const client = await createExtractedClient()
         const message = await client.sendMessage(TEST_ROOM_ID, 'Hello world')
 
-        expect(message.id).toBe('activity-123')
+        expect(message.id).toBe(TEST_ACTIVITY_ID)
         expect(message.text).toBe('Hello world')
         expect(message.personEmail).toBe('test@example.com')
         expect(message.created).toBe('2026-01-01T00:00:00.000Z')
@@ -670,7 +758,7 @@ describe('WebexClient', () => {
         const client = await createExtractedClient()
         const messages = await client.listMessages(TEST_ROOM_ID)
 
-        expect(messages[0].id).toBe('activity-123')
+        expect(messages[0].id).toBe(TEST_ACTIVITY_ID)
         expect(messages[0].text).toBe('Hello')
         expect(messages[0].personEmail).toBe('test@example.com')
         expect(messages[0].created).toBe('2026-01-01T00:00:00.000Z')
@@ -713,7 +801,7 @@ describe('WebexClient', () => {
         const client = await createExtractedClient()
         const message = await client.getMessage('activity-123')
 
-        expect(message.id).toBe('activity-123')
+        expect(message.id).toBe(TEST_ACTIVITY_ID)
         expect(message.text).toBe('Hello')
         expect(message.personEmail).toBe('test@example.com')
       })
@@ -843,7 +931,7 @@ describe('WebexClient', () => {
 
         const client = await createExtractedClient()
         const message = await client.editMessage('activity-123', TEST_ROOM_ID, 'Edited text')
-        expect(message.id).toBe('activity-123')
+        expect(message.id).toBe(TEST_ACTIVITY_ID)
       })
 
       it('throws when server returns activity linked to a different parent', async () => {
@@ -916,7 +1004,7 @@ describe('WebexClient', () => {
         expect(fetchCalls[0].url).toContain('/rooms?type=direct&max=100')
         expect(fetchCalls[1].url).toContain('/memberships?roomId=')
         expect(fetchCalls[2].url).toBe(`${CONV_BASE}/activities`)
-        expect(message.id).toBe('activity-123')
+        expect(message.id).toBe(TEST_ACTIVITY_ID)
       })
 
       it('throws WebexError when no existing direct conversation found', async () => {

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -1,5 +1,6 @@
 import { WebexCredentialManager } from './credential-manager'
 import { WebexEncryptionService } from './encryption'
+import { decodeWebexId, toRestId } from './id-normalizer'
 import { KmsKeyProvider } from './kms-key-provider'
 import { escapeHtml, markdownToHtml, stripMarkdown } from './markdown-to-html'
 import type { WebexConfig, WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './types'
@@ -15,6 +16,10 @@ interface RateLimitBucket {
   resetAt: number
 }
 
+interface WebexClientOptions {
+  roomResolutionWarningPrefix?: string
+}
+
 export class WebexClient {
   private token: string | null = null
   private deviceUrl: string | null = null
@@ -22,6 +27,13 @@ export class WebexClient {
   private buckets: Map<string, RateLimitBucket> = new Map()
   private globalRateLimitUntil: number = 0
   private encryption: WebexEncryptionService | null = null
+  private clusteredRoomIds = new Map<string, string>()
+  private roomIdLookups = new Map<string, Promise<string>>()
+  private roomResolutionWarningPrefix: string
+
+  constructor(options: WebexClientOptions = {}) {
+    this.roomResolutionWarningPrefix = options.roomResolutionWarningPrefix ?? '[webex]'
+  }
 
   async login(credentials?: { token: string; deviceUrl?: string; tokenType?: string }): Promise<this> {
     if (credentials) {
@@ -245,8 +257,55 @@ export class WebexClient {
     }
   }
 
+  async resolveRoomId(roomId: string): Promise<string> {
+    const decoded = decodeWebexId(roomId)
+    let uuid: string
+    let fallback: string
+
+    if (decoded) {
+      if (decoded.type !== 'ROOM' || decoded.cluster.startsWith('urn:')) return roomId
+      uuid = decoded.uuid
+      fallback = roomId
+    } else if (looksLikeUuid(roomId)) {
+      uuid = roomId
+      fallback = toRestId(roomId, 'ROOM')
+    } else {
+      return roomId
+    }
+
+    const cached = this.clusteredRoomIds.get(uuid)
+    if (cached) return cached
+
+    const inFlight = this.roomIdLookups.get(uuid)
+    if (inFlight) return inFlight
+
+    const lookup = this.lookupRoomId(uuid, fallback)
+    this.roomIdLookups.set(uuid, lookup)
+    try {
+      return await lookup
+    } finally {
+      this.roomIdLookups.delete(uuid)
+    }
+  }
+
+  async resolvePersonId(personId: string): Promise<string> {
+    if (!personId || decodeWebexId(personId)) return personId
+
+    if (looksLikeEmail(personId)) {
+      const [person] = await this.listPeople({ email: personId, max: 1 })
+      if (!person) {
+        throw new WebexError(`Person not found for ref: ${personId}`, 'not_found')
+      }
+      return person.id
+    }
+
+    if (looksLikeUuid(personId)) return toRestId(personId, 'PEOPLE')
+    return personId
+  }
+
   async getSpace(spaceId: string): Promise<WebexSpace> {
-    return this.request<WebexSpace>('GET', `/rooms/${spaceId}`)
+    const resolvedSpaceId = await this.resolveRoomId(spaceId)
+    return this.request<WebexSpace>('GET', `/rooms/${resolvedSpaceId}`)
   }
 
   async sendMessage(
@@ -254,14 +313,17 @@ export class WebexClient {
     text: string,
     options?: { markdown?: boolean; parentId?: string; files?: string[] },
   ): Promise<WebexMessage> {
+    const resolvedRoomId = await this.resolveRoomId(roomId)
+    const resolvedOptions = this.resolveMessageOptions(options)
+
     if (this.useInternalAPI) {
-      return this.sendMessageInternal(roomId, text, options)
+      return this.sendMessageInternal(resolvedRoomId, text, resolvedOptions)
     }
-    const body: Record<string, unknown> = { roomId }
-    if (options?.markdown) body.markdown = text
+    const body: Record<string, unknown> = { roomId: resolvedRoomId }
+    if (resolvedOptions?.markdown) body.markdown = text
     else body.text = text
-    if (options?.parentId) body.parentId = options.parentId
-    if (options?.files?.length) body.files = options.files
+    if (resolvedOptions?.parentId) body.parentId = resolvedOptions.parentId
+    if (resolvedOptions?.files?.length) body.files = resolvedOptions.files
     return this.request<WebexMessage>('POST', '/messages', body)
   }
 
@@ -283,7 +345,7 @@ export class WebexClient {
   }
 
   private decodeConvUuid(roomId: string): string {
-    return Buffer.from(roomId, 'base64').toString('utf8').split('/').pop() ?? roomId
+    return decodeWebexId(roomId)?.uuid ?? roomId
   }
 
   private async internalRequest<T>(path: string, init?: RequestInit): Promise<T> {
@@ -315,11 +377,11 @@ export class WebexClient {
     }
 
     return {
-      id: a.id,
+      id: this.normalizeMessageId(a.id),
       roomId,
       roomType: 'group' as const,
       text,
-      personId: a.actor?.entryUUID ?? a.actor?.id ?? '',
+      personId: this.normalizePersonId(a.actor?.entryUUID ?? a.actor?.id ?? ''),
       personEmail: a.actor?.emailAddress ?? '',
       created: a.published,
     }
@@ -425,27 +487,31 @@ export class WebexClient {
     roomId: string,
     options?: { max?: number; mentionedPeople?: string; parentId?: string },
   ): Promise<WebexMessage[]> {
+    const resolvedRoomId = await this.resolveRoomId(roomId)
+    const resolvedOptions = await this.resolveListMessageOptions(options)
+
     if (this.useInternalAPI) {
-      const convUuid = this.decodeConvUuid(roomId)
-      const max = options?.max ?? 50
+      const convUuid = this.decodeConvUuid(resolvedRoomId)
+      const max = resolvedOptions?.max ?? 50
       const conv = await this.internalRequest<InternalConversation>(
         `/conversations/${convUuid}?activitiesLimit=${max}&participantsLimit=0`,
       )
       const activities = (conv.activities?.items ?? []).filter((a) => a.verb === 'post')
-      return Promise.all(activities.map((a) => this.activityToMessage(a, roomId)))
+      return Promise.all(activities.map((a) => this.activityToMessage(a, resolvedRoomId)))
     }
     const params = new URLSearchParams()
-    params.set('roomId', roomId)
-    params.set('max', String(options?.max ?? 50))
-    if (options?.mentionedPeople) params.set('mentionedPeople', options.mentionedPeople)
-    if (options?.parentId) params.set('parentId', options.parentId)
+    params.set('roomId', resolvedRoomId)
+    params.set('max', String(resolvedOptions?.max ?? 50))
+    if (resolvedOptions?.mentionedPeople) params.set('mentionedPeople', resolvedOptions.mentionedPeople)
+    if (resolvedOptions?.parentId) params.set('parentId', resolvedOptions.parentId)
     const data = await this.request<{ items: WebexMessage[] }>('GET', `/messages?${params}`)
     return data.items
   }
 
   async getMessage(messageId: string): Promise<WebexMessage> {
     if (this.useInternalAPI) {
-      const activity = await this.internalRequest<InternalActivity>(`/activities/${messageId}`)
+      const activityId = this.toMessageRef(messageId)
+      const activity = await this.internalRequest<InternalActivity>(`/activities/${activityId}`)
       const convId = activity.target?.id ?? ''
       // Internal API responses don't carry the cluster shard (e.g. `us-west-2_r`) the
       // public roomId encoding requires. The `unknown` placeholder is a sentinel — it
@@ -455,25 +521,26 @@ export class WebexClient {
       const roomId = convId ? Buffer.from(`ciscospark://urn:TEAM:unknown/ROOM/${convId}`).toString('base64') : ''
       return this.activityToMessage(activity, roomId)
     }
-    return this.request<WebexMessage>('GET', `/messages/${messageId}`)
+    return this.request<WebexMessage>('GET', `/messages/${this.resolveMessageId(messageId)}`)
   }
 
   async deleteMessage(messageId: string): Promise<void> {
     if (this.useInternalAPI) {
-      const activity = await this.internalRequest<InternalActivity>(`/activities/${messageId}`)
+      const activityId = this.toMessageRef(messageId)
+      const activity = await this.internalRequest<InternalActivity>(`/activities/${activityId}`)
       const convId = activity.target?.id
       if (!convId) throw new WebexError('Cannot determine conversation for activity', 'internal_error')
       await this.internalRequest<unknown>('/activities', {
         method: 'POST',
         body: JSON.stringify({
           verb: 'delete',
-          object: { id: messageId, objectType: 'activity' },
+          object: { id: activityId, objectType: 'activity' },
           target: { id: convId, objectType: 'conversation' },
         }),
       })
       return
     }
-    return this.request<void>('DELETE', `/messages/${messageId}`)
+    return this.request<void>('DELETE', `/messages/${this.resolveMessageId(messageId)}`)
   }
 
   async editMessage(
@@ -482,8 +549,11 @@ export class WebexClient {
     text: string,
     options?: { markdown?: boolean },
   ): Promise<WebexMessage> {
+    const resolvedRoomId = await this.resolveRoomId(roomId)
+
     if (this.useInternalAPI) {
-      const convUuid = this.decodeConvUuid(roomId)
+      const activityId = this.toMessageRef(messageId)
+      const convUuid = this.decodeConvUuid(resolvedRoomId)
       const { object, encryptionKeyUrl } = await this.buildEncryptedObject(convUuid, text, {
         ...options,
         forEdit: true,
@@ -493,7 +563,7 @@ export class WebexClient {
         verb: 'post',
         object,
         target: { id: convUuid, objectType: 'conversation' },
-        parent: { id: messageId, type: 'edit' },
+        parent: { id: activityId, type: 'edit' },
         clientTempId: `tmp-${Date.now()}-edit`,
       }
 
@@ -508,17 +578,17 @@ export class WebexClient {
 
       // Tolerate responses that omit `parent` (server may return minimal shape) —
       // only fail on an explicit mismatch between the echoed parent and the edited id.
-      if (result.parent && result.parent.id !== messageId) {
+      if (result.parent && result.parent.id !== activityId) {
         throw new WebexError(
-          `Edit rejected: server linked the new activity ${result.id} to ${result.parent.id} instead of ${messageId}.`,
+          `Edit rejected: server linked the new activity ${result.id} to ${result.parent.id} instead of ${activityId}.`,
           'edit_failed',
         )
       }
 
-      return this.activityToMessage(result, roomId)
+      return this.activityToMessage(result, resolvedRoomId)
     }
-    const body = options?.markdown ? { roomId, markdown: text } : { roomId, text }
-    return this.request<WebexMessage>('PUT', `/messages/${messageId}`, body)
+    const body = options?.markdown ? { roomId: resolvedRoomId, markdown: text } : { roomId: resolvedRoomId, text }
+    return this.request<WebexMessage>('PUT', `/messages/${this.resolveMessageId(messageId)}`, body)
   }
 
   async listPeople(options?: { email?: string; displayName?: string; max?: number }): Promise<WebexPerson[]> {
@@ -533,7 +603,14 @@ export class WebexClient {
   }
 
   async getPerson(personId: string): Promise<WebexPerson> {
-    return this.request<WebexPerson>('GET', `/people/${personId}`)
+    if (!decodeWebexId(personId) && looksLikeEmail(personId)) {
+      const [person] = await this.listPeople({ email: personId, max: 1 })
+      if (!person) {
+        throw new WebexError(`Person not found for ref: ${personId}`, 'not_found')
+      }
+      return person
+    }
+    return this.request<WebexPerson>('GET', `/people/${await this.resolvePersonId(personId)}`)
   }
 
   async listMyMemberships(options?: { max?: number }): Promise<WebexMembership[]> {
@@ -544,8 +621,9 @@ export class WebexClient {
   }
 
   async listMemberships(roomId: string, options?: { max?: number }): Promise<WebexMembership[]> {
+    const resolvedRoomId = await this.resolveRoomId(roomId)
     const params = new URLSearchParams()
-    params.set('roomId', roomId)
+    params.set('roomId', resolvedRoomId)
     if (options?.max) params.set('max', String(options.max))
     const data = await this.request<{ items: WebexMembership[] }>('GET', `/memberships?${params}`)
     return data.items
@@ -556,12 +634,14 @@ export class WebexClient {
     file: { content: Blob; filename: string },
     options?: { text?: string; markdown?: boolean; parentId?: string },
   ): Promise<WebexMessage> {
+    const resolvedRoomId = await this.resolveRoomId(roomId)
+    const resolvedParentId = options?.parentId ? this.resolveMessageId(options.parentId) : undefined
     const form = new FormData()
-    form.set('roomId', roomId)
+    form.set('roomId', resolvedRoomId)
     if (options?.text) {
       form.set(options.markdown ? 'markdown' : 'text', options.text)
     }
-    if (options?.parentId) form.set('parentId', options.parentId)
+    if (resolvedParentId) form.set('parentId', resolvedParentId)
     form.set('files', file.content, file.filename)
 
     const response = await fetch(`${BASE_URL}/messages`, {
@@ -575,6 +655,80 @@ export class WebexClient {
       throw new WebexError(errorBody?.message ?? `HTTP ${response.status}`, `http_${response.status}`)
     }
     return response.json() as Promise<WebexMessage>
+  }
+
+  private async lookupRoomId(uuid: string, fallback: string): Promise<string> {
+    try {
+      // Page through every room the account belongs to, stopping as soon as the
+      // trailing UUID matches because room titles are not stable identifiers.
+      for await (const room of this.iterateSpaces({ max: 1000 })) {
+        if (decodeWebexId(room.id)?.uuid === uuid) {
+          this.clusteredRoomIds.set(uuid, room.id)
+          return room.id
+        }
+      }
+    } catch {
+      // Network/auth failure: fail open to the un-corrected id rather than block the call.
+      return fallback
+    }
+
+    console.warn(
+      `${this.roomResolutionWarningPrefix} Could not resolve clustered room id for ${uuid}; falling back to the un-clustered id. ` +
+        'Room-scoped calls may fail if this room lives on a non-default Webex cluster.',
+    )
+    return fallback
+  }
+
+  private resolveMessageOptions(options?: {
+    markdown?: boolean
+    parentId?: string
+    files?: string[]
+  }): { markdown?: boolean; parentId?: string; files?: string[] } | undefined {
+    if (!options?.parentId) return options
+    return { ...options, parentId: this.resolveMessageId(options.parentId) }
+  }
+
+  private async resolveListMessageOptions(options?: {
+    max?: number
+    mentionedPeople?: string
+    parentId?: string
+  }): Promise<{ max?: number; mentionedPeople?: string; parentId?: string } | undefined> {
+    if (!options) return undefined
+    const resolved = { ...options }
+    if (options.mentionedPeople) {
+      resolved.mentionedPeople = await this.resolveMentionedPeople(options.mentionedPeople)
+    }
+    if (options.parentId) {
+      resolved.parentId = this.resolveMessageId(options.parentId)
+    }
+    return resolved
+  }
+
+  private async resolveMentionedPeople(mentionedPeople: string): Promise<string> {
+    if (mentionedPeople === 'me') return mentionedPeople
+    return this.resolvePersonId(mentionedPeople)
+  }
+
+  private resolveMessageId(messageId: string): string {
+    if (!messageId || decodeWebexId(messageId)) return messageId
+    // A lone message UUID does not identify its room cluster, so cluster correction
+    // is not possible without the room context.
+    if (looksLikeUuid(messageId)) return toRestId(messageId, 'MESSAGE')
+    return messageId
+  }
+
+  private toMessageRef(messageId: string): string {
+    return decodeWebexId(messageId)?.uuid ?? messageId
+  }
+
+  private normalizeMessageId(messageId: string): string {
+    if (!messageId || decodeWebexId(messageId)) return messageId
+    return toRestId(messageId, 'MESSAGE')
+  }
+
+  private normalizePersonId(personId: string): string {
+    if (!personId || decodeWebexId(personId)) return personId
+    return toRestId(personId, 'PEOPLE')
   }
 
   async downloadContent(contentRef: string): Promise<{ data: ArrayBuffer; filename: string; contentType: string }> {
@@ -636,6 +790,14 @@ function sanitizeFilename(name: string | undefined): string | undefined {
   const base = name.replace(/\\/g, '/').split('/').pop()
   if (!base || base === '.' || base === '..') return undefined
   return base
+}
+
+function looksLikeUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
+function looksLikeEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
 }
 
 interface InternalActivity {

--- a/src/platforms/webex/commands/auth.test.ts
+++ b/src/platforms/webex/commands/auth.test.ts
@@ -9,6 +9,8 @@ import { WebexTokenExtractor } from '../token-extractor'
 import { WebexError } from '../types'
 import { extractAction, loginAction, logoutAction, oauthAction, statusAction } from './auth'
 
+const personId = Buffer.from('ciscospark://us/PEOPLE/person-1').toString('base64url')
+
 let promptQueue: string[] = []
 mock.module('node:readline/promises', () => ({
   createInterface: () => ({
@@ -33,7 +35,7 @@ describe('auth commands', () => {
   let originalStdinTTY: boolean | undefined
   let originalStdoutTTY: boolean | undefined
   const mockPerson = {
-    id: 'person-1',
+    id: personId,
     displayName: 'Test User',
     emails: ['test@example.com'],
     orgId: 'org-1',

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -12,6 +12,7 @@ import { info, debug, error as stderrError } from '@/shared/utils/stderr'
 import { getWebexAppCredentials } from '../app-config'
 import { WebexClient } from '../client'
 import { WebexCredentialManager } from '../credential-manager'
+import { toRef } from '../id-normalizer'
 import { loginWithPassword, WEB_CLIENT_ID, WEB_CLIENT_SECRET } from '../password-login'
 import { WebexTokenExtractor } from '../token-extractor'
 import { WebexError } from '../types'
@@ -19,6 +20,10 @@ import { WebexError } from '../types'
 interface ResolvedCredentials {
   clientId: string
   clientSecret: string
+}
+
+function formatAuthUser(person: { id: string; displayName: string; emails: string[] }) {
+  return { id: person.id, ref: toRef(person.id), displayName: person.displayName, emails: person.emails }
 }
 
 async function openBrowser(url: string): Promise<void> {
@@ -170,7 +175,7 @@ async function loginWithToken(credManager: WebexCredentialManager, token: string
   console.log(
     formatOutput(
       {
-        user: { id: person.id, displayName: person.displayName, emails: person.emails },
+        user: formatAuthUser(person),
         authenticated: true,
       },
       pretty,
@@ -205,7 +210,7 @@ async function loginWithEmailPassword(
     formatOutput(
       {
         authenticated: true,
-        user: { id: person.id, displayName: person.displayName, emails: person.emails },
+        user: formatAuthUser(person),
       },
       options.pretty,
     ),
@@ -259,7 +264,7 @@ export async function oauthAction(options: OAuthOptions): Promise<void> {
     console.log(
       formatOutput(
         {
-          user: { id: person.id, displayName: person.displayName, emails: person.emails },
+          user: formatAuthUser(person),
           authenticated: true,
         },
         options.pretty,
@@ -308,7 +313,7 @@ async function finishDeviceGrant(credManager: WebexCredentialManager, options: O
       formatOutput(
         {
           authenticated: true,
-          user: { id: person.id, displayName: person.displayName, emails: person.emails },
+          user: formatAuthUser(person),
         },
         options.pretty,
       ),
@@ -364,7 +369,7 @@ export async function statusAction(options: { pretty?: boolean }): Promise<void>
         formatOutput(
           {
             authenticated: true,
-            user: { id: person.id, displayName: person.displayName, emails: person.emails },
+            user: formatAuthUser(person),
           },
           options.pretty,
         ),
@@ -436,11 +441,11 @@ export async function extractAction(options: {
       tokenType: 'extracted',
     })
 
-    let person: { id: string; displayName: string; emails: string[] } | null = null
+    let person: ReturnType<typeof formatAuthUser> | null = null
     try {
       const result = await client.testAuth()
       if (result.id) {
-        person = { id: result.id, displayName: result.displayName, emails: result.emails }
+        person = formatAuthUser(result)
       }
     } catch (authError) {
       const isAuthFailure =

--- a/src/platforms/webex/commands/member.test.ts
+++ b/src/platforms/webex/commands/member.test.ts
@@ -3,20 +3,26 @@ import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 import { WebexClient } from '../client'
 import { WebexError } from '../types'
 
+const restId = (type: string, ref: string) => Buffer.from(`ciscospark://us/${type}/${ref}`).toString('base64url')
+const member1Id = restId('MEMBERSHIP', 'person-1:room-1')
+const member2Id = restId('MEMBERSHIP', 'person-2:room-1')
+const person1Id = restId('PEOPLE', 'person-1')
+const person2Id = restId('PEOPLE', 'person-2')
+
 const mockMembers = [
   {
-    id: 'mem-1',
+    id: member1Id,
     roomId: 'room-1',
-    personId: 'person-1',
+    personId: person1Id,
     personEmail: 'alice@example.com',
     personDisplayName: 'Alice',
     isModerator: true,
     created: '2024-01-01T00:00:00.000Z',
   },
   {
-    id: 'mem-2',
+    id: member2Id,
     roomId: 'room-1',
-    personId: 'person-2',
+    personId: person2Id,
     personEmail: 'bob@example.com',
     personDisplayName: 'Bob',
     isModerator: false,
@@ -66,16 +72,20 @@ describe('member commands', () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       JSON.stringify([
         {
-          id: 'mem-1',
-          personId: 'person-1',
+          id: member1Id,
+          ref: 'person-1:room-1',
+          personId: person1Id,
+          personRef: 'person-1',
           personEmail: 'alice@example.com',
           personDisplayName: 'Alice',
           isModerator: true,
           created: '2024-01-01T00:00:00.000Z',
         },
         {
-          id: 'mem-2',
-          personId: 'person-2',
+          id: member2Id,
+          ref: 'person-2:room-1',
+          personId: person2Id,
+          personRef: 'person-2',
           personEmail: 'bob@example.com',
           personDisplayName: 'Bob',
           isModerator: false,

--- a/src/platforms/webex/commands/member.ts
+++ b/src/platforms/webex/commands/member.ts
@@ -4,6 +4,7 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
+import { toRef } from '../id-normalizer'
 
 export async function listAction(spaceId: string, options: { limit?: number; pretty?: boolean }): Promise<void> {
   try {
@@ -12,7 +13,9 @@ export async function listAction(spaceId: string, options: { limit?: number; pre
 
     const output = members.map((m) => ({
       id: m.id,
+      ref: toRef(m.id),
       personId: m.personId,
+      personRef: toRef(m.personId),
       personEmail: m.personEmail,
       personDisplayName: m.personDisplayName,
       isModerator: m.isModerator,

--- a/src/platforms/webex/commands/message.test.ts
+++ b/src/platforms/webex/commands/message.test.ts
@@ -1,26 +1,32 @@
 import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
 import { WebexClient } from '../client'
+import { toRestId } from '../id-normalizer'
 import { WebexError } from '../types'
 
+const messageId = toRestId('msg_123', 'MESSAGE')
+const message2Id = toRestId('msg_124', 'MESSAGE')
+const roomId = toRestId('space_456', 'ROOM')
+const personId = toRestId('person_789', 'PEOPLE')
+
 const mockMessage = {
-  id: 'msg_123',
-  roomId: 'space_456',
+  id: messageId,
+  roomId,
   roomType: 'group' as const,
   text: 'Hello world',
   html: '<p>Hello <a href="https://example.com">world</a></p>',
-  personId: 'person_789',
+  personId,
   personEmail: 'user@example.com',
   created: '2025-01-29T10:00:00.000Z',
 }
 
 const mockMessage2 = {
-  id: 'msg_124',
-  roomId: 'space_456',
+  id: message2Id,
+  roomId,
   roomType: 'group' as const,
   text: 'Second message',
   html: '<p>Second message</p>',
-  personId: 'person_789',
+  personId,
   personEmail: 'user@example.com',
   created: '2025-01-29T10:01:00.000Z',
 }
@@ -78,10 +84,12 @@ it('calls sendMessage with correct args and outputs result', async () => {
     markdown: undefined,
   })
   expect(consoleLogSpy).toHaveBeenCalled()
-  const output = consoleLogSpy.mock.calls[0][0]
-  expect(output).toContain('msg_123')
-  expect(output).toContain('space_456')
-  expect(output).toContain('user@example.com')
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output.id).toBe(messageId)
+  expect(output.ref).toBe('msg_123')
+  expect(output.roomId).toBe(roomId)
+  expect(output.roomRef).toBe('space_456')
+  expect(output.personEmail).toBe('user@example.com')
   expect(mockDispose).toHaveBeenCalled()
 })
 
@@ -115,8 +123,8 @@ it('calls sendDirectMessage with email and text', async () => {
     markdown: undefined,
   })
   expect(consoleLogSpy).toHaveBeenCalled()
-  const output = consoleLogSpy.mock.calls[0][0]
-  expect(output).toContain('msg_123')
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output.ref).toBe('msg_123')
 })
 
 it('passes markdown option to sendDirectMessage when --markdown flag is set', async () => {
@@ -132,10 +140,10 @@ it('calls listMessages with limit and outputs array', async () => {
 
   expect(mockListMessages).toHaveBeenCalledWith('space_456', { max: 50 })
   expect(consoleLogSpy).toHaveBeenCalled()
-  const output = consoleLogSpy.mock.calls[0][0]
-  expect(output).toContain('msg_123')
-  expect(output).toContain('msg_124')
-  expect(output).toContain('https://example.com')
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output[0].ref).toBe('msg_123')
+  expect(output[1].ref).toBe('msg_124')
+  expect(output[0].html).toContain('https://example.com')
 })
 
 it('calls getMessage with correct id and outputs result', async () => {
@@ -143,10 +151,10 @@ it('calls getMessage with correct id and outputs result', async () => {
 
   expect(mockGetMessage).toHaveBeenCalledWith('msg_123')
   expect(consoleLogSpy).toHaveBeenCalled()
-  const output = consoleLogSpy.mock.calls[0][0]
-  expect(output).toContain('msg_123')
-  expect(output).toContain('user@example.com')
-  expect(output).toContain('https://example.com')
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output.ref).toBe('msg_123')
+  expect(output.personEmail).toBe('user@example.com')
+  expect(output.html).toContain('https://example.com')
 })
 
 it('calls deleteMessage and outputs deleted id when --force flag is set', async () => {
@@ -178,9 +186,9 @@ it('calls editMessage with roomId in args and outputs result', async () => {
     markdown: undefined,
   })
   expect(consoleLogSpy).toHaveBeenCalled()
-  const output = consoleLogSpy.mock.calls[0][0]
-  expect(output).toContain('msg_123')
-  expect(output).toContain('Updated message')
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output.ref).toBe('msg_123')
+  expect(output.text).toBe('Updated message')
   expect(mockDispose).toHaveBeenCalled()
 })
 

--- a/src/platforms/webex/commands/message.ts
+++ b/src/platforms/webex/commands/message.ts
@@ -4,12 +4,15 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
+import { toRef } from '../id-normalizer'
 import type { WebexMessage } from '../types'
 
 function formatMessageOutput(message: WebexMessage) {
   return {
     id: message.id,
+    ref: toRef(message.id),
     roomId: message.roomId,
+    roomRef: toRef(message.roomId),
     text: message.text,
     html: message.html,
     personEmail: message.personEmail,

--- a/src/platforms/webex/commands/snapshot.test.ts
+++ b/src/platforms/webex/commands/snapshot.test.ts
@@ -3,32 +3,38 @@ import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 import { WebexClient } from '../client'
 import { WebexError } from '../types'
 
+const restId = (type: string, ref: string) => Buffer.from(`ciscospark://us/${type}/${ref}`).toString('base64url')
+const space1Id = restId('ROOM', 'space-1')
+const space2Id = restId('ROOM', 'space-2')
+const member1Id = restId('MEMBERSHIP', 'person-1:space-1')
+const person1Id = restId('PEOPLE', 'person-1')
+
 const mockSpaces = [
   {
-    id: 'space-1',
+    id: space1Id,
     title: 'General',
     type: 'group',
     isLocked: false,
     lastActivity: '2024-01-15T00:00:00.000Z',
     created: '2024-01-01T00:00:00.000Z',
-    creatorId: 'person-1',
+    creatorId: person1Id,
   },
   {
-    id: 'space-2',
+    id: space2Id,
     title: 'Random',
     type: 'group',
     isLocked: false,
     lastActivity: '2024-01-14T00:00:00.000Z',
     created: '2024-01-01T00:00:00.000Z',
-    creatorId: 'person-1',
+    creatorId: person1Id,
   },
 ]
 
 const mockMyMemberships = [
   {
-    id: 'mem-1',
-    roomId: 'space-1',
-    personId: 'person-1',
+    id: member1Id,
+    roomId: space1Id,
+    personId: person1Id,
     personEmail: 'alice@example.com',
     personDisplayName: 'Alice',
     isModerator: true,
@@ -77,7 +83,8 @@ describe('snapshot command', () => {
     expect(consoleSpy).toHaveBeenCalled()
     const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
     expect(output.spaces).toHaveLength(1)
-    expect(output.spaces[0].id).toBe('space-1')
+    expect(output.spaces[0].id).toBe(space1Id)
+    expect(output.spaces[0].ref).toBe('space-1')
     expect(output.spaces[0].title).toBe('General')
     expect(output.spaces[0].type).toBeUndefined()
     expect(output.hint).toBeDefined()
@@ -89,7 +96,8 @@ describe('snapshot command', () => {
     expect(consoleSpy).toHaveBeenCalled()
     const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
     expect(output.spaces).toHaveLength(1)
-    expect(output.spaces[0].id).toBe('space-1')
+    expect(output.spaces[0].id).toBe(space1Id)
+    expect(output.spaces[0].ref).toBe('space-1')
     expect(output.spaces[0].title).toBe('General')
     expect(output.spaces[0].type).toBe('group')
     expect(output.spaces[0].lastActivity).toBe('2024-01-15T00:00:00.000Z')
@@ -101,7 +109,7 @@ describe('snapshot command', () => {
 
     const output = JSON.parse(consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0])
     expect(output.spaces).toHaveLength(1)
-    expect(output.spaces[0].id).toBe('space-1')
+    expect(output.spaces[0].id).toBe(space1Id)
   })
 
   it('exits with code 1 when not authenticated', async () => {

--- a/src/platforms/webex/commands/snapshot.ts
+++ b/src/platforms/webex/commands/snapshot.ts
@@ -4,6 +4,7 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
+import { toRef } from '../id-normalizer'
 
 export async function snapshotAction(options: { full?: boolean; pretty?: boolean }): Promise<void> {
   try {
@@ -19,11 +20,12 @@ export async function snapshotAction(options: { full?: boolean; pretty?: boolean
       spaces: options.full
         ? spaces.map((s) => ({
             id: s.id,
+            ref: toRef(s.id),
             title: s.title,
             type: s.type,
             lastActivity: s.lastActivity,
           }))
-        : spaces.map((s) => ({ id: s.id, title: s.title })),
+        : spaces.map((s) => ({ id: s.id, ref: toRef(s.id), title: s.title })),
     }
 
     if (!options.full) {

--- a/src/platforms/webex/commands/space.test.ts
+++ b/src/platforms/webex/commands/space.test.ts
@@ -3,36 +3,43 @@ import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 import { WebexClient } from '../client'
 import { WebexError } from '../types'
 
+const restId = (type: string, ref: string) => Buffer.from(`ciscospark://us/${type}/${ref}`).toString('base64url')
+const space1Id = restId('ROOM', 'space-1')
+const space2Id = restId('ROOM', 'space-2')
+const person1Id = restId('PEOPLE', 'person-1')
+const person2Id = restId('PEOPLE', 'person-2')
+const teamId = restId('TEAM', 'team-abc')
+
 const mockSpaces = [
   {
-    id: 'space-1',
+    id: space1Id,
     title: 'General',
     type: 'group' as const,
     isLocked: false,
     lastActivity: '2024-01-02T00:00:00.000Z',
     created: '2024-01-01T00:00:00.000Z',
-    creatorId: 'person-1',
+    creatorId: person1Id,
   },
   {
-    id: 'space-2',
+    id: space2Id,
     title: 'Direct with Alice',
     type: 'direct' as const,
     isLocked: false,
     lastActivity: '2024-01-03T00:00:00.000Z',
     created: '2024-01-01T00:00:00.000Z',
-    creatorId: 'person-2',
+    creatorId: person2Id,
   },
 ]
 
 const mockSpace = {
-  id: 'space-1',
+  id: space1Id,
   title: 'General',
   type: 'group' as const,
   isLocked: false,
-  teamId: 'team-abc',
+  teamId,
   lastActivity: '2024-01-02T00:00:00.000Z',
   created: '2024-01-01T00:00:00.000Z',
-  creatorId: 'person-1',
+  creatorId: person1Id,
 }
 
 import { infoAction, listAction } from './space'
@@ -79,14 +86,16 @@ describe('listAction', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(
       JSON.stringify([
         {
-          id: 'space-1',
+          id: space1Id,
+          ref: 'space-1',
           title: 'General',
           type: 'group',
           lastActivity: '2024-01-02T00:00:00.000Z',
           created: '2024-01-01T00:00:00.000Z',
         },
         {
-          id: 'space-2',
+          id: space2Id,
+          ref: 'space-2',
           title: 'Direct with Alice',
           type: 'direct',
           lastActivity: '2024-01-03T00:00:00.000Z',
@@ -115,14 +124,16 @@ describe('listAction', () => {
       JSON.stringify(
         [
           {
-            id: 'space-1',
+            id: space1Id,
+            ref: 'space-1',
             title: 'General',
             type: 'group',
             lastActivity: '2024-01-02T00:00:00.000Z',
             created: '2024-01-01T00:00:00.000Z',
           },
           {
-            id: 'space-2',
+            id: space2Id,
+            ref: 'space-2',
             title: 'Direct with Alice',
             type: 'direct',
             lastActivity: '2024-01-03T00:00:00.000Z',
@@ -152,14 +163,17 @@ describe('infoAction', () => {
     expect(mockGetSpace).toHaveBeenCalledWith('space-1')
     expect(consoleLogSpy).toHaveBeenCalledWith(
       JSON.stringify({
-        id: 'space-1',
+        id: space1Id,
+        ref: 'space-1',
         title: 'General',
         type: 'group',
         isLocked: false,
-        teamId: 'team-abc',
+        teamId,
+        teamRef: 'team-abc',
         lastActivity: '2024-01-02T00:00:00.000Z',
         created: '2024-01-01T00:00:00.000Z',
-        creatorId: 'person-1',
+        creatorId: person1Id,
+        creatorRef: 'person-1',
       }),
     )
   })
@@ -171,8 +185,10 @@ describe('infoAction', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string) as {
       teamId: null
+      teamRef: null
     }
     expect(output.teamId).toBeNull()
+    expect(output.teamRef).toBeNull()
   })
 
   it('outputs pretty-printed JSON when pretty is true', async () => {
@@ -181,14 +197,17 @@ describe('infoAction', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(
       JSON.stringify(
         {
-          id: 'space-1',
+          id: space1Id,
+          ref: 'space-1',
           title: 'General',
           type: 'group',
           isLocked: false,
-          teamId: 'team-abc',
+          teamId,
+          teamRef: 'team-abc',
           lastActivity: '2024-01-02T00:00:00.000Z',
           created: '2024-01-01T00:00:00.000Z',
-          creatorId: 'person-1',
+          creatorId: person1Id,
+          creatorRef: 'person-1',
         },
         null,
         2,

--- a/src/platforms/webex/commands/space.ts
+++ b/src/platforms/webex/commands/space.ts
@@ -4,6 +4,7 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
+import { toRef } from '../id-normalizer'
 
 export async function listAction(options: { type?: string; limit?: number; pretty?: boolean }): Promise<void> {
   try {
@@ -11,6 +12,7 @@ export async function listAction(options: { type?: string; limit?: number; prett
     const spaces = await client.listSpaces({ type: options.type, max: options.limit })
     const output = spaces.map((s) => ({
       id: s.id,
+      ref: toRef(s.id),
       title: s.title,
       type: s.type,
       lastActivity: s.lastActivity,
@@ -28,13 +30,16 @@ export async function infoAction(spaceId: string, options: { pretty?: boolean })
     const space = await client.getSpace(spaceId)
     const output = {
       id: space.id,
+      ref: toRef(space.id),
       title: space.title,
       type: space.type,
       isLocked: space.isLocked,
       teamId: space.teamId || null,
+      teamRef: space.teamId ? toRef(space.teamId) : null,
       lastActivity: space.lastActivity,
       created: space.created,
       creatorId: space.creatorId,
+      creatorRef: toRef(space.creatorId),
     }
     console.log(formatOutput(output, options.pretty))
   } catch (error) {

--- a/src/platforms/webex/commands/whoami.test.ts
+++ b/src/platforms/webex/commands/whoami.test.ts
@@ -1,18 +1,22 @@
 import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
 import { WebexClient } from '../client'
+import { toRestId } from '../id-normalizer'
 import { WebexError } from '../types'
 import { whoamiCommand } from './whoami'
 
+const orgId = Buffer.from('ciscospark://us/ORGANIZATION/org-123').toString('base64url')
+const personId = toRestId('person-123', 'PEOPLE')
+
 const mockUser = {
-  id: 'person-123',
+  id: personId,
   emails: ['test@example.com'],
   displayName: 'Test User',
   nickName: 'Testy',
   firstName: 'Test',
   lastName: 'User',
   avatar: 'https://example.com/avatar.jpg',
-  orgId: 'org-123',
+  orgId,
   type: 'person' as const,
   created: '2024-01-01T00:00:00.000Z',
 }
@@ -58,14 +62,16 @@ it('whoami calls testAuth and outputs user fields', async () => {
   // then: outputs all expected fields
   expect(consoleLogSpy).toHaveBeenCalledWith(
     JSON.stringify({
-      id: 'person-123',
+      id: personId,
+      ref: 'person-123',
       emails: ['test@example.com'],
       displayName: 'Test User',
       nickName: 'Testy',
       firstName: 'Test',
       lastName: 'User',
       avatar: 'https://example.com/avatar.jpg',
-      orgId: 'org-123',
+      orgId,
+      orgRef: 'org-123',
       type: 'person',
     }),
   )
@@ -80,14 +86,16 @@ it('whoami outputs pretty-printed JSON when --pretty flag is passed', async () =
   expect(consoleLogSpy).toHaveBeenCalledWith(
     JSON.stringify(
       {
-        id: 'person-123',
+        id: personId,
+        ref: 'person-123',
         emails: ['test@example.com'],
         displayName: 'Test User',
         nickName: 'Testy',
         firstName: 'Test',
         lastName: 'User',
         avatar: 'https://example.com/avatar.jpg',
-        orgId: 'org-123',
+        orgId,
+        orgRef: 'org-123',
         type: 'person',
       },
       null,

--- a/src/platforms/webex/commands/whoami.ts
+++ b/src/platforms/webex/commands/whoami.ts
@@ -4,6 +4,7 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
+import { toRef } from '../id-normalizer'
 
 export async function whoamiAction(options: { pretty?: boolean }): Promise<void> {
   try {
@@ -12,6 +13,7 @@ export async function whoamiAction(options: { pretty?: boolean }): Promise<void>
 
     const output = {
       id: user.id,
+      ref: toRef(user.id),
       emails: user.emails,
       displayName: user.displayName,
       nickName: user.nickName,
@@ -19,6 +21,7 @@ export async function whoamiAction(options: { pretty?: boolean }): Promise<void>
       lastName: user.lastName,
       avatar: user.avatar,
       orgId: user.orgId,
+      orgRef: toRef(user.orgId),
       type: user.type,
     }
     console.log(formatOutput(output, options.pretty))

--- a/src/platforms/webex/id-normalizer.test.ts
+++ b/src/platforms/webex/id-normalizer.test.ts
@@ -17,6 +17,7 @@ import {
   normalizeMessage,
   normalizeRoomActivity,
   toRestId,
+  toRef,
 } from './id-normalizer'
 
 const RAW: MercuryActivity = {
@@ -27,6 +28,8 @@ const RAW: MercuryActivity = {
   target: { id: 'room-uuid', objectType: 'conversation' },
   published: '2024-01-01T00:00:00Z',
 }
+
+const restId = (type: string, ref: string) => Buffer.from(`ciscospark://us/${type}/${ref}`).toString('base64url')
 
 describe('toRestId / fromRestId', () => {
   it('encodes a uuid into a ciscospark REST id round-trippable to the uuid', () => {
@@ -55,6 +58,40 @@ describe('toRestId / fromRestId', () => {
 
   it('returns empty input unchanged', () => {
     expect(toRestId('', 'MESSAGE')).toBe('')
+  })
+})
+
+describe('toRef', () => {
+  it('returns a room uuid ref', () => {
+    const uuid = '12345678-1234-1234-1234-1234567890ab'
+
+    expect(toRef(toRestId(uuid, 'ROOM'))).toBe(uuid)
+  })
+
+  it('returns a person uuid ref', () => {
+    const uuid = '22222222-2222-2222-2222-222222222222'
+
+    expect(toRef(toRestId(uuid, 'PEOPLE'))).toBe(uuid)
+  })
+
+  it('returns a legacy person email ref', () => {
+    expect(toRef(toRestId('legacy@example.com', 'PEOPLE'))).toBe('legacy@example.com')
+  })
+
+  it('returns an organization uuid ref', () => {
+    const uuid = '33333333-3333-3333-3333-333333333333'
+
+    expect(toRef(restId('ORGANIZATION', uuid))).toBe(uuid)
+  })
+
+  it('returns a membership person-room pair ref', () => {
+    const membershipRef = '44444444-4444-4444-4444-444444444444:55555555-5555-5555-5555-555555555555'
+
+    expect(toRef(restId('MEMBERSHIP', membershipRef))).toBe(membershipRef)
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(toRef('')).toBe('')
   })
 })
 

--- a/src/platforms/webex/id-normalizer.ts
+++ b/src/platforms/webex/id-normalizer.ts
@@ -13,6 +13,27 @@ export { fromRestId }
 // (the resource type behind GET /v1/attachment/actions).
 export type WebexRestIdType = 'MESSAGE' | 'PEOPLE' | 'ROOM' | 'ATTACHMENT_ACTION'
 
+export interface DecodedWebexId {
+  cluster: string
+  type: string
+  uuid: string
+}
+
+export function toRef(id: string): string {
+  if (!id) return id
+  return fromRestId(id)
+}
+
+// Webex REST ids are base64(url) of `ciscospark://<cluster>/<TYPE>/<uuid>`; room
+// cluster correction needs all three parts, not just the trailing ref value.
+export function decodeWebexId(restId: string): DecodedWebexId | null {
+  if (!restId) return null
+  const decoded = Buffer.from(restId, 'base64').toString('utf-8')
+  const match = decoded.match(/^ciscospark:\/\/([^/]+)\/([^/]+)\/(.+)$/)
+  if (!match) return null
+  return { cluster: match[1], type: match[2], uuid: match[3] }
+}
+
 /**
  * Encode a raw Mercury UUID as a Webex REST ID. Empty input is returned unchanged
  * so an absent ID never becomes a bogus `ciscospark://us/{TYPE}/` value.

--- a/src/platforms/webexbot/client.ts
+++ b/src/platforms/webexbot/client.ts
@@ -2,32 +2,9 @@ import { WebexClient } from '../webex/client'
 import type { WebexMembership, WebexMessage, WebexPerson, WebexSpace } from '../webex/types'
 import { WebexBotError } from './types'
 
-interface DecodedWebexId {
-  cluster: string
-  type: string
-  uuid: string
-}
-
-// Webex REST ids are base64(url) of `ciscospark://<cluster>/<TYPE>/<uuid>`; the
-// cluster correction needs all three parts, not just the <uuid> `fromRestId` returns.
-function decodeWebexId(restId: string): DecodedWebexId | null {
-  if (!restId) return null
-  const decoded = Buffer.from(restId, 'base64').toString('utf-8')
-  const match = decoded.match(/^ciscospark:\/\/([^/]+)\/([^/]+)\/(.+)$/)
-  if (!match) return null
-  return { cluster: match[1], type: match[2], uuid: match[3] }
-}
-
 export class WebexBotClient {
-  private client = new WebexClient()
+  private client = new WebexClient({ roomResolutionWarningPrefix: '[webexbot]' })
   private token: string | null = null
-
-  // The listener flattens room ids to `ciscospark://us/ROOM/<uuid>`, but team/group
-  // rooms live on `ciscospark://urn:TEAM:<cluster>/ROOM/<uuid>` — a cluster the bare
-  // uuid cannot recover. Cache the real clustered id per uuid and dedupe concurrent
-  // lookups so a burst of calls triggers a single `listSpaces`.
-  private clusteredRoomIds = new Map<string, string>()
-  private roomIdLookups = new Map<string, Promise<string>>()
 
   async login(credentials?: { token: string }): Promise<this> {
     if (credentials) {
@@ -64,7 +41,7 @@ export class WebexBotClient {
   }
 
   async getSpace(spaceId: string): Promise<WebexSpace> {
-    return this.client.getSpace(await this.resolveRoomId(spaceId))
+    return this.client.getSpace(spaceId)
   }
 
   async sendMessage(
@@ -72,7 +49,7 @@ export class WebexBotClient {
     text: string,
     options?: { markdown?: boolean; parentId?: string; files?: string[] },
   ): Promise<WebexMessage> {
-    return this.client.sendMessage(await this.resolveRoomId(roomId), text, options)
+    return this.client.sendMessage(roomId, text, options)
   }
 
   async sendDirectMessage(personEmail: string, text: string, options?: { markdown?: boolean }): Promise<WebexMessage> {
@@ -80,14 +57,14 @@ export class WebexBotClient {
   }
 
   async listMessages(roomId: string, options?: { max?: number; parentId?: string }): Promise<WebexMessage[]> {
-    const resolvedRoomId = await this.resolveRoomId(roomId)
+    const resolvedRoomId = await this.client.resolveRoomId(roomId)
     const space = await this.client.getSpace(resolvedRoomId)
     const messageOptions = space.type === 'group' ? { ...options, mentionedPeople: 'me' } : options
     return this.client.listMessages(resolvedRoomId, messageOptions)
   }
 
   async listReplies(roomId: string, parentId: string, options?: { max?: number }): Promise<WebexMessage[]> {
-    return this.client.listMessages(await this.resolveRoomId(roomId), { ...options, parentId })
+    return this.client.listMessages(roomId, { ...options, parentId })
   }
 
   async getMessage(messageId: string): Promise<WebexMessage> {
@@ -108,7 +85,7 @@ export class WebexBotClient {
     text: string,
     options?: { markdown?: boolean },
   ): Promise<WebexMessage> {
-    return this.client.editMessage(messageId, await this.resolveRoomId(roomId), text, options)
+    return this.client.editMessage(messageId, roomId, text, options)
   }
 
   async listPeople(options?: { email?: string; displayName?: string; max?: number }): Promise<WebexPerson[]> {
@@ -124,7 +101,7 @@ export class WebexBotClient {
   }
 
   async listMemberships(roomId: string, options?: { max?: number }): Promise<WebexMembership[]> {
-    return this.client.listMemberships(await this.resolveRoomId(roomId), options)
+    return this.client.listMemberships(roomId, options)
   }
 
   async uploadFile(
@@ -132,53 +109,10 @@ export class WebexBotClient {
     file: { content: Blob; filename: string },
     options?: { text?: string; markdown?: boolean; parentId?: string },
   ): Promise<WebexMessage> {
-    return this.client.uploadFile(await this.resolveRoomId(roomId), file, options)
+    return this.client.uploadFile(roomId, file, options)
   }
 
   async downloadContent(contentRef: string): Promise<{ data: ArrayBuffer; filename: string; contentType: string }> {
     return this.client.downloadContent(contentRef)
-  }
-
-  private async resolveRoomId(roomId: string): Promise<string> {
-    const decoded = decodeWebexId(roomId)
-    // Already cluster-qualified or undecodable: nothing to correct.
-    if (!decoded || decoded.cluster.startsWith('urn:')) return roomId
-
-    const { uuid } = decoded
-    const cached = this.clusteredRoomIds.get(uuid)
-    if (cached) return cached
-
-    const inFlight = this.roomIdLookups.get(uuid)
-    if (inFlight) return inFlight
-
-    const lookup = this.lookupRoomId(uuid, roomId)
-    this.roomIdLookups.set(uuid, lookup)
-    try {
-      return await lookup
-    } finally {
-      this.roomIdLookups.delete(uuid)
-    }
-  }
-
-  private async lookupRoomId(uuid: string, fallback: string): Promise<string> {
-    try {
-      // Page through every room the bot belongs to (largest page size, following
-      // `Link` pages), stopping as soon as the trailing UUID matches.
-      for await (const room of this.client.iterateSpaces({ max: 1000 })) {
-        if (decodeWebexId(room.id)?.uuid === uuid) {
-          this.clusteredRoomIds.set(uuid, room.id)
-          return room.id
-        }
-      }
-    } catch {
-      // Network/auth failure: fail open to the un-corrected id rather than block the call.
-      return fallback
-    }
-
-    console.warn(
-      `[webexbot] Could not resolve clustered room id for ${uuid}; falling back to the un-clustered id. ` +
-        'Room-scoped calls may fail if this room lives on a non-default Webex cluster.',
-    )
-    return fallback
   }
 }

--- a/src/platforms/webexbot/commands/file.ts
+++ b/src/platforms/webexbot/commands/file.ts
@@ -5,12 +5,15 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface FileResult {
   id?: string
+  ref?: string
   roomId?: string
+  roomRef?: string
   files?: string[]
   created?: string
   downloaded?: string
@@ -37,7 +40,9 @@ export async function uploadAction(
 
     return {
       id: message.id,
+      ref: toRef(message.id),
       roomId: message.roomId,
+      roomRef: toRef(message.roomId),
       files: message.files,
       created: message.created,
     }

--- a/src/platforms/webexbot/commands/member.ts
+++ b/src/platforms/webexbot/commands/member.ts
@@ -2,13 +2,16 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface MemberResult {
   members?: Array<{
     id: string
+    ref: string
     personId: string
+    personRef: string
     personEmail: string
     personDisplayName: string
     isModerator: boolean
@@ -26,7 +29,9 @@ export async function listAction(space: string, options: BotOption & { max?: str
     return {
       members: members.map((m) => ({
         id: m.id,
+        ref: toRef(m.id),
         personId: m.personId,
+        personRef: toRef(m.personId),
         personEmail: m.personEmail,
         personDisplayName: m.personDisplayName,
         isModerator: m.isModerator,

--- a/src/platforms/webexbot/commands/message.ts
+++ b/src/platforms/webexbot/commands/message.ts
@@ -2,13 +2,16 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { WebexMessage } from '../../webex/types'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface MessageResult {
   id?: string
+  ref?: string
   roomId?: string
+  roomRef?: string
   text?: string
   markdown?: string
   html?: string
@@ -16,7 +19,9 @@ interface MessageResult {
   created?: string
   messages?: Array<{
     id: string
+    ref: string
     roomId: string
+    roomRef: string
     text?: string
     personEmail: string
     created: string
@@ -28,7 +33,9 @@ interface MessageResult {
 function formatMessage(message: WebexMessage): MessageResult {
   return {
     id: message.id,
+    ref: toRef(message.id),
     roomId: message.roomId,
+    roomRef: toRef(message.roomId),
     text: message.text,
     markdown: message.markdown,
     html: message.html,
@@ -81,7 +88,9 @@ export async function repliesAction(
     return {
       messages: messages.map((msg) => ({
         id: msg.id,
+        ref: toRef(msg.id),
         roomId: msg.roomId,
+        roomRef: toRef(msg.roomId),
         text: msg.text,
         personEmail: msg.personEmail,
         created: msg.created,
@@ -116,7 +125,9 @@ export async function listAction(space: string, options: BotOption & { max?: str
     return {
       messages: messages.map((msg) => ({
         id: msg.id,
+        ref: toRef(msg.id),
         roomId: msg.roomId,
+        roomRef: toRef(msg.roomId),
         text: msg.text,
         personEmail: msg.personEmail,
         created: msg.created,

--- a/src/platforms/webexbot/commands/snapshot.ts
+++ b/src/platforms/webexbot/commands/snapshot.ts
@@ -2,17 +2,20 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface SnapshotResult {
   bot?: {
     id: string
+    ref: string
     displayName: string
     emails: string[]
   }
   spaces?: Array<{
     id: string
+    ref: string
     title: string
     type?: 'group' | 'direct'
     lastActivity?: string
@@ -31,12 +34,19 @@ export async function snapshotAction(options: BotOption & { full?: boolean; max?
     const result: SnapshotResult = {
       bot: {
         id: me.id,
+        ref: toRef(me.id),
         displayName: me.displayName,
         emails: me.emails,
       },
       spaces: options.full
-        ? spaces.map((s) => ({ id: s.id, title: s.title, type: s.type, lastActivity: s.lastActivity }))
-        : spaces.map((s) => ({ id: s.id, title: s.title })),
+        ? spaces.map((s) => ({
+            id: s.id,
+            ref: toRef(s.id),
+            title: s.title,
+            type: s.type,
+            lastActivity: s.lastActivity,
+          }))
+        : spaces.map((s) => ({ id: s.id, ref: toRef(s.id), title: s.title })),
     }
 
     if (!options.full) {

--- a/src/platforms/webexbot/commands/space.ts
+++ b/src/platforms/webexbot/commands/space.ts
@@ -2,20 +2,25 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface SpaceResult {
   id?: string
+  ref?: string
   title?: string
   type?: 'group' | 'direct'
   isLocked?: boolean
   teamId?: string | null
+  teamRef?: string | null
   lastActivity?: string
   created?: string
   creatorId?: string
+  creatorRef?: string
   spaces?: Array<{
     id: string
+    ref: string
     title: string
     type: 'group' | 'direct'
     lastActivity: string
@@ -33,6 +38,7 @@ export async function listAction(options: BotOption & { max?: string; type?: str
     return {
       spaces: spaces.map((s) => ({
         id: s.id,
+        ref: toRef(s.id),
         title: s.title,
         type: s.type,
         lastActivity: s.lastActivity,
@@ -50,13 +56,16 @@ export async function infoAction(spaceId: string, options: BotOption): Promise<S
     const space = await client.getSpace(spaceId)
     return {
       id: space.id,
+      ref: toRef(space.id),
       title: space.title,
       type: space.type,
       isLocked: space.isLocked,
       teamId: space.teamId || null,
+      teamRef: space.teamId ? toRef(space.teamId) : null,
       lastActivity: space.lastActivity,
       created: space.created,
       creatorId: space.creatorId,
+      creatorRef: toRef(space.creatorId),
     }
   } catch (error) {
     return { error: (error as Error).message }

--- a/src/platforms/webexbot/commands/user.test.ts
+++ b/src/platforms/webexbot/commands/user.test.ts
@@ -4,13 +4,17 @@ import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+const restId = (type: string, ref: string) => Buffer.from(`ciscospark://us/${type}/${ref}`).toString('base64url')
+const personId = restId('PEOPLE', 'p1')
+const orgId = restId('ORGANIZATION', 'o1')
+
 const mockListPeople = mock(() =>
   Promise.resolve([
     {
-      id: 'p1',
+      id: personId,
       emails: ['alice@example.com'],
       displayName: 'Alice',
-      orgId: 'o1',
+      orgId,
       type: 'person' as const,
       created: '',
     },
@@ -19,10 +23,10 @@ const mockListPeople = mock(() =>
 
 const mockGetPerson = mock(() =>
   Promise.resolve({
-    id: 'p1',
+    id: personId,
     emails: ['alice@example.com'],
     displayName: 'Alice',
-    orgId: 'o1',
+    orgId,
     type: 'person' as const,
     created: '2024-01-01T00:00:00Z',
   }),
@@ -65,13 +69,15 @@ describe('webexbot user commands', () => {
 
     expect(result.users).toHaveLength(1)
     expect(result.users?.[0].displayName).toBe('Alice')
+    expect(result.users?.[0].ref).toBe('p1')
     expect(mockListPeople).toHaveBeenCalled()
   })
 
   it('gets a person by id', async () => {
     const result = await infoAction('p1', { _credManager: manager })
 
-    expect(result.id).toBe('p1')
+    expect(result.id).toBe(personId)
+    expect(result.ref).toBe('p1')
     expect(result.displayName).toBe('Alice')
   })
 })

--- a/src/platforms/webexbot/commands/user.ts
+++ b/src/platforms/webexbot/commands/user.ts
@@ -2,12 +2,14 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { WebexPerson } from '../../webex/types'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface UserResult {
   id?: string
+  ref?: string
   emails?: string[]
   displayName?: string
   nickName?: string
@@ -15,10 +17,12 @@ interface UserResult {
   lastName?: string
   avatar?: string
   orgId?: string
+  orgRef?: string
   type?: 'person' | 'bot'
   created?: string
   users?: Array<{
     id: string
+    ref: string
     emails: string[]
     displayName: string
     type: 'person' | 'bot'
@@ -29,6 +33,7 @@ interface UserResult {
 function formatPerson(person: WebexPerson): UserResult {
   return {
     id: person.id,
+    ref: toRef(person.id),
     emails: person.emails,
     displayName: person.displayName,
     nickName: person.nickName,
@@ -36,6 +41,7 @@ function formatPerson(person: WebexPerson): UserResult {
     lastName: person.lastName,
     avatar: person.avatar,
     orgId: person.orgId,
+    orgRef: toRef(person.orgId),
     type: person.type,
     created: person.created,
   }
@@ -52,6 +58,7 @@ export async function listAction(
     return {
       users: people.map((p) => ({
         id: p.id,
+        ref: toRef(p.id),
         emails: p.emails,
         displayName: p.displayName,
         type: p.type,

--- a/src/platforms/webexbot/commands/whoami.ts
+++ b/src/platforms/webexbot/commands/whoami.ts
@@ -2,15 +2,18 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
+import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
 interface WhoamiResult {
   id?: string
+  ref?: string
   emails?: string[]
   displayName?: string
   avatar?: string
   orgId?: string
+  orgRef?: string
   type?: 'person' | 'bot'
   created?: string
   error?: string
@@ -22,10 +25,12 @@ export async function whoamiAction(options: BotOption): Promise<WhoamiResult> {
     const info = await client.testAuth()
     return {
       id: info.id,
+      ref: toRef(info.id),
       emails: info.emails,
       displayName: info.displayName,
       avatar: info.avatar,
       orgId: info.orgId,
+      orgRef: toRef(info.orgId),
       type: info.type,
       created: info.created,
     }

--- a/src/tui/adapters/types.ts
+++ b/src/tui/adapters/types.ts
@@ -1,12 +1,15 @@
 export interface UnifiedChannel {
   id: string
+  ref?: string
   name: string
   parentId?: string
 }
 
 export interface UnifiedMessage {
   id: string
+  ref?: string
   channelId: string
+  channelRef?: string
   author: string
   content: string
   timestamp: string

--- a/src/tui/adapters/webex-adapter.ts
+++ b/src/tui/adapters/webex-adapter.ts
@@ -3,6 +3,7 @@ import { exec } from 'node:child_process'
 import { getWebexAppCredentials } from '@/platforms/webex/app-config'
 import { WebexClient } from '@/platforms/webex/client'
 import { WebexCredentialManager } from '@/platforms/webex/credential-manager'
+import { toRef } from '@/platforms/webex/id-normalizer'
 
 import type { AuthHint, AuthIO, PlatformAdapter, UnifiedChannel, UnifiedMessage } from './types'
 
@@ -25,6 +26,7 @@ export class WebexAdapter implements PlatformAdapter {
     const spaces = await this.client!.listSpaces()
     return spaces.map((space) => ({
       id: space.id,
+      ref: toRef(space.id),
       name: space.title,
     }))
   }
@@ -35,7 +37,9 @@ export class WebexAdapter implements PlatformAdapter {
     return messages
       .map((msg) => ({
         id: msg.id,
+        ref: toRef(msg.id),
         channelId: msg.roomId,
+        channelRef: toRef(msg.roomId),
         author: msg.personEmail,
         content: msg.text ?? '',
         timestamp: msg.created,


### PR DESCRIPTION
## What

Webex REST ids are base64 of `ciscospark://<cluster>/<TYPE>/<uuid>` — an opaque blob that's hard to read, log, or pass around. This adds a human-friendly **`ref`** alongside every id in CLI/SDK output, and accepts a `ref` as input anywhere an id is expected.

`ref` is the decoded trailing value:

| Entity | `ref` |
| --- | --- |
| Room / Org / Message | plain UUID |
| Person | UUID — **or email** for legacy Hydra accounts |
| Membership | composite `personUUID:roomUUID` pair |

The canonical base64 `id` is **kept unchanged** in all output — `ref` is purely additive, so nothing downstream breaks.

## Why

- A bare base64 id (`Y2lzY29zcGFyazovL3Vyb...`) is unreadable. `ref` gives a short, copy-pasteable handle.
- Users/agents can now pass the short form back in (`message send <uuid> ...`) instead of the full blob.

## How

**Output** — additive `*Ref` siblings at every id sink (user CLI, bot CLI, TUI adapter): `ref`, `personRef`, `creatorRef`, `roomRef`, `orgRef`, etc., via a new `toRef(id)` helper (`= fromRestId(id)`).

**Input** — a `ref` is resolved back to the canonical id **before** any API call:
- **Room refs** need the real cluster (group rooms live on `urn:TEAM:...`, not `us`), so a bare room UUID is resolved against the account's rooms and cached. **`us` is never hardcoded.**
- **Person refs** resolve by email lookup (`/people?email=`) or UUID reconstruction.
- **Message refs**: a lone message UUID can't recover its room cluster, matching the existing documented limitation in `getMessage`.

**Refactor (DRY)** — `decodeWebexId` and the room cluster resolver move from `WebexBotClient` into the shared `WebexClient` / `id-normalizer`, so both clients reuse one implementation. `WebexBotClient` shrinks by ~74 lines and now delegates (the `[webexbot]` warning prefix is preserved via a constructor option).

## Notes for reviewers

- The trailing value is **not always a UUID** — legacy people encode an email, memberships are a `person:room` pair. `toRef` handles all three; tests cover each.
- Fail-open behavior on lookup network errors is preserved (returns the un-corrected id rather than blocking the call).
- No `as any` / `@ts-ignore`. No existing `id` fields removed or renamed.

## Test plan

- `toRef`: room uuid, person uuid, **legacy person email**, org, **membership pair**, empty input
- `WebexClient` id resolution: bare room UUID, `us`-cluster room id, already-clustered id, fail-open warning, person email, bare person/message UUIDs
- `bun typecheck` ✅ · `bun lint` ✅ (0 warnings/errors) · `bun run format:check` ✅ (changed files) · `bun run test` ✅ **3216 pass / 0 fail**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds human‑friendly ref ids to all Webex outputs and accepts refs as input for rooms, people, and messages. Keeps base64 ids unchanged and resolves refs before API calls, including room cluster correction.

- New Features
  - Output now includes ref fields (ref, personRef, creatorRef, roomRef, teamRef, orgRef) across Webex CLI, `webexbot`, and TUI.
  - Input accepts refs anywhere ids are expected (rooms, people, messages, parentId, mentionedPeople). Rooms resolve to the real clustered id; people resolve by email or UUID; messages reconstruct REST ids from UUIDs (cluster still not inferred).
  - Internal API message ids are normalized to REST ids in outputs.

- Refactors
  - Shared id logic in `id-normalizer`/`WebexClient` (`toRef`, `decodeWebexId`, `toRestId`, room/person/message id resolution). `WebexBotClient` delegates and preserves the `[webexbot]` warning prefix via a client option.
  - No breaking changes; refs are additive alongside existing base64 ids.
  - Docs updated: `SKILL.md` and CLI docs reflect id/ref fields in snapshots.

<sup>Written for commit 348f0b3e7ddd259243fea51bd3680971faf8acbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

