### PR TITLE
fix(slack): recover all workspaces from a single session cookie

### DIFF
--- a/src/platforms/slack/commands/auth.ts
+++ b/src/platforms/slack/commands/auth.ts
@@ -8,7 +8,8 @@ import { debug } from '@/shared/utils/stderr'
 
 import { SlackClient, SlackError } from '../client'
 import { CredentialManager } from '../credential-manager'
-import { refreshCookie, tryWebTokenRefresh } from '../ensure-auth'
+import { refreshCookie, refreshKnownWorkspaceDomains, tryWebTokenRefresh } from '../ensure-auth'
+import type { RefreshResult } from '../ensure-auth'
 import { loginWithQr } from '../qr-http-login'
 import { type ExtractedWorkspace, TokenExtractor } from '../token-extractor'
 
@@ -80,6 +81,8 @@ async function extractAction(options: {
 
     const validWorkspaces = []
     const failureReasons: string[] = []
+    const resolvedTeamIds = new Set<string>()
+    const refreshCache = new Map<string, RefreshResult | null>()
     for (const ws of workspaces) {
       if (options.debug) {
         debug(`[debug] Testing credentials for ${ws.workspace_id}...`)
@@ -88,10 +91,14 @@ async function extractAction(options: {
       try {
         const client = await new SlackClient().login({ token: ws.token, cookie: ws.cookie })
         const authInfo = await client.testAuth()
+        if (!authInfo.team_id) throw new SlackError('testAuth returned empty team_id', 'invalid_auth')
         ws.workspace_id = authInfo.team_id
         ws.workspace_name = authInfo.team || ws.workspace_name
-        validWorkspaces.push(ws)
-        await credManager.setWorkspace(ws)
+        if (!resolvedTeamIds.has(ws.workspace_id)) {
+          resolvedTeamIds.add(ws.workspace_id)
+          validWorkspaces.push(ws)
+          await credManager.setWorkspace(ws)
+        }
 
         if (options.debug) {
           debug(`[debug] ✓ Valid: ${authInfo.team} (${authInfo.user})`)
@@ -112,11 +119,12 @@ async function extractAction(options: {
             : `${ws.workspace_id} (trying all known domains)`
           debug(`[debug] Attempting web token refresh for ${target}...`)
         }
-        const refreshed = await tryWebTokenRefresh(ws, workspaceDomains)
-        if (refreshed) {
+        const refreshed = await tryWebTokenRefresh(ws, workspaceDomains, { resolvedTeamIds, refreshCache })
+        if (refreshed && !resolvedTeamIds.has(refreshed.workspace_id)) {
           ws.token = refreshed.token
           ws.workspace_id = refreshed.workspace_id
           ws.workspace_name = refreshed.workspace_name
+          resolvedTeamIds.add(ws.workspace_id)
           validWorkspaces.push(ws)
           await credManager.setWorkspace(ws)
 
@@ -125,6 +133,26 @@ async function extractAction(options: {
           }
         } else if (options.debug) {
           debug('[debug] ✗ Web refresh failed')
+        }
+      }
+    }
+
+    for (const cookie of new Set(workspaces.map((ws) => ws.cookie).filter(Boolean))) {
+      const enumerated = await refreshKnownWorkspaceDomains(cookie, workspaceDomains, {
+        resolvedTeamIds,
+        refreshCache,
+      })
+      for (const result of enumerated) {
+        const ws: ExtractedWorkspace = {
+          workspace_id: result.workspace_id,
+          workspace_name: result.workspace_name,
+          token: result.token,
+          cookie,
+        }
+        validWorkspaces.push(ws)
+        await credManager.setWorkspace(ws)
+        if (options.debug) {
+          debug(`[debug] ✓ Recovered via domain enumeration: ${result.workspace_id}/${result.workspace_name}`)
         }
       }
     }

--- a/src/platforms/slack/ensure-auth.test.ts
+++ b/src/platforms/slack/ensure-auth.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 
 import { SlackClient } from './client'
 import { CredentialManager } from './credential-manager'
-import { ensureSlackAuth, refreshTokenFromWeb } from './ensure-auth'
+import { ensureSlackAuth, refreshKnownWorkspaceDomains, refreshTokenFromWeb, tryWebTokenRefresh } from './ensure-auth'
 import { TokenExtractor } from './token-extractor'
 
 let getWorkspaceSpy: ReturnType<typeof spyOn>
@@ -358,8 +358,8 @@ describe('ensureSlackAuth', () => {
     )
   })
 
-  it('stops trying domains once a refresh+verify succeeds', async () => {
-    // given — exact-match domain succeeds on first attempt; the fallback domain must not be fetched
+  it('enumerates all known domains to recover every authenticatable workspace', async () => {
+    // given — one stale extracted token, but the cookie is valid for two workspaces
     extractSpy.mockResolvedValue([
       { workspace_id: 'T_TARGET', workspace_name: 'target', token: 'xoxc-stale', cookie: 'xoxd-valid' },
     ])
@@ -368,21 +368,27 @@ describe('ensureSlackAuth', () => {
       T_OTHER: 'other-domain',
     })
 
-    fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh"</html>', { status: 200 }))
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.startsWith('https://target-domain.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-target"</html>', { status: 200 }))
+      }
+      if (url.startsWith('https://other-domain.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-other"</html>', { status: 200 }))
+      }
+      return Promise.resolve(new Response('', { status: 500 }))
+    })
 
     authResponseByToken({
-      'xoxc-fresh': { team_id: 'T_TARGET', team: 'Target' },
+      'xoxc-fresh-target': { team_id: 'T_TARGET', team: 'Target' },
+      'xoxc-fresh-other': { team_id: 'T_OTHER', team: 'Other' },
     })
 
     // when
     await ensureSlackAuth()
 
-    // then — the exact-match domain is tried, fallback domain is not
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://target-domain.slack.com/ssb/redirect',
-      expect.objectContaining({ headers: { Cookie: 'd=xoxd-valid' } }),
-    )
-    expect(fetchSpy).not.toHaveBeenCalledWith('https://other-domain.slack.com/ssb/redirect', expect.anything())
+    // then — both workspaces are recovered from the single cookie, each saved once
+    const savedIds = setWorkspaceSpy.mock.calls.map((c) => (c[0] as { workspace_id: string }).workspace_id)
+    expect(savedIds.sort()).toEqual(['T_OTHER', 'T_TARGET'])
   })
 
   it('returns failure when no known domain validates the cookie', async () => {
@@ -496,24 +502,129 @@ describe('ensureSlackAuth', () => {
     expect(refreshCalls.length).toBe(2)
   })
 
-  it('caps domain attempts at MAX_DOMAIN_ATTEMPTS', async () => {
-    // given — 20 candidate domains; only the first 16 should be attempted
-    extractSpy.mockResolvedValue([
-      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
-    ])
+  it('caps single-candidate fallback at MAX_DOMAIN_ATTEMPTS', async () => {
+    // given — 20 candidate domains; the per-token fallback only probes the first 16
     const manyDomains: Record<string, string> = {}
     for (let i = 0; i < 20; i++) manyDomains[`T_${i}`] = `dom${i}`
-    getWorkspaceDomainsSpy.mockReturnValue(manyDomains)
-
     fetchSpy.mockResolvedValue(new Response('', { status: 500 }))
     testAuthSpy.mockRejectedValue(new Error('invalid_auth'))
 
     // when
-    await ensureSlackAuth()
+    await tryWebTokenRefresh(
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-stale', cookie: 'xoxd-valid' },
+      manyDomains,
+    )
 
     // then — exactly 16 refresh attempts
     const refreshCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('/ssb/redirect'))
     expect(refreshCalls.length).toBe(16)
+  })
+
+  it('enumerates ALL known domains without the MAX_DOMAIN_ATTEMPTS cap', async () => {
+    // given — 20 candidate domains; enumeration must probe every one
+    const manyDomains: Record<string, string> = {}
+    for (let i = 0; i < 20; i++) manyDomains[`T_${i}`] = `dom${i}`
+    fetchSpy.mockResolvedValue(new Response('', { status: 500 }))
+    testAuthSpy.mockRejectedValue(new Error('invalid_auth'))
+
+    // when
+    await refreshKnownWorkspaceDomains('xoxd-valid', manyDomains)
+
+    // then — all 20 domains attempted
+    const refreshCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('/ssb/redirect'))
+    expect(refreshCalls.length).toBe(20)
+  })
+
+  it('dedupes by verified team_id even when no context is supplied', async () => {
+    // given — two domains whose cookie verifies to the same team_id, called without a context set
+    getWorkspaceDomainsSpy.mockReturnValue({})
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.startsWith('https://primary.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-primary"</html>', { status: 200 }))
+      }
+      if (url.startsWith('https://alias.slack.com/')) {
+        return Promise.resolve(new Response('<html>"api_token":"xoxc-fresh-alias"</html>', { status: 200 }))
+      }
+      return Promise.resolve(new Response('', { status: 500 }))
+    })
+    authResponseByToken({
+      'xoxc-fresh-primary': { team_id: 'T_SAME', team: 'Same' },
+      'xoxc-fresh-alias': { team_id: 'T_SAME', team: 'Same' },
+    })
+
+    // when
+    const results = await refreshKnownWorkspaceDomains('xoxd-valid', { T_A: 'primary', T_B: 'alias' })
+
+    // then — the duplicate team is returned only once
+    expect(results.map((r) => r.workspace_id)).toEqual(['T_SAME'])
+  })
+
+  it('recovers all workspaces from one cookie when only one token is extracted', async () => {
+    // given — extractor yields one token deduped into two entries (one with a team id, one unknown),
+    // both sharing a single cookie that is valid for five workspaces
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'T1', workspace_name: 'unknown', token: 'xoxc-shared', cookie: 'xoxd-valid' },
+      { workspace_id: 'unknown', workspace_name: 'unknown', token: 'xoxc-shared', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({
+      T1: 'one',
+      T2: 'two',
+      T3: 'three',
+      T4: 'four',
+      T5: 'five',
+    })
+
+    const domainToToken: Record<string, string> = {
+      one: 'xoxc-fresh-1',
+      two: 'xoxc-fresh-2',
+      three: 'xoxc-fresh-3',
+      four: 'xoxc-fresh-4',
+      five: 'xoxc-fresh-5',
+    }
+    fetchSpy.mockImplementation((url: string) => {
+      const domain = String(url).match(/https:\/\/([^.]+)\.slack\.com/)?.[1] ?? ''
+      const token = domainToToken[domain]
+      return Promise.resolve(
+        token
+          ? new Response(`<html>"api_token":"${token}"</html>`, { status: 200 })
+          : new Response('', { status: 500 }),
+      )
+    })
+    authResponseByToken({
+      'xoxc-shared': new Error('invalid_auth'),
+      'xoxc-fresh-1': { team_id: 'T1', team: 'one' },
+      'xoxc-fresh-2': { team_id: 'T2', team: 'two' },
+      'xoxc-fresh-3': { team_id: 'T3', team: 'three' },
+      'xoxc-fresh-4': { team_id: 'T4', team: 'four' },
+      'xoxc-fresh-5': { team_id: 'T5', team: 'five' },
+    })
+
+    // when
+    await ensureSlackAuth()
+
+    // then — all five teams recovered, each saved exactly once
+    const savedIds = setWorkspaceSpy.mock.calls.map((c) => (c[0] as { workspace_id: string }).workspace_id)
+    expect(savedIds.sort()).toEqual(['T1', 'T2', 'T3', 'T4', 'T5'])
+  })
+
+  it('keeps a valid extracted token without overwriting it via enumeration', async () => {
+    // given — a single extracted token that authenticates directly
+    extractSpy.mockResolvedValue([
+      { workspace_id: 'T1', workspace_name: 'ws1', token: 'xoxc-good', cookie: 'xoxd-valid' },
+    ])
+    getWorkspaceDomainsSpy.mockReturnValue({ T1: 'one' })
+    authResponseByToken({
+      'xoxc-good': { team_id: 'T1', team: 'ws1' },
+      'xoxc-fresh-1': { team_id: 'T1', team: 'ws1' },
+    })
+    fetchSpy.mockResolvedValue(new Response('<html>"api_token":"xoxc-fresh-1"</html>', { status: 200 }))
+
+    // when
+    await ensureSlackAuth()
+
+    // then — saved once with the original valid token, not the web-refreshed one
+    expect(setWorkspaceSpy).toHaveBeenCalledTimes(1)
+    expect(setWorkspaceSpy).toHaveBeenCalledWith(expect.objectContaining({ workspace_id: 'T1', token: 'xoxc-good' }))
   })
 
   it('skips web refresh when workspace has no cookie', async () => {

--- a/src/platforms/slack/ensure-auth.ts
+++ b/src/platforms/slack/ensure-auth.ts
@@ -50,6 +50,23 @@ export async function ensureSlackAuth(): Promise<void> {
       }
     }
 
+    for (const cookie of new Set(workspaces.map((ws) => ws.cookie).filter(Boolean))) {
+      const enumerated = await refreshKnownWorkspaceDomains(cookie, workspaceDomains, {
+        resolvedTeamIds,
+        refreshCache,
+      })
+      for (const result of enumerated) {
+        const ws: ExtractedWorkspace = {
+          workspace_id: result.workspace_id,
+          workspace_name: result.workspace_name,
+          token: result.token,
+          cookie,
+        }
+        await credManager.setWorkspace(ws)
+        validWorkspaces.push(ws)
+      }
+    }
+
     const config = await credManager.load()
     if (!config.current_workspace && validWorkspaces.length > 0) {
       await credManager.setCurrentWorkspace(validWorkspaces[0].workspace_id)
@@ -76,6 +93,40 @@ export type RefreshResult = { token: string; workspace_id: string; workspace_nam
 export type RefreshContext = {
   resolvedTeamIds?: Set<string>
   refreshCache?: Map<string, RefreshResult | null>
+}
+
+// A single valid Slack `d` cookie can authenticate every workspace the user is signed into.
+// Given the workspace->domain map from root-state.json, enumerate ALL known domains via web
+// refresh so that workspaces without their own extracted xoxc token are still recovered. The
+// number of recoverable workspaces must not be bounded by the number of extracted token blobs.
+export async function refreshKnownWorkspaceDomains(
+  cookie: string,
+  workspaceDomains: Record<string, string>,
+  context: RefreshContext = {},
+): Promise<RefreshResult[]> {
+  if (!cookie) return []
+
+  const resolvedTeamIds = context.resolvedTeamIds ?? new Set<string>()
+  const results: RefreshResult[] = []
+  for (const domain of Object.values(workspaceDomains)) {
+    if (!SLACK_DOMAIN_REGEX.test(domain)) continue
+
+    const cacheKey = `${cookie}\u0000${domain}`
+    let result: RefreshResult | null
+    const cached = context.refreshCache?.get(cacheKey)
+    if (cached !== undefined) {
+      result = cached
+    } else {
+      result = await refreshAndVerify(cookie, domain, domain)
+      context.refreshCache?.set(cacheKey, result)
+    }
+
+    if (!result) continue
+    if (resolvedTeamIds.has(result.workspace_id)) continue
+    resolvedTeamIds.add(result.workspace_id)
+    results.push(result)
+  }
+  return results
 }
 
 export async function tryWebTokenRefresh(


### PR DESCRIPTION
## Problem

A valid Slack `d` session cookie can authenticate **every** workspace the user is signed into. But auth resolution was effectively bounded by the number of `xoxc` token blobs the extractor pulled from the desktop app's local storage.

When the desktop app yields only a single token — frequently deduped into one entry with a real `team_id` plus one `"unknown"` entry sharing the same cookie — the web-refresh fallback (`tryWebTokenRefresh`) resolved each extracted entry to the **first responding domain**. The result:

- Duplicate workspaces (the same team resolved twice)
- Every other workspace the cookie could authenticate was silently dropped

Concretely, a user signed into 5 workspaces could end up with `auth extract` reporting only one workspace listed twice, with no error.

## Fix

Add `refreshKnownWorkspaceDomains()` in `ensure-auth.ts`. Given a valid cookie and the `workspace -> domain` map (from `root-state.json`), it enumerates **all** known domains via web refresh and dedupes by the **verified `team_id`** returned by `testAuth()` — trusting the API response over the (possibly stale) map key.

This is wired into both `ensureSlackAuth()` and the `auth extract` command behind a single shared dedup/cache context, so the number of recovered workspaces is no longer tied to the number of extracted tokens.

### Correctness & safety

- **Happy path preserved** — valid extracted tokens with known team IDs are kept as-is, never overwritten by a web-refreshed duplicate.
- **Enumeration is uncapped** — the `MAX_DOMAIN_ATTEMPTS` cap remains only on the per-token single-candidate fallback, where it makes sense; exhaustive recovery from an explicit domain map must not be capped.
- **Shared context** — `auth extract` now uses one `resolvedTeamIds` + `refreshCache` context for the whole run (previously it passed no context, unlike `ensureSlackAuth`), preventing duplicate resolution and redundant network calls.
- **Cookie fan-out stays scoped** — domains still pass `SLACK_DOMAIN_REGEX`, and requests are only ever constructed as `https://<domain>.slack.com/...`, so the session cookie is never sent off-domain.

## Tests

- Recovers all workspaces from one cookie when only one token is extracted (the core regression).
- Enumerates all known domains to recover every authenticatable workspace.
- Enumeration is **not** subject to `MAX_DOMAIN_ATTEMPTS`; the per-token fallback still caps at 16.
- Keeps a valid extracted token without overwriting it via enumeration.
- Existing dedup, invalid-domain skipping, empty-`team_id` rejection, and cookie-scoping tests retained.

All 3282 tests pass; lint, format, and typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover all Slack workspaces from a single valid `d` session cookie by enumerating all known workspace domains and deduping by verified `team_id`. Fixes duplicate entries and missing workspaces when only one `xoxc` token is extracted.

- **Bug Fixes**
  - Added `refreshKnownWorkspaceDomains()` to enumerate all domains from the workspace→domain map; dedupe by verified `team_id` from `testAuth()`.
  - Wired into `ensureSlackAuth()` and `auth extract`, enumerating per unique cookie with shared `resolvedTeamIds` + `refreshCache` to avoid duplicates and extra network calls.
  - Skip saving duplicates and require non-empty `team_id`; keep valid extracted tokens and do not overwrite them with web-refreshed ones.
  - Keep `MAX_DOMAIN_ATTEMPTS` only for the per-token fallback in `tryWebTokenRefresh`; enumeration is uncapped and scoped to `https://<domain>.slack.com`.

- **Migration**
  - No migration needed; SKILL.md/docs unchanged.

<sup>Written for commit 6cf8b5742e3fe264318f7dbad0a1e9feac240f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

