### PR TITLE
docs: recommend QR sign-in for Slack and Discord

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -24,6 +24,7 @@ Or within Claude Code:
 Enables AI agents to interact with messaging platforms through CLI interfaces:
 
 ### Slack (`agent-slack`)
+- **QR code sign-in** — recommended, safest auth (no credential extraction)
 - **Send messages** to channels and threads
 - **Read channels** and message history
 - **Manage reactions** (add/remove/list)
@@ -46,6 +47,7 @@ Enables AI agents to interact with messaging platforms through CLI interfaces:
 - Designed for **server-side and CI/CD** use cases
 
 ### Discord (`agent-discord`)
+- **QR code sign-in** — recommended, scan with the mobile app (no credential extraction)
 - **Send messages** to channels
 - **Read channels** and message history
 - **Manage reactions** (add/remove/list)
@@ -141,7 +143,19 @@ Enables AI agents to interact with messaging platforms through CLI interfaces:
 
 ### Zero-Config Authentication
 
-Credentials are automatically extracted from your desktop apps on first command — no manual auth step needed. You can also extract manually:
+Credentials are automatically extracted from your desktop apps on first command — no manual auth step needed. You can also authenticate manually.
+
+For **Slack and Discord, QR code sign-in is the recommended method** — it's the safest and most reliable option because it authenticates through the platform's own login flow instead of reading credentials off disk, and it works without a desktop app or browser:
+
+```bash
+# Slack — paste the QR from "Sign in on mobile" (recommended)
+pbpaste | agent-slack auth qr
+
+# Discord — scan the QR with the Discord mobile app (recommended)
+agent-discord auth qr
+```
+
+Or extract credentials directly from your desktop apps / browsers:
 
 ```bash
 # Slack
@@ -174,7 +188,7 @@ All commands output JSON by default for easy AI consumption. Use `--pretty` for 
 
 ## Requirements
 
-- Desktop app installed and logged in for the platform(s) you want to use (Slack, Discord, Teams, KakaoTalk, and/or Channel Talk). Instagram uses username/password auth
+- Desktop app installed and logged in for the platform(s) you want to use (Slack, Discord, Teams, KakaoTalk, and/or Channel Talk). For Slack and Discord, QR code sign-in is the recommended alternative — no desktop app required (Discord needs the mobile app to scan). Instagram uses username/password auth
 - For Telegram: TDLib is bundled; API credentials are auto-provisioned on first login
 - Node.js 18+ or Bun runtime
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Every platform gates API access behind OAuth apps that need admin approval — d
 
 Agent Messenger reads session tokens from your Slack, Discord, Teams, KakaoTalk, or Channel Talk desktop app — zero config. If the desktop app isn't installed, it falls back to extracting from Chromium browsers, with `auth extract --browser-profile <path>` for custom Chromium profile locations. Webex and Instagram tokens are extracted directly from browsers. Telegram authenticates with a one-time phone code, and WhatsApp with a QR code or pairing code. Either way, your agent operates **as you** — same name, same permissions, same context. Bot tokens are fully supported too for server-side and CI/CD use cases.
 
+> [!TIP]
+> **For Slack and Discord, QR code sign-in (`auth qr`) is the recommended way to authenticate** — it's the safest and most reliable method. It signs you in through the platform's own login flow instead of reading credentials off disk, and works even without the desktop app. See the [Slack](skills/agent-slack/references/authentication.md) and [Discord](skills/agent-discord/references/authentication.md) auth guides.
+
+- **QR Code Sign-In (Slack & Discord)** — The recommended, safest auth: sign in through the platform's official flow, no credential extraction and no desktop app required (Discord scans with the mobile app)
 - **Auto-Extract Auth** — Reads tokens from Slack, Discord, Teams, KakaoTalk, and Channel Talk desktop apps, with browser fallback and custom Chromium profile paths via `--browser-profile`. Webex and Instagram tokens extracted from Chromium browsers. Telegram and WhatsApp authenticate with a one-time code — still under a minute
 - **Act As Yourself** — Extracts your user session — not a bot token. Your agent sends messages, reacts, and searches as you. Need bot mode? Bot CLIs are included too
 - **One Interface** — Consistent command style across 7 platforms for supported actions (e.g. message send, message search, channel list, snapshot). Learn once
@@ -134,6 +138,13 @@ agent-slack message send general "Hello from the CLI!"
 ```
 
 That's it. Credentials are extracted automatically from your Slack desktop app on first run. No OAuth flows. No API tokens. No configuration files.
+
+> **No desktop app?** QR code sign-in is the recommended way to authenticate Slack and Discord. In Slack, open "Sign in on mobile", copy the QR image, and pipe it in; in Discord, scan the printed QR with the mobile app:
+>
+> ```bash
+> pbpaste | agent-slack auth qr   # paste Slack's "Sign in on mobile" QR
+> agent-discord auth qr           # scan the printed QR with the Discord app
+> ```
 
 ### Custom config directory
 
@@ -227,6 +238,22 @@ import { loginWithQr, SlackClient } from 'agent-messenger/slack'
 
 const session = await loginWithQr(dataUrl)
 const client = await new SlackClient().login({ token: session.token, cookie: session.cookie })
+```
+
+### QR Code Login (Discord)
+
+Sign in by scanning a QR code with the Discord mobile app — no desktop app or browser token extraction required. `loginWithRemoteAuth` runs Discord's Remote Auth protocol and hands you a QR URL to display; once the user scans and confirms on their phone, you receive the user token.
+
+```typescript
+import { DiscordClient, loginWithRemoteAuth } from 'agent-messenger/discord'
+
+const session = await loginWithRemoteAuth({
+  onQrUrl: (url) => {
+    // Render this URL as a QR code (e.g. with the `qrcode` package)
+    console.log('Scan this with the Discord mobile app:', url)
+  },
+})
+const client = await new DiscordClient().login({ token: session.token })
 ```
 
 ### Real-time Events (Slack)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,7 +41,7 @@ Before running E2E tests, you need:
 
 ## Running E2E Tests Locally
 
-### Step 1: Extract Credentials
+### Step 1: Authenticate
 
 First, make sure the desktop apps (Slack/Discord) are running and logged into your **test** workspaces.
 
@@ -55,6 +55,8 @@ agent-discord auth extract
 # Extract Teams credentials
 agent-teams auth extract
 ```
+
+> For local runs you can also use QR code sign-in for the **test** accounts (`agent-slack auth qr` / `agent-discord auth qr`) instead of extraction — it's the recommended auth method and doesn't require the desktop app. CI uses the environment variables below (extracted token/cookie values), since QR sign-in is interactive.
 
 ### Step 2: Switch to Test Workspace
 

--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -39,8 +39,20 @@ On macOS, the system may prompt for your Keychain password the first time (requi
 
 **Obtaining tokens** — two options:
 
-- **`agent-discord auth extract`** (default): extracts from the Discord desktop app first, falling back to Chromium browsers if the app isn't installed. Best for automated/headless use.
-- **`agent-discord auth qr`**: signs in by scanning a QR code with the Discord mobile app (Settings → Scan QR Code). Use this when there is no desktop app or browser session to extract from. Requires a phone, so it cannot run headlessly.
+- **`agent-discord auth qr` — recommended**: signs in by scanning a QR code with the Discord mobile app (Settings → Scan QR Code). This is the safest and most reliable method — it authenticates through Discord's official Remote Auth flow instead of reading credentials off disk, and needs no desktop app or browser. Requires a phone to scan, so it cannot run headlessly.
+- **`agent-discord auth extract`**: extracts from the Discord desktop app first, falling back to Chromium browsers if the app isn't installed. Best for automated/headless use where no phone is available to scan.
+
+### QR Code Sign-In (Recommended)
+
+```bash
+# Generate a QR code and wait for you to scan it with the Discord mobile app
+agent-discord auth qr
+
+# Show protocol details while debugging
+agent-discord auth qr --debug
+```
+
+Open the Discord mobile app → **Settings → Scan QR Code**, scan the printed code, and confirm on your phone. The token (plus all discovered servers) is validated and stored like `auth extract`. The QR code expires after ~150 seconds — re-run the command to generate a fresh one. See [references/authentication.md](references/authentication.md) for the full flow.
 
 ### Multi-Server Support
 
@@ -418,7 +430,7 @@ All commands return consistent error format:
 
 Common errors:
 
-- `Not authenticated`: No valid token (auto-extraction failed — see Troubleshooting)
+- `Not authenticated`: No valid token (auto-extraction failed — run `auth qr` to sign in, or see Troubleshooting)
 - `No current server set`: Run `server switch <id>` first
 - `Message not found`: Invalid message ID
 - `Unknown Channel`: Invalid channel ID
@@ -451,6 +463,25 @@ if (!token) {
 }
 const client = await new DiscordClient().login({ token })
 ```
+
+### QR Code Login (Recommended)
+
+`loginWithRemoteAuth` signs in by scanning a QR code with the Discord mobile app — no desktop app or token extraction required. It runs Discord's Remote Auth protocol and hands you a QR URL to display; once the user scans and confirms on their phone, you receive the user token.
+
+```typescript
+import { DiscordClient, loginWithRemoteAuth } from 'agent-messenger/discord'
+
+const session = await loginWithRemoteAuth({
+  onQrUrl: (url) => {
+    // Render this URL as a QR code (e.g. with the `qrcode` package)
+    console.log('Scan this with the Discord mobile app:', url)
+  },
+})
+
+const client = await new DiscordClient().login({ token: session.token })
+```
+
+`session` is `{ token, user }`, where `user` may be `null` if the gateway skips the user payload — call `await client.testAuth()` after login if you need the identity. If Discord requires a captcha on the final token exchange, the call rejects with a `DiscordError` of code `remote_auth_captcha`; fall back to `auth extract` in that case. Requires a phone with the Discord app, so it cannot run headlessly.
 
 ### Example
 

--- a/skills/agent-discord/references/authentication.md
+++ b/skills/agent-discord/references/authentication.md
@@ -2,7 +2,40 @@
 
 ## Overview
 
-agent-discord uses Discord's user token extracted from the Discord desktop application, with automatic fallback to Chromium browser profiles (Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium) when the desktop app isn't installed.
+agent-discord supports two ways to authenticate:
+
+- **QR code sign-in (`auth qr`) — recommended.** Scan a QR code with the Discord mobile app to sign in through Discord's own Remote Auth flow. This is the safest and most reliable method: it never reads stored credentials off disk, works without a desktop app or browser, and uses Discord's official login confirmation on your phone.
+- **Token extraction (`auth extract`).** Reads Discord's user token from the desktop application, with automatic fallback to Chromium browser profiles (Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium). Best for automated/headless environments where no phone is available to scan.
+
+> **Recommendation:** Prefer `agent-discord auth qr` whenever you can scan a QR code. Use `auth extract` for headless/CI setups where interactive scanning isn't possible.
+
+## QR Code Sign-In (Recommended)
+
+Sign in by scanning a QR code with the Discord mobile app — no desktop app or browser token extraction required. This runs Discord's official Remote Auth protocol, so you authenticate through Discord's own login confirmation rather than by reading stored credentials.
+
+```bash
+# Generate a QR code and wait for you to scan it
+agent-discord auth qr
+
+# Show protocol details while debugging
+agent-discord auth qr --debug
+
+# Human-readable output
+agent-discord auth qr --pretty
+```
+
+How it works:
+
+1. Opens a WebSocket to Discord's remote-auth gateway and performs an RSA key exchange
+2. Renders a QR code in your terminal (and opens it in the browser as a fallback)
+3. You scan it with the Discord mobile app: **Settings → Scan QR Code**, then confirm on your phone
+4. Discord returns an encrypted ticket, which is exchanged for your user token, validated, and stored like `auth extract` — along with all discovered servers
+
+Notes:
+
+- **Requires the Discord mobile app** (logged in) to scan. Because it's interactive, it cannot run headlessly — use `auth extract` for CI.
+- The QR code expires after about 150 seconds. Re-run `agent-discord auth qr` to generate a fresh one.
+- If Discord presents a captcha challenge during the token exchange, the CLI surfaces a typed error directing you to fall back to `auth extract`.
 
 ## Token Extraction
 
@@ -186,7 +219,10 @@ Discord user tokens can be invalidated when:
 If commands start failing with auth errors:
 
 ```bash
-# Re-extract credentials
+# Recommended: re-authenticate with a QR code
+agent-discord auth qr
+
+# Or re-extract credentials from the desktop app / browser
 agent-discord auth extract
 
 # Verify it worked
@@ -216,8 +252,9 @@ This shows:
 
 **Solution**:
 
-1. Log in to discord.com in a Chromium browser (Chrome, Edge, Arc, Brave) — the CLI will extract from browser automatically
-2. Or install the Discord desktop app, log in, and run `agent-discord auth extract` again
+1. Recommended: run `agent-discord auth qr` and scan the QR code with the Discord mobile app — no desktop app or browser required
+2. Or log in to discord.com in a Chromium browser (Chrome, Edge, Arc, Brave) — the CLI will extract from browser automatically
+3. Or install the Discord desktop app, log in, and run `agent-discord auth extract` again
 
 ### "No Discord token found"
 
@@ -275,10 +312,11 @@ With extracted credentials, agent-discord has the same permissions as you in Dis
 
 ### Best Practices
 
-1. **Protect credentials.json**: Never commit to version control
-2. **Use server switching**: Keep different contexts separate
-3. **Re-extract periodically**: Keep tokens fresh
-4. **Revoke if compromised**: Change your Discord password to invalidate tokens
+1. **Prefer QR sign-in**: Use `auth qr` when possible — it authenticates through Discord's official flow instead of reading credentials off disk
+2. **Protect credentials.json**: Never commit to version control
+3. **Use server switching**: Keep different contexts separate
+4. **Re-authenticate periodically**: Keep tokens fresh
+5. **Revoke if compromised**: Change your Discord password to invalidate tokens
 
 ## Manual Token Management (Advanced)
 

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -37,11 +37,14 @@ Credentials are extracted automatically from the Slack desktop app (or Chromium 
 
 On macOS, the system may prompt for your Keychain password the first time (required to decrypt Slack's stored token). This is a one-time prompt.
 
-**IMPORTANT**: Always use `agent-slack auth extract` to obtain tokens. The CLI extracts from the desktop app first, falling back to Chromium browsers if the app isn't installed.
+**Two ways to obtain tokens:**
 
-### QR Code Sign-In (No Desktop App Required)
+- **`agent-slack auth qr` — recommended.** Sign in with a QR code from Slack's "Sign in on mobile" screen. It's the safest and most reliable method: it authenticates through Slack's own login flow over plain HTTP instead of reading credentials off disk, and needs no desktop app or browser.
+- **`agent-slack auth extract`.** Extracts tokens from the Slack desktop app first, falling back to Chromium browsers if the app isn't installed. Best for automated/headless environments.
 
-If the Slack desktop app isn't installed (or extraction fails), you can sign in with a QR code from any device where you're already logged into Slack — no browser automation, fully over HTTP:
+### QR Code Sign-In (Recommended)
+
+Sign in with a QR code from any device where you're already logged into Slack — no desktop app, no browser automation, fully over HTTP:
 
 ```bash
 # In Slack (desktop or web): your name (top-left) → "Sign in on mobile".

--- a/skills/agent-slack/references/authentication.md
+++ b/skills/agent-slack/references/authentication.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-agent-slack uses Slack's web client credentials (xoxc token + xoxd cookie) extracted from the Slack desktop application, with automatic fallback to Chromium browser profiles (Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium) when the desktop app isn't installed.
+agent-slack supports two ways to authenticate:
+
+- **QR code sign-in (`auth qr`) — recommended.** Sign in with a QR code from Slack's "Sign in on mobile" screen. This is the safest and most reliable method: it authenticates through Slack's own login flow over plain HTTP instead of reading stored credentials off disk, and works without a desktop app or browser.
+- **Token extraction (`auth extract`).** Reads Slack's web client credentials (xoxc token + xoxd cookie) from the desktop application, with automatic fallback to Chromium browser profiles (Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium). Best for automated/headless environments.
+
+> **Recommendation:** Prefer `agent-slack auth qr`. Use `auth extract` for headless/CI setups or when you'd rather reuse an existing desktop/browser session.
 
 ## Token Extraction
 
@@ -34,9 +39,9 @@ This command:
 
 Use `--browser-profile <path>` for agent-browser profiles, custom Chrome user data dirs, or portable browser profiles. The option can be repeated or given comma-separated paths, and explicit paths are included even when desktop credentials are also present.
 
-### QR Code Sign-In
+### QR Code Sign-In (Recommended)
 
-When the desktop app isn't installed and browser extraction isn't an option, you can sign in with a QR code from a device where you're already logged into Slack. This runs entirely over HTTP — no browser automation:
+The recommended way to authenticate: sign in with a QR code from a device where you're already logged into Slack. This runs entirely over HTTP — no browser automation, and no desktop app required:
 
 ```bash
 # In Slack (desktop or web): your name (top-left) → "Sign in on mobile".


### PR DESCRIPTION
## Summary

QR code sign-in (`auth qr`) was added for Slack and Discord in prior PRs. This PR positions it as the **recommended** authentication method across all related docs — skills, READMEs, SDK reference, and e2e guide. Docs-only change; no source code or behavior changes.

The core motivation: QR sign-in authenticates through each platform's own login flow rather than reading stored credentials off disk, making it the safer and more reliable default for anyone with a phone available. Headless/CI environments (where interactive scanning isn't possible) still use `auth extract`.

## What Changed

| File | What was updated |
|------|-----------------|
| skills/agent-discord/references/authentication.md | **Biggest gap filled.** Added a full "QR Code Sign-In (Recommended)" section that was entirely absent: overview reframed to two methods, how-it-works steps, notes, re-auth path, troubleshooting entry, and best-practices bullet. |
| skills/agent-discord/SKILL.md | Expanded the one-line QR mention into a recommended subsection; added an SDK `loginWithRemoteAuth` example; updated the "Not authenticated" error hint. |
| skills/agent-slack/references/authentication.md | Overview reframed from "extraction only" to two methods with QR recommended; QR section header updated to "(Recommended)". |
| skills/agent-slack/SKILL.md | Replaced the "always use auth extract" note with a two-method summary that leads with QR; section header updated to "(Recommended)". |
| README.md | Added a `[!TIP]` callout and Quick Start note; added a Discord SDK "QR Code Login" section (Slack already had one). |
| .claude-plugin/README.md | Added QR sign-in to Zero-Config Authentication, the Slack/Discord feature bullets, and Requirements. |
| e2e/README.md | Noted QR sign-in as an auth option for local test accounts; clarified that CI uses extracted-token env vars since QR is interactive. |

## Notes for Reviewers

- **Docs only.** No production source files were modified.
- The Discord SDK example uses the real `loginWithRemoteAuth` API surface.
  It matches `src/platforms/discord/remote-auth.ts`:
  - Emits an `onQrUrl` callback with the scannable URL.
  - Resolves to a session object where the user field may be null.
  - Rejects with a `remote_auth_captcha` error if Discord presents a captcha.
- Framing is intentionally consistent across all files:
  - QR = recommended / safest / most reliable — appropriate for anyone with a phone.
  - `auth extract` = best for headless/CI where interactive scanning isn't possible.
  - Slack QR is pure HTTP (no app needed). Discord QR requires the mobile app to scan; it cannot run headlessly.
- Bot variants (agent-slackbot, agent-discordbot) are intentionally untouched — QR login does not apply to bot tokens.

## Verification

| Check | Result |
|-------|--------|
| `bun lint` | ✅ 0 warnings, 0 errors |
| `bun typecheck` | ✅ pass |
| `bun test` | ✅ 3301 tests, 0 fail |
| `bun run format:check` | ⚠️ Pre-existing failure on main (Tailwind CSS resolution in docs/src/app/globals.css); none of the 7 changed files are formatter-checked (oxfmt ignores markdown and .claude-plugin). |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make QR code sign-in (`auth qr`) the recommended authentication for Slack and Discord across the docs. Docs-only change; updated SKILL.md, auth guides, and READMEs; `auth extract` remains for headless/CI.

- **Docs**
  - Discord: added “QR Code Sign-In (Recommended)” to `references/authentication.md`; recommended QR in `SKILL.md`; added SDK `loginWithRemoteAuth` example and improved “Not authenticated” hint
  - Slack: reframed auth to two methods with QR as recommended in `SKILL.md` and `references/authentication.md`; expanded QR section
  - README: added QR sign-in tip and a Discord SDK “QR Code Login” example
  - `.claude-plugin/README.md`: added QR sign-in to features, Zero-Config Authentication, and Requirements
  - `e2e/README.md`: noted QR sign-in for local tests; CI stays on extracted env vars

<sup>Written for commit cf847e52803b819c61b6d486014dec144e4b9bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

