### PR TITLE
feat(webex): expose ref-enriched listener event types to SDK consumers

### DIFF
--- a/src/platforms/webex/id-normalizer.ts
+++ b/src/platforms/webex/id-normalizer.ts
@@ -7,7 +7,16 @@ import type {
   RoomActivity,
 } from 'webex-message-handler'
 
-import type { WebexMembership, WebexMessage, WebexPerson } from './types'
+import type {
+  WebexAttachmentActionEvent,
+  WebexDeletedMessageEvent,
+  WebexMembership,
+  WebexMembershipEvent,
+  WebexMessage,
+  WebexMessageEvent,
+  WebexPerson,
+  WebexRoomEvent,
+} from './types'
 
 export { fromRestId }
 
@@ -51,7 +60,7 @@ export function toRestId(uuid: string, type: WebexRestIdType): string {
   return Buffer.from(`ciscospark://us/${type}/${uuid}`).toString('base64url')
 }
 
-export function normalizeMessage(message: DecryptedMessage): DecryptedMessage {
+export function normalizeMessage(message: DecryptedMessage): WebexMessageEvent {
   const id = toRestId(message.id, 'MESSAGE')
   const parentId = message.parentId ? toRestId(message.parentId, 'MESSAGE') : message.parentId
   const roomId = toRestId(message.roomId, 'ROOM')
@@ -72,7 +81,7 @@ export function normalizeMessage(message: DecryptedMessage): DecryptedMessage {
   }
 }
 
-export function normalizeDeletedMessage(message: DeletedMessage): DeletedMessage {
+export function normalizeDeletedMessage(message: DeletedMessage): WebexDeletedMessageEvent {
   const messageId = toRestId(message.messageId, 'MESSAGE')
   const roomId = toRestId(message.roomId, 'ROOM')
   const personId = toRestId(message.personId, 'PEOPLE')
@@ -86,7 +95,7 @@ export function normalizeDeletedMessage(message: DeletedMessage): DeletedMessage
   }
 }
 
-export function normalizeMembership(activity: MembershipActivity): MembershipActivity {
+export function normalizeMembership(activity: MembershipActivity): WebexMembershipEvent {
   // `id` stays raw: it is a Mercury activity UUID, not a REST membership ID, so
   // its ref is the id itself rather than a decoded REST id.
   const actorId = toRestId(activity.actorId, 'PEOPLE')
@@ -104,7 +113,7 @@ export function normalizeMembership(activity: MembershipActivity): MembershipAct
   }
 }
 
-export function normalizeAttachmentAction(action: AttachmentAction): AttachmentAction {
+export function normalizeAttachmentAction(action: AttachmentAction): WebexAttachmentActionEvent {
   const id = toRestId(action.id, 'ATTACHMENT_ACTION')
   const messageId = action.messageId ? toRestId(action.messageId, 'MESSAGE') : action.messageId
   const personId = toRestId(action.personId, 'PEOPLE')
@@ -122,7 +131,7 @@ export function normalizeAttachmentAction(action: AttachmentAction): AttachmentA
   }
 }
 
-export function normalizeRoomActivity(activity: RoomActivity): RoomActivity {
+export function normalizeRoomActivity(activity: RoomActivity): WebexRoomEvent {
   // `id` stays raw: the Mercury conversation activity UUID has no consumer-facing
   // REST resource, so its ref is the id itself (the comparable REST id is `roomId`).
   const roomId = toRestId(activity.roomId, 'ROOM')

--- a/src/platforms/webex/index.ts
+++ b/src/platforms/webex/index.ts
@@ -9,7 +9,19 @@ export type { PasswordLoginOptions, PasswordLoginResult } from './password-login
 export { WebexTokenExtractor } from './token-extractor'
 export type { ExtractedWebexToken } from './token-extractor'
 export { WebexError } from './types'
-export type { WebexConfig, WebexMembership, WebexMessage, WebexPerson, WebexSpace } from './types'
+export type {
+  WebexAttachmentActionEvent,
+  WebexConfig,
+  WebexDeletedMessageEvent,
+  WebexMembership,
+  WebexMembershipEvent,
+  WebexMessage,
+  WebexMessageEvent,
+  WebexPerson,
+  WebexRealtimeEvent,
+  WebexRoomEvent,
+  WebexSpace,
+} from './types'
 export {
   WebexConfigSchema,
   WebexMembershipSchema,

--- a/src/platforms/webex/listener.ts
+++ b/src/platforms/webex/listener.ts
@@ -21,6 +21,14 @@ import {
   normalizeMessage,
   normalizeRoomActivity,
 } from './id-normalizer'
+import type {
+  WebexAttachmentActionEvent,
+  WebexDeletedMessageEvent,
+  WebexMembershipEvent,
+  WebexMessageEvent,
+  WebexRealtimeEvent,
+  WebexRoomEvent,
+} from './types'
 import { createWdmRewriteFetch, discoverWdmDevicesUrl } from './wdm-discovery'
 
 type EventKey = keyof WebexListenerEventMap
@@ -49,14 +57,14 @@ export interface WebexListenerOptions {
 }
 
 export interface WebexListenerEventMap {
-  message_created: [event: DecryptedMessage]
-  message_updated: [event: DecryptedMessage]
-  message_deleted: [event: DeletedMessage]
-  membership_created: [event: MembershipActivity]
-  attachment_action: [event: AttachmentAction]
-  room_created: [event: RoomActivity]
-  room_updated: [event: RoomActivity]
-  webex_event: [event: DecryptedMessage | DeletedMessage | MembershipActivity | AttachmentAction | RoomActivity]
+  message_created: [event: WebexMessageEvent]
+  message_updated: [event: WebexMessageEvent]
+  message_deleted: [event: WebexDeletedMessageEvent]
+  membership_created: [event: WebexMembershipEvent]
+  attachment_action: [event: WebexAttachmentActionEvent]
+  room_created: [event: WebexRoomEvent]
+  room_updated: [event: WebexRoomEvent]
+  webex_event: [event: WebexRealtimeEvent]
   connected: [info: { connected: boolean; status: HandlerStatus }]
   reconnecting: [attempt: number]
   disconnected: [reason: string]

--- a/src/platforms/webex/types.ts
+++ b/src/platforms/webex/types.ts
@@ -1,3 +1,10 @@
+import type {
+  AttachmentAction,
+  DecryptedMessage,
+  DeletedMessage,
+  MembershipActivity,
+  RoomActivity,
+} from 'webex-message-handler'
 import { z } from 'zod'
 
 export interface WebexSpace {
@@ -70,6 +77,47 @@ export interface WebexConfig {
   userId?: string
   encryptionKeys?: Record<string, string>
 }
+
+export type WebexMessageEvent = DecryptedMessage & {
+  ref: string
+  parentRef?: string
+  roomRef: string
+  personRef: string
+  mentionedPeopleRefs: string[]
+}
+
+export type WebexDeletedMessageEvent = DeletedMessage & {
+  messageRef: string
+  roomRef: string
+  personRef: string
+}
+
+export type WebexMembershipEvent = MembershipActivity & {
+  ref: string
+  actorRef: string
+  personRef: string
+  roomRef: string
+}
+
+export type WebexAttachmentActionEvent = AttachmentAction & {
+  ref: string
+  messageRef: string
+  personRef: string
+  roomRef: string
+}
+
+export type WebexRoomEvent = RoomActivity & {
+  ref: string
+  roomRef: string
+  actorRef: string
+}
+
+export type WebexRealtimeEvent =
+  | WebexMessageEvent
+  | WebexDeletedMessageEvent
+  | WebexMembershipEvent
+  | WebexAttachmentActionEvent
+  | WebexRoomEvent
 
 export class WebexError extends Error {
   code: string

--- a/src/platforms/webexbot/index.ts
+++ b/src/platforms/webexbot/index.ts
@@ -6,5 +6,16 @@ export { WebexBotListener } from './listener'
 export type { WebexBotListenerOptions } from './listener'
 export type { WebexBotConfig, WebexBotCredentials, WebexBotEntry, WebexBotListenerEventMap } from './types'
 export { WebexBotConfigSchema, WebexBotCredentialsSchema, WebexBotEntrySchema, WebexBotError } from './types'
-export type { WebexMembership, WebexMessage, WebexPerson, WebexSpace } from '../webex/types'
+export type {
+  WebexAttachmentActionEvent,
+  WebexDeletedMessageEvent,
+  WebexMembership,
+  WebexMembershipEvent,
+  WebexMessage,
+  WebexMessageEvent,
+  WebexPerson,
+  WebexRealtimeEvent,
+  WebexRoomEvent,
+  WebexSpace,
+} from '../webex/types'
 export { WebexMembershipSchema, WebexMessageSchema, WebexPersonSchema, WebexSpaceSchema } from '../webex/types'


### PR DESCRIPTION
## Problem

The Webex listener event payloads carry `ref`/`*Ref` fields (`ref`, `roomRef`, `personRef`, `parentRef`, `mentionedPeopleRefs`) at runtime, but **SDK consumers couldn't see them in the type graph**.

The fields were declared only through an ambient `declare module 'webex-message-handler'` augmentation under `src/platforms/webex/typings/`. This is a **types-only packaging gap**:

1. **Ambient `.d.ts` augmentation files are never emitted by `tsc`.** They're used to type-check this repo internally, but `dist/` never contains them — so they aren't published.
2. **Even if shipped, the augmentation wouldn't merge.** The upstream `webex-message-handler` declares its event interfaces locally and surfaces them via an aggregate `export { type DecryptedMessage, ... }`. A `declare module` interface augmentation does **not** merge into that re-exported local declaration, so the `ref` fields never attach to the consumer-visible `DecryptedMessage`.

Net effect: `listener.on('message_created', e => e.roomRef)` failed to type-check for downstream consumers (e.g. TypeClaw), even though `e.roomRef` exists at runtime.

## Fix

Stop relying on third-party module augmentation for the public surface. Expose **first-class normalized event types** from the SDK instead:

- **`types.ts`** — add `WebexMessageEvent`, `WebexDeletedMessageEvent`, `WebexMembershipEvent`, `WebexAttachmentActionEvent`, `WebexRoomEvent`, and the `WebexRealtimeEvent` union. Each is an intersection of the upstream event type plus the normalized `ref`/`*Ref` fields, so it stays aligned with upstream automatically and only adds what we guarantee.
- **`id-normalizer.ts`** — `normalize*` functions now return these enriched types (runtime bodies unchanged; they already produced these shapes).
- **`listener.ts`** — `WebexListenerEventMap` uses the enriched types. Internal raw handler callbacks still accept the upstream types.
- **`index.ts` / `webexbot/index.ts`** — re-export the new event types from the public entry points.

The internal ambient `typings/` augmentation is left untouched (still used for this repo's own type-checking against `webex-message-handler`).

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun test` — **3233 pass, 0 fail**
- **Consumer proof**: built the package, materialized it as an installed dependency, and type-checked a consumer under `moduleResolution: nodenext`:
  - `listener.on('message_created', e => e.roomRef)` and all event ref fields now resolve via `agent-messenger/webex` **and** `agent-messenger/webexbot`.
  - Negative control confirmed a bogus field still errors (`TS2339`), proving the check is real.

## Notes

- Consumers who imported `DecryptedMessage` directly from `webex-message-handler` expecting the ref fields should switch to the `agent-messenger/webex` event types (`WebexMessageEvent`, etc.). The normalized SDK types are the supported surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose first-class Webex listener event types that include normalized refs, so consumers see `ref`, `roomRef`, `personRef`, `parentRef`, and `mentionedPeopleRefs` in types. This replaces brittle augmentation of `webex-message-handler` and fixes missing fields for downstream users.

- New Features
  - Added `WebexMessageEvent`, `WebexDeletedMessageEvent`, `WebexMembershipEvent`, `WebexAttachmentActionEvent`, `WebexRoomEvent`, and `WebexRealtimeEvent`.
  - `normalize*` now returns these types; `WebexListenerEventMap` uses them; re-exported from `agent-messenger/webex` and `agent-messenger/webexbot`.

- Migration
  - Import event types from `agent-messenger/webex` or `agent-messenger/webexbot` instead of `webex-message-handler`.
  - No runtime behavior change; types only.
  - Docs: SKILL.md/docs not updated in this PR.

<sup>Written for commit eab1dc8e0297a2fb35f3661b6b317219a2a32379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

