### PR TITLE
feat(webex): attach raw uuid refs to every id on listener events

### DIFF
--- a/src/platforms/webex/id-normalizer.test.ts
+++ b/src/platforms/webex/id-normalizer.test.ts
@@ -122,6 +122,23 @@ describe('normalizeMessage', () => {
     expect(result.mentionedPeople).toEqual([toRestId('mention-uuid-1', 'PEOPLE'), toRestId('mention-uuid-2', 'PEOPLE')])
   })
 
+  it('adds a raw uuid ref alongside every id', () => {
+    const result = normalizeMessage(message)
+
+    expect(result.ref).toBe('msg-uuid')
+    expect(result.parentRef).toBe('parent-uuid')
+    expect(result.roomRef).toBe('room-uuid')
+    expect(result.personRef).toBe('person-uuid')
+    expect(result.mentionedPeopleRefs).toEqual(['mention-uuid-1', 'mention-uuid-2'])
+  })
+
+  it('omits parentRef when parentId is absent', () => {
+    const { parentId: _omit, ...withoutParent } = message
+    const result = normalizeMessage(withoutParent)
+
+    expect(result.parentRef).toBeUndefined()
+  })
+
   it('leaves non-id fields and raw untouched', () => {
     const result = normalizeMessage(message)
 
@@ -157,8 +174,11 @@ describe('normalizeDeletedMessage', () => {
 
     expect(normalizeDeletedMessage(deleted)).toEqual({
       messageId: toRestId('msg-uuid', 'MESSAGE'),
+      messageRef: 'msg-uuid',
       roomId: toRestId('room-uuid', 'ROOM'),
+      roomRef: 'room-uuid',
       personId: toRestId('person-uuid', 'PEOPLE'),
+      personRef: 'person-uuid',
     })
   })
 })
@@ -182,6 +202,25 @@ describe('normalizeMembership', () => {
     expect(result.personId).toBe(toRestId('member-uuid', 'PEOPLE'))
     expect(result.roomId).toBe(toRestId('room-uuid', 'ROOM'))
     expect(result.raw).toBe(RAW)
+  })
+
+  it('sets ref to the raw activity id and adds refs for the rest', () => {
+    const membership: MembershipActivity = {
+      id: 'activity-uuid',
+      actorId: 'actor-uuid',
+      personId: 'member-uuid',
+      roomId: 'room-uuid',
+      action: 'add',
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    const result = normalizeMembership(membership)
+
+    expect(result.ref).toBe('activity-uuid')
+    expect(result.actorRef).toBe('actor-uuid')
+    expect(result.personRef).toBe('member-uuid')
+    expect(result.roomRef).toBe('room-uuid')
   })
 })
 
@@ -207,7 +246,27 @@ describe('normalizeAttachmentAction', () => {
     expect(result.inputs).toEqual({ choice: 'yes' })
   })
 
-  it('preserves an empty messageId', () => {
+  it('adds a raw uuid ref alongside every id', () => {
+    const action: AttachmentAction = {
+      id: 'action-uuid',
+      messageId: 'msg-uuid',
+      personId: 'person-uuid',
+      personEmail: 'user@example.com',
+      roomId: 'room-uuid',
+      inputs: { choice: 'yes' },
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    const result = normalizeAttachmentAction(action)
+
+    expect(result.ref).toBe('action-uuid')
+    expect(result.messageRef).toBe('msg-uuid')
+    expect(result.personRef).toBe('person-uuid')
+    expect(result.roomRef).toBe('room-uuid')
+  })
+
+  it('preserves an empty messageId and its ref', () => {
     const action: AttachmentAction = {
       id: 'action-uuid',
       messageId: '',
@@ -219,7 +278,9 @@ describe('normalizeAttachmentAction', () => {
       raw: RAW,
     }
 
-    expect(normalizeAttachmentAction(action).messageId).toBe('')
+    const result = normalizeAttachmentAction(action)
+    expect(result.messageId).toBe('')
+    expect(result.messageRef).toBe('')
   })
 })
 
@@ -240,5 +301,22 @@ describe('normalizeRoomActivity', () => {
     expect(result.roomId).toBe(toRestId('room-uuid', 'ROOM'))
     expect(result.actorId).toBe(toRestId('actor-uuid', 'PEOPLE'))
     expect(result.raw).toBe(RAW)
+  })
+
+  it('sets ref to the raw activity id and adds refs for the rest', () => {
+    const room: RoomActivity = {
+      id: 'activity-uuid',
+      roomId: 'room-uuid',
+      actorId: 'actor-uuid',
+      action: 'created',
+      created: '2024-01-01T00:00:00Z',
+      raw: RAW,
+    }
+
+    const result = normalizeRoomActivity(room)
+
+    expect(result.ref).toBe('activity-uuid')
+    expect(result.roomRef).toBe('room-uuid')
+    expect(result.actorRef).toBe('actor-uuid')
   })
 })

--- a/src/platforms/webex/id-normalizer.ts
+++ b/src/platforms/webex/id-normalizer.ts
@@ -48,50 +48,87 @@ export function toRestId(uuid: string, type: WebexRestIdType): string {
 }
 
 export function normalizeMessage(message: DecryptedMessage): DecryptedMessage {
+  const id = toRestId(message.id, 'MESSAGE')
+  const parentId = message.parentId ? toRestId(message.parentId, 'MESSAGE') : message.parentId
+  const roomId = toRestId(message.roomId, 'ROOM')
+  const personId = toRestId(message.personId, 'PEOPLE')
+  const mentionedPeople = message.mentionedPeople.map((person) => toRestId(person, 'PEOPLE'))
   return {
     ...message,
-    id: toRestId(message.id, 'MESSAGE'),
-    parentId: message.parentId ? toRestId(message.parentId, 'MESSAGE') : message.parentId,
-    roomId: toRestId(message.roomId, 'ROOM'),
-    personId: toRestId(message.personId, 'PEOPLE'),
-    mentionedPeople: message.mentionedPeople.map((id) => toRestId(id, 'PEOPLE')),
+    id,
+    ref: toRef(id),
+    parentId,
+    parentRef: parentId ? toRef(parentId) : parentId,
+    roomId,
+    roomRef: toRef(roomId),
+    personId,
+    personRef: toRef(personId),
+    mentionedPeople,
+    mentionedPeopleRefs: mentionedPeople.map(toRef),
   }
 }
 
 export function normalizeDeletedMessage(message: DeletedMessage): DeletedMessage {
+  const messageId = toRestId(message.messageId, 'MESSAGE')
+  const roomId = toRestId(message.roomId, 'ROOM')
+  const personId = toRestId(message.personId, 'PEOPLE')
   return {
-    messageId: toRestId(message.messageId, 'MESSAGE'),
-    roomId: toRestId(message.roomId, 'ROOM'),
-    personId: toRestId(message.personId, 'PEOPLE'),
+    messageId,
+    messageRef: toRef(messageId),
+    roomId,
+    roomRef: toRef(roomId),
+    personId,
+    personRef: toRef(personId),
   }
 }
 
 export function normalizeMembership(activity: MembershipActivity): MembershipActivity {
-  // `id` stays raw: it is a Mercury activity UUID, not a REST membership ID.
+  // `id` stays raw: it is a Mercury activity UUID, not a REST membership ID, so
+  // its ref is the id itself rather than a decoded REST id.
+  const actorId = toRestId(activity.actorId, 'PEOPLE')
+  const personId = toRestId(activity.personId, 'PEOPLE')
+  const roomId = toRestId(activity.roomId, 'ROOM')
   return {
     ...activity,
-    actorId: toRestId(activity.actorId, 'PEOPLE'),
-    personId: toRestId(activity.personId, 'PEOPLE'),
-    roomId: toRestId(activity.roomId, 'ROOM'),
+    ref: activity.id,
+    actorId,
+    actorRef: toRef(actorId),
+    personId,
+    personRef: toRef(personId),
+    roomId,
+    roomRef: toRef(roomId),
   }
 }
 
 export function normalizeAttachmentAction(action: AttachmentAction): AttachmentAction {
+  const id = toRestId(action.id, 'ATTACHMENT_ACTION')
+  const messageId = action.messageId ? toRestId(action.messageId, 'MESSAGE') : action.messageId
+  const personId = toRestId(action.personId, 'PEOPLE')
+  const roomId = toRestId(action.roomId, 'ROOM')
   return {
     ...action,
-    id: toRestId(action.id, 'ATTACHMENT_ACTION'),
-    messageId: action.messageId ? toRestId(action.messageId, 'MESSAGE') : action.messageId,
-    personId: toRestId(action.personId, 'PEOPLE'),
-    roomId: toRestId(action.roomId, 'ROOM'),
+    id,
+    ref: toRef(id),
+    messageId,
+    messageRef: toRef(messageId),
+    personId,
+    personRef: toRef(personId),
+    roomId,
+    roomRef: toRef(roomId),
   }
 }
 
 export function normalizeRoomActivity(activity: RoomActivity): RoomActivity {
-  // `id` stays raw: the Mercury conversation activity UUID has no
-  // consumer-facing REST resource (the comparable REST ID is `roomId`).
+  // `id` stays raw: the Mercury conversation activity UUID has no consumer-facing
+  // REST resource, so its ref is the id itself (the comparable REST id is `roomId`).
+  const roomId = toRestId(activity.roomId, 'ROOM')
+  const actorId = toRestId(activity.actorId, 'PEOPLE')
   return {
     ...activity,
-    roomId: toRestId(activity.roomId, 'ROOM'),
-    actorId: toRestId(activity.actorId, 'PEOPLE'),
+    ref: activity.id,
+    roomId,
+    roomRef: toRef(roomId),
+    actorId,
+    actorRef: toRef(actorId),
   }
 }

--- a/src/platforms/webex/listener.test.ts
+++ b/src/platforms/webex/listener.test.ts
@@ -81,8 +81,11 @@ describe('WebexListener', () => {
 
     const expected = expect.objectContaining({
       id: toRestId('message-123', 'MESSAGE'),
+      ref: 'message-123',
       roomId: toRestId('room-123', 'ROOM'),
+      roomRef: 'room-123',
       personId: toRestId('person-123', 'PEOPLE'),
+      personRef: 'person-123',
       personEmail: 'user@example.com',
       text: 'hello',
       raw: RAW_ACTIVITY,

--- a/src/platforms/webex/typings/webex-message-handler.d.ts
+++ b/src/platforms/webex/typings/webex-message-handler.d.ts
@@ -155,6 +155,8 @@ declare module 'webex-message-handler' {
   export interface DecryptedMessage {
     /** Mercury activity UUID. Works as parentId for threaded replies. */
     id: string
+    /** Raw UUID ref for `id`. */
+    ref: string
     /**
      * Full Conversation-service activity URL, when present on the raw Mercury
      * activity (e.g. for an outbound "acknowledge" read-receipt). Undefined if
@@ -163,8 +165,14 @@ declare module 'webex-message-handler' {
     url?: string
     /** Parent activity UUID for threaded replies. Undefined if not a thread reply. */
     parentId?: string
+    /** Raw UUID ref for `parentId`. Undefined when `parentId` is absent. */
+    parentRef?: string
     roomId: string
+    /** Raw UUID ref for `roomId`. */
+    roomRef: string
     personId: string
+    /** Raw UUID ref for `personId`. */
+    personRef: string
     personEmail: string
     text: string
     html?: string
@@ -172,6 +180,8 @@ declare module 'webex-message-handler' {
     roomType?: string
     /** Person UUIDs mentioned via @mention in the message. */
     mentionedPeople: string[]
+    /** Raw UUID refs for `mentionedPeople`, index-aligned. */
+    mentionedPeopleRefs: string[]
     /** Group mention types (e.g. "all") in the message. */
     mentionedGroups: string[]
     /** File URLs attached to the message. Empty if no files. */
@@ -181,19 +191,33 @@ declare module 'webex-message-handler' {
 
   export interface DeletedMessage {
     messageId: string
+    /** Raw UUID ref for `messageId`. */
+    messageRef: string
     roomId: string
+    /** Raw UUID ref for `roomId`. */
+    roomRef: string
     personId: string
+    /** Raw UUID ref for `personId`. */
+    personRef: string
   }
 
   export interface MembershipActivity {
-    /** Activity ID. */
+    /** Activity ID (raw Mercury activity UUID). */
     id: string
+    /** Raw UUID ref for `id`. Equal to `id` since the activity id is already raw. */
+    ref: string
     /** ID of the person who performed the action. */
     actorId: string
+    /** Raw UUID ref for `actorId`. */
+    actorRef: string
     /** ID of the member affected. */
     personId: string
+    /** Raw UUID ref for `personId`. */
+    personRef: string
     /** Conversation/space ID. */
     roomId: string
+    /** Raw UUID ref for `roomId`. */
+    roomRef: string
     /** Membership action: "add", "leave", "assignModerator", or "unassignModerator". */
     action: string
     /** ISO 8601 timestamp. */
@@ -207,14 +231,22 @@ declare module 'webex-message-handler' {
   export interface AttachmentAction {
     /** Activity ID. */
     id: string
+    /** Raw UUID ref for `id`. */
+    ref: string
     /** ID of the message the card was attached to. */
     messageId: string
+    /** Raw UUID ref for `messageId`. Empty when `messageId` is empty. */
+    messageRef: string
     /** ID of the person who submitted the card. */
     personId: string
+    /** Raw UUID ref for `personId`. */
+    personRef: string
     /** Email of the person who submitted the card. */
     personEmail: string
     /** Conversation/space ID. */
     roomId: string
+    /** Raw UUID ref for `roomId`. */
+    roomRef: string
     /** Card form input values. */
     inputs: Record<string, unknown>
     /** ISO 8601 timestamp. */
@@ -224,12 +256,18 @@ declare module 'webex-message-handler' {
   }
 
   export interface RoomActivity {
-    /** Activity ID. */
+    /** Activity ID (raw Mercury activity UUID). */
     id: string
+    /** Raw UUID ref for `id`. Equal to `id` since the activity id is already raw. */
+    ref: string
     /** Conversation/space ID. */
     roomId: string
+    /** Raw UUID ref for `roomId`. */
+    roomRef: string
     /** ID of the person who performed the action. */
     actorId: string
+    /** Raw UUID ref for `actorId`. */
+    actorRef: string
     /** Room action: "created" or "updated". */
     action: string
     /** ISO 8601 timestamp. */


### PR DESCRIPTION
## What

Add a `ref` sibling next to every id field on Webex real-time listener events. Every event type now carries the raw Mercury UUID alongside the REST-encoded id, with no changes to existing fields.

New sibling ref fields per event type:

| Event type | New ref fields |
| --- | --- |
| `DecryptedMessage` | `ref`, `parentRef` (optional), `roomRef`, `personRef`, `mentionedPeopleRefs[]` |
| `DeletedMessage` | `messageRef`, `roomRef`, `personRef` |
| `MembershipActivity` | `ref`, `actorRef`, `personRef`, `roomRef` |
| `AttachmentAction` | `ref`, `messageRef`, `personRef`, `roomRef` |
| `RoomActivity` | `ref`, `roomRef`, `actorRef` |

## Why

Listener events only carried REST-encoded ids (`Y2lzY29zcGFy…` blobs). Consumers who needed the raw UUID had to call `toRef(event.id)` themselves, meaning every downstream handler repeated the same boilerplate. Guaranteeing a `ref` sibling on every id field eliminates that friction — the raw UUID is always present wherever an id is.

## How

The refs are populated centrally inside the `normalize*` functions in `src/platforms/webex/id-normalizer.ts` — the single source of truth shared by both the `webex` and `webexbot` platforms. No changes needed at call sites in the listener bridge; the normalizers already mediate every inbound payload.

**Key design notes for reviewers:**

- For REST-encoded ids, `ref = toRef(restId)`, which base64-decodes back to the original raw UUID.
- `MembershipActivity.id` and `RoomActivity.id` are **already raw Mercury activity UUIDs** — `toRestId` is intentionally not applied to them. For these two types, `ref = id` (identity assignment). Running `toRef()` on an already-raw UUID would base64-decode a UUID and yield garbage. Code comments document this invariant to prevent a future incorrect "fix."
- Edge cases are preserved: absent `parentId` → `parentRef` is `undefined`; empty `messageId` → `messageRef` is `""`.
- The change is strictly additive — no existing fields are renamed, removed, or retyped.

## Files changed

- `src/platforms/webex/typings/webex-message-handler.d.ts` — extended event interfaces with ref siblings
- `src/platforms/webex/id-normalizer.ts` — populate ref fields in each `normalize*` function
- `src/platforms/webex/id-normalizer.test.ts` — ref assertions for every `normalize*` path
- `src/platforms/webex/listener.test.ts` — ref assertions on the listener bridge integration

## Test plan

- `bun typecheck` ✅
- `bun lint` ✅ (0 warnings / 0 errors)
- `bun run test` ✅ 3220 pass / 0 fail
- `oxfmt --check` on changed files ✅ clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach raw UUID refs to every id on Webex listener events so consumers always have both the REST id and the raw UUID. Change is additive and handled centrally in the normalizers; no call-site updates needed.

- **New Features**
  - Added ref siblings: ref, parentRef, roomRef, personRef, mentionedPeopleRefs, messageRef, actorRef.
  - Kept MembershipActivity.id and RoomActivity.id as raw; their ref equals id.
  - Preserved edge cases: missing parentId → parentRef undefined; empty messageId → messageRef "".

- **Migration**
  - No changes required.
  - SKILL.md/docs: not updated.

<sup>Written for commit 74bf53ecc892a534ff7c0d47bdbc3da0828914f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

