### PR TITLE
feat(webex): add typing indicator support

### DIFF
--- a/docs/content/docs/cli/webex.mdx
+++ b/docs/content/docs/cli/webex.mdx
@@ -193,7 +193,14 @@ agent-webex message edit msg123 abc123 "Updated text" --markdown
 # Delete a message
 agent-webex message delete <message-id>
 agent-webex message delete <message-id> --force
+
+# Send a typing indicator ("…is typing")
+agent-webex message typing <space-id>
+# Clear the typing indicator
+agent-webex message typing <space-id> --stop
 ```
+
+Typing indicators require an extracted (browser) or password token — bot and OAuth tokens are not supported. The indicator is ephemeral and auto-expires after a few seconds.
 
 ### Member Commands
 

--- a/docs/content/docs/sdk/webex.mdx
+++ b/docs/content/docs/sdk/webex.mdx
@@ -84,7 +84,14 @@ await client.editMessage(messageId, roomId, '**Updated**', { markdown: true })
 
 // Delete a message
 await client.deleteMessage(messageId)
+
+// Send a typing indicator ("…is typing")
+await client.setTyping(roomId)
+// Clear the typing indicator
+await client.setTyping(roomId, false)
 ```
+
+Typing indicators are sent over Webex's internal conversation service, which the public REST API does not expose. They require an extracted (browser) or password token — bot and OAuth tokens have no device URL and throw a `WebexError`. The indicator is ephemeral and auto-expires after a few seconds, so re-send periodically to sustain it.
 
 ### People
 

--- a/skills/agent-webex/SKILL.md
+++ b/skills/agent-webex/SKILL.md
@@ -304,6 +304,10 @@ agent-webex message delete <message-id> --force
 # Edit a message
 agent-webex message edit <message-id> <space-id> <text>
 agent-webex message edit <message-id> <space-id> "Updated text" --markdown
+
+# Send a typing indicator (requires extracted/browser or password token)
+agent-webex message typing <space-id>
+agent-webex message typing <space-id> --stop
 ```
 
 ### Member Commands
@@ -467,6 +471,7 @@ See the [Webex SDK documentation](https://agent-messenger.dev/docs/sdk/webex) fo
 - No reactions / emoji support
 - No thread support
 - No message search
+- Typing indicators require an extracted (browser) or password token; bot/OAuth tokens are not supported for typing
 - No voice/video or meeting support
 - No space management (create/delete spaces, roles)
 

--- a/src/platforms/webex/client.test.ts
+++ b/src/platforms/webex/client.test.ts
@@ -760,6 +760,54 @@ describe('WebexClient', () => {
       })
     })
 
+    describe('setTyping', () => {
+      it('sends start_typing via internal API for extracted token', async () => {
+        // given
+        mockResponse(null, 204)
+        const client = await createExtractedClient()
+
+        // when
+        await client.setTyping(TEST_ROOM_ID)
+
+        // then
+        expect(fetchCalls).toHaveLength(1)
+        expect(fetchCalls[0].url).toContain('conv-r.wbx2.com/conversation/api/v1/conversations/')
+        expect(fetchCalls[0].url).toContain('/status/typing')
+        expect(fetchCalls[0].options?.method).toBe('POST')
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body).toEqual({
+          conversationId: TEST_CONV_UUID,
+          eventType: 'status.start_typing',
+        })
+      })
+
+      it('sends stop_typing when typing is false', async () => {
+        // given
+        mockResponse(null, 204)
+        const client = await createExtractedClient()
+
+        // when
+        await client.setTyping(TEST_ROOM_ID, false)
+
+        // then
+        const body = JSON.parse(fetchCalls[0].options?.body as string)
+        expect(body.eventType).toBe('status.stop_typing')
+        expect(body.conversationId).toBe(TEST_CONV_UUID)
+      })
+
+      it('throws for non-internal token', async () => {
+        // given
+        const client = await new WebexClient().login({ token: 'plain-token' })
+
+        // when / then
+        await expect(client.setTyping('roomId')).rejects.toThrow(WebexError)
+        await expect(client.setTyping('roomId')).rejects.toThrow(
+          'Typing indicator requires an extracted or password token with a device URL',
+        )
+        expect(fetchCalls).toHaveLength(0)
+      })
+    })
+
     describe('listMessages', () => {
       it('calls GET on conversations endpoint with activitiesLimit and participantsLimit', async () => {
         mockResponse(mockConversation([mockActivity('Hello')]))

--- a/src/platforms/webex/client.ts
+++ b/src/platforms/webex/client.ts
@@ -363,6 +363,23 @@ export class WebexClient {
     return normalizeSdkMessage(await this.request<WebexMessage>('POST', '/messages', body))
   }
 
+  async setTyping(roomId: string, typing: boolean = true): Promise<void> {
+    if (!this.useInternalAPI) {
+      throw new WebexError('Typing indicator requires an extracted or password token with a device URL', 'unsupported')
+    }
+
+    const resolvedRoomId = await this.resolveRoomId(roomId)
+    const convUuid = this.decodeConvUuid(resolvedRoomId)
+
+    await this.internalRequest<void>(`/conversations/${convUuid}/status/typing`, {
+      method: 'POST',
+      body: JSON.stringify({
+        conversationId: convUuid,
+        eventType: typing ? 'status.start_typing' : 'status.stop_typing',
+      }),
+    })
+  }
+
   private get useInternalAPI(): boolean {
     return (this.tokenType === 'extracted' || this.tokenType === 'password') && this.deviceUrl !== null
   }

--- a/src/platforms/webex/commands/message.test.ts
+++ b/src/platforms/webex/commands/message.test.ts
@@ -37,7 +37,7 @@ const mockMessage2 = {
   created: '2025-01-29T10:01:00.000Z',
 }
 
-import { deleteAction, dmAction, editAction, getAction, listAction, sendAction } from './message'
+import { deleteAction, dmAction, editAction, getAction, listAction, sendAction, typingAction } from './message'
 
 let mockSendMessage: ReturnType<typeof spyOn>
 let mockSendDirectMessage: ReturnType<typeof spyOn>
@@ -45,6 +45,7 @@ let mockListMessages: ReturnType<typeof spyOn>
 let mockGetMessage: ReturnType<typeof spyOn>
 let mockDeleteMessage: ReturnType<typeof spyOn>
 let mockEditMessage: ReturnType<typeof spyOn>
+let mockSetTyping: ReturnType<typeof spyOn>
 let mockLogin: ReturnType<typeof spyOn>
 let mockDispose: ReturnType<typeof spyOn>
 let consoleLogSpy: ReturnType<typeof spyOn>
@@ -69,6 +70,7 @@ beforeEach(() => {
   mockGetMessage = protoSpy('getMessage').mockResolvedValue(mockMessage)
   mockDeleteMessage = protoSpy('deleteMessage').mockResolvedValue(undefined)
   mockEditMessage = protoSpy('editMessage').mockResolvedValue({ ...mockMessage, text: 'Updated message' })
+  mockSetTyping = protoSpy('setTyping').mockResolvedValue(undefined)
 
   consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
   consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
@@ -204,4 +206,30 @@ it('passes markdown option to editMessage when --markdown flag is set', async ()
   expect(mockEditMessage).toHaveBeenCalledWith('msg_123', 'space_456', '**updated**', {
     markdown: true,
   })
+})
+
+it('calls setTyping with start-typing by default and outputs result', async () => {
+  await typingAction('space_456', { pretty: false })
+
+  expect(mockSetTyping).toHaveBeenCalledWith('space_456', true)
+  expect(consoleLogSpy).toHaveBeenCalled()
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output).toEqual({ spaceId: 'space_456', typing: true })
+  expect(mockDispose).toHaveBeenCalled()
+})
+
+it('calls setTyping with stop-typing when --stop flag is set', async () => {
+  await typingAction('space_456', { stop: true, pretty: false })
+
+  expect(mockSetTyping).toHaveBeenCalledWith('space_456', false)
+  const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string)
+  expect(output).toEqual({ spaceId: 'space_456', typing: false })
+})
+
+it('disposes the client when setTyping fails', async () => {
+  mockSetTyping.mockRejectedValue(new WebexError('Typing failed', 'unsupported'))
+
+  await typingAction('space_456', { pretty: false })
+
+  expect(mockDispose).toHaveBeenCalled()
 })

--- a/src/platforms/webex/commands/message.ts
+++ b/src/platforms/webex/commands/message.ts
@@ -116,6 +116,16 @@ export async function dmAction(
   }
 }
 
+export async function typingAction(spaceId: string, options: { stop?: boolean; pretty?: boolean }): Promise<void> {
+  try {
+    await withWebexClient((client) => client.setTyping(spaceId, !options.stop))
+
+    console.log(formatOutput({ spaceId, typing: !options.stop }, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export const messageCommand = new Command('message')
   .description('Message commands')
   .addCommand(
@@ -173,4 +183,12 @@ export const messageCommand = new Command('message')
       .option('--markdown', 'Send as markdown')
       .option('--pretty', 'Pretty print JSON output')
       .action(editAction),
+  )
+  .addCommand(
+    new Command('typing')
+      .description('Send a typing indicator to a space')
+      .argument('<space-id>', 'Space/Room ID')
+      .option('--stop', 'Send stop-typing instead of start-typing')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(typingAction),
   )


### PR DESCRIPTION
## Summary

Adds support for sending Webex **typing indicators** ("…is typing").

Webex does not expose typing indicators through its public REST API (`webexapis.com`). The web client sends them over the **internal conversation service (convd)** — the same internal API this client already uses for end-to-end-encrypted messages. This PR reuses that existing transport to send a typing event.

Reverse-engineered from the official `@webex/internal-plugin-conversation` SDK (`updateTypingStatus`): a plain HTTP `POST` to `/conversations/{uuid}/status/typing` with a `status.start_typing` / `status.stop_typing` event, returning `204 No Content`.

## Changes

- **`WebexClient.setTyping(roomId, typing = true)`** — POSTs a `status.start_typing` (or `status.stop_typing` when `typing` is `false`) event to the internal conversation endpoint, reusing the existing `internalRequest` transport (device URL + `cisco-device-url` header).
- **CLI**: `agent-webex message typing <space-id>` (and `--stop` to clear), following the existing `message` subcommand patterns.
- **Docs**: documented the new command and its token requirement in `skills/agent-webex/SKILL.md`.
- **Tests**: start/stop typing over the internal API, and rejection for non-internal (public/bot/OAuth) tokens.

## Token requirement

Typing requires an **extracted (browser)** or **password** token, which carry a device URL. Bot and OAuth tokens have no device URL and cannot reach the internal conversation service, so `setTyping` throws a clear `WebexError` for them.

## Usage

```bash
# Show "…is typing" in a space
agent-webex message typing <space-id>

# Clear the typing indicator
agent-webex message typing <space-id> --stop
```

Note: the indicator is ephemeral and auto-expires server-side after a few seconds; callers that want a sustained indicator should re-send periodically and `--stop` when done.

## Verification

- `bun typecheck` — passes
- `bun lint` — 0 warnings, 0 errors
- `bun test src/platforms/webex/` — 366 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Webex typing indicators so spaces can show “…is typing”. Includes a new client method and a CLI command.

- **New Features**
  - Added `WebexClient.setTyping(roomId, typing = true)` that POSTs `status.start_typing` / `status.stop_typing` to `/conversations/{uuid}/status/typing` via the internal conversation service (per `@webex/internal-plugin-conversation` behavior).
  - CLI: `agent-webex message typing <space-id>` with `--stop` to clear.
  - Token requirement: only extracted/browser or password tokens with a device URL are supported; bot/OAuth tokens are rejected with a clear error.
  - Docs updated: `docs/cli/webex` and `docs/sdk/webex` pages, plus `skills/agent-webex/SKILL.md`, with command usage and token notes.

<sup>Written for commit 0ba41e80a382a99697831bf11d4472751ab4c214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

