### PR TITLE
fix(discord): deliver gateway events to user-token listeners

### DIFF
--- a/docs/content/docs/sdk/discord.mdx
+++ b/docs/content/docs/sdk/discord.mdx
@@ -257,15 +257,7 @@ await listener.start() // connects via Gateway WebSocket
 // listener.stop()      // clean shutdown
 ```
 
-Custom intents (default includes non-privileged message/reaction/typing intents — add `MessageContent` to read message text):
-
-```typescript
-import { DiscordIntent } from 'agent-messenger/discord'
-
-const listener = new DiscordListener(client, {
-  intents: DiscordIntent.Guilds | DiscordIntent.GuildMessages | DiscordIntent.MessageContent, // MessageContent is privileged
-})
-```
+The user-account listener does not take intents — Gateway intents are a bot concept. It identifies as a user session and automatically receives full message content (including other users' messages), so no configuration is required.
 
 ### Available Events
 

--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -509,12 +509,10 @@ await client.sendMessage(thread.id, 'First message in thread')
 `DiscordListener` connects to Discord's Gateway WebSocket for instant event streaming:
 
 ```typescript
-import { DiscordClient, DiscordListener, DiscordIntent } from 'agent-messenger/discord'
+import { DiscordClient, DiscordListener } from 'agent-messenger/discord'
 
 const client = await new DiscordClient().login()
-const listener = new DiscordListener(client, {
-  intents: DiscordIntent.Guilds | DiscordIntent.GuildMessages | DiscordIntent.MessageContent,
-})
+const listener = new DiscordListener(client)
 
 listener.on('message_create', (event) => {
   console.log(`${event.author.username}: ${event.content}`)

--- a/src/platforms/discord/listener.test.ts
+++ b/src/platforms/discord/listener.test.ts
@@ -171,7 +171,7 @@ describe('DiscordListener', () => {
       expect(identifyMsg.d.token).toBe('fake-token')
     })
 
-    it('sends a user-account Identify without bot intents', async () => {
+    it('sends a user-account Identify with the load-bearing default shape', async () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
@@ -183,11 +183,16 @@ describe('DiscordListener', () => {
       const identifyMsg = sentMessages.find((m) => m.op === 2)
 
       expect(identifyMsg).toBeDefined()
-      expect(identifyMsg.d.intents).toBeUndefined()
-      expect(typeof identifyMsg.d.capabilities).toBe('number')
-      expect(identifyMsg.d.capabilities).toBeGreaterThan(0)
+      expect(identifyMsg.d.capabilities).toBe(16381)
       expect(identifyMsg.d.client_state).toEqual({ guild_versions: {} })
+      expect(identifyMsg.d.compress).toBe(false)
+      expect(identifyMsg.d.presence).toEqual({ status: 'online', since: 0, activities: [], afk: false })
       expect(identifyMsg.d.properties.browser).toBe('Chrome')
+      expect(identifyMsg.d.properties.client_build_number).toBe(648814)
+
+      // All intents incl. MESSAGE_CONTENT (1<<15); user sessions blank other users' content without it
+      expect(identifyMsg.d.intents).toBe(33_554_431)
+      expect(identifyMsg.d.intents & (1 << 15)).toBe(1 << 15)
     })
   })
 

--- a/src/platforms/discord/listener.test.ts
+++ b/src/platforms/discord/listener.test.ts
@@ -171,10 +171,9 @@ describe('DiscordListener', () => {
       expect(identifyMsg.d.token).toBe('fake-token')
     })
 
-    it('sends Identify with custom intents', async () => {
+    it('sends a user-account Identify without bot intents', async () => {
       const client = createMockClient()
-      const customIntents = 1 << 9
-      listener = new DiscordListener(client, { intents: customIntents })
+      listener = new DiscordListener(client)
 
       await listener.start()
       mockWsInstance.simulateOpen()
@@ -184,7 +183,11 @@ describe('DiscordListener', () => {
       const identifyMsg = sentMessages.find((m) => m.op === 2)
 
       expect(identifyMsg).toBeDefined()
-      expect(identifyMsg.d.intents).toBe(customIntents)
+      expect(identifyMsg.d.intents).toBeUndefined()
+      expect(typeof identifyMsg.d.capabilities).toBe('number')
+      expect(identifyMsg.d.capabilities).toBeGreaterThan(0)
+      expect(identifyMsg.d.client_state).toEqual({ guild_versions: {} })
+      expect(identifyMsg.d.properties.browser).toBe('Chrome')
     })
   })
 

--- a/src/platforms/discord/listener.ts
+++ b/src/platforms/discord/listener.ts
@@ -13,11 +13,14 @@ const RECONNECT_MAX_DELAY = 30_000
 const NON_RECOVERABLE_CLOSE_CODES = [4004, 4010, 4011, 4012, 4013, 4014]
 const SESSION_RESET_CLOSE_CODES = [4007, 4009]
 
-// User (non-bot) gateway capabilities bitmask. Discord delivers MESSAGE_CREATE and other
-// session events to user accounts based on these capabilities, NOT the bot `intents` field
-// (which user sessions ignore). Bit 10 (client_state_v2) requires client_state.guild_versions.
-// Mirrors discord.py-self's default capability set.
+// User (non-bot) gateway capabilities bitmask, mirroring discord.py-self's default set.
+// Capabilities shape the READY payload; bit 10 (client_state_v2) requires client_state.guild_versions.
 const USER_GATEWAY_CAPABILITIES = 16381
+
+// Without MESSAGE_CONTENT (1<<15), Discord blanks `content`/`embeds`/`attachments` on messages
+// from OTHER users (self/DM/mention content still arrives). User sessions get all intents only
+// when `intents` is omitted OR explicitly set, so we send an all-intents value to guarantee content.
+const USER_GATEWAY_INTENTS = 33_554_431
 
 // Discord validates client_build_number against recent web-client builds; a stale value can
 // yield a connected-but-degraded session that fires READY yet delivers no message events.
@@ -235,6 +238,7 @@ export class DiscordListener {
         d: {
           token: this.token,
           capabilities: USER_GATEWAY_CAPABILITIES,
+          intents: USER_GATEWAY_INTENTS,
           properties: {
             os: 'Linux',
             browser: 'Chrome',

--- a/src/platforms/discord/listener.ts
+++ b/src/platforms/discord/listener.ts
@@ -4,7 +4,7 @@ import WebSocket from 'ws'
 
 import type { DiscordClient } from './client'
 import type { DiscordListenerEventMap, DiscordGatewayGenericEvent } from './types'
-import { DiscordGatewayOpcode, DiscordIntent } from './types'
+import { DiscordGatewayOpcode } from './types'
 
 const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json'
 const GATEWAY_QUERY = '?v=10&encoding=json'
@@ -13,20 +13,22 @@ const RECONNECT_MAX_DELAY = 30_000
 const NON_RECOVERABLE_CLOSE_CODES = [4004, 4010, 4011, 4012, 4013, 4014]
 const SESSION_RESET_CLOSE_CODES = [4007, 4009]
 
-const DEFAULT_INTENTS =
-  DiscordIntent.Guilds |
-  DiscordIntent.GuildMessages |
-  DiscordIntent.GuildMessageReactions |
-  DiscordIntent.GuildMessageTyping |
-  DiscordIntent.DirectMessages |
-  DiscordIntent.DirectMessageReactions |
-  DiscordIntent.DirectMessageTyping
+// User (non-bot) gateway capabilities bitmask. Discord delivers MESSAGE_CREATE and other
+// session events to user accounts based on these capabilities, NOT the bot `intents` field
+// (which user sessions ignore). Bit 10 (client_state_v2) requires client_state.guild_versions.
+// Mirrors discord.py-self's default capability set.
+const USER_GATEWAY_CAPABILITIES = 16381
+
+// Discord validates client_build_number against recent web-client builds; a stale value can
+// yield a connected-but-degraded session that fires READY yet delivers no message events.
+// Overridable via env so it can be refreshed without a release when it eventually goes stale.
+const DEFAULT_CLIENT_BUILD_NUMBER = 648814
+const USER_GATEWAY_BUILD_NUMBER = Number(process.env.AGENT_DISCORD_BUILD_NUMBER) || DEFAULT_CLIENT_BUILD_NUMBER
 
 type EventKey = keyof DiscordListenerEventMap
 
 export class DiscordListener {
   private client: DiscordClient
-  private intents: number
   private running = false
   private ws: WebSocket | null = null
   private emitter = new EventEmitter()
@@ -43,9 +45,8 @@ export class DiscordListener {
   private cachedUser: { id: string; username: string } | null = null
   private generation = 0
 
-  constructor(client: DiscordClient, options?: { intents?: number }) {
+  constructor(client: DiscordClient) {
     this.client = client
-    this.intents = options?.intents ?? DEFAULT_INTENTS
   }
 
   async start(): Promise<void> {
@@ -233,12 +234,27 @@ export class DiscordListener {
         op: DiscordGatewayOpcode.Identify,
         d: {
           token: this.token,
-          intents: this.intents,
+          capabilities: USER_GATEWAY_CAPABILITIES,
           properties: {
-            os: 'linux',
-            browser: 'agent-messenger',
-            device: 'agent-messenger',
+            os: 'Linux',
+            browser: 'Chrome',
+            device: '',
+            system_locale: 'en-US',
+            browser_user_agent:
+              'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+            browser_version: '131.0.0.0',
+            os_version: '',
+            referrer: '',
+            referring_domain: '',
+            referrer_current: '',
+            referring_domain_current: '',
+            release_channel: 'stable',
+            client_build_number: USER_GATEWAY_BUILD_NUMBER,
+            client_event_source: null,
           },
+          presence: { status: 'online', since: 0, activities: [], afk: false },
+          compress: false,
+          client_state: { guild_versions: {} },
         },
       }),
     )


### PR DESCRIPTION
## Summary

The Discord realtime listener (`DiscordListener`, the **user-token** SDK path) had two bugs that made it unusable for receiving messages. Both are fixed here and **verified live against the Discord gateway**.

### Bug 1 — No events delivered at all
The listener sent a **bot-style** `IDENTIFY` (`{ token, intents, properties }`). A user token sending a bot identify connects and fires `READY`, but Discord delivers **no `MESSAGE_CREATE`** (or other) dispatches, because user sessions are not driven by the bot identify shape.

**Fix:** send a **user-account `IDENTIFY`** — `capabilities`, rich client `properties`, `presence`, `compress: false`, `client_state: { guild_versions: {} }`. `client_build_number` defaults to a known-good web build (`648814`) and is overridable via `AGENT_DISCORD_BUILD_NUMBER` (a stale build yields a connected-but-degraded session that fires READY but drops events).

### Bug 2 — Other users' message content was empty
After Bug 1, events arrived but messages from **other users** came through with `content: ""` (self/DM/mention content was fine). This is Discord's **MESSAGE_CONTENT** gating: user sessions only receive full `content`/`embeds`/`attachments` for other users when the `MESSAGE_CONTENT (1<<15)` intent is active. User accounts get all intents only when `intents` is omitted *or* explicitly set — so we send an explicit all-intents value.

**Fix:** include `intents` (all intents, incl. `MESSAGE_CONTENT`) in the user `IDENTIFY`.

Because the user listener no longer relies on a caller-supplied bot intents value, the obsolete `intents` constructor option, `DEFAULT_INTENTS`, and `private intents` field were removed. (The separate **`DiscordBotListener`** is unchanged — bots legitimately use intents.)

## Live verification

Run against a real server (`agent-discord` used to send a message, patched listener observing):

```
PROBE_MSG self=true  from=<me>     contentLen=88 content="<my message>"
PROBE_MSG self=false from=<other>  contentLen=65 content="<their reply, populated>"
```

- Before: user token → only `connected`/READY, **zero** dispatches.
- After Bug 1 fix: `MESSAGE_CREATE` + `PRESENCE_UPDATE` + `READY_SUPPLEMENTAL` dispatches flow.
- After Bug 2 fix: a **non-self** user's `content` arrives populated (was `""`).

## Test plan

- [x] `bun test` — **3301 pass / 0 fail** (35 in `discord/listener.test.ts`)
- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 warnings / 0 errors
- [x] `bunx oxfmt --check` on changed files — correctly formatted
- [x] Live gateway verification (above)
- Updated the identify test: asserts user-shape (`capabilities`, `client_state`) **and** that `MESSAGE_CONTENT` bit is set.

> Note: a pre-existing `format:check` failure in `docs/` (`Can't resolve 'fumadocs-ui/css/neutral.css'`) is unrelated to this change.

## Notes

Payload shape derived from the canonical user-account libraries (`dolfies/discord.py-self`, `aiko-chan-ai/discord.js-selfbot-v13`). User-token gateway usage ("act as you") is inherently a self-bot pattern; this PR only makes the existing listener function as intended and does not change the auth model.
