### PR TITLE
fix(webex): initialize E2E encryption for explicit-credential login

### DIFF
--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -81,6 +81,38 @@ describe('WebexClient', () => {
       expect((client as any).deviceUrl).toBe('https://wdm-r.wbx2.com/wdm/api/v1/devices/dev-1')
       expect((client as any).tokenType).toBe('extracted')
     })
+
+    const DEVICE_URL = 'https://wdm-r.wbx2.com/wdm/api/v1/devices/dev-1'
+    const encryptionOf = (client: WebexClient) =>
+      (client as unknown as { encryption: WebexEncryptionService | null }).encryption
+
+    it('initializes encryption for explicit extracted credentials with a device URL', async () => {
+      const client = await new WebexClient().login({
+        token: 'extracted-token',
+        deviceUrl: DEVICE_URL,
+        tokenType: 'extracted',
+      })
+      expect(encryptionOf(client)).toBeInstanceOf(WebexEncryptionService)
+    })
+
+    it('initializes encryption for explicit password credentials with a device URL', async () => {
+      const client = await new WebexClient().login({
+        token: 'password-token',
+        deviceUrl: DEVICE_URL,
+        tokenType: 'password',
+      })
+      expect(encryptionOf(client)).toBeInstanceOf(WebexEncryptionService)
+    })
+
+    it('does not initialize encryption for a plain token without device URL', async () => {
+      const client = await new WebexClient().login({ token: 'plain-token' })
+      expect(encryptionOf(client)).toBeNull()
+    })
+
+    it('does not initialize encryption when device URL is absent', async () => {
+      const client = await new WebexClient().login({ token: 'extracted-token', tokenType: 'extracted' })
+      expect(encryptionOf(client)).toBeNull()
+    })
   })
 
   describe('testAuth', () => {
@@ -623,12 +655,17 @@ describe('WebexClient', () => {
       activities: { items: activities },
     })
 
+    // These tests exercise the cleartext internal-API shape, so the KMS-backed
+    // encryption service is cleared after login; the encrypted path has its own
+    // createEncryptedClient that re-attaches a stub service.
     const createExtractedClient = async () => {
-      return new WebexClient().login({
+      const client = await new WebexClient().login({
         token: 'extracted-token',
         deviceUrl: TEST_DEVICE_URL,
         tokenType: 'extracted',
       })
+      ;(client as unknown as { encryption: null }).encryption = null
+      return client
     }
 
     describe('sendMessage', () => {
@@ -987,6 +1024,31 @@ describe('WebexClient', () => {
         expect(body.encryptionKeyUrl).toBe(TEST_KEY_URI)
         expect(decodeJweHeader(body.object.displayName).kid).toBe(TEST_KEY_URI)
         expect(decodeJweHeader(body.object.content).kid).toBe(TEST_KEY_URI)
+      })
+
+      it('explicit-credential login encrypts the send without manually attaching a service', async () => {
+        const keystore = jose.JWK.createKeyStore()
+        const key = await keystore.generate('oct', 256, { alg: 'A256GCM' })
+        const serializedKey = JSON.stringify({ uri: TEST_KEY_URI, jwk: key.toJSON(true) })
+
+        const client = await new WebexClient().login({
+          token: 'extracted-token',
+          deviceUrl: TEST_DEVICE_URL,
+          tokenType: 'extracted',
+        })
+        const service = (client as unknown as { encryption: WebexEncryptionService | null }).encryption
+        expect(service).toBeInstanceOf(WebexEncryptionService)
+        service?.setKeyProvider({ fetchKey: async () => serializedKey })
+
+        mockResponse({ id: TEST_CONV_UUID, defaultActivityEncryptionKeyUrl: TEST_KEY_URI })
+        mockResponse(mockActivity('Hello world'))
+
+        await client.sendMessage(TEST_ROOM_ID, 'Hello world')
+
+        const body = JSON.parse(fetchCalls[1].options?.body as string)
+        expect(body.object.displayName.startsWith('eyJ')).toBe(true)
+        expect(body.encryptionKeyUrl).toBe(TEST_KEY_URI)
+        expect(decodeJweHeader(body.object.displayName).kid).toBe(TEST_KEY_URI)
       })
     })
 

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -52,6 +52,7 @@ export class WebexClient {
       this.token = credentials.token
       if (credentials.deviceUrl !== undefined) this.deviceUrl = credentials.deviceUrl
       if (credentials.tokenType !== undefined) this.tokenType = credentials.tokenType
+      this.initializeEncryption(credentials.token)
       return this
     }
 
@@ -63,27 +64,44 @@ export class WebexClient {
     if (!token) {
       throw new WebexError('No Webex credentials found. Run "auth login" to authenticate.', 'no_credentials')
     }
+    this.token = token
     this.deviceUrl = config?.deviceUrl ?? null
     this.tokenType = config?.tokenType ?? null
-    await this.login({ token })
-
-    if (this.tokenType === 'extracted' || this.tokenType === 'password') {
-      const keysMap = new Map(Object.entries(config?.encryptionKeys ?? {}))
-      this.encryption = new WebexEncryptionService(keysMap)
-      const kmsProvider = new KmsKeyProvider({ token })
-      this.encryption.setKeyProvider({
-        fetchKey: async (keyUri: string) => {
-          const serializedKey = await kmsProvider.fetchKey(keyUri)
-          if (serializedKey) {
-            await this.persistEncryptionKey(credManager, keyUri, serializedKey)
-          }
-          return serializedKey
-        },
-        close: () => kmsProvider.close(),
-      })
-    }
+    this.initializeEncryption(token, {
+      cachedKeys: config?.encryptionKeys,
+      persist: (keyUri, serializedKey) => this.persistEncryptionKey(credManager, keyUri, serializedKey),
+    })
 
     return this
+  }
+
+  // Both login paths must run this. Explicit-credential callers would otherwise
+  // skip encryption setup and send cleartext on the internal conversation API,
+  // which Webex flags as "not encrypted before it was sent". Gated on a
+  // device-backed extracted/password session, the only case E2E applies to.
+  private initializeEncryption(
+    token: string,
+    options?: {
+      cachedKeys?: Record<string, string>
+      persist?: (keyUri: string, serializedKey: string) => Promise<void>
+    },
+  ): void {
+    if (this.tokenType !== 'extracted' && this.tokenType !== 'password') return
+    if (this.deviceUrl === null) return
+
+    const keysMap = new Map(Object.entries(options?.cachedKeys ?? {}))
+    this.encryption = new WebexEncryptionService(keysMap)
+    const kmsProvider = new KmsKeyProvider({ token })
+    this.encryption.setKeyProvider({
+      fetchKey: async (keyUri: string) => {
+        const serializedKey = await kmsProvider.fetchKey(keyUri)
+        if (serializedKey) {
+          await options?.persist?.(keyUri, serializedKey)
+        }
+        return serializedKey
+      },
+      close: () => kmsProvider.close(),
+    })
   }
 
   async dispose(): Promise<void> {


### PR DESCRIPTION
## Problem

Messages sent through the Webex SDK with **explicit credentials** were transmitted as cleartext, and the Webex client flagged them with **"This message was not encrypted before it was sent."** This affected SDK consumers that log in with a token they already hold (e.g. [typeclaw](https://github.com/typeclaw/typeclaw), which stores credentials in its own `secrets.json` and calls `client.login({ token, deviceUrl, tokenType: 'password' })`).

Browser-extracted CLI sessions (`auth extract`) were unaffected, which is why the bug was easy to miss — only the explicit-credential code path was broken.

## Root cause

`WebexClient.login()` only initialized the KMS-backed `WebexEncryptionService` on the **no-argument (auto-extraction)** path:

```ts
async login(credentials?) {
  if (credentials) {
    // ...set token / deviceUrl / tokenType
    return this              // ← early return: this.encryption stays null
  }
  // ...auto-extraction...
  if (this.tokenType === 'extracted' || this.tokenType === 'password') {
    this.encryption = new WebexEncryptionService(...)   // only reached here
  }
}
```

When credentials are passed explicitly, the method returns at the early `return this` and never sets up `this.encryption`. But with `tokenType: 'password' | 'extracted'` + a `deviceUrl`, `useInternalAPI` is `true`, so `sendMessage` still routes through the internal conversation API — where `buildEncryptedObject` sees `encryption === null` and posts the body in cleartext. Webex then renders the "not encrypted" warning.

## Fix

Extract the encryption setup into a private `initializeEncryption()` helper and run it from **both** login paths, gated on a device-backed `extracted`/`password` session (the only case Webex E2E applies to). The explicit-credential path starts with an empty key map and lets `KmsKeyProvider` negotiate the conversation key; the auto-extraction path additionally seeds cached keys and persists newly fetched ones.

## Verification

Reproduced end-to-end with a real account before/after the change:

- **Before** — explicit-credential `login()` → message shows the "not encrypted before it was sent" warning in the Webex client.
- **After** (encryption service wired by login) — message sends through the encrypted activity path (JWE `displayName`, `encryptionKeyUrl` set), no warning.

## Tests

- `login()` initializes encryption for explicit `extracted` + deviceUrl credentials
- `login()` initializes encryption for explicit `password` + deviceUrl credentials
- `login()` does **not** initialize encryption for a plain token (no deviceUrl/tokenType)
- `login()` does **not** initialize encryption when deviceUrl is absent
- end-to-end: explicit-credential login encrypts the send without manually attaching a service (asserts JWE `displayName` + `encryptionKeyUrl` + `kid`)

All checks pass: lint (0/0), typecheck clean, full suite **3253 pass / 0 fail**.

> Note: repo-wide `format:check` reports a pre-existing, unrelated error in `docs/src/app/globals.css` (`Can't resolve 'fumadocs-ui/css/neutral.css'`). The two changed files are correctly formatted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Webex E2E encryption for explicit-credential login so messages are sent encrypted and the client warning disappears. Adds `initializeEncryption()` and runs it for both login paths when using a device-backed `extracted` or `password` session.

- **Bug Fixes**
  - Initialize KMS-backed `WebexEncryptionService` on explicit-credential login via `initializeEncryption()`; keys negotiated by `KmsKeyProvider`.
  - Gate encryption to `tokenType: 'extracted' | 'password'` with a `deviceUrl`; auto-extracted path seeds and persists keys.
  - Add regression tests for init across token types and an end-to-end encrypted send.
  - Docs: SKILL.md/docs not updated (platform behavior fix, no API changes).

<sup>Written for commit ae5ad28ea9da682dfca75a9069dfe4f7a5271db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

