### PR TITLE
feat(webex): support file upload for browser-extracted tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 | Threads                    |  ✅   |   ✅    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Channels & Users           |  ✅   |   ✅    |  ✅   |  ✅   | partial  |    —     |  ✅   |   ✅    |     —     |    —      |         ✅          |
 | Reactions                  |  ✅   |   ✅    |  ✅   |   —   |    —     |    ✅     |   —   |   —    |     —     |    —      |         —           |
-| File uploads               |  ✅   |   ✅    |  ✅   |   —   |    —     |    —     |   —   |   —    |     —     |    ✅     |         —           |
-| File downloads             |  ✅   |    —    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
+| File uploads               |  ✅   |   ✅    |  ✅   |  ✅   |    —     |    —     |   —   |   —    |     —     |    ✅     |         —           |
+| File downloads             |  ✅   |    —    |   —   |  ✅   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Workspace snapshots        |  ✅   |   ✅    |  ✅   |  ✅   |    —     |    —     |   —   |   —    |     —     |    —      |         ✅          |
 | Multi-workspace / account  |  ✅   |   ✅    |  ✅   |   —   |    ✅     |    ✅     |  ✅   |   ✅    |    ✅     |    ✅     |         ✅          |
 | Activity feed              |  ✅   |    —    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |

--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -203,6 +203,19 @@ agent-webex member list <space-id>
 agent-webex member list abc123 --limit 100
 ```
 
+### File Commands
+
+```bash
+# Upload a local file to a space
+agent-webex file upload <space-id> <path>
+agent-webex file upload abc123 ./report.pdf --text "Latest report"
+agent-webex file upload abc123 ./image.png --text "**Done**" --markdown
+
+# Download a file attachment by content URL or ID
+agent-webex file download <content-url-or-id>
+agent-webex file download <content-url-or-id> ./out.pdf
+```
+
 ### Snapshot Command
 
 Get workspace overview for AI agents (brief by default):

--- a/docs/content/docs/sdk/webex.mdx
+++ b/docs/content/docs/sdk/webex.mdx
@@ -104,6 +104,18 @@ const limited = await client.listMemberships(roomId, { max: 100 })
 // → WebexMembership[]
 ```
 
+### Files
+
+```typescript
+// Upload a file to a space (optionally with a text comment)
+const msg = await client.uploadFile(roomId, { content: blob, filename: 'report.pdf' }, { text: 'Latest report' })
+// → WebexMessage { id, roomId, files, ... }
+
+// Download a file attachment by content URL or ID
+const { data, filename, contentType } = await client.downloadContent(contentUrlOrId)
+// → { data: ArrayBuffer, filename: string, contentType: string }
+```
+
 ## WebexCredentialManager
 
 Manages Webex credentials stored at `~/.config/agent-messenger/webex-credentials.json`. Files are written with `0o600` permissions. Supports OAuth Device Grant flow, bot tokens, and PATs.

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -314,6 +314,19 @@ agent-webex member list <space-id>
 agent-webex member list <space-id> --limit 100
 ```
 
+### File Commands
+
+```bash
+# Upload a local file to a space
+agent-webex file upload <space-id> <path>
+agent-webex file upload <space-id> ./report.pdf --text "Latest report"
+agent-webex file upload <space-id> ./image.png --text "**Done**" --markdown
+
+# Download a file attachment by content URL or ID
+agent-webex file download <content-url-or-id>
+agent-webex file download <content-url-or-id> ./out.pdf
+```
+
 ### Snapshot Command
 
 Get workspace overview for AI agents (brief by default):
@@ -451,7 +464,6 @@ See the [Webex SDK documentation](https://agent-messenger.dev/docs/sdk/webex) fo
 
 ## Limitations
 
-- No file upload or download
 - No reactions / emoji support
 - No thread support
 - No message search

--- a/src/platforms/webex/cli.ts
+++ b/src/platforms/webex/cli.ts
@@ -4,7 +4,15 @@ import type { Command as CommandType } from 'commander'
 import { Command } from 'commander'
 
 import pkg from '../../../package.json' with { type: 'json' }
-import { authCommand, memberCommand, messageCommand, snapshotCommand, spaceCommand, whoamiCommand } from './commands'
+import {
+  authCommand,
+  fileCommand,
+  memberCommand,
+  messageCommand,
+  snapshotCommand,
+  spaceCommand,
+  whoamiCommand,
+} from './commands'
 import { ensureWebexAuth } from './ensure-auth'
 
 function isAuthCommand(command: CommandType): boolean {
@@ -26,6 +34,7 @@ program.hook('preAction', async (_thisCommand, actionCommand) => {
 })
 
 program.addCommand(authCommand)
+program.addCommand(fileCommand)
 program.addCommand(memberCommand)
 program.addCommand(messageCommand)
 program.addCommand(snapshotCommand)

--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -1018,6 +1018,98 @@ describe('WebexClient', () => {
       })
     })
 
+    describe('uploadFile', () => {
+      const mockUploadFlow = () => {
+        // given: the full internal share flow — conv lookup, space, session, PUT, finish, content
+        mockResponse({ id: TEST_CONV_UUID })
+        mockResponse({ spaceUrl: 'https://files.wbx2.com/spaces/sp1' })
+        mockResponse({
+          uploadUrl: 'https://up.wbx2.com/upload/sess1',
+          finishUploadUrl: 'https://up.wbx2.com/upload/sess1/finish',
+        })
+        mockResponse({}, 200)
+        mockResponse({ downloadUrl: 'https://files.wbx2.com/files/f1' })
+        mockResponse({ ...mockActivity(''), verb: 'share' })
+      }
+
+      const file = () => ({ content: new Blob(['hello world']), filename: 'note.txt' })
+
+      it('routes to the internal conversation API instead of the public messages endpoint', async () => {
+        mockUploadFlow()
+
+        const client = await createExtractedClient()
+        await client.uploadFile(TEST_ROOM_ID, file())
+
+        expect(fetchCalls.every((c) => !c.url.includes('webexapis.com/v1/messages'))).toBe(true)
+        expect(fetchCalls.at(-1)?.url).toBe(`${CONV_BASE}/conversations/${TEST_CONV_UUID}/content`)
+        expect(fetchCalls.at(-1)?.options?.method).toBe('POST')
+      })
+
+      it('requests a space, opens an upload session, PUTs the bytes, then finalizes', async () => {
+        mockUploadFlow()
+
+        const client = await createExtractedClient()
+        await client.uploadFile(TEST_ROOM_ID, file())
+
+        expect(fetchCalls[1].url).toBe(`${CONV_BASE}/conversations/${TEST_CONV_UUID}/space`)
+        expect(fetchCalls[1].options?.method).toBe('PUT')
+        expect(fetchCalls[2].url).toBe('https://files.wbx2.com/spaces/sp1/upload_sessions')
+        expect(fetchCalls[3].url).toBe('https://up.wbx2.com/upload/sess1')
+        expect(fetchCalls[3].options?.method).toBe('PUT')
+        expect(fetchCalls[4].url).toBe('https://up.wbx2.com/upload/sess1/finish')
+      })
+
+      it('finalize body carries fileSize and a sha256 fileHash of the uploaded bytes', async () => {
+        mockUploadFlow()
+
+        const client = await createExtractedClient()
+        await client.uploadFile(TEST_ROOM_ID, file())
+
+        const body = JSON.parse(fetchCalls[4].options?.body as string)
+        expect(body.fileSize).toBe(11)
+        expect(body.fileHash).toMatch(/^[0-9a-f]{64}$/)
+      })
+
+      it('share activity references the uploaded file with download url and metadata', async () => {
+        mockUploadFlow()
+
+        const client = await createExtractedClient()
+        await client.uploadFile(TEST_ROOM_ID, file())
+
+        const body = JSON.parse(fetchCalls.at(-1)?.options?.body as string)
+        expect(body.verb).toBe('share')
+        expect(body.object.objectType).toBe('content')
+        expect(body.object.contentCategory).toBe('documents')
+        const item = body.object.files.items[0]
+        expect(item.objectType).toBe('file')
+        expect(item.url).toBe('https://files.wbx2.com/files/f1')
+        expect(item.fileSize).toBe(11)
+        expect(item.mimeType).toBe('text/plain')
+        expect(item.displayName).toBe('note.txt')
+      })
+
+      it('attaches an optional text comment to the share activity', async () => {
+        mockUploadFlow()
+
+        const client = await createExtractedClient()
+        await client.uploadFile(TEST_ROOM_ID, file(), { text: 'see attached' })
+
+        const body = JSON.parse(fetchCalls.at(-1)?.options?.body as string)
+        expect(body.object.displayName).toBe('see attached')
+      })
+
+      it('categorizes images by mime type', async () => {
+        mockUploadFlow()
+
+        const client = await createExtractedClient()
+        await client.uploadFile(TEST_ROOM_ID, { content: new Blob(['x']), filename: 'photo.png' })
+
+        const body = JSON.parse(fetchCalls.at(-1)?.options?.body as string)
+        expect(body.object.contentCategory).toBe('images')
+        expect(body.object.files.items[0].mimeType).toBe('image/png')
+      })
+    })
+
     describe('error handling', () => {
       it('throws WebexError when internal API returns non-OK response', async () => {
         fetchResponses.push(

--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -1108,6 +1108,29 @@ describe('WebexClient', () => {
         expect(body.object.contentCategory).toBe('images')
         expect(body.object.files.items[0].mimeType).toBe('image/png')
       })
+
+      it('refuses to upload when the server returns an untrusted space url', async () => {
+        mockResponse({ id: TEST_CONV_UUID })
+        mockResponse({ spaceUrl: 'https://evil.example.com/spaces/sp1' })
+
+        const client = await createExtractedClient()
+
+        await expect(client.uploadFile(TEST_ROOM_ID, file())).rejects.toThrow('untrusted host')
+        expect(fetchCalls.every((c) => !c.url.includes('evil.example.com'))).toBe(true)
+      })
+
+      it('refuses to upload when the server returns a non-https upload url', async () => {
+        mockResponse({ id: TEST_CONV_UUID })
+        mockResponse({ spaceUrl: 'https://files.wbx2.com/spaces/sp1' })
+        mockResponse({
+          uploadUrl: 'http://up.wbx2.com/upload/sess1',
+          finishUploadUrl: 'https://up.wbx2.com/upload/sess1/finish',
+        })
+
+        const client = await createExtractedClient()
+
+        await expect(client.uploadFile(TEST_ROOM_ID, file())).rejects.toThrow('untrusted host')
+      })
     })
 
     describe('error handling', () => {

--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -1131,6 +1131,22 @@ describe('WebexClient', () => {
 
         await expect(client.uploadFile(TEST_ROOM_ID, file())).rejects.toThrow('untrusted host')
       })
+
+      it('accepts trusted Webex urls that carry an explicit port', async () => {
+        mockResponse({ id: TEST_CONV_UUID })
+        mockResponse({ spaceUrl: 'https://files.wbx2.com:443/spaces/sp1' })
+        mockResponse({
+          uploadUrl: 'https://up.wbx2.com:443/upload/sess1',
+          finishUploadUrl: 'https://up.wbx2.com:443/upload/sess1/finish',
+        })
+        mockResponse({}, 200)
+        mockResponse({ downloadUrl: 'https://files.wbx2.com/files/f1' })
+        mockResponse({ ...mockActivity(''), verb: 'share' })
+
+        const client = await createExtractedClient()
+
+        await expect(client.uploadFile(TEST_ROOM_ID, file())).resolves.toBeDefined()
+      })
     })
 
     describe('error handling', () => {

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -1,5 +1,8 @@
+import { createHash } from 'node:crypto'
+
 import { WebexCredentialManager } from './credential-manager'
 import { WebexEncryptionService } from './encryption'
+import type { WebexScr } from './encryption'
 import {
   decodeWebexId,
   normalizeSdkMembership,
@@ -655,6 +658,11 @@ export class WebexClient {
     options?: { text?: string; markdown?: boolean; parentId?: string },
   ): Promise<WebexMessage> {
     const resolvedRoomId = await this.resolveRoomId(roomId)
+
+    if (this.useInternalAPI) {
+      return this.uploadFileInternal(resolvedRoomId, file, options)
+    }
+
     const resolvedParentId = options?.parentId ? this.resolveMessageId(options.parentId) : undefined
     const form = new FormData()
     form.set('roomId', resolvedRoomId)
@@ -675,6 +683,137 @@ export class WebexClient {
       throw new WebexError(errorBody?.message ?? `HTTP ${response.status}`, `http_${response.status}`)
     }
     return normalizeSdkMessage((await response.json()) as WebexMessage)
+  }
+
+  private async uploadFileInternal(
+    roomId: string,
+    file: { content: Blob; filename: string },
+    options?: { text?: string; markdown?: boolean; parentId?: string },
+  ): Promise<WebexMessage> {
+    const convUuid = this.decodeConvUuid(roomId)
+    const conversationUrl = `${this.convBaseUrl}/conversations/${convUuid}`
+    const conv = await this.internalRequest<InternalConversation>(
+      `/conversations/${convUuid}?activitiesLimit=0&participantsLimit=0`,
+    )
+    const keyUri = conv.defaultActivityEncryptionKeyUrl
+
+    const bytes = new Uint8Array(await file.content.arrayBuffer())
+    const fileItem = await this.uploadFileContent(conversationUrl, file.filename, bytes, keyUri)
+
+    const object: Record<string, unknown> = {
+      objectType: 'content',
+      contentCategory: contentCategoryFor(fileItem.mimeType),
+      files: { items: [fileItem.item] },
+    }
+    let encryptionKeyUrl: string | undefined
+    if (options?.text) {
+      const built = await this.buildEncryptedObject(convUuid, options.text, { markdown: options.markdown })
+      object.displayName = built.object.displayName
+      if (built.object.content) object.content = built.object.content
+      encryptionKeyUrl = built.encryptionKeyUrl
+    }
+
+    const activity: Record<string, unknown> = {
+      verb: 'share',
+      object,
+      target: { id: convUuid, objectType: 'conversation' },
+      clientTempId: `tmp-${Date.now()}-share`,
+    }
+    if (options?.parentId) {
+      activity.parent = { id: this.toMessageRef(options.parentId), type: 'reply' }
+    }
+    if (encryptionKeyUrl ?? keyUri) {
+      activity.encryptionKeyUrl = encryptionKeyUrl ?? keyUri
+    }
+
+    const result = await this.internalActivityRequest<InternalActivity>(`${conversationUrl}/content`, {
+      method: 'POST',
+      body: JSON.stringify(activity),
+    })
+    return this.activityToMessage(result, roomId)
+  }
+
+  private async uploadFileContent(
+    conversationUrl: string,
+    filename: string,
+    bytes: Uint8Array,
+    keyUri: string | undefined,
+  ): Promise<{ item: Record<string, unknown>; mimeType: string }> {
+    const space = await this.internalActivityRequest<{ spaceUrl: string }>(`${conversationUrl}/space`, {
+      method: 'PUT',
+    })
+
+    let body: Uint8Array
+    let scr: WebexScr | undefined
+    if (this.encryption && keyUri) {
+      const encrypted = this.encryption.encryptBinary(bytes)
+      body = encrypted.ciphertext
+      scr = encrypted.scr
+    } else {
+      body = bytes
+    }
+
+    const downloadUrl = await this.uploadToSpace(space.spaceUrl, body)
+
+    const mimeType = guessMimeType(filename)
+    const item: Record<string, unknown> = {
+      objectType: 'file',
+      displayName: filename,
+      fileSize: bytes.byteLength,
+      mimeType,
+      url: downloadUrl,
+    }
+
+    if (scr && keyUri && this.encryption) {
+      scr.loc = downloadUrl
+      const encryptedScr = await this.encryption.encryptScr(keyUri, scr)
+      if (!encryptedScr) {
+        throw new WebexError('Cannot encrypt file for Webex E2E conversation', 'encryption_failed')
+      }
+      item.scr = encryptedScr
+      item.displayName = (await this.encryption.encryptText(keyUri, filename)) ?? filename
+    }
+
+    return { item, mimeType }
+  }
+
+  private async uploadToSpace(spaceUrl: string, body: Uint8Array): Promise<string> {
+    const session = await this.internalActivityRequest<{ uploadUrl: string; finishUploadUrl: string }>(
+      `${spaceUrl}/upload_sessions`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ uploadProtocol: 'content-length', fileSize: body.byteLength }),
+      },
+    )
+
+    const putResponse = await fetch(session.uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/octet-stream', 'Content-Length': String(body.byteLength) },
+      body,
+    })
+    if (!putResponse.ok) {
+      throw new WebexError(`File upload failed: HTTP ${putResponse.status}`, `http_${putResponse.status}`)
+    }
+
+    const fileHash = createHash('sha256').update(body).digest('hex')
+    const finished = await this.internalActivityRequest<{ downloadUrl: string }>(session.finishUploadUrl, {
+      method: 'POST',
+      body: JSON.stringify({ fileSize: body.byteLength, fileHash }),
+    })
+    return finished.downloadUrl
+  }
+
+  private async internalActivityRequest<T>(url: string, init: RequestInit): Promise<T> {
+    const response = await fetch(url, {
+      ...init,
+      headers: { ...this.internalHeaders, ...(init.headers as Record<string, string>) },
+    })
+    if (!response.ok) {
+      const errorBody = (await response.json().catch(() => null)) as { message?: string } | null
+      throw new WebexError(errorBody?.message ?? `HTTP ${response.status}`, `http_${response.status}`)
+    }
+    if (response.status === 204) return undefined as T
+    return response.json() as Promise<T>
   }
 
   private async lookupRoomId(uuid: string, fallback: string): Promise<string> {
@@ -814,6 +953,35 @@ function sanitizeFilename(name: string | undefined): string | undefined {
 
 function looksLikeUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
+const MIME_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  webm: 'video/webm',
+  pdf: 'application/pdf',
+  txt: 'text/plain',
+  md: 'text/markdown',
+  json: 'application/json',
+  csv: 'text/csv',
+  zip: 'application/zip',
+}
+
+function guessMimeType(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+  return MIME_TYPES[ext] ?? 'application/octet-stream'
+}
+
+function contentCategoryFor(mimeType: string): string {
+  if (mimeType.startsWith('image/')) return 'images'
+  if (mimeType.startsWith('video/')) return 'videos'
+  return 'documents'
 }
 
 function looksLikeEmail(value: string): boolean {

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -976,7 +976,7 @@ function assertTrustedWebexUrl(url: string): string {
   } catch {
     throw new WebexError(`Invalid Webex URL: ${url}`, 'invalid_url')
   }
-  if (parsed.protocol !== 'https:' || !isTrustedWebexHost(parsed.host)) {
+  if (parsed.protocol !== 'https:' || !isTrustedWebexHost(parsed.hostname)) {
     throw new WebexError(`Refusing to send request to untrusted host: ${parsed.origin}`, 'untrusted_url')
   }
   return parsed.toString()

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -786,7 +786,7 @@ export class WebexClient {
       },
     )
 
-    const putResponse = await fetch(session.uploadUrl, {
+    const putResponse = await fetch(assertTrustedWebexUrl(session.uploadUrl), {
       method: 'PUT',
       headers: { 'Content-Type': 'application/octet-stream', 'Content-Length': String(body.byteLength) },
       body,
@@ -804,7 +804,7 @@ export class WebexClient {
   }
 
   private async internalActivityRequest<T>(url: string, init: RequestInit): Promise<T> {
-    const response = await fetch(url, {
+    const response = await fetch(assertTrustedWebexUrl(url), {
       ...init,
       headers: { ...this.internalHeaders, ...(init.headers as Record<string, string>) },
     })
@@ -953,6 +953,33 @@ function sanitizeFilename(name: string | undefined): string | undefined {
 
 function looksLikeUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
+function isTrustedWebexHost(host: string): boolean {
+  return (
+    host === 'webex.com' ||
+    host.endsWith('.webex.com') ||
+    host === 'wbx2.com' ||
+    host.endsWith('.wbx2.com') ||
+    host === 'ciscospark.com' ||
+    host.endsWith('.ciscospark.com')
+  )
+}
+
+// Pin server-returned upload URLs to HTTPS Webex hosts: they receive the bearer
+// token (activity calls) and file bytes, so a compromised response must not be
+// able to exfiltrate them to an attacker-controlled host (SSRF/token leak).
+function assertTrustedWebexUrl(url: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new WebexError(`Invalid Webex URL: ${url}`, 'invalid_url')
+  }
+  if (parsed.protocol !== 'https:' || !isTrustedWebexHost(parsed.host)) {
+    throw new WebexError(`Refusing to send request to untrusted host: ${parsed.origin}`, 'untrusted_url')
+  }
+  return parsed.toString()
 }
 
 const MIME_TYPES: Record<string, string> = {

--- a/src/platforms/webex/commands/file.test.ts
+++ b/src/platforms/webex/commands/file.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, expect, it, spyOn } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { WebexClient } from '../client'
+import { toRestId } from '../id-normalizer'
+
+const roomId = toRestId('space_456', 'ROOM')
+
+const mockMessage = {
+  id: toRestId('msg_123', 'MESSAGE'),
+  ref: 'msg_123',
+  roomId,
+  roomRef: 'space_456',
+  roomType: 'group' as const,
+  text: '',
+  personId: toRestId('person_789', 'PEOPLE'),
+  personRef: 'person_789',
+  personEmail: 'user@example.com',
+  files: ['https://files.wbx2.com/files/f1'],
+  created: '2025-01-29T10:00:00.000Z',
+}
+
+import { downloadAction, uploadAction } from './file'
+
+let mockUploadFile: ReturnType<typeof spyOn>
+let mockDownloadContent: ReturnType<typeof spyOn>
+let consoleLogSpy: ReturnType<typeof spyOn>
+const protoSpies: ReturnType<typeof spyOn>[] = []
+let workDir: string
+
+function protoSpy(method: keyof WebexClient) {
+  const s = spyOn(WebexClient.prototype, method as never)
+  protoSpies.push(s)
+  return s
+}
+
+beforeEach(() => {
+  protoSpy('login').mockImplementation(async function (this: WebexClient) {
+    return this
+  })
+  protoSpy('dispose').mockResolvedValue(undefined)
+  mockUploadFile = protoSpy('uploadFile').mockResolvedValue(mockMessage)
+  mockDownloadContent = protoSpy('downloadContent').mockResolvedValue({
+    data: new TextEncoder().encode('file-bytes').buffer,
+    filename: 'report.pdf',
+    contentType: 'application/pdf',
+  })
+  consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+  workDir = mkdtempSync(join(tmpdir(), 'webex-file-test-'))
+})
+
+afterEach(() => {
+  for (const s of protoSpies) s.mockRestore()
+  protoSpies.length = 0
+  consoleLogSpy.mockRestore()
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+it('upload reads the local file and forwards filename plus text to uploadFile', async () => {
+  const filePath = join(workDir, 'note.txt')
+  writeFileSync(filePath, 'hello world')
+
+  await uploadAction(roomId, filePath, { text: 'see attached' })
+
+  expect(mockUploadFile).toHaveBeenCalledTimes(1)
+  const [space, file, options] = mockUploadFile.mock.calls[0] as [
+    string,
+    { content: Blob; filename: string },
+    { text?: string },
+  ]
+  expect(space).toBe(roomId)
+  expect(file.filename).toBe('note.txt')
+  expect(options.text).toBe('see attached')
+})
+
+it('upload prints the resulting message with file urls', async () => {
+  const filePath = join(workDir, 'note.txt')
+  writeFileSync(filePath, 'hello world')
+
+  await uploadAction(roomId, filePath, {})
+
+  const printed = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string)
+  expect(printed.id).toBe(mockMessage.id)
+  expect(printed.files).toEqual(['https://files.wbx2.com/files/f1'])
+})
+
+it('download writes content to the given output path', async () => {
+  const outPath = join(workDir, 'out.pdf')
+
+  await downloadAction('https://webexapis.com/v1/contents/c1', outPath, {})
+
+  expect(mockDownloadContent).toHaveBeenCalledWith('https://webexapis.com/v1/contents/c1')
+  expect(readFileSync(outPath, 'utf8')).toBe('file-bytes')
+})

--- a/src/platforms/webex/commands/file.ts
+++ b/src/platforms/webex/commands/file.ts
@@ -1,0 +1,87 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { basename, resolve } from 'node:path'
+
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { WebexClient } from '../client'
+
+async function withWebexClient<T>(run: (client: WebexClient) => Promise<T>): Promise<T> {
+  const client = new WebexClient()
+  try {
+    await client.login()
+    return await run(client)
+  } finally {
+    await client.dispose()
+  }
+}
+
+export async function uploadAction(
+  space: string,
+  path: string,
+  options: { text?: string; markdown?: boolean; parent?: string; pretty?: boolean },
+): Promise<void> {
+  try {
+    const filePath = resolve(path)
+    const content = await readFile(filePath)
+    const message = await withWebexClient((client) =>
+      client.uploadFile(
+        space,
+        { content: new Blob([content]), filename: basename(filePath) },
+        { text: options.text, markdown: options.markdown, parentId: options.parent },
+      ),
+    )
+
+    const output = {
+      id: message.id,
+      ref: message.ref,
+      roomId: message.roomId,
+      roomRef: message.roomRef,
+      files: message.files,
+      created: message.created,
+    }
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export async function downloadAction(
+  content: string,
+  output: string | undefined,
+  options: { pretty?: boolean },
+): Promise<void> {
+  try {
+    const { data, filename, contentType } = await withWebexClient((client) => client.downloadContent(content))
+    const outputPath = output ? resolve(output) : resolve(process.cwd(), basename(filename))
+    await writeFile(outputPath, Buffer.from(data))
+
+    console.log(formatOutput({ downloaded: outputPath, filename, contentType, size: data.byteLength }, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const fileCommand = new Command('file')
+  .description('File commands')
+  .addCommand(
+    new Command('upload')
+      .description('Upload a local file to a space')
+      .argument('<space>', 'Space/Room ID')
+      .argument('<path>', 'Local file path')
+      .option('--text <text>', 'Optional message to send with the file')
+      .option('--markdown', 'Treat --text as markdown')
+      .option('--parent <id>', 'Reply within a thread (parent message ID)')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(uploadAction),
+  )
+  .addCommand(
+    new Command('download')
+      .description('Download a file attachment by content URL or ID')
+      .argument('<content>', 'File content URL (from message.files) or content ID')
+      .argument('[output]', 'Output path (defaults to original filename)')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(downloadAction),
+  )

--- a/src/platforms/webex/commands/index.ts
+++ b/src/platforms/webex/commands/index.ts
@@ -1,4 +1,5 @@
 export { authCommand } from './auth'
+export { fileCommand } from './file'
 export { memberCommand } from './member'
 export { messageCommand } from './message'
 export { snapshotAction, snapshotCommand } from './snapshot'

--- a/src/platforms/webex/encryption.test.ts
+++ b/src/platforms/webex/encryption.test.ts
@@ -106,4 +106,42 @@ describe('WebexEncryptionService', () => {
     expect(key).not.toBeNull()
     expect(provider.fetchKey).toHaveBeenCalledTimes(1)
   })
+
+  it('encryptBinary produces A256GCM scr material and ciphertext that differs from input', async () => {
+    const service = new WebexEncryptionService(new Map())
+
+    const plaintext = new Uint8Array([1, 2, 3, 4, 5])
+    const { scr, ciphertext } = service.encryptBinary(plaintext)
+
+    expect(scr.enc).toBe('A256GCM')
+    expect(scr.key).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(scr.iv).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(scr.tag).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(Buffer.from(scr.key, 'base64url')).toHaveLength(32)
+    expect(Buffer.from(scr.iv, 'base64url')).toHaveLength(12)
+    expect(Buffer.from(ciphertext)).not.toEqual(Buffer.from(plaintext))
+  })
+
+  it('encryptScr requires loc to be set before encrypting', async () => {
+    const service = await createKeyring(keyUri)
+    const { scr } = service.encryptBinary(new Uint8Array([9, 9, 9]))
+
+    const result = await service.encryptScr(keyUri, scr)
+
+    expect(result).toBeNull()
+  })
+
+  it('encryptScr wraps the scr as a JWE with kid once loc is set', async () => {
+    const service = await createKeyring(keyUri)
+    const { scr } = service.encryptBinary(new Uint8Array([9, 9, 9]))
+    scr.loc = 'https://files.wbx2.com/files/f1'
+
+    const jwe = await service.encryptScr(keyUri, scr)
+
+    expect(jwe).not.toBeNull()
+    const header = decodeJweHeader(jwe as string)
+    expect(header.alg).toBe('dir')
+    expect(header.enc).toBe('A256GCM')
+    expect(header.kid).toBe(keyUri)
+  })
 })

--- a/src/platforms/webex/encryption.ts
+++ b/src/platforms/webex/encryption.ts
@@ -1,8 +1,30 @@
+import { createCipheriv, randomBytes } from 'node:crypto'
+
 import * as jose from 'node-jose'
 
 export interface WebexKeyProvider {
   fetchKey(keyUri: string): Promise<string | null>
   close?(): Promise<void>
+}
+
+// SCR (Secure Content Resource): Webex's per-file AES-256-GCM material. The file bytes
+// are encrypted with this key, then the SCR itself is JWE-wrapped with the conversation key.
+export interface WebexScr {
+  enc: 'A256GCM'
+  key: string
+  iv: string
+  aad: string
+  loc?: string
+  tag: string
+}
+
+export interface WebexEncryptedBinary {
+  scr: WebexScr
+  ciphertext: Uint8Array
+}
+
+function toBase64Url(buffer: Buffer): string {
+  return buffer.toString('base64url')
 }
 
 export class WebexEncryptionService {
@@ -66,6 +88,43 @@ export class WebexEncryptionService {
     try {
       const result = await jose.JWE.createDecrypt(key).decrypt(ciphertext)
       return result.plaintext.toString('utf8')
+    } catch {
+      return null
+    }
+  }
+
+  encryptBinary(plaintext: Uint8Array): WebexEncryptedBinary {
+    const key = randomBytes(32)
+    const iv = randomBytes(12)
+    const aad = new Date().toISOString()
+
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    cipher.setAAD(Buffer.from(aad, 'utf8'))
+    const ciphertext = Buffer.concat([cipher.update(Buffer.from(plaintext)), cipher.final()])
+    const tag = cipher.getAuthTag()
+
+    return {
+      scr: {
+        enc: 'A256GCM',
+        key: toBase64Url(key),
+        iv: toBase64Url(iv),
+        aad,
+        tag: toBase64Url(tag),
+      },
+      ciphertext,
+    }
+  }
+
+  async encryptScr(keyUri: string, scr: WebexScr): Promise<string | null> {
+    if (!scr.loc) return null
+    const key = await this.getKey(keyUri)
+    if (!key) return null
+
+    try {
+      return await jose.JWE.createEncrypt(
+        { format: 'compact', contentAlg: 'A256GCM' },
+        { key, header: { alg: 'dir', kid: keyUri }, reference: null },
+      ).final(JSON.stringify(scr), 'utf8')
     } catch {
       return null
     }


### PR DESCRIPTION
## Problem

Uploading an attachment via `WebexClient.uploadFile()` returned **403** for browser-extracted / password tokens, while text messages sent fine:

```
The server understood the request, but refused to fulfill it because the access token
is missing required scopes or the user is missing required roles or licenses.
```

### Root cause

When a token is browser-extracted (`tokenType: 'extracted' | 'password'` + a device URL), the client runs in `useInternalAPI` mode and routes **messaging** (`sendMessage`, `editMessage`, `deleteMessage`, `listMessages`) through the **internal conversation API** (Mercury/E2E).

`uploadFile()`, however, **unconditionally** POSTed multipart form data to the **public** `webexapis.com/v1/messages` endpoint. First-party browser tokens don't carry the `spark:files:write` scope the public API requires, so they get a 403 regardless of account licensing. That asymmetry is why text worked and attachments didn't.

## Fix

Add `uploadFileInternal()` mirroring the existing `sendMessageInternal()` pattern. `uploadFile()` now routes to it whenever `useInternalAPI` is true.

The internal share flow:

1. `PUT  {conversationUrl}/space` — obtain the file-sharing space URL
2. `POST {spaceUrl}/upload_sessions` — open an upload session
3. `PUT  {uploadUrl}` — upload the (encrypted) bytes
4. `POST {finishUploadUrl}` — finalize with `fileSize` + sha256 `fileHash`
5. `POST {conversationUrl}/content` — submit a `share` activity referencing the file

For E2E conversations, file bytes are encrypted with a **per-file SCR** (Secure Content Resource, AES-256-GCM). The SCR key material is then JWE-wrapped with the conversation key, matching how the Webex web client does it. Non-E2E conversations upload plaintext and omit the SCR.

Also exposes `file upload` / `file download` on the **`agent-webex` user CLI** to match `agent-webexbot` (previously only the SDK and bot CLI could upload).

## Verification

Tested live against a real space with a browser-extracted token:

- Attachment upload now succeeds (previously 403). The `share` activity lands with `objectType: content`, the correct `contentCategory`, and an encrypted SCR on the file item.
- Text messaging still works unchanged.
- `agent-webex file upload <space> <path> --text ...` works end-to-end via the CLI.

### Checks

- `bun typecheck` — clean
- `bun lint` — 0 warnings / 0 errors
- `bun test` — 3245 pass / 0 fail (9 new tests: internal upload flow, `encryptBinary`/`encryptScr`, file CLI commands)
- `oxfmt --check` on all changed files — clean

> Note: `bun run format:check` reports a **pre-existing** `docs/globals.css` fumadocs CSS resolution error that also fails on a clean `main`; it is unrelated to this change.

## Changes

- `src/platforms/webex/encryption.ts` — add `encryptBinary()` (SCR / AES-256-GCM) and `encryptScr()` (JWE-wrap the SCR)
- `src/platforms/webex/client.ts` — `uploadFileInternal()` and the multi-step share/upload flow; route `uploadFile()` to it under `useInternalAPI`
- `src/platforms/webex/commands/file.ts` — new `file upload` / `file download` commands for the user CLI
- `src/platforms/webex/cli.ts`, `commands/index.ts` — register the file command
- tests + `skills/agent-webex/SKILL.md` + `README.md` feature matrix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 403s on Webex file uploads for browser‑extracted/password tokens by routing `uploadFile()` through the internal conversation API and validating upload URLs to trusted Webex hosts (now accepts trusted hosts with explicit ports). Adds `agent-webex` CLI commands for uploading and downloading files.

- **Bug Fixes**
  - Route `uploadFile()` to the internal API when `useInternalAPI` is true.
  - Use the internal share flow (space → upload session → PUT bytes → finalize → share activity).
  - Support E2E spaces by encrypting bytes with a per-file SCR (AES-256-GCM) and JWE-wrapping the SCR with the conversation key.
  - Validate server-returned `spaceUrl`, `uploadUrl`, and `finishUploadUrl` with HTTPS and a trusted host check (`*.wbx2.com`, `*.webex.com`, `*.ciscospark.com`), rejecting untrusted URLs; guard matches the hostname and allows explicit ports (e.g. `:443`).

- **New Features**
  - `agent-webex file upload` and `agent-webex file download` commands.
  - MIME-based detection and content categorization (images/videos/documents).
  - Docs updated: README feature matrix, `docs/cli/webex.mdx`, `docs/sdk/webex.mdx`, and `skills/agent-webex/SKILL.md` (note: SKILL.md and docs updated since platform source changed).

<sup>Written for commit d17406e2d5e0808ed21cac898da3510f0381ceaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

