### PR TITLE
fix(linejs): null-guard res.data.e in requestCore error branch

### DIFF
--- a/src/vendor/linejs/base/request/mod.js
+++ b/src/vendor/linejs/base/request/mod.js
@@ -158,7 +158,7 @@ const square = [
       throw new InternalError("RequestError", `Request internal failed, ${methodName}(${path}) -> ` + JSON.stringify(res.data.e), res.data.e);
     }
     if (hasError && !isRefresh) {
-      if (res.data.e.code === "NOT_AUTHORIZED_DEVICE") {
+      if (res.data.e && res.data.e.code === "NOT_AUTHORIZED_DEVICE") {
         delete this.client.authToken;
         this.client.emit("end", this.client.profile);
       }

--- a/src/vendor/linejs/base/request/mod.test.ts
+++ b/src/vendor/linejs/base/request/mod.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test'
+
+import { InternalError } from '../core/mod.js'
+import { RequestClient } from './mod.js'
+
+// Regression: a thrift error response can set hasError (empty res.data[0]) while
+// omitting the exception struct (res.data[1] absent), leaving res.data.e undefined.
+function createClient(readThriftResult: { data: Record<string, unknown> }) {
+  const deviceDetails = {
+    device: 'TEST',
+    appVersion: '0.0.0',
+    systemName: 'TEST',
+    systemVersion: '0.0.0',
+  }
+  const stubClient = {
+    deviceDetails,
+    endpoint: 'legy.line-apps.test',
+    authToken: 'expired-token',
+    config: { timeout: 1000 },
+    storage: { get: async () => undefined },
+    log: () => {},
+    emit: () => {},
+    fetch: async () => ({
+      headers: { get: () => null },
+      arrayBuffer: async () => new ArrayBuffer(0),
+    }),
+    thrift: {
+      writeThrift: () => new Uint8Array(),
+      readThrift: () => readThriftResult,
+      rename_data: () => {},
+    },
+  }
+
+  return new RequestClient(stubClient as never)
+}
+
+describe('RequestClient.requestCore error handling', () => {
+  it('throws a clean RequestError when hasError is set but no exception struct is present', async () => {
+    // given: an error response with an empty success slot and no exception struct
+    const client = createClient({ data: { 0: undefined, someField: 1 } })
+
+    // when / then: the error branch must throw InternalError, not a TypeError
+    let thrown: unknown
+    try {
+      await client.requestCore('/S3', [], 'testMethod', 3)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(InternalError)
+    expect((thrown as InternalError).type).toBe('RequestError')
+    expect(thrown).not.toBeInstanceOf(TypeError)
+  })
+})


### PR DESCRIPTION
## Summary

In the vendored linejs SDK (`src/vendor/linejs/base/request/mod.js`), `requestCore` dereferenced `res.data.e.code` without a null guard in the `if (hasError && !isRefresh)` branch:

```js
if (res.data.e.code === "NOT_AUTHORIZED_DEVICE") {
```

When the LINE server returns a thrift error response that sets `hasError` (empty `res.data[0]`) but has **no exception struct** (`res.data[1]` absent, so `res.data.e` is never populated), this throws:

```
undefined is not an object (evaluating 'res.data.e.code')
```

masking the real auth failure. This reproduces when logging in with a fully-expired `auth_token`.

## Fix

Null-guard the access, mirroring the `res.data.e &&` guards already used above (lines 156-158):

```js
if (res.data.e && res.data.e.code === "NOT_AUTHORIZED_DEVICE") {
```

With the guard, the branch falls through to the existing clean `RequestError` throw (`JSON.stringify(res.data)`), surfacing the actual error instead of a `TypeError`.

## Notes on "matching dist/ build output"

The vendored SDK's `_dist/` directory (`src/vendor/linejs/_dist/`) contains **only `.d.ts` declaration files** — there is no `.js` runtime build there, so there is no second JS file to patch. The shipped runtime for this vendored SDK is `src/vendor/linejs/base/request/mod.js` itself, which is the file changed here. The repo's top-level `dist/` is gitignored and contains only the agent-messenger app build (not the vendored linejs).

## Test

Added `src/vendor/linejs/base/request/mod.test.ts` with a regression test that exercises `requestCore` with a stubbed client whose thrift response triggers `hasError` without an exception struct. It asserts the call throws a clean `InternalError("RequestError")` rather than a `TypeError`.

Verified TDD red/green: the test fails with the exact `TypeError: undefined is not an object (evaluating 'res.data.e.code')` against the unpatched code, and passes with the fix.

## Verification

- `bun typecheck` — pass (exit 0)
- `bun lint` — 0 warnings, 0 errors
- `bun test` — 3254 pass, 0 fail (includes the new test)
- `bun run format:check` — pre-existing unrelated failure in `docs/src/app/globals.css` (`fumadocs-ui/css/neutral.css` resolution), present on `main` and untouched here; vendor paths are excluded from oxfmt/oxlint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a crash in the vendored `linejs` SDK by null-guarding `res.data.e` in `requestCore`, so auth failures surface a clean RequestError instead of a TypeError. Adds a regression test for the hasError-without-exception case.

- **Bug Fixes**
  - Guard "NOT_AUTHORIZED_DEVICE" check with `res.data.e &&` in `src/vendor/linejs/base/request/mod.js`.
  - Ensures hasError responses without an exception struct don't throw a TypeError and fall through to the existing RequestError.
  - Added `src/vendor/linejs/base/request/mod.test.ts` to cover this regression.

- **Migration**
  - No action needed. SKILL.md and docs not updated.

<sup>Written for commit 385149895b3c9fa5329542520ccb43c65037527c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

