### PR TITLE
fix(webex): allowlist webexcontent.com upload hosts

### DIFF
--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -1209,6 +1209,32 @@ describe('WebexClient', () => {
 
         await expect(client.uploadFile(TEST_ROOM_ID, file())).resolves.toBeDefined()
       })
+
+      it('accepts webexcontent.com upload urls returned by the server', async () => {
+        mockResponse({ id: TEST_CONV_UUID })
+        mockResponse({ spaceUrl: 'https://files-prod-us-west-2.webexcontent.com/spaces/sp1' })
+        mockResponse({
+          uploadUrl: 'https://files-prod-us-west-2.webexcontent.com/upload/sess1',
+          finishUploadUrl: 'https://files-prod-us-west-2.webexcontent.com/upload/sess1/finish',
+        })
+        mockResponse({}, 200)
+        mockResponse({ downloadUrl: 'https://files-prod-us-west-2.webexcontent.com/files/f1' })
+        mockResponse({ ...mockActivity(''), verb: 'share' })
+
+        const client = await createExtractedClient()
+
+        await expect(client.uploadFile(TEST_ROOM_ID, file())).resolves.toBeDefined()
+      })
+
+      it('refuses non-webex upload hosts that merely contain a trusted host', async () => {
+        mockResponse({ id: TEST_CONV_UUID })
+        mockResponse({ spaceUrl: 'https://webexcontent.com.evil.example/spaces/sp1' })
+
+        const client = await createExtractedClient()
+
+        await expect(client.uploadFile(TEST_ROOM_ID, file())).rejects.toThrow('untrusted host')
+        expect(fetchCalls.every((c) => !c.url.includes('evil.example'))).toBe(true)
+      })
     })
 
     describe('error handling', () => {

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -980,7 +980,9 @@ function isTrustedWebexHost(host: string): boolean {
     host === 'wbx2.com' ||
     host.endsWith('.wbx2.com') ||
     host === 'ciscospark.com' ||
-    host.endsWith('.ciscospark.com')
+    host.endsWith('.ciscospark.com') ||
+    host === 'webexcontent.com' ||
+    host.endsWith('.webexcontent.com')
   )
 }
 


### PR DESCRIPTION
## Summary

Webex returns upload URLs on the `files-prod-*.webexcontent.com` domain for file
attachments. The trusted-host guard inside `isTrustedWebexHost()` did not include this
domain, so every attachment upload threw "Refusing to send request to untrusted host"
and failed.

## Why

Webex-owned file storage moved to the `webexcontent.com` domain. The allowlist was
never updated to include it, so the security guard that prevents SSRF and bearer-token
leakage was blocking legitimate Webex-owned upload URLs.

The fix is minimal: add a check for `webexcontent.com` and its subdomains inside
`isTrustedWebexHost()`. All existing guarantees are preserved — HTTPS-only enforcement
and host-pinning still apply; the bearer token and file bytes are still only sent to
Webex-owned domains.

## Changes

### `src/platforms/webex/client.ts`

Added an allowlist entry for `webexcontent.com` and its subdomains alongside the
existing three allowlisted domains (webex.com, wbx2.com, ciscospark.com).

### `src/platforms/webex/client.test.ts`

Two new tests in the `uploadFile` suite:

- Uploading to a `files-prod-us-west-2.webexcontent.com` URL now passes the guard
  and the upload resolves.
- The look-alike host `webexcontent.com.evil.example` (trusted name as a non-suffix
  substring) is still rejected with "untrusted host"; no request is sent to it.

## Testing

- 94 Webex client tests pass.
- `bun typecheck` — clean.
- `bun lint` — clean.

## Review Notes

The only behavioral change is in `isTrustedWebexHost()`. The evil-subdomain test
confirms the `endsWith` check cannot be bypassed by a hostname that contains the
trusted string as a non-suffix substring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allowlisted `webexcontent.com` and its subdomains in the Webex upload guard to restore file uploads. HTTPS-only and host-pinning checks remain enforced.

- **Bug Fixes**
  - Updated `isTrustedWebexHost()` to accept `webexcontent.com` and subdomains used by `files-prod-*.webexcontent.com`.
  - Added tests to accept real `webexcontent.com` uploads and reject look-alike hosts (e.g., `webexcontent.com.evil.example`).

- **Docs**
  - No changes to SKILL.md or docs were needed.

<sup>Written for commit 7dabe608f838904c4ab699c59a9b4b1636071cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

