### PR TITLE
test: cover node:sqlite path for ChromiumCookieReader

### DIFF
--- a/src/shared/chromium/cookie-reader-node-test.ts
+++ b/src/shared/chromium/cookie-reader-node-test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ChromiumCookieReader } from '@/shared/chromium'
+
+const require = createRequire(import.meta.url)
+const { DatabaseSync } = require('node:sqlite')
+
+function fail(message: string): never {
+  console.error(message)
+  process.exit(1)
+}
+
+const tempDir = mkdtempSync(join(tmpdir(), 'cookie-reader-node-test-'))
+const dbPath = join(tempDir, 'Cookies')
+
+try {
+  const db = new DatabaseSync(dbPath)
+  db.exec('CREATE TABLE cookies (name TEXT, value TEXT, host_key TEXT, last_access_utc INTEGER)')
+  const insert = db.prepare('INSERT INTO cookies (name, value, host_key, last_access_utc) VALUES (?, ?, ?, ?)')
+  insert.run('d', 'xoxd-newer', '.slack.com', 200)
+  insert.run('d', 'xoxd-older', '.slack.com', 100)
+  insert.run('other', 'ignored', '.example.com', 300)
+  db.close()
+
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined') {
+    fail('Expected Node.js runtime (node:sqlite), but Bun was detected')
+  }
+
+  const reader = new ChromiumCookieReader()
+
+  const first = await reader.queryFirst<{ value: string }>(
+    dbPath,
+    "SELECT value FROM cookies WHERE name = 'd' AND host_key LIKE ? ORDER BY last_access_utc DESC LIMIT 1",
+    ['%slack.com%'],
+  )
+  if (first?.value !== 'xoxd-newer') fail(`queryFirst expected xoxd-newer, got ${String(first?.value)}`)
+
+  const all = await reader.queryAll<{ value: string }>(
+    dbPath,
+    "SELECT value FROM cookies WHERE name = 'd' ORDER BY last_access_utc DESC",
+  )
+  if (all.length !== 2) fail(`queryAll expected 2 rows, got ${all.length}`)
+  if (all[0]?.value !== 'xoxd-newer') fail('queryAll expected newest-first ordering')
+
+  const none = await reader.queryFirst(dbPath, "SELECT value FROM cookies WHERE host_key = 'no.match'")
+  if (none !== null) fail(`no-row queryFirst expected null, got ${String(none)}`)
+
+  console.log('ok')
+} finally {
+  rmSync(tempDir, { recursive: true })
+}

--- a/src/shared/chromium/cookie-reader-node.test.ts
+++ b/src/shared/chromium/cookie-reader-node.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'bun:test'
+import { execSync } from 'node:child_process'
+
+it('ChromiumCookieReader works in Node.js (node:sqlite)', () => {
+  const result = execSync('bun tsx src/shared/chromium/cookie-reader-node-test.ts', {
+    cwd: process.cwd(),
+    encoding: 'utf-8',
+  })
+  expect(result.trim()).toBe('ok')
+})


### PR DESCRIPTION
## Summary

Adds a committed test that exercises the **`node:sqlite`** code path for `ChromiumCookieReader` — the shared SQLite reader used by the Slack/Teams/Instagram/Channel Talk browser-cookie fallback.

Follow-up to #252, which migrated off `better-sqlite3`. That PR's tests covered the `node:sqlite` path only for the Slack token extractor; this extends the same coverage to the shared reader.

## Why

Under `bun test`, the helper always selects `bun:sqlite`, so the `node:sqlite` branch is never hit in-process. The established pattern (see `slack/token-extractor-node.test.ts`) is to run a small harness under **Node** via `bun tsx`, invoked from a `bun test` wrapper. This makes a single `bun test` run validate **both** drivers.

## What changed

- `src/shared/chromium/cookie-reader-node-test.ts` — Node-runtime harness: builds a Chromium-shaped SQLite DB with `node:sqlite`, then drives the real `ChromiumCookieReader` to assert `queryFirst` (newest-first), `queryAll`, and the `undefined`→`null` no-row normalization. Guards that it runs under Node, not Bun.
- `src/shared/chromium/cookie-reader-node.test.ts` — `bun test` wrapper that runs the harness via `bun tsx` and asserts `ok`.

No production code changes.

## Testing

- `bun run lint` / `format:check` / `typecheck` — clean
- `bun run test` — **3284 pass, 0 fail** (the new Node-path test runs on real Node via tsx)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to cover the `node:sqlite` path in `ChromiumCookieReader` by running a Node.js harness via `bun tsx`, so a single `bun test` run validates both SQLite drivers. No production code changes; no SKILL.md or docs updates.

- **New Tests**
  - `src/shared/chromium/cookie-reader-node-test.ts`: Node harness creates a Chromium-like DB with `node:sqlite`, verifies `queryFirst` newest-first, `queryAll`, and no-row `undefined`→`null` normalization; guards against running under Bun.
  - `src/shared/chromium/cookie-reader-node.test.ts`: `bun test` wrapper executes the harness and asserts `ok`.

<sup>Written for commit ed2c1337a8b9a6aff3f7b09af07c7e691443fc1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

