### PR TITLE
Harden node:sqlite migration: cover BLOB/large-int reads, silence experimental warning

### DIFF
--- a/src/shared/chromium/cookie-reader-node-test.ts
+++ b/src/shared/chromium/cookie-reader-node-test.ts
@@ -18,11 +18,16 @@ const dbPath = join(tempDir, 'Cookies')
 
 try {
   const db = new DatabaseSync(dbPath)
-  db.exec('CREATE TABLE cookies (name TEXT, value TEXT, host_key TEXT, last_access_utc INTEGER)')
-  const insert = db.prepare('INSERT INTO cookies (name, value, host_key, last_access_utc) VALUES (?, ?, ?, ?)')
-  insert.run('d', 'xoxd-newer', '.slack.com', 200)
-  insert.run('d', 'xoxd-older', '.slack.com', 100)
-  insert.run('other', 'ignored', '.example.com', 300)
+  db.exec('CREATE TABLE cookies (name TEXT, value TEXT, encrypted_value BLOB, host_key TEXT, last_access_utc INTEGER)')
+  const insert = db.prepare(
+    'INSERT INTO cookies (name, value, encrypted_value, host_key, last_access_utc) VALUES (?, ?, ?, ?, ?)',
+  )
+  // Chromium *_utc columns are microseconds since 1601; real values exceed
+  // Number.MAX_SAFE_INTEGER, which node:sqlite throws on when SELECTed.
+  insert.run('d', 'xoxd-newer', null, '.slack.com', 13380000000000200n)
+  insert.run('d', 'xoxd-older', null, '.slack.com', 13380000000000100n)
+  insert.run('other', 'ignored', null, '.example.com', 13380000000000300n)
+  insert.run('enc', '', Buffer.from('v10-secret-bytes'), '.slack.com', 13380000000000100n)
   db.close()
 
   if (typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined') {
@@ -47,6 +52,17 @@ try {
 
   const none = await reader.queryFirst(dbPath, "SELECT value FROM cookies WHERE host_key = 'no.match'")
   if (none !== null) fail(`no-row queryFirst expected null, got ${String(none)}`)
+
+  // node:sqlite returns BLOBs as Uint8Array (not Buffer); Buffer.from must
+  // preserve the bytes so cookie decryption keeps working
+  const encrypted = await reader.queryFirst<{ encrypted_value?: Uint8Array }>(
+    dbPath,
+    "SELECT encrypted_value FROM cookies WHERE name = 'enc' LIMIT 1",
+  )
+  if (!(encrypted?.encrypted_value instanceof Uint8Array)) fail('encrypted_value expected Uint8Array')
+  if (Buffer.from(encrypted.encrypted_value).toString('utf8') !== 'v10-secret-bytes') {
+    fail('Buffer.from(BLOB) did not round-trip the original bytes')
+  }
 
   console.log('ok')
 } finally {

--- a/src/shared/sqlite.ts
+++ b/src/shared/sqlite.ts
@@ -16,6 +16,13 @@ type ReadonlyDatabaseConstructor = new (path: string, options: { readOnly: boole
 
 // Uses the runtime's built-in driver (bun:sqlite on Bun, node:sqlite on Node >= 22.13)
 // to avoid a native addon dependency.
+//
+// Runtime quirks callers must respect (both drivers behave this way):
+// - BLOB columns are returned as Uint8Array, not Buffer. Wrap with Buffer.from()
+//   before any Buffer-specific call (e.g. .toString('utf8'), node:crypto helpers).
+// - node:sqlite throws ERR_OUT_OF_RANGE when reading an INTEGER above
+//   Number.MAX_SAFE_INTEGER, so never SELECT raw microsecond timestamps such as
+//   Chromium's *_utc columns; use them only in WHERE / ORDER BY clauses.
 export function openReadonlyDatabase(path: string): ReadonlyDatabase {
   if (typeof globalThis.Bun !== 'undefined') {
     const { Database } = require('bun:sqlite')
@@ -23,12 +30,31 @@ export function openReadonlyDatabase(path: string): ReadonlyDatabase {
   }
 
   let DatabaseSync: ReadonlyDatabaseConstructor
+  // node:sqlite emits a one-time ExperimentalWarning to stderr on load
+  // (Node < 24.15) that clutters the CLI's output. Suppress just that warning
+  // while loading the module, then restore the original handler.
+  const originalEmitWarning = process.emitWarning
+  const filteredEmitWarning = (...args: unknown[]): void => {
+    const [warning, second] = args
+    const name =
+      warning instanceof Error
+        ? warning.name
+        : typeof second === 'string'
+          ? second
+          : (second as { type?: string } | undefined)?.type
+    const message = warning instanceof Error ? warning.message : String(warning)
+    if (name === 'ExperimentalWarning' && message.includes('SQLite')) return
+    ;(originalEmitWarning as (...forwarded: unknown[]) => void).apply(process, args)
+  }
+  process.emitWarning = filteredEmitWarning as typeof process.emitWarning
   try {
     DatabaseSync = require('node:sqlite').DatabaseSync
   } catch {
     throw new Error(
       'SQLite support requires Node.js >= 22.13.0 (the built-in node:sqlite module) or Bun. Please upgrade Node.js.',
     )
+  } finally {
+    process.emitWarning = originalEmitWarning
   }
 
   return new DatabaseSync(path, { readOnly: true })


### PR DESCRIPTION
## Summary

Pre-release hardening for the `better-sqlite3` → built-in SQLite migration. The migration itself is sound — every cookie consumer already wraps BLOBs in `Buffer.from()` and the `readOnly`/`readonly` casing is correct per runtime. This PR closes the two remaining coverage gaps and removes a stderr nuisance.

Builds on #253, which added the first `node:sqlite` harness for `ChromiumCookieReader` but only exercised TEXT columns and small timestamps.

## Why

`bun test` runs under Bun, so it only exercises the `bun:sqlite` branch of `openReadonlyDatabase`. The `node:sqlite` branch — what npm/Node consumers actually run — is only reached through the `bun tsx` Node harnesses. Two behaviors differ from `better-sqlite3` and were untested:

- **BLOB → `Uint8Array`** (not `Buffer`). `Uint8Array.prototype.toString('utf8')` ignores the encoding, so a missing `Buffer.from()` wrap would silently break the `v10`/`v11` prefix check and all cookie decryption.
- **Large integers throw.** `node:sqlite` raises `ERR_OUT_OF_RANGE` when reading an `INTEGER` above `Number.MAX_SAFE_INTEGER`. Chromium's `*_utc` microsecond timestamps exceed it, so they must only appear in `WHERE`/`ORDER BY`, never in `SELECT`.

## Changes

- **`test`: cover BLOB + large-integer reads** in the existing `cookie-reader-node-test.ts` harness:
  - Adds a BLOB `encrypted_value` row and asserts it returns as `Uint8Array` and that `Buffer.from(blob)` round-trips the bytes.
  - Bumps `last_access_utc` values past `Number.MAX_SAFE_INTEGER` so the existing `ORDER BY` queries prove no `ERR_OUT_OF_RANGE` is thrown.
- **`fix`: silence the `node:sqlite` ExperimentalWarning** emitted to stderr on module load (Node < 24.15), scoped to the `require` and restored immediately so unrelated warnings are untouched. Also documents the BLOB/large-integer pitfalls on `openReadonlyDatabase`.

## Testing

- `bun run lint` — 0 warnings, 0 errors
- `bun run typecheck` — clean
- `bun run format:check` — clean
- `bun run test` — 3284 pass, 0 fail (both `node:sqlite` Node harnesses included)
- `bun run build` + `node dist/src/cli.js --help` — runs clean on Node
- Verified the warning suppression: opening a DB through `openReadonlyDatabase` under Node now produces clean stderr.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `node:sqlite` migration by testing BLOB and large-integer reads and suppressing the module’s ExperimentalWarning during load. This keeps cookie decryption correct under Node and produces clean CLI stderr.

- **Bug Fixes**
  - Expanded Node harness to cover BLOB `encrypted_value` reads: asserts `Uint8Array` return and `Buffer.from()` byte round-trip; bumped `last_access_utc` past `Number.MAX_SAFE_INTEGER` and verified ORDER BY does not throw `ERR_OUT_OF_RANGE`.
  - Suppressed `node:sqlite` ExperimentalWarning during `require` on Node < 24.15 and restored the original handler; documented `Uint8Array` BLOBs and large-integer SELECT pitfalls in `openReadonlyDatabase`.

Docs: No SKILL.md or docs changes.

<sup>Written for commit 7d0340143260272684929f82ea524b276403b582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

