### PR TITLE
feat(webex): attach raw uuid refs to every id on SDK responses

### DIFF
--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -1,6 +1,12 @@
 import { WebexCredentialManager } from './credential-manager'
 import { WebexEncryptionService } from './encryption'
-import { decodeWebexId, toRestId } from './id-normalizer'
+import {
+  decodeWebexId,
+  normalizeSdkMembership,
+  normalizeSdkMessage,
+  normalizeSdkPerson,
+  toRestId,
+} from './id-normalizer'
 import { KmsKeyProvider } from './kms-key-provider'
 import { escapeHtml, markdownToHtml, stripMarkdown } from './markdown-to-html'
 import type { WebexConfig, WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './types'
@@ -216,15 +222,24 @@ export class WebexClient {
   async testAuth(): Promise<WebexPerson> {
     if (this.useInternalAPI) {
       try {
-        return await this.request<WebexPerson>('GET', '/people/me')
+        return normalizeSdkPerson(await this.request<WebexPerson>('GET', '/people/me'))
       } catch (err) {
         const isAuthError = err instanceof WebexError && (err.code === 'http_401' || err.code === 'http_403')
         if (!isAuthError) throw err
         await this.testAuthInternal()
-        return { id: '', emails: [], displayName: '', orgId: '', type: 'person', created: '' } as WebexPerson
+        return normalizeSdkPerson({
+          id: '',
+          ref: '',
+          emails: [],
+          displayName: '',
+          orgId: '',
+          orgRef: '',
+          type: 'person',
+          created: '',
+        })
       }
     }
-    return this.request<WebexPerson>('GET', '/people/me')
+    return normalizeSdkPerson(await this.request<WebexPerson>('GET', '/people/me'))
   }
 
   private async testAuthInternal(): Promise<void> {
@@ -324,7 +339,7 @@ export class WebexClient {
     else body.text = text
     if (resolvedOptions?.parentId) body.parentId = resolvedOptions.parentId
     if (resolvedOptions?.files?.length) body.files = resolvedOptions.files
-    return this.request<WebexMessage>('POST', '/messages', body)
+    return normalizeSdkMessage(await this.request<WebexMessage>('POST', '/messages', body))
   }
 
   private get useInternalAPI(): boolean {
@@ -376,15 +391,18 @@ export class WebexClient {
       }
     }
 
-    return {
+    return normalizeSdkMessage({
       id: this.normalizeMessageId(a.id),
+      ref: '',
       roomId,
+      roomRef: '',
       roomType: 'group' as const,
       text,
       personId: this.normalizePersonId(a.actor?.entryUUID ?? a.actor?.id ?? ''),
+      personRef: '',
       personEmail: a.actor?.emailAddress ?? '',
       created: a.published,
-    }
+    })
   }
 
   private async buildEncryptedObject(
@@ -469,7 +487,7 @@ export class WebexClient {
     const body = options?.markdown
       ? { toPersonEmail: personEmail, markdown: text }
       : { toPersonEmail: personEmail, text }
-    return this.request<WebexMessage>('POST', '/messages', body)
+    return normalizeSdkMessage(await this.request<WebexMessage>('POST', '/messages', body))
   }
 
   private async findDirectRoomByEmail(email: string): Promise<string | null> {
@@ -505,7 +523,7 @@ export class WebexClient {
     if (resolvedOptions?.mentionedPeople) params.set('mentionedPeople', resolvedOptions.mentionedPeople)
     if (resolvedOptions?.parentId) params.set('parentId', resolvedOptions.parentId)
     const data = await this.request<{ items: WebexMessage[] }>('GET', `/messages?${params}`)
-    return data.items
+    return data.items.map(normalizeSdkMessage)
   }
 
   async getMessage(messageId: string): Promise<WebexMessage> {
@@ -521,7 +539,7 @@ export class WebexClient {
       const roomId = convId ? Buffer.from(`ciscospark://urn:TEAM:unknown/ROOM/${convId}`).toString('base64') : ''
       return this.activityToMessage(activity, roomId)
     }
-    return this.request<WebexMessage>('GET', `/messages/${this.resolveMessageId(messageId)}`)
+    return normalizeSdkMessage(await this.request<WebexMessage>('GET', `/messages/${this.resolveMessageId(messageId)}`))
   }
 
   async deleteMessage(messageId: string): Promise<void> {
@@ -588,7 +606,9 @@ export class WebexClient {
       return this.activityToMessage(result, resolvedRoomId)
     }
     const body = options?.markdown ? { roomId: resolvedRoomId, markdown: text } : { roomId: resolvedRoomId, text }
-    return this.request<WebexMessage>('PUT', `/messages/${this.resolveMessageId(messageId)}`, body)
+    return normalizeSdkMessage(
+      await this.request<WebexMessage>('PUT', `/messages/${this.resolveMessageId(messageId)}`, body),
+    )
   }
 
   async listPeople(options?: { email?: string; displayName?: string; max?: number }): Promise<WebexPerson[]> {
@@ -599,7 +619,7 @@ export class WebexClient {
     const query = params.toString()
     const path = query ? `/people?${query}` : '/people'
     const data = await this.request<{ items: WebexPerson[] }>('GET', path)
-    return data.items
+    return data.items.map(normalizeSdkPerson)
   }
 
   async getPerson(personId: string): Promise<WebexPerson> {
@@ -610,14 +630,14 @@ export class WebexClient {
       }
       return person
     }
-    return this.request<WebexPerson>('GET', `/people/${await this.resolvePersonId(personId)}`)
+    return normalizeSdkPerson(await this.request<WebexPerson>('GET', `/people/${await this.resolvePersonId(personId)}`))
   }
 
   async listMyMemberships(options?: { max?: number }): Promise<WebexMembership[]> {
     const params = new URLSearchParams()
     params.set('max', String(options?.max ?? 100))
     const data = await this.request<{ items: WebexMembership[] }>('GET', `/memberships?${params}`)
-    return data.items
+    return data.items.map(normalizeSdkMembership)
   }
 
   async listMemberships(roomId: string, options?: { max?: number }): Promise<WebexMembership[]> {
@@ -626,7 +646,7 @@ export class WebexClient {
     params.set('roomId', resolvedRoomId)
     if (options?.max) params.set('max', String(options.max))
     const data = await this.request<{ items: WebexMembership[] }>('GET', `/memberships?${params}`)
-    return data.items
+    return data.items.map(normalizeSdkMembership)
   }
 
   async uploadFile(
@@ -654,7 +674,7 @@ export class WebexClient {
       const errorBody = (await response.json().catch(() => null)) as { message?: string } | null
       throw new WebexError(errorBody?.message ?? `HTTP ${response.status}`, `http_${response.status}`)
     }
-    return response.json() as Promise<WebexMessage>
+    return normalizeSdkMessage((await response.json()) as WebexMessage)
   }
 
   private async lookupRoomId(uuid: string, fallback: string): Promise<string> {

--- a/src/platforms/webex/commands/auth.ts
+++ b/src/platforms/webex/commands/auth.ts
@@ -12,9 +12,9 @@ import { info, debug, error as stderrError } from '@/shared/utils/stderr'
 import { getWebexAppCredentials } from '../app-config'
 import { WebexClient } from '../client'
 import { WebexCredentialManager } from '../credential-manager'
-import { toRef } from '../id-normalizer'
 import { loginWithPassword, WEB_CLIENT_ID, WEB_CLIENT_SECRET } from '../password-login'
 import { WebexTokenExtractor } from '../token-extractor'
+import type { WebexPerson } from '../types'
 import { WebexError } from '../types'
 
 interface ResolvedCredentials {
@@ -22,8 +22,8 @@ interface ResolvedCredentials {
   clientSecret: string
 }
 
-function formatAuthUser(person: { id: string; displayName: string; emails: string[] }) {
-  return { id: person.id, ref: toRef(person.id), displayName: person.displayName, emails: person.emails }
+function formatAuthUser(person: WebexPerson) {
+  return { id: person.id, ref: person.ref, displayName: person.displayName, emails: person.emails }
 }
 
 async function openBrowser(url: string): Promise<void> {

--- a/src/platforms/webex/commands/member.test.ts
+++ b/src/platforms/webex/commands/member.test.ts
@@ -12,8 +12,11 @@ const person2Id = restId('PEOPLE', 'person-2')
 const mockMembers = [
   {
     id: member1Id,
+    ref: 'person-1:room-1',
     roomId: 'room-1',
+    roomRef: 'room-1',
     personId: person1Id,
+    personRef: 'person-1',
     personEmail: 'alice@example.com',
     personDisplayName: 'Alice',
     isModerator: true,
@@ -21,8 +24,11 @@ const mockMembers = [
   },
   {
     id: member2Id,
+    ref: 'person-2:room-1',
     roomId: 'room-1',
+    roomRef: 'room-1',
     personId: person2Id,
+    personRef: 'person-2',
     personEmail: 'bob@example.com',
     personDisplayName: 'Bob',
     isModerator: false,

--- a/src/platforms/webex/commands/member.ts
+++ b/src/platforms/webex/commands/member.ts
@@ -4,7 +4,6 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
-import { toRef } from '../id-normalizer'
 
 export async function listAction(spaceId: string, options: { limit?: number; pretty?: boolean }): Promise<void> {
   try {
@@ -13,9 +12,9 @@ export async function listAction(spaceId: string, options: { limit?: number; pre
 
     const output = members.map((m) => ({
       id: m.id,
-      ref: toRef(m.id),
+      ref: m.ref,
       personId: m.personId,
-      personRef: toRef(m.personId),
+      personRef: m.personRef,
       personEmail: m.personEmail,
       personDisplayName: m.personDisplayName,
       isModerator: m.isModerator,

--- a/src/platforms/webex/commands/message.test.ts
+++ b/src/platforms/webex/commands/message.test.ts
@@ -11,22 +11,28 @@ const personId = toRestId('person_789', 'PEOPLE')
 
 const mockMessage = {
   id: messageId,
+  ref: 'msg_123',
   roomId,
+  roomRef: 'space_456',
   roomType: 'group' as const,
   text: 'Hello world',
   html: '<p>Hello <a href="https://example.com">world</a></p>',
   personId,
+  personRef: 'person_789',
   personEmail: 'user@example.com',
   created: '2025-01-29T10:00:00.000Z',
 }
 
 const mockMessage2 = {
   id: message2Id,
+  ref: 'msg_124',
   roomId,
+  roomRef: 'space_456',
   roomType: 'group' as const,
   text: 'Second message',
   html: '<p>Second message</p>',
   personId,
+  personRef: 'person_789',
   personEmail: 'user@example.com',
   created: '2025-01-29T10:01:00.000Z',
 }

--- a/src/platforms/webex/commands/message.ts
+++ b/src/platforms/webex/commands/message.ts
@@ -4,15 +4,14 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
-import { toRef } from '../id-normalizer'
 import type { WebexMessage } from '../types'
 
 function formatMessageOutput(message: WebexMessage) {
   return {
     id: message.id,
-    ref: toRef(message.id),
+    ref: message.ref,
     roomId: message.roomId,
-    roomRef: toRef(message.roomId),
+    roomRef: message.roomRef,
     text: message.text,
     html: message.html,
     personEmail: message.personEmail,

--- a/src/platforms/webex/commands/whoami.test.ts
+++ b/src/platforms/webex/commands/whoami.test.ts
@@ -10,6 +10,7 @@ const personId = toRestId('person-123', 'PEOPLE')
 
 const mockUser = {
   id: personId,
+  ref: 'person-123',
   emails: ['test@example.com'],
   displayName: 'Test User',
   nickName: 'Testy',
@@ -17,6 +18,7 @@ const mockUser = {
   lastName: 'User',
   avatar: 'https://example.com/avatar.jpg',
   orgId,
+  orgRef: 'org-123',
   type: 'person' as const,
   created: '2024-01-01T00:00:00.000Z',
 }

--- a/src/platforms/webex/commands/whoami.ts
+++ b/src/platforms/webex/commands/whoami.ts
@@ -4,7 +4,6 @@ import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
 
 import { WebexClient } from '../client'
-import { toRef } from '../id-normalizer'
 
 export async function whoamiAction(options: { pretty?: boolean }): Promise<void> {
   try {
@@ -13,7 +12,7 @@ export async function whoamiAction(options: { pretty?: boolean }): Promise<void>
 
     const output = {
       id: user.id,
-      ref: toRef(user.id),
+      ref: user.ref,
       emails: user.emails,
       displayName: user.displayName,
       nickName: user.nickName,
@@ -21,7 +20,7 @@ export async function whoamiAction(options: { pretty?: boolean }): Promise<void>
       lastName: user.lastName,
       avatar: user.avatar,
       orgId: user.orgId,
-      orgRef: toRef(user.orgId),
+      orgRef: user.orgRef,
       type: user.type,
     }
     console.log(formatOutput(output, options.pretty))

--- a/src/platforms/webex/id-normalizer.test.ts
+++ b/src/platforms/webex/id-normalizer.test.ts
@@ -16,9 +16,13 @@ import {
   normalizeMembership,
   normalizeMessage,
   normalizeRoomActivity,
+  normalizeSdkMembership,
+  normalizeSdkMessage,
+  normalizeSdkPerson,
   toRestId,
   toRef,
 } from './id-normalizer'
+import type { WebexMembership, WebexMessage, WebexPerson } from './types'
 
 const RAW: MercuryActivity = {
   id: 'activity-uuid',
@@ -318,5 +322,166 @@ describe('normalizeRoomActivity', () => {
     expect(result.ref).toBe('activity-uuid')
     expect(result.roomRef).toBe('room-uuid')
     expect(result.actorRef).toBe('actor-uuid')
+  })
+})
+
+describe('normalizeSdkPerson', () => {
+  const person: WebexPerson = {
+    id: restId('PEOPLE', 'person-uuid'),
+    ref: '',
+    emails: ['user@example.com'],
+    displayName: 'User',
+    orgId: restId('ORGANIZATION', 'org-uuid'),
+    orgRef: '',
+    type: 'person',
+    created: '2024-01-01T00:00:00Z',
+  }
+
+  it('decodes the bot identity id and orgId into raw uuid refs', () => {
+    const result = normalizeSdkPerson(person)
+
+    expect(result.ref).toBe('person-uuid')
+    expect(result.orgRef).toBe('org-uuid')
+  })
+
+  it('does not re-encode the already-REST ids', () => {
+    const result = normalizeSdkPerson(person)
+
+    expect(result.id).toBe(restId('PEOPLE', 'person-uuid'))
+    expect(result.orgId).toBe(restId('ORGANIZATION', 'org-uuid'))
+  })
+
+  it('leaves empty ids and refs empty', () => {
+    const result = normalizeSdkPerson({ ...person, id: '', orgId: '' })
+
+    expect(result.ref).toBe('')
+    expect(result.orgRef).toBe('')
+  })
+
+  it('returns a new object without mutating the input', () => {
+    const result = normalizeSdkPerson(person)
+
+    expect(result).not.toBe(person)
+    expect(person.ref).toBe('')
+  })
+})
+
+describe('normalizeSdkMessage', () => {
+  const message: WebexMessage = {
+    id: restId('MESSAGE', 'msg-uuid'),
+    ref: '',
+    roomId: restId('ROOM', 'room-uuid'),
+    roomRef: '',
+    roomType: 'group',
+    text: 'hello',
+    personId: restId('PEOPLE', 'person-uuid'),
+    personRef: '',
+    personEmail: 'user@example.com',
+    created: '2024-01-01T00:00:00Z',
+    parentId: restId('MESSAGE', 'parent-uuid'),
+    mentionedPeople: [restId('PEOPLE', 'mention-1'), restId('PEOPLE', 'mention-2')],
+  }
+
+  it('decodes id, roomId, personId and parentId into raw uuid refs', () => {
+    const result = normalizeSdkMessage(message)
+
+    expect(result.ref).toBe('msg-uuid')
+    expect(result.roomRef).toBe('room-uuid')
+    expect(result.personRef).toBe('person-uuid')
+    expect(result.parentRef).toBe('parent-uuid')
+  })
+
+  it('adds a mentionedPeopleRefs array of raw uuids', () => {
+    const result = normalizeSdkMessage(message)
+
+    expect(result.mentionedPeopleRefs).toEqual(['mention-1', 'mention-2'])
+  })
+
+  it('omits parentRef when parentId is absent', () => {
+    const { parentId: _omit, ...withoutParent } = message
+    const result = normalizeSdkMessage(withoutParent)
+
+    expect(result.parentRef).toBeUndefined()
+  })
+
+  it('omits mentionedPeopleRefs when mentionedPeople is absent', () => {
+    const { mentionedPeople: _omit, ...withoutMentions } = message
+    const result = normalizeSdkMessage(withoutMentions)
+
+    expect(result.mentionedPeopleRefs).toBeUndefined()
+  })
+
+  it('does not re-encode the already-REST ids', () => {
+    const result = normalizeSdkMessage(message)
+
+    expect(result.id).toBe(restId('MESSAGE', 'msg-uuid'))
+    expect(result.roomId).toBe(restId('ROOM', 'room-uuid'))
+  })
+})
+
+describe('normalizeSdkMembership', () => {
+  const membership: WebexMembership = {
+    id: restId('MEMBERSHIP', 'membership-uuid'),
+    ref: '',
+    roomId: restId('ROOM', 'room-uuid'),
+    roomRef: '',
+    personId: restId('PEOPLE', 'person-uuid'),
+    personRef: '',
+    personEmail: 'user@example.com',
+    personDisplayName: 'User',
+    isModerator: false,
+    created: '2024-01-01T00:00:00Z',
+  }
+
+  it('decodes id, roomId and personId into raw uuid refs', () => {
+    const result = normalizeSdkMembership(membership)
+
+    expect(result.ref).toBe('membership-uuid')
+    expect(result.roomRef).toBe('room-uuid')
+    expect(result.personRef).toBe('person-uuid')
+  })
+
+  it('does not re-encode the already-REST ids', () => {
+    const result = normalizeSdkMembership(membership)
+
+    expect(result.id).toBe(restId('MEMBERSHIP', 'membership-uuid'))
+    expect(result.personId).toBe(restId('PEOPLE', 'person-uuid'))
+  })
+})
+
+describe('SDK and event refs agree for the same person', () => {
+  it('matches the bot identity ref against an event mention ref so self/mention detection holds', () => {
+    const personUuid = 'bot-person-uuid'
+
+    // given: the bot identity from a REST response (testAuth path)
+    const bot = normalizeSdkPerson({
+      id: restId('PEOPLE', personUuid),
+      ref: '',
+      emails: ['bot@webex.bot'],
+      displayName: 'Bot',
+      orgId: restId('ORGANIZATION', 'org-uuid'),
+      orgRef: '',
+      type: 'bot',
+      created: '2024-01-01T00:00:00Z',
+    })
+
+    // when: an event carries the same person as a raw Mercury uuid
+    const event = normalizeMessage({
+      id: 'msg-uuid',
+      roomId: 'room-uuid',
+      personId: personUuid,
+      personEmail: 'bot@webex.bot',
+      text: 'hi',
+      created: '2024-01-01T00:00:00Z',
+      mentionedPeople: [personUuid],
+      mentionedGroups: [],
+      files: [],
+      raw: RAW,
+    })
+
+    // then: both paths decode to the same raw uuid ref
+    expect(bot.ref).toBe(personUuid)
+    expect(event.personRef).toBe(personUuid)
+    expect(event.mentionedPeopleRefs.includes(bot.ref)).toBe(true)
   })
 })

--- a/src/platforms/webex/id-normalizer.ts
+++ b/src/platforms/webex/id-normalizer.ts
@@ -7,6 +7,8 @@ import type {
   RoomActivity,
 } from 'webex-message-handler'
 
+import type { WebexMembership, WebexMessage, WebexPerson } from './types'
+
 export { fromRestId }
 
 // Superset of webex-message-handler's toRestId union, which omits ATTACHMENT_ACTION
@@ -20,7 +22,9 @@ export interface DecodedWebexId {
 }
 
 export function toRef(id: string): string {
-  if (!id) return id
+  // fromRestId throws on values that are not base64-encoded ciscospark ids; fail
+  // open so a non-REST id (legacy/sentinel) yields the id itself instead of crashing.
+  if (!id || !decodeWebexId(id)) return id
   return fromRestId(id)
 }
 
@@ -130,5 +134,35 @@ export function normalizeRoomActivity(activity: RoomActivity): RoomActivity {
     roomRef: toRef(roomId),
     actorId,
     actorRef: toRef(actorId),
+  }
+}
+
+// SDK REST responses (people/messages/memberships) already carry REST-encoded ids,
+// so unlike the event normalizers above we only attach raw uuid refs — no re-encoding.
+export function normalizeSdkPerson(person: WebexPerson): WebexPerson {
+  return {
+    ...person,
+    ref: toRef(person.id),
+    orgRef: toRef(person.orgId),
+  }
+}
+
+export function normalizeSdkMessage(message: WebexMessage): WebexMessage {
+  return {
+    ...message,
+    ref: toRef(message.id),
+    roomRef: toRef(message.roomId),
+    personRef: toRef(message.personId),
+    parentRef: message.parentId ? toRef(message.parentId) : message.parentId,
+    mentionedPeopleRefs: message.mentionedPeople?.map(toRef),
+  }
+}
+
+export function normalizeSdkMembership(membership: WebexMembership): WebexMembership {
+  return {
+    ...membership,
+    ref: toRef(membership.id),
+    roomRef: toRef(membership.roomId),
+    personRef: toRef(membership.personId),
   }
 }

--- a/src/platforms/webex/types.test.ts
+++ b/src/platforms/webex/types.test.ts
@@ -73,10 +73,13 @@ it('WebexSpaceSchema rejects invalid type', () => {
 it('WebexMessageSchema validates valid message', () => {
   const result = WebexMessageSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL01FU1NBR0UvbXNn',
+    ref: 'msg',
     roomId: 'Y2lzY29zcGFyazovL3VzL1JPT00vYWJj',
+    roomRef: 'abc',
     roomType: 'group',
     text: 'Hello world',
     personId: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hYmM',
+    personRef: 'abc',
     personEmail: 'user@example.com',
     created: '2024-01-15T10:30:00.000Z',
   })
@@ -86,17 +89,22 @@ it('WebexMessageSchema validates valid message', () => {
 it('WebexMessageSchema validates message with optional fields', () => {
   const result = WebexMessageSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL01FU1NBR0UvbXNn',
+    ref: 'msg',
     roomId: 'Y2lzY29zcGFyazovL3VzL1JPT00vYWJj',
+    roomRef: 'abc',
     roomType: 'group',
     text: 'Hello world',
     markdown: '**Hello world**',
     html: '<strong>Hello world</strong>',
     files: ['https://webexapis.com/v1/contents/file1'],
     personId: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hYmM',
+    personRef: 'abc',
     personEmail: 'user@example.com',
     created: '2024-01-15T10:30:00.000Z',
     parentId: 'Y2lzY29zcGFyazovL3VzL01FU1NBR0UvcGFyZW50',
+    parentRef: 'parent',
     mentionedPeople: ['Y2lzY29zcGFyazovL3VzL1BFT1BMRS9tZW50aW9u'],
+    mentionedPeopleRefs: ['mention'],
   })
   expect(result.success).toBe(true)
 })
@@ -125,9 +133,11 @@ it('WebexMessageSchema rejects invalid roomType', () => {
 it('WebexPersonSchema validates valid person', () => {
   const result = WebexPersonSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hYmM',
+    ref: 'abc',
     emails: ['user@example.com'],
     displayName: 'Test User',
     orgId: 'Y2lzY29zcGFyazovL3VzL09SR0FOSVpBVElPTi9vcmc',
+    orgRef: 'org',
     type: 'person',
     created: '2024-01-01T00:00:00.000Z',
   })
@@ -137,6 +147,7 @@ it('WebexPersonSchema validates valid person', () => {
 it('WebexPersonSchema validates person with optional fields', () => {
   const result = WebexPersonSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hYmM',
+    ref: 'abc',
     emails: ['user@example.com', 'user@work.com'],
     displayName: 'Test User',
     nickName: 'Tester',
@@ -144,6 +155,7 @@ it('WebexPersonSchema validates person with optional fields', () => {
     lastName: 'User',
     avatar: 'https://example.com/avatar.jpg',
     orgId: 'Y2lzY29zcGFyazovL3VzL09SR0FOSVpBVElPTi9vcmc',
+    orgRef: 'org',
     type: 'person',
     created: '2024-01-01T00:00:00.000Z',
   })
@@ -153,9 +165,11 @@ it('WebexPersonSchema validates person with optional fields', () => {
 it('WebexPersonSchema validates bot type', () => {
   const result = WebexPersonSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9ib3Q',
+    ref: 'bot',
     emails: ['bot@webex.bot'],
     displayName: 'My Bot',
     orgId: 'Y2lzY29zcGFyazovL3VzL09SR0FOSVpBVElPTi9vcmc',
+    orgRef: 'org',
     type: 'bot',
     created: '2024-01-01T00:00:00.000Z',
   })
@@ -185,8 +199,11 @@ it('WebexPersonSchema rejects invalid type', () => {
 it('WebexMembershipSchema validates valid membership', () => {
   const result = WebexMembershipSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL01FTUJFUlNISVAvbWVt',
+    ref: 'mem',
     roomId: 'Y2lzY29zcGFyazovL3VzL1JPT00vYWJj',
+    roomRef: 'abc',
     personId: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hYmM',
+    personRef: 'abc',
     personEmail: 'user@example.com',
     personDisplayName: 'Test User',
     isModerator: false,
@@ -198,8 +215,11 @@ it('WebexMembershipSchema validates valid membership', () => {
 it('WebexMembershipSchema validates moderator membership', () => {
   const result = WebexMembershipSchema.safeParse({
     id: 'Y2lzY29zcGFyazovL3VzL01FTUJFUlNISVAvbWVt',
+    ref: 'mem',
     roomId: 'Y2lzY29zcGFyazovL3VzL1JPT00vYWJj',
+    roomRef: 'abc',
     personId: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hYmM',
+    personRef: 'abc',
     personEmail: 'moderator@example.com',
     personDisplayName: 'Moderator User',
     isModerator: true,

--- a/src/platforms/webex/types.ts
+++ b/src/platforms/webex/types.ts
@@ -13,21 +13,27 @@ export interface WebexSpace {
 
 export interface WebexMessage {
   id: string
+  ref: string
   roomId: string
+  roomRef: string
   roomType: 'group' | 'direct'
   text?: string
   markdown?: string
   html?: string
   files?: string[]
   personId: string
+  personRef: string
   personEmail: string
   created: string
   parentId?: string
+  parentRef?: string
   mentionedPeople?: string[]
+  mentionedPeopleRefs?: string[]
 }
 
 export interface WebexPerson {
   id: string
+  ref: string
   emails: string[]
   displayName: string
   nickName?: string
@@ -35,14 +41,18 @@ export interface WebexPerson {
   lastName?: string
   avatar?: string
   orgId: string
+  orgRef: string
   type: 'person' | 'bot'
   created: string
 }
 
 export interface WebexMembership {
   id: string
+  ref: string
   roomId: string
+  roomRef: string
   personId: string
+  personRef: string
   personEmail: string
   personDisplayName: string
   isModerator: boolean
@@ -84,21 +94,27 @@ export const WebexSpaceSchema = z.object({
 
 export const WebexMessageSchema = z.object({
   id: z.string(),
+  ref: z.string(),
   roomId: z.string(),
+  roomRef: z.string(),
   roomType: z.enum(['group', 'direct']),
   text: z.string().optional(),
   markdown: z.string().optional(),
   html: z.string().optional(),
   files: z.array(z.string()).optional(),
   personId: z.string(),
+  personRef: z.string(),
   personEmail: z.string(),
   created: z.string(),
   parentId: z.string().optional(),
+  parentRef: z.string().optional(),
   mentionedPeople: z.array(z.string()).optional(),
+  mentionedPeopleRefs: z.array(z.string()).optional(),
 })
 
 export const WebexPersonSchema = z.object({
   id: z.string(),
+  ref: z.string(),
   emails: z.array(z.string()),
   displayName: z.string(),
   nickName: z.string().optional(),
@@ -106,14 +122,18 @@ export const WebexPersonSchema = z.object({
   lastName: z.string().optional(),
   avatar: z.string().optional(),
   orgId: z.string(),
+  orgRef: z.string(),
   type: z.enum(['person', 'bot']),
   created: z.string(),
 })
 
 export const WebexMembershipSchema = z.object({
   id: z.string(),
+  ref: z.string(),
   roomId: z.string(),
+  roomRef: z.string(),
   personId: z.string(),
+  personRef: z.string(),
   personEmail: z.string(),
   personDisplayName: z.string(),
   isModerator: z.boolean(),

--- a/src/platforms/webexbot/commands/file.ts
+++ b/src/platforms/webexbot/commands/file.ts
@@ -5,7 +5,6 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
-import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
@@ -40,9 +39,9 @@ export async function uploadAction(
 
     return {
       id: message.id,
-      ref: toRef(message.id),
+      ref: message.ref,
       roomId: message.roomId,
-      roomRef: toRef(message.roomId),
+      roomRef: message.roomRef,
       files: message.files,
       created: message.created,
     }

--- a/src/platforms/webexbot/commands/member.ts
+++ b/src/platforms/webexbot/commands/member.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
-import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
@@ -29,9 +28,9 @@ export async function listAction(space: string, options: BotOption & { max?: str
     return {
       members: members.map((m) => ({
         id: m.id,
-        ref: toRef(m.id),
+        ref: m.ref,
         personId: m.personId,
-        personRef: toRef(m.personId),
+        personRef: m.personRef,
         personEmail: m.personEmail,
         personDisplayName: m.personDisplayName,
         isModerator: m.isModerator,

--- a/src/platforms/webexbot/commands/message.ts
+++ b/src/platforms/webexbot/commands/message.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
-import { toRef } from '../../webex/id-normalizer'
 import type { WebexMessage } from '../../webex/types'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
@@ -33,9 +32,9 @@ interface MessageResult {
 function formatMessage(message: WebexMessage): MessageResult {
   return {
     id: message.id,
-    ref: toRef(message.id),
+    ref: message.ref,
     roomId: message.roomId,
-    roomRef: toRef(message.roomId),
+    roomRef: message.roomRef,
     text: message.text,
     markdown: message.markdown,
     html: message.html,
@@ -88,9 +87,9 @@ export async function repliesAction(
     return {
       messages: messages.map((msg) => ({
         id: msg.id,
-        ref: toRef(msg.id),
+        ref: msg.ref,
         roomId: msg.roomId,
-        roomRef: toRef(msg.roomId),
+        roomRef: msg.roomRef,
         text: msg.text,
         personEmail: msg.personEmail,
         created: msg.created,
@@ -125,9 +124,9 @@ export async function listAction(space: string, options: BotOption & { max?: str
     return {
       messages: messages.map((msg) => ({
         id: msg.id,
-        ref: toRef(msg.id),
+        ref: msg.ref,
         roomId: msg.roomId,
-        roomRef: toRef(msg.roomId),
+        roomRef: msg.roomRef,
         text: msg.text,
         personEmail: msg.personEmail,
         created: msg.created,

--- a/src/platforms/webexbot/commands/snapshot.ts
+++ b/src/platforms/webexbot/commands/snapshot.ts
@@ -34,7 +34,7 @@ export async function snapshotAction(options: BotOption & { full?: boolean; max?
     const result: SnapshotResult = {
       bot: {
         id: me.id,
-        ref: toRef(me.id),
+        ref: me.ref,
         displayName: me.displayName,
         emails: me.emails,
       },

--- a/src/platforms/webexbot/commands/user.test.ts
+++ b/src/platforms/webexbot/commands/user.test.ts
@@ -12,9 +12,11 @@ const mockListPeople = mock(() =>
   Promise.resolve([
     {
       id: personId,
+      ref: 'p1',
       emails: ['alice@example.com'],
       displayName: 'Alice',
       orgId,
+      orgRef: 'o1',
       type: 'person' as const,
       created: '',
     },
@@ -24,9 +26,11 @@ const mockListPeople = mock(() =>
 const mockGetPerson = mock(() =>
   Promise.resolve({
     id: personId,
+    ref: 'p1',
     emails: ['alice@example.com'],
     displayName: 'Alice',
     orgId,
+    orgRef: 'o1',
     type: 'person' as const,
     created: '2024-01-01T00:00:00Z',
   }),

--- a/src/platforms/webexbot/commands/user.ts
+++ b/src/platforms/webexbot/commands/user.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
-import { toRef } from '../../webex/id-normalizer'
 import type { WebexPerson } from '../../webex/types'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
@@ -33,7 +32,7 @@ interface UserResult {
 function formatPerson(person: WebexPerson): UserResult {
   return {
     id: person.id,
-    ref: toRef(person.id),
+    ref: person.ref,
     emails: person.emails,
     displayName: person.displayName,
     nickName: person.nickName,
@@ -41,7 +40,7 @@ function formatPerson(person: WebexPerson): UserResult {
     lastName: person.lastName,
     avatar: person.avatar,
     orgId: person.orgId,
-    orgRef: toRef(person.orgId),
+    orgRef: person.orgRef,
     type: person.type,
     created: person.created,
   }
@@ -58,7 +57,7 @@ export async function listAction(
     return {
       users: people.map((p) => ({
         id: p.id,
-        ref: toRef(p.id),
+        ref: p.ref,
         emails: p.emails,
         displayName: p.displayName,
         type: p.type,

--- a/src/platforms/webexbot/commands/whoami.ts
+++ b/src/platforms/webexbot/commands/whoami.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander'
 
 import { cliOutput } from '@/shared/utils/cli-output'
 
-import { toRef } from '../../webex/id-normalizer'
 import type { BotOption } from './shared'
 import { getClient } from './shared'
 
@@ -25,12 +24,12 @@ export async function whoamiAction(options: BotOption): Promise<WhoamiResult> {
     const info = await client.testAuth()
     return {
       id: info.id,
-      ref: toRef(info.id),
+      ref: info.ref,
       emails: info.emails,
       displayName: info.displayName,
       avatar: info.avatar,
       orgId: info.orgId,
-      orgRef: toRef(info.orgId),
+      orgRef: info.orgRef,
       type: info.type,
       created: info.created,
     }

--- a/src/tui/adapters/webex-adapter.ts
+++ b/src/tui/adapters/webex-adapter.ts
@@ -37,9 +37,9 @@ export class WebexAdapter implements PlatformAdapter {
     return messages
       .map((msg) => ({
         id: msg.id,
-        ref: toRef(msg.id),
+        ref: msg.ref,
         channelId: msg.roomId,
-        channelRef: toRef(msg.roomId),
+        channelRef: msg.roomRef,
         author: msg.personEmail,
         content: msg.text ?? '',
         timestamp: msg.created,


### PR DESCRIPTION
## Summary

#244 added raw-uuid `ref` siblings to Webex **listener event** payloads (`roomRef`, `personRef`, `ref`, `parentRef`, `mentionedPeopleRefs`). But consumers also read ids from two other id-bearing surfaces that #244 didn't touch — **REST query responses** (`WebexMessage`, `WebexMembership`) and **identity** (`WebexPerson`). This PR closes that gap by extending the same "ref everywhere" principle from events to every object the SDK returns.

The unifying principle: **every object the SDK returns that carries an id now gets a ref sibling** — not just events. A consumer (e.g. TypeClaw) can store raw uuids end-to-end with zero hand-decoding.

## Gap closed

| Surface | Field needed | Before | After |
| --- | --- | --- | --- |
| Listener events | roomRef/personRef/ref/parentRef/mentionedPeopleRefs | yes (#244) | yes |
| `WebexPerson` (testAuth/getPerson/listPeople) | `ref`, `orgRef` | gap (blocking) | yes |
| `WebexMembership` (listMemberships) | `ref`, `roomRef`, `personRef` | gap | yes |
| `WebexMessage` (listMessages/getMessage/send/edit/dm/upload) | `ref`, `roomRef`, `personRef`, `parentRef`, `mentionedPeopleRefs` | gap | yes |
| Outbound (resolveRoomId/resolvePersonId accept uuid) | — | already done | yes |

`WebexPerson.ref` was the #1 blocking gap: `botPersonId` comes from `testAuth()`, and the core mention/self checks compare `event.personRef === botPersonRef` and `event.mentionedPeopleRefs.includes(botPersonRef)`. Without a `ref` on `WebexPerson`, that comparison silently breaks.

## Approach

- **types.ts** — added `ref` siblings to the `WebexPerson` / `WebexMessage` / `WebexMembership` interfaces and their Zod schemas.
- **id-normalizer.ts** — added `normalizeSdk{Person,Message,Membership}`. Unlike the event normalizers (which take raw Mercury uuids and call `toRestId` first), SDK responses already carry REST ids, so these helpers **only attach refs and never re-encode**. `toRef` now fails open on a non-decodable id (legacy email ids, the internal `unknown`-cluster room sentinel) instead of throwing.
- **client.ts** — enrichment wired at every `WebexClient` return boundary (incl. the internal-API `activityToMessage` path, which covers internal list/get/edit/send). `WebexBotClient` inherits this via its pass-through delegation.
- **consumers** — dropped the now-redundant ad-hoc `toRef(obj.id)` calls in the webex/webexbot commands and the TUI adapter; they read refs straight off the objects. `WebexSpace` is intentionally untouched (no ref field yet).

### Why refs are consistent across paths
- Event path: raw uuid -> `toRestId(uuid, TYPE)` -> `toRef()` -> raw uuid
- SDK path: REST id -> `toRef()` -> raw uuid

Both decode to the same trailing uuid regardless of cluster, so `testAuth().ref === event.personRef` holds for the same person — verified by a dedicated cross-path regression test.

## Testing

- New unit tests for `normalizeSdk{Person,Message,Membership}` (decode, no-re-encode, empty/optional handling, immutability).
- Cross-path consistency test guarding the self/mention-detection invariant.
- Updated Zod schema tests and webex/webexbot command fixtures to the enriched shape.
- `bun typecheck`, `bun lint`, `bun test` (3233 pass / 0 fail) all green.

## Commits

1. `feat(webex): add ref siblings to SDK response types` — types + schemas + normalizers + tests
2. `feat(webex): enrich WebexClient responses with refs` — wiring at return points
3. `refactor(webex): read refs from SDK objects instead of toRef()` — drop redundant consumer calls

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add raw-UUID `ref` siblings to all Webex SDK response objects and wire normalization into `WebexClient`. Consumers can now read `ref` fields directly from `WebexPerson`, `WebexMessage`, and `WebexMembership` with consistent refs across REST and event paths.

- **New Features**
  - Added `ref` siblings to SDK types: `WebexPerson` (`ref`, `orgRef`), `WebexMessage` (`ref`, `roomRef`, `personRef`, `parentRef`, `mentionedPeopleRefs`), and `WebexMembership` (`ref`, `roomRef`, `personRef`).
  - Introduced `normalizeSdkPerson`, `normalizeSdkMessage`, and `normalizeSdkMembership`, and applied them across all `WebexClient` return points (`testAuth`, people, memberships, and message list/get/send/edit/upload).
  - Removed ad‑hoc `toRef()` calls in webex/webexbot commands and the TUI adapter; they now read refs from the enriched objects.

- **Migration**
  - No breaking changes. If you previously used `toRef(obj.id)`, read `obj.ref` (and `roomRef`, `personRef`, `orgRef`) instead. Note: `toRef()` now fails open on non-decodable ids to avoid crashes.
  - Docs: SKILL.md/docs were not updated (additive fields only).

<sup>Written for commit cfefa0e983d0fa24ef861cea21c9becae46613b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

