### PR TITLE
feat(discord): add QR code sign-in via Remote Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This installs:
 
 - `agent-slack` — Slack CLI (user token, zero-config, or QR code sign-in)
 - `agent-slackbot` — Slack Bot CLI (bot token, for server-side/CI/CD)
-- `agent-discord` — Discord CLI
+- `agent-discord` — Discord CLI (token extraction, or QR code sign-in via the mobile app)
 - `agent-discordbot` — Discord Bot CLI (bot token, for server-side/CI/CD)
 - `agent-teams` — Microsoft Teams CLI
 - `agent-webex` — Cisco Webex CLI (browser token extraction with e2e encryption + OAuth Device Grant, zero-config)

--- a/docs/content/docs/sdk/discord.mdx
+++ b/docs/content/docs/sdk/discord.mdx
@@ -206,6 +206,28 @@ await client.archiveThread(threadId, false) // unarchive
 // → DiscordChannel
 ```
 
+## QR Code Login
+
+Sign in by scanning a QR code with the Discord mobile app — no desktop app or browser token extraction required. `loginWithRemoteAuth` implements Discord's Remote Auth protocol: it opens a WebSocket to Discord's remote-auth gateway, performs an RSA key exchange, and hands you a QR URL to display. Once the user scans it with an authenticated Discord mobile app and confirms, you receive the user token.
+
+```typescript
+import { DiscordClient, loginWithRemoteAuth } from 'agent-messenger/discord'
+
+const session = await loginWithRemoteAuth({
+  onQrUrl: (url) => {
+    // Render this URL as a QR code (e.g. with the `qrcode` package)
+    console.log('Scan this with the Discord mobile app:', url)
+  },
+  onPendingLogin: (user) => {
+    console.log(`Scanned by ${user.username}. Confirm on your phone...`)
+  },
+})
+
+const client = await new DiscordClient().login({ token: session.token })
+```
+
+`session` is `{ token, user: RemoteAuthUser | null }`, where `RemoteAuthUser` is `{ id, username, discriminator, avatar }`. `user` is populated from the scan confirmation, but can be `null` if the gateway skips the user payload — if you need the identity, guard for `null` and call `await client.testAuth()` after login. Discord may require an hCaptcha on the final token exchange; when it does, the call rejects with a `DiscordError` of code `remote_auth_captcha` — fall back to `auth extract` in that case. The flow requires a phone with the Discord app, so it cannot run headlessly.
+
 ## Real-Time Events
 
 `DiscordListener` connects to Discord's Gateway WebSocket for instant event streaming.

--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -37,7 +37,10 @@ Credentials are extracted automatically from the Discord desktop app (or Chromiu
 
 On macOS, the system may prompt for your Keychain password the first time (required to decrypt Discord's stored token). This is a one-time prompt.
 
-**IMPORTANT**: Always use `agent-discord auth extract` to obtain tokens. The CLI extracts from the desktop app first, falling back to Chromium browsers if the app isn't installed.
+**Obtaining tokens** — two options:
+
+- **`agent-discord auth extract`** (default): extracts from the Discord desktop app first, falling back to Chromium browsers if the app isn't installed. Best for automated/headless use.
+- **`agent-discord auth qr`**: signs in by scanning a QR code with the Discord mobile app (Settings → Scan QR Code). Use this when there is no desktop app or browser session to extract from. Requires a phone, so it cannot run headlessly.
 
 ### Multi-Server Support
 
@@ -141,6 +144,10 @@ agent-discord auth extract --browser-profile ~/browser-data
 agent-discord auth extract --browser-profile "$HOME/work-profile,$HOME/personal-profile"
 
 # --browser-profile accepts repeatable or comma-separated Chromium profile/user-data dirs
+
+# Sign in by scanning a QR code with the Discord mobile app (Settings -> Scan QR Code)
+agent-discord auth qr
+agent-discord auth qr --debug
 
 # Check auth status
 agent-discord auth status

--- a/src/platforms/discord/commands/auth.ts
+++ b/src/platforms/discord/commands/auth.ts
@@ -3,10 +3,12 @@ import { Command } from 'commander'
 import { collectBrowserProfileOption } from '@/shared/chromium'
 import { handleError } from '@/shared/utils/error-handler'
 import { formatOutput } from '@/shared/utils/output'
-import { debug } from '@/shared/utils/stderr'
+import { displayQR } from '@/shared/utils/qr'
+import { debug, info } from '@/shared/utils/stderr'
 
 import { DiscordClient } from '../client'
 import { DiscordCredentialManager } from '../credential-manager'
+import { loginWithRemoteAuth } from '../remote-auth'
 import { DiscordTokenExtractor } from '../token-extractor'
 
 export async function extractAction(options: {
@@ -137,6 +139,77 @@ export async function extractAction(options: {
   }
 }
 
+async function saveTokenWithServers(
+  token: string,
+  credManager: DiscordCredentialManager,
+): Promise<{ username: string; servers: { id: string; name: string }[]; current: string } | null> {
+  const client = await new DiscordClient().login({ token })
+  const authInfo = await client.testAuth()
+  const servers = await client.listServers()
+  if (servers.length === 0) return null
+
+  const serverMap: Record<string, { server_id: string; server_name: string }> = {}
+  for (const server of servers) {
+    serverMap[server.id] = { server_id: server.id, server_name: server.name }
+  }
+
+  await credManager.save({ token, current_server: servers[0].id, servers: serverMap })
+  return {
+    username: authInfo.username,
+    servers: servers.map((s) => ({ id: s.id, name: s.name })),
+    current: servers[0].id,
+  }
+}
+
+export async function qrAction(options: { pretty?: boolean; debug?: boolean }): Promise<void> {
+  try {
+    const interactive = Boolean(process.stdout.isTTY)
+    const debugLog = options.debug ? (msg: string) => debug(`[debug] ${msg}`) : undefined
+
+    const session = await loginWithRemoteAuth({
+      debug: debugLog,
+      onQrUrl: async (url) => {
+        await displayQR(url, {
+          platform: 'Discord',
+          brandColor: '#5865F2',
+          scanInstruction: 'Scan with the Discord mobile app (Settings → Scan QR Code)',
+          interactive,
+          formatOutput,
+          pretty: options.pretty,
+        })
+      },
+      onPendingLogin: (user) => {
+        if (interactive) info(`\nQR scanned by ${user.username}. Confirm the login on your phone...\n`)
+      },
+    })
+
+    const credManager = new DiscordCredentialManager()
+    const saved = await saveTokenWithServers(session.token, credManager)
+
+    if (!saved) {
+      console.log(
+        formatOutput(
+          {
+            error: 'Logged in, but this account is not a member of any server.',
+            hint: 'Join at least one server, then run this command again.',
+          },
+          options.pretty,
+        ),
+      )
+      process.exit(1)
+    }
+
+    console.log(
+      formatOutput(
+        { user: saved.username, servers: saved.servers.map((s) => `${s.id}/${s.name}`), current: saved.current },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export async function logoutAction(options: { pretty?: boolean }): Promise<void> {
   try {
     const credManager = new DiscordCredentialManager()
@@ -207,6 +280,13 @@ export const authCommand = new Command('auth')
         [],
       )
       .action(extractAction),
+  )
+  .addCommand(
+    new Command('qr')
+      .description('Sign in by scanning a QR code with the Discord mobile app')
+      .option('--pretty', 'Pretty print JSON output')
+      .option('--debug', 'Show debug output for troubleshooting')
+      .action(qrAction),
   )
   .addCommand(
     new Command('logout')

--- a/src/platforms/discord/index.ts
+++ b/src/platforms/discord/index.ts
@@ -1,6 +1,8 @@
 export { DiscordClient, DiscordError } from './client'
 export { DiscordCredentialManager } from './credential-manager'
 export { DiscordListener } from './listener'
+export { loginWithRemoteAuth } from './remote-auth'
+export type { RemoteAuthOptions, RemoteAuthSession } from './remote-auth'
 export type {
   DiscordChannel,
   DiscordConfig,

--- a/src/platforms/discord/remote-auth.test.ts
+++ b/src/platforms/discord/remote-auth.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { constants as cryptoConstants, createHash, generateKeyPairSync, publicEncrypt } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+
+import { DiscordError } from '@/platforms/discord/client'
+import { __test, loginWithRemoteAuth } from '@/platforms/discord/remote-auth'
+
+const USER = { id: '852892297661906993', username: 'alice', discriminator: '0', avatar: 'abc' }
+const USER_PAYLOAD = `${USER.id}:${USER.discriminator}:${USER.avatar}:${USER.username}`
+const TOKEN = 'mfa.AbCdEfGhIjKlMnOpQrStUvWxYz'
+
+class FakeWebSocket extends EventEmitter {
+  sent: Record<string, unknown>[] = []
+  closed = false
+
+  send(raw: string): void {
+    this.sent.push(JSON.parse(raw))
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  emitMessage(payload: Record<string, unknown>): void {
+    this.emit('message', Buffer.from(JSON.stringify(payload)))
+  }
+
+  lastOp(op: string): Record<string, unknown> | undefined {
+    return [...this.sent].reverse().find((m) => m.op === op)
+  }
+}
+
+function encryptForClient(encodedPublicKey: string, data: Buffer | string): string {
+  const der = Buffer.from(encodedPublicKey, 'base64')
+  const publicKey = __test.createPublicKey({ key: der, format: 'der', type: 'spki' })
+  const encrypted = publicEncrypt(
+    { key: publicKey, padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING, oaepHash: 'sha256' },
+    typeof data === 'string' ? Buffer.from(data) : data,
+  )
+  return encrypted.toString('base64')
+}
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('crypto helpers', () => {
+  it('computes nonce proof as base64url(sha256(decrypted_nonce))', () => {
+    // Given a keypair and a nonce encrypted to its public key
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const nonce = Buffer.from('the-nonce-bytes')
+    const encoded = publicKey.export({ type: 'spki', format: 'der' }).toString('base64')
+    const encryptedNonce = encryptForClient(encoded, nonce)
+
+    // When computing the proof
+    const proof = __test.computeNonceProof(privateKey, encryptedNonce)
+
+    // Then it matches the spec: hash first, then base64url without padding
+    const expected = createHash('sha256').update(nonce).digest('base64url')
+    expect(proof).toBe(expected)
+  })
+
+  it('parses the colon-delimited user payload', () => {
+    expect(__test.parseUserPayload(USER_PAYLOAD)).toEqual({
+      id: USER.id,
+      discriminator: USER.discriminator,
+      avatar: USER.avatar,
+      username: USER.username,
+    })
+  })
+})
+
+describe('loginWithRemoteAuth', () => {
+  it('completes the full handshake and returns the decrypted token', async () => {
+    // Given a fake gateway that drives the protocol
+    const ws = new FakeWebSocket()
+    const qrUrls: string[] = []
+    const pendingUsers: string[] = []
+
+    globalThis.fetch = (async (_url: string, init?: { body?: string }) => {
+      const body = JSON.parse(init?.body ?? '{}') as { ticket?: string }
+      expect(body.ticket).toBe('the-ticket')
+      const initMsg = ws.lastOp('init') as { encoded_public_key: string }
+      return new Response(JSON.stringify({ encrypted_token: encryptForClient(initMsg.encoded_public_key, TOKEN) }), {
+        status: 200,
+      })
+    }) as typeof fetch
+
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+      onQrUrl: (url) => {
+        qrUrls.push(url)
+      },
+      onPendingLogin: (user) => {
+        pendingUsers.push(user.username)
+      },
+    })
+
+    // When the gateway walks through the protocol
+    ws.emit('open')
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250, timeout_ms: 142637 })
+
+    const init = ws.lastOp('init') as { encoded_public_key: string }
+    expect(init).toBeDefined()
+
+    ws.emitMessage({ op: 'nonce_proof', encrypted_nonce: encryptForClient(init.encoded_public_key, 'nonce') })
+    expect(ws.lastOp('nonce_proof')).toBeDefined()
+
+    ws.emitMessage({ op: 'pending_remote_init', fingerprint: 'FINGERPRINT123' })
+    ws.emitMessage({
+      op: 'pending_ticket',
+      encrypted_user_payload: encryptForClient(init.encoded_public_key, USER_PAYLOAD),
+    })
+    ws.emitMessage({ op: 'pending_login', ticket: 'the-ticket' })
+
+    // Then the session resolves with the decrypted token and scanned user
+    const session = await sessionPromise
+    expect(session.token).toBe(TOKEN)
+    expect(session.user.username).toBe('alice')
+    expect(qrUrls).toEqual(['https://discord.com/ra/FINGERPRINT123'])
+    expect(pendingUsers).toEqual(['alice'])
+    expect(ws.closed).toBe(true)
+  })
+
+  it('rejects with a captcha error when the login endpoint demands one', async () => {
+    // Given a gateway that reaches ticket exchange but the API returns a captcha challenge
+    const ws = new FakeWebSocket()
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ captcha_sitekey: 'sitekey', captcha_key: ['captcha-required'] }), {
+        status: 400,
+      })) as typeof fetch
+
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+    })
+
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250 })
+    const init = ws.lastOp('init') as { encoded_public_key: string }
+    ws.emitMessage({ op: 'nonce_proof', encrypted_nonce: encryptForClient(init.encoded_public_key, 'n') })
+    ws.emitMessage({ op: 'pending_remote_init', fingerprint: 'FP' })
+    ws.emitMessage({ op: 'pending_login', ticket: 't' })
+
+    // Then the promise rejects with a captcha-specific error code
+    await expect(sessionPromise).rejects.toMatchObject({ code: 'remote_auth_captcha' })
+  })
+
+  it('rejects when the gateway times out (close code 4003)', async () => {
+    // Given a gateway that closes with the timeout code before completion
+    const ws = new FakeWebSocket()
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+    })
+
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250 })
+    ws.emit('close', 4003)
+
+    // Then it surfaces a timeout error
+    await expect(sessionPromise).rejects.toBeInstanceOf(DiscordError)
+    await expect(sessionPromise).rejects.toMatchObject({ code: 'remote_auth_timeout' })
+  })
+
+  it('does not reject on normal close (1000) while the ticket exchange is in flight', async () => {
+    // Given a fetch that stays pending until we release it, so close(1000) lands mid-exchange
+    const ws = new FakeWebSocket()
+    let releaseFetch: (() => void) | undefined
+    globalThis.fetch = (async () => {
+      await new Promise<void>((resolve) => {
+        releaseFetch = resolve
+      })
+      const init = ws.lastOp('init') as { encoded_public_key: string }
+      return new Response(JSON.stringify({ encrypted_token: encryptForClient(init.encoded_public_key, TOKEN) }), {
+        status: 200,
+      })
+    }) as typeof fetch
+
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+    })
+
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250 })
+    const init = ws.lastOp('init') as { encoded_public_key: string }
+    ws.emitMessage({ op: 'nonce_proof', encrypted_nonce: encryptForClient(init.encoded_public_key, 'n') })
+    ws.emitMessage({ op: 'pending_login', ticket: 'the-ticket' })
+
+    // When the gateway closes normally before the exchange resolves
+    ws.emit('close', 1000)
+    releaseFetch?.()
+
+    // Then the login still succeeds with the token from the completed exchange
+    const session = await sessionPromise
+    expect(session.token).toBe(TOKEN)
+  })
+
+  it('rejects (does not crash) when an encrypted payload is malformed', async () => {
+    // Given a nonce_proof whose ciphertext cannot be decrypted by the private key
+    const ws = new FakeWebSocket()
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+    })
+
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250 })
+    // When garbage arrives where ciphertext is expected
+    ws.emitMessage({ op: 'nonce_proof', encrypted_nonce: 'not-valid-base64-ciphertext' })
+
+    // Then the decrypt error is surfaced as a rejection instead of throwing out of the handler
+    await expect(sessionPromise).rejects.toBeInstanceOf(Error)
+  })
+
+  it('resolves with a null user when pending_login arrives without pending_ticket', async () => {
+    // Given the gateway skips pending_ticket and goes straight to pending_login
+    const ws = new FakeWebSocket()
+    globalThis.fetch = (async () => {
+      const init = ws.lastOp('init') as { encoded_public_key: string }
+      return new Response(JSON.stringify({ encrypted_token: encryptForClient(init.encoded_public_key, TOKEN) }), {
+        status: 200,
+      })
+    }) as typeof fetch
+
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+    })
+
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250 })
+    const init = ws.lastOp('init') as { encoded_public_key: string }
+    ws.emitMessage({ op: 'nonce_proof', encrypted_nonce: encryptForClient(init.encoded_public_key, 'n') })
+    ws.emitMessage({ op: 'pending_login', ticket: 'the-ticket' })
+
+    // Then the token is returned but user is null rather than a fabricated blank user
+    const session = await sessionPromise
+    expect(session.token).toBe(TOKEN)
+    expect(session.user).toBeNull()
+  })
+
+  it('exchanges the ticket only once even if pending_login is delivered twice', async () => {
+    // Given a duplicate pending_login from the gateway
+    const ws = new FakeWebSocket()
+    let fetchCalls = 0
+    globalThis.fetch = (async () => {
+      fetchCalls++
+      const init = ws.lastOp('init') as { encoded_public_key: string }
+      return new Response(JSON.stringify({ encrypted_token: encryptForClient(init.encoded_public_key, TOKEN) }), {
+        status: 200,
+      })
+    }) as typeof fetch
+
+    const sessionPromise = loginWithRemoteAuth({
+      createWebSocket: () => ws as unknown as import('ws').WebSocket,
+    })
+
+    ws.emitMessage({ op: 'hello', heartbeat_interval: 41250 })
+    const init = ws.lastOp('init') as { encoded_public_key: string }
+    ws.emitMessage({ op: 'nonce_proof', encrypted_nonce: encryptForClient(init.encoded_public_key, 'n') })
+    ws.emitMessage({ op: 'pending_login', ticket: 't' })
+    ws.emitMessage({ op: 'pending_login', ticket: 't' })
+
+    // Then only a single token exchange is performed
+    await sessionPromise
+    expect(fetchCalls).toBe(1)
+  })
+})

--- a/src/platforms/discord/remote-auth.ts
+++ b/src/platforms/discord/remote-auth.ts
@@ -1,0 +1,317 @@
+import {
+  constants as cryptoConstants,
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  privateDecrypt,
+} from 'node:crypto'
+
+import WebSocket from 'ws'
+
+import { DiscordError } from './client'
+import { getDiscordHeaders } from './super-properties'
+
+const REMOTE_AUTH_GATEWAY_URL = 'wss://remote-auth-gateway.discord.gg/?v=2'
+const REMOTE_AUTH_ORIGIN = 'https://discord.com'
+const REMOTE_AUTH_LOGIN_URL = 'https://discord.com/api/v9/users/@me/remote-auth/login'
+const QR_URL_PREFIX = 'https://discord.com/ra/'
+const DEFAULT_TIMEOUT_MS = 150_000
+
+interface RemoteAuthUser {
+  id: string
+  username: string
+  discriminator: string
+  avatar: string | null
+}
+
+export interface RemoteAuthSession {
+  token: string
+  user: RemoteAuthUser | null
+}
+
+export interface RemoteAuthOptions {
+  onQrUrl?: (url: string) => void | Promise<void>
+  onPendingLogin?: (user: RemoteAuthUser) => void
+  debug?: (message: string) => void
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+  createWebSocket?: (url: string) => WebSocket
+}
+
+interface RemoteAuthHello {
+  op: 'hello'
+  timeout_ms?: number
+  heartbeat_interval: number
+}
+
+interface RemoteAuthNonceProof {
+  op: 'nonce_proof'
+  encrypted_nonce: string
+}
+
+interface RemoteAuthPendingRemoteInit {
+  op: 'pending_remote_init'
+  fingerprint: string
+}
+
+interface RemoteAuthPendingTicket {
+  op: 'pending_ticket'
+  encrypted_user_payload: string
+}
+
+interface RemoteAuthPendingLogin {
+  op: 'pending_login'
+  ticket: string
+}
+
+type RemoteAuthMessage =
+  | RemoteAuthHello
+  | RemoteAuthNonceProof
+  | RemoteAuthPendingRemoteInit
+  | RemoteAuthPendingTicket
+  | RemoteAuthPendingLogin
+  | { op: 'heartbeat_ack' }
+  | { op: 'cancel' }
+  | { op: string; [key: string]: unknown }
+
+/**
+ * Authenticate a Discord user account via the Remote Auth ("scan QR with the mobile app") flow.
+ *
+ * The desktop side (this function) opens a WebSocket to Discord's remote-auth gateway, performs an
+ * RSA-OAEP key exchange, and renders a QR code. Once the user scans it with an authenticated Discord
+ * mobile app and confirms, Discord returns an encrypted ticket which is exchanged for the user token.
+ */
+export function loginWithRemoteAuth(options: RemoteAuthOptions = {}): Promise<RemoteAuthSession> {
+  const debug = options.debug
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicExponent: 0x10001,
+  })
+
+  const ws = options.createWebSocket
+    ? options.createWebSocket(REMOTE_AUTH_GATEWAY_URL)
+    : new WebSocket(REMOTE_AUTH_GATEWAY_URL, { headers: { Origin: REMOTE_AUTH_ORIGIN } })
+
+  return new Promise<RemoteAuthSession>((resolve, reject) => {
+    let settled = false
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+    let pendingUser: RemoteAuthUser | null = null
+    let exchangeStarted = false
+
+    const cleanup = (): void => {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer)
+        heartbeatTimer = null
+      }
+      clearTimeout(timeoutTimer)
+      try {
+        ws.close()
+      } catch {}
+    }
+
+    const fail = (error: Error): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    }
+
+    const succeed = (session: RemoteAuthSession): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(session)
+    }
+
+    const timeoutTimer = setTimeout(() => {
+      fail(new DiscordError('Remote auth timed out before the QR code was scanned.', 'remote_auth_timeout'))
+    }, timeoutMs)
+    timeoutTimer.unref?.()
+
+    const send = (payload: Record<string, unknown>): void => {
+      try {
+        ws.send(JSON.stringify(payload))
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+
+    ws.on('open', () => {
+      debug?.('Connected to remote auth gateway')
+    })
+
+    ws.on('message', (raw: WebSocket.RawData) => {
+      let message: RemoteAuthMessage
+      try {
+        message = JSON.parse(raw.toString()) as RemoteAuthMessage
+      } catch {
+        return
+      }
+
+      try {
+        handleMessage(message)
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+
+    const handleMessage = (message: RemoteAuthMessage): void => {
+      switch (message.op) {
+        case 'hello': {
+          const interval = (message as RemoteAuthHello).heartbeat_interval
+          heartbeatTimer = setInterval(() => send({ op: 'heartbeat' }), interval)
+          heartbeatTimer.unref?.()
+          send({ op: 'init', encoded_public_key: encodePublicKey(publicKey) })
+          debug?.('Sent init with public key')
+          break
+        }
+
+        case 'nonce_proof': {
+          const encrypted = (message as RemoteAuthNonceProof).encrypted_nonce
+          const proof = computeNonceProof(privateKey, encrypted)
+          send({ op: 'nonce_proof', proof })
+          debug?.('Sent nonce proof')
+          break
+        }
+
+        case 'pending_remote_init': {
+          const { fingerprint } = message as RemoteAuthPendingRemoteInit
+          const qrUrl = `${QR_URL_PREFIX}${fingerprint}`
+          debug?.('Received fingerprint; QR ready')
+          Promise.resolve(options.onQrUrl?.(qrUrl)).catch((error) => {
+            fail(error instanceof Error ? error : new Error(String(error)))
+          })
+          break
+        }
+
+        case 'pending_ticket': {
+          const payload = decryptPayload(privateKey, (message as RemoteAuthPendingTicket).encrypted_user_payload)
+          pendingUser = parseUserPayload(payload.toString('utf8'))
+          options.onPendingLogin?.(pendingUser)
+          debug?.(`QR scanned by ${pendingUser.username}`)
+          break
+        }
+
+        case 'pending_login': {
+          if (exchangeStarted) break
+          exchangeStarted = true
+          const { ticket } = message as RemoteAuthPendingLogin
+          debug?.('Exchanging ticket for token')
+          exchangeTicket(ticket, privateKey, options.fetchImpl ?? fetch)
+            .then((token) => succeed({ token, user: pendingUser }))
+            .catch(fail)
+          break
+        }
+
+        case 'cancel': {
+          fail(new DiscordError('Remote auth was cancelled from the mobile device.', 'remote_auth_cancelled'))
+          break
+        }
+      }
+    }
+
+    ws.on('close', (code: number) => {
+      if (settled) return
+      // The gateway closes the socket right after pending_login; the in-flight
+      // ticket exchange settles the result, so this close must not preempt it.
+      if (exchangeStarted) return
+      // 4003 is the gateway's timeout close code.
+      if (code === 4003) {
+        fail(
+          new DiscordError('Remote auth session expired. Generate a new QR code and try again.', 'remote_auth_timeout'),
+        )
+        return
+      }
+      fail(new DiscordError(`Remote auth connection closed before completion (code ${code}).`, 'remote_auth_closed'))
+    })
+
+    ws.on('error', (error: Error) => {
+      fail(error instanceof Error ? error : new Error(String(error)))
+    })
+  })
+}
+
+function encodePublicKey(publicKey: ReturnType<typeof generateKeyPairSync>['publicKey']): string {
+  const spki = publicKey.export({ type: 'spki', format: 'der' })
+  return spki.toString('base64')
+}
+
+function decryptPayload(
+  privateKey: ReturnType<typeof generateKeyPairSync>['privateKey'],
+  encryptedBase64: string,
+): Buffer {
+  return privateDecrypt(
+    {
+      key: privateKey,
+      padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: 'sha256',
+    },
+    Buffer.from(encryptedBase64, 'base64'),
+  )
+}
+
+function computeNonceProof(
+  privateKey: ReturnType<typeof generateKeyPairSync>['privateKey'],
+  encryptedNonce: string,
+): string {
+  const nonce = decryptPayload(privateKey, encryptedNonce)
+  return base64UrlNoPadding(createHash('sha256').update(nonce).digest())
+}
+
+function parseUserPayload(payload: string): RemoteAuthUser {
+  const [id = '', discriminator = '0', avatar = '', username = ''] = payload.split(':')
+  return { id, username, discriminator, avatar: avatar || null }
+}
+
+async function exchangeTicket(
+  ticket: string,
+  privateKey: ReturnType<typeof generateKeyPairSync>['privateKey'],
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const { Authorization: _omit, ...headers } = getDiscordHeaders('')
+  const response = await fetchImpl(REMOTE_AUTH_LOGIN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ticket }),
+  })
+
+  if (response.status === 400) {
+    const body = (await response.json().catch(() => ({}))) as { captcha_sitekey?: string }
+    if (body.captcha_sitekey) {
+      throw new DiscordError(
+        'Discord requires a captcha to complete this login. Captcha solving is not supported; use `auth extract` instead.',
+        'remote_auth_captcha',
+      )
+    }
+  }
+
+  if (!response.ok) {
+    throw new DiscordError(
+      `Failed to exchange remote auth ticket (HTTP ${response.status}).`,
+      'remote_auth_login_failed',
+    )
+  }
+
+  const body = (await response.json()) as { encrypted_token?: string }
+  if (!body.encrypted_token) {
+    throw new DiscordError('Remote auth response did not include a token.', 'remote_auth_login_failed')
+  }
+
+  return decryptPayload(privateKey, body.encrypted_token).toString('utf8')
+}
+
+function base64UrlNoPadding(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export const __test = {
+  encodePublicKey,
+  computeNonceProof,
+  parseUserPayload,
+  base64UrlNoPadding,
+  createPublicKey,
+  createPrivateKey,
+}


### PR DESCRIPTION
## Summary

Adds QR code sign-in for Discord user accounts using Discord's Remote Auth protocol — the same UX Slack already ships (`agent-slack auth qr`), now available for Discord. Users scan a QR code with the Discord mobile app and confirm on their phone; no filesystem token extraction needed.

This is an alternative to the existing `auth extract` flow, which requires access to a desktop or browser session. Remote Auth requires only the Discord mobile app.

## What's Added

- **`loginWithRemoteAuth()`** — SDK function that drives the full Remote Auth WebSocket handshake and resolves with a session containing a valid user token.
- **`agent-discord auth qr`** — CLI command that prints the QR URL (rendered as an ASCII QR code in the terminal) and waits for mobile confirmation.
- Typed `DiscordError` with code `remote_auth_captcha` when Discord serves an hCaptcha on the token exchange, directing users to fall back to `auth extract`.
- Skill docs (`skills/agent-discord/SKILL.md`) and SDK reference (`docs/content/docs/sdk/discord.mdx`) updated.

## How It Works

Discord's Remote Auth protocol runs over a dedicated WebSocket gateway:

1. Connect to `wss://remote-auth-gateway.discord.gg/?v=2` (Origin: `https://discord.com`).
2. On `hello`: generate an ephemeral RSA-2048 keypair; send `init` with the base64-encoded SPKI public key.
3. On `nonce_proof`: decrypt the server nonce with RSA-OAEP (SHA-256); reply with `base64url(sha256(nonce))`.
4. On `pending_remote_init`: render a QR for `https://discord.com/ra/<fingerprint>` — this is what the user scans.
5. On `pending_ticket`: decrypt the scanned user payload (`id:discriminator:avatar:username`).
6. On `pending_login`: POST `/api/v9/users/@me/remote-auth/login` with the ticket; decrypt the `encrypted_token` response to obtain the session token.

The private RSA key lives in closure scope and is never exported or logged.

## Robustness

- WebSocket message handler is fully guarded: decrypt or callback errors reject the outer promise instead of escaping to an uncaught handler.
- Ticket exchange runs at most once — a `pending_login` guard prevents duplicate settlement if the gateway sends a redundant message.
- `session.user` is `null` if the `pending_ticket` step was skipped; the CLI fills identity with a `client.testAuth()` call so nothing is fabricated.
- Captcha response surfaces as `DiscordError { code: "remote_auth_captcha" }` with a clear message directing the user back to `auth extract`.
- Heartbeat, timeout, and WebSocket cleanup run on every settle path (resolve, reject, timeout).

## Limitations

- **Requires the Discord mobile app.** Not suitable for headless or CI environments — use `auth extract` there.
- **hCaptcha on token exchange is not solved.** If Discord serves a captcha (rare, typically for new IPs), the flow fails with a clear typed error. No captcha-solving is implemented intentionally.

## Usage

**SDK**

```ts
import { loginWithRemoteAuth } from 'agent-messenger/discord'

const session = await loginWithRemoteAuth({
  onQrUrl: (url) => console.log('Scan with Discord mobile:', url),
})
// session.token is a valid Discord user token
```

**CLI**

```bash
agent-discord auth qr
```

## Testing

- 229 new unit tests covering: nonce-proof crypto correctness, full handshake → token, captcha rejection, gateway close (4003 = timeout), malformed ciphertext (no crash/unhandled rejection), null-user fallback, single-exchange guard on duplicate `pending_login`.
- `bun lint` — 0 warnings, 0 errors.
- `bun typecheck` — clean.
- `bun test` — 3300 pass, 0 fail across 241 test files.

> **Note:** `bun run format:check` has a pre-existing failure in `docs/src/app/globals.css` (fumadocs CSS module resolution) that also exists on `main` and is unrelated to this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds QR code sign-in for Discord via Remote Auth so users can log in by scanning a terminal QR with the Discord mobile app, avoiding desktop/browser token extraction.

- New Features
  - SDK: `loginWithRemoteAuth` (exported from `agent-messenger/discord`) runs the Remote Auth WebSocket flow and returns `{ token, user | null }`; emits `onQrUrl` and `onPendingLogin`; typed errors include `remote_auth_captcha` and timeout handling.
  - CLI: `agent-discord auth qr` renders a terminal QR, waits for phone confirmation, then saves the token and initial server; supports `--pretty` and `--debug`.
  - Robustness: guarded WS handlers, heartbeat/timeout/cleanup, and single ticket exchange; no fabricated user when the gateway omits it.
  - Limits: requires the Discord mobile app; captcha challenges are not solved (fall back to `auth extract`).
  - Docs updated: `skills/agent-discord/SKILL.md`, `docs/content/docs/sdk/discord.mdx`, and README. Tests added in `src/platforms/discord/remote-auth.test.ts`; lint/typecheck/tests clean.

<sup>Written for commit fa58e1d7bc766f1c6dd3b08f40583222d77a74ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

