### PR TITLE
fix(slack): detailed SSO-aware QR sign-in errors + auth token fallback

### DIFF
--- a/src/platforms/slack/commands/auth.test.ts
+++ b/src/platforms/slack/commands/auth.test.ts
@@ -7,6 +7,7 @@ import {
   formatCredentialDebug,
   getExtractionErrorMessage,
   getNoWorkspacesFoundMessage,
+  normalizeDCookie,
 } from '@/platforms/slack/commands/auth'
 import { CredentialManager } from '@/platforms/slack/credential-manager'
 import { type ExtractedWorkspace, TokenExtractor } from '@/platforms/slack/token-extractor'
@@ -498,5 +499,23 @@ describe('Error Handling', () => {
 
     // Then: Should return empty array (no tokens found)
     expect(result).toEqual([])
+  })
+})
+
+describe('normalizeDCookie', () => {
+  it('strips a leading d= prefix', () => {
+    expect(normalizeDCookie('d=xoxd-abc123')).toBe('xoxd-abc123')
+  })
+
+  it('passes through a bare xoxd- value', () => {
+    expect(normalizeDCookie('xoxd-abc123')).toBe('xoxd-abc123')
+  })
+
+  it('url-decodes percent-encoded values', () => {
+    expect(normalizeDCookie('d=xoxd-abc%2Bdef')).toBe('xoxd-abc+def')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeDCookie('  xoxd-abc123  ')).toBe('xoxd-abc123')
   })
 })

--- a/src/platforms/slack/commands/auth.ts
+++ b/src/platforms/slack/commands/auth.ts
@@ -1,8 +1,11 @@
+import { Writable } from 'node:stream'
+
 import { Command } from 'commander'
 
 import { collectBrowserProfileOption } from '@/shared/chromium'
 import type { BrowserProfileOption } from '@/shared/chromium'
 import { handleError } from '@/shared/utils/error-handler'
+import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { debug } from '@/shared/utils/stderr'
 
@@ -323,6 +326,106 @@ function readStdin(): Promise<string> {
   })
 }
 
+const TOKEN_PREFIX = 'xoxc-'
+const COOKIE_PREFIX = 'xoxd-'
+
+async function tokenAction(
+  tokenArg: string | undefined,
+  options: { cookie?: string; pretty?: boolean },
+): Promise<void> {
+  try {
+    const stdinToken = tokenArg ? undefined : (await readStdin()).trim() || undefined
+    const token = tokenArg ?? stdinToken ?? (await promptHidden('Slack token (xoxc-...)'))
+    const rawCookie = options.cookie ?? (await promptHidden('Slack d cookie (xoxd-...)'))
+
+    if (!token || !rawCookie) {
+      console.log(
+        formatOutput(
+          {
+            error: 'Both a Slack token (xoxc-...) and d cookie (xoxd-...) are required.',
+            hint: 'In your browser on app.slack.com: DevTools → Application → Cookies → copy the "d" cookie (xoxd-...), and read the xoxc- token from localStorage localConfig_v2.',
+          },
+          options.pretty,
+        ),
+      )
+      process.exit(1)
+    }
+
+    const cookie = normalizeDCookie(rawCookie)
+    if (!token.startsWith(TOKEN_PREFIX) || !cookie.startsWith(COOKIE_PREFIX)) {
+      console.log(
+        formatOutput(
+          { error: `Token must start with "${TOKEN_PREFIX}" and cookie must start with "${COOKIE_PREFIX}".` },
+          options.pretty,
+        ),
+      )
+      process.exit(1)
+    }
+
+    const client = await new SlackClient().login({ token, cookie })
+    const authInfo = await client.testAuth()
+
+    const credManager = new CredentialManager()
+    const workspace: ExtractedWorkspace = {
+      workspace_id: authInfo.team_id,
+      workspace_name: authInfo.team || 'unknown',
+      token,
+      cookie,
+    }
+    await credManager.setWorkspace(workspace)
+
+    if (!(await credManager.load()).current_workspace) {
+      await credManager.setCurrentWorkspace(workspace.workspace_id)
+    }
+
+    console.log(
+      formatOutput(
+        {
+          workspace: `${workspace.workspace_id}/${workspace.workspace_name}`,
+          user: authInfo.user,
+          current: (await credManager.load()).current_workspace,
+        },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export function normalizeDCookie(raw: string): string {
+  const trimmed = raw.trim()
+  const withoutPrefix = trimmed.startsWith('d=') ? trimmed.slice(2) : trimmed
+  return decodeURIComponent(withoutPrefix)
+}
+
+class HiddenWritable extends Writable {
+  muted = false
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    if (!this.muted) process.stdout.write(chunk as Buffer)
+    callback()
+  }
+}
+
+async function promptHidden(message: string): Promise<string | undefined> {
+  if (!isInteractive()) return undefined
+
+  const { createInterface } = await import('node:readline/promises')
+  const hiddenOutput = new HiddenWritable()
+  const rl = createInterface({ input: process.stdin, output: hiddenOutput, terminal: true })
+
+  try {
+    hiddenOutput.muted = true
+    process.stdout.write(`${message}: `)
+    const answer = await rl.question('')
+    process.stdout.write('\n')
+    return answer.trim() || undefined
+  } finally {
+    hiddenOutput.muted = false
+    rl.close()
+  }
+}
+
 export function getExtractionErrorMessage(failureReasons: string[]): string {
   if (failureReasons.includes('missing_cookie')) {
     return 'Cookie extraction failed. Grant Keychain access when prompted, and make sure you are signed into Slack in the desktop app or a supported Chromium browser.'
@@ -360,6 +463,14 @@ export const authCommand = new Command('auth')
       .option('--pretty', 'Pretty print JSON output')
       .option('--debug', 'Show debug output for troubleshooting')
       .action(qrAction),
+  )
+  .addCommand(
+    new Command('token')
+      .description('Sign in by pasting a Slack token (xoxc-...) and d cookie (xoxd-...)')
+      .argument('[token]', 'Slack user token (xoxc-...); prompted if omitted')
+      .option('--cookie <cookie>', 'Slack d cookie (xoxd-...); prompted if omitted')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(tokenAction),
   )
   .addCommand(
     new Command('logout')

--- a/src/platforms/slack/qr-http-login.test.ts
+++ b/src/platforms/slack/qr-http-login.test.ts
@@ -132,6 +132,53 @@ describe('loginWithQr', () => {
     await expect(promise).rejects.toThrow(/expired/)
   })
 
+  it('reports SSO enforcement when the z-app hop redirects to an identity provider', async () => {
+    // Given a workspace whose z-app hop redirects off Slack to an SSO IdP (no d cookie issued)
+    const dataUrl = await qrDataUrl(ZAPP_URL)
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`)
+      }
+      return redirect('https://accounts.google.com/o/oauth2/auth?redirect_uri=https://slack.com/sso/google')
+    }) as typeof fetch
+
+    // When logging in, the error names SSO + the detected provider and points to a working auth method
+    await expect(loginWithQr(dataUrl, { fetchImpl })).rejects.toThrow(/enforces SSO \(via Google\)/)
+    await expect(loginWithQr(dataUrl, { fetchImpl })).rejects.toThrow(/auth extract/)
+  })
+
+  it('reports SSO enforcement for an unrecognized/vanity IdP host', async () => {
+    // Given a z-app hop that redirects off Slack to a custom SAML IdP not in the known-provider list
+    const dataUrl = await qrDataUrl(ZAPP_URL)
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`)
+      }
+      return redirect('https://login.acme.example/saml')
+    }) as typeof fetch
+
+    // When logging in, it is still classified as SSO (without naming a provider) and routes to auth extract
+    await expect(loginWithQr(dataUrl, { fetchImpl })).rejects.toThrow(/enforces SSO/)
+    await expect(loginWithQr(dataUrl, { fetchImpl })).rejects.toThrow(/auth extract/)
+  })
+
+  it('reports an expired link when the final page is Slack\u2019s "Link Expired" page', async () => {
+    // Given a z-app chain that completes on a Slack host but returns the expired page with no d cookie
+    const dataUrl = await qrDataUrl(ZAPP_URL)
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`)
+      }
+      return new Response('<title>Link Expired | Slack</title>', { status: 200 })
+    }) as typeof fetch
+
+    // When logging in, the error names the expiry explicitly
+    await expect(loginWithQr(dataUrl, { fetchImpl })).rejects.toThrow(/has expired or was already used/)
+  })
+
   it('fails with qr_token_failed when the token cannot be retrieved', async () => {
     const dataUrl = await qrDataUrl(ZAPP_URL)
 

--- a/src/platforms/slack/qr-http-login.ts
+++ b/src/platforms/slack/qr-http-login.ts
@@ -23,10 +23,10 @@ export async function loginWithQr(dataUrl: string, options: QrLoginOptions = {})
   const debug = options.debug
   debug?.(`Decoded QR for workspace ${login.workspace}`)
 
-  const cookie = await captureDCookie(login.url, options)
+  const { cookie, denialReason, ssoProvider } = await captureDCookie(login.url, options)
   if (!cookie) {
     throw new SlackError(
-      'Could not establish a Slack session from the QR code. The link may have expired — generate a new QR code and try again.',
+      qrSessionFailureMessage(denialReason, { workspace: login.workspace, ssoProvider }),
       'qr_session_failed',
     )
   }
@@ -44,13 +44,76 @@ export async function loginWithQr(dataUrl: string, options: QrLoginOptions = {})
   return { token, cookie, workspace: login.workspace }
 }
 
-async function captureDCookie(startUrl: string, options: QrLoginOptions): Promise<string | null> {
+interface QrFailureContext {
+  workspace?: string
+  ssoProvider?: string | null
+}
+
+function qrSessionFailureMessage(denialReason: string | null, context: QrFailureContext = {}): string {
+  const workspace = context.workspace ? `"${context.workspace}"` : 'this workspace'
+
+  if (denialReason === 'sso_required') {
+    const via = context.ssoProvider ? ` (via ${context.ssoProvider})` : ''
+    return [
+      `Slack workspace ${workspace} enforces SSO${via}, so QR sign-in cannot complete here.`,
+      '',
+      `Why: scanning the QR redirects the login to your identity provider${via}. agent-slack follows the`,
+      'redirect chain over plain HTTP and never sends your session cookie off Slack-owned hosts, so it',
+      'stops at the IdP and no Slack session (the "d" cookie) is ever issued. Completing SSO requires a',
+      'real browser, which a headless environment does not have.',
+      '',
+      'What to do instead:',
+      '  1. On a computer where you are already signed in to Slack (desktop app or a Chromium browser),',
+      '     run:  agent-slack auth extract',
+      '     This reads your existing session locally — no SSO re-login, no DevTools.',
+      '  2. Or pass credentials directly:  agent-slack auth token  (provide the xoxc- token and xoxd- "d"',
+      '     cookie; the command reads them from an argument, stdin, or an interactive prompt).',
+      '',
+      'Background: https://github.com/agent-messenger/agent-messenger/issues/260',
+    ].join('\n')
+  }
+  if (denialReason === 'link_expired') {
+    return [
+      `The Slack QR code for ${workspace} has expired or was already used.`,
+      'The z-app sign-in link is single-use and short-lived: it is consumed the first time it is opened',
+      '(including previewing or scanning it), and re-using it returns "Link Expired".',
+      '',
+      'Generate a fresh QR (your name → "Sign in on mobile") and pipe it in immediately, without',
+      'previewing or scanning it first.',
+    ].join('\n')
+  }
+  if (denialReason === 'awaiting_device_confirmation') {
+    return [
+      `Slack requires this sign-in to ${workspace} to be confirmed on an already-authenticated device.`,
+      'QR sign-in over HTTP cannot complete that approval step.',
+      '',
+      'Use  agent-slack auth extract  on a computer already signed in to Slack instead.',
+    ].join('\n')
+  }
+  return [
+    `Could not establish a Slack session for ${workspace} from the QR code.`,
+    'The link may have expired, or the workspace requires a sign-in step that QR-over-HTTP cannot complete.',
+    '',
+    'Generate a fresh QR and try again, or run  agent-slack auth extract  on a computer already signed in',
+    'to Slack.',
+  ].join('\n')
+}
+
+interface CookieCapture {
+  cookie: string | null
+  denialReason: string | null
+  ssoProvider: string | null
+}
+
+async function captureDCookie(startUrl: string, options: QrLoginOptions): Promise<CookieCapture> {
   const doFetch = options.fetchImpl ?? fetch
   const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS
   const debug = options.debug
 
   let url = startUrl
   let dCookie: string | null = null
+  let sessionDenialReason: string | null = null
+  let ssoProvider: string | null = null
   const cookieJar: string[] = []
 
   for (let hop = 0; hop < maxRedirects; hop++) {
@@ -72,27 +135,71 @@ async function captureDCookie(startUrl: string, options: QrLoginOptions): Promis
       },
     })
 
+    const cookieNames: string[] = []
     for (const setCookie of getSetCookies(response)) {
       const value = parseDCookie(setCookie)
       if (value) dCookie = value
+      const name = setCookie.split('=')[0]?.trim()
+      if (name) cookieNames.push(name)
       const pair = setCookie.split(';')[0]?.trim()
       if (pair) cookieJar.push(pair)
     }
 
-    debug?.(`hop ${hop}: ${response.status}`)
+    debug?.(`hop ${hop}: ${response.status} set-cookie=[${cookieNames.join(',') || 'none'}]`)
 
     const location = response.status >= 300 && response.status < 400 ? response.headers.get('location') : null
-    if (!location) break
+    if (!location) {
+      if (!dCookie) sessionDenialReason = await classifySessionDenial(response)
+      break
+    }
 
     const next = new URL(location, url).toString()
     if (!isSlackHost(next)) {
-      debug?.(`hop ${hop}: redirect target is not a Slack host, stopping`)
+      // A no-cookie login QR that redirects off Slack is an SSO/IdP hand-off the
+      // HTTP flow cannot complete — classify it regardless of whether the IdP
+      // host is a recognized provider (custom/vanity SAML domains included).
+      if (!dCookie) {
+        sessionDenialReason = 'sso_required'
+        ssoProvider = ssoProviderFromUrl(next)
+      }
+      debug?.(`hop ${hop}: redirect target is not a Slack host (${new URL(next).hostname}), stopping`)
       break
     }
     url = next
   }
 
-  return dCookie
+  return { cookie: dCookie, denialReason: sessionDenialReason, ssoProvider }
+}
+
+function ssoProviderFromUrl(rawUrl: string): string | null {
+  let hostname: string
+  try {
+    hostname = new URL(rawUrl).hostname
+  } catch {
+    return null
+  }
+  if (hostname === 'accounts.google.com') return 'Google'
+  if (hostname.endsWith('.okta.com') || hostname.endsWith('.oktapreview.com')) return 'Okta'
+  if (hostname === 'login.microsoftonline.com') return 'Microsoft'
+  if (hostname.endsWith('.onelogin.com')) return 'OneLogin'
+  if (hostname.endsWith('.pingidentity.com') || hostname.endsWith('.pingone.com')) return 'Ping Identity'
+  if (hostname.endsWith('.auth0.com')) return 'Auth0'
+  return null
+}
+
+async function classifySessionDenial(response: Response): Promise<string | null> {
+  try {
+    const body = await response.text()
+    if (/Link Expired/i.test(body) || /trouble signing you in/i.test(body)) {
+      return 'link_expired'
+    }
+    if (/sign in on your other device/i.test(body) || /open Slack/i.test(body) || /confirm/i.test(body)) {
+      return 'awaiting_device_confirmation'
+    }
+    return null
+  } catch {
+    return null
+  }
 }
 
 export function isSlackHost(rawUrl: string): boolean {


### PR DESCRIPTION
## What

Improves Slack authentication when `auth qr` cannot complete sign-in, and adds a manual credential fallback.

1. **`fix(slack)`: detailed, actionable QR sign-in errors.** When the QR redirect chain leaves Slack for an identity provider (Google, Okta, Microsoft, OneLogin, Ping, Auth0), `auth qr` now reports that the workspace enforces SSO — naming the provider and workspace — and explains exactly what to do instead, rather than a generic "link may have expired". Single-use/expired links and device-confirmation cases get their own accurate messages too. Per-hop `Set-Cookie` names are logged under `--debug`.
2. **`feat(slack)`: `auth token` command.** Sign in by providing an `xoxc-` token and `xoxd-` `d` cookie directly (positional arg → stdin → interactive hidden prompt), for headless/SSO environments where `auth extract` and QR are unavailable.

## Why

QR sign-in over plain HTTP fundamentally cannot complete for SSO-enforced workspaces: the `z-app` hop 302-redirects off Slack to the IdP, the follower refuses to send the session cookie off Slack hosts (correct), and the `d` cookie is never issued. The previous error implied a transient/expired link, sending users in circles. See #260 for the full root-cause analysis (redirect traces, single-use secret, `redirect_uri` lock, why no headless completion exists).

## Behavior

Non-SSO workspaces are unaffected — QR sign-in continues to work exactly as before. Only the failure path (no `d` cookie captured) changes, to produce a precise diagnosis and route users to a method that works.

Example (SSO workspace):

```
Slack workspace "acme" enforces SSO (via Google), so QR sign-in cannot complete here.

Why: scanning the QR redirects the login to your identity provider (via Google). ...

What to do instead:
  1. On a computer where you are already signed in to Slack ... run: agent-slack auth extract
  2. Or pass credentials directly: agent-slack auth token ...
```

## Testing

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun test src/platforms/slack/` — 529 pass, 0 fail (adds tests for SSO detection, expired-link messaging, and `d` cookie normalization)

Closes #260

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SSO-aware errors for Slack QR sign-in and a new `auth token` fallback that signs in with an `xoxc-` token and `xoxd-` cookie when QR/SSO flows can’t complete. This gives users clear guidance and a reliable path to sign in in headless or SSO-enforced environments.

- **New Features**
  - Added `agent-slack auth token` to sign in with `xoxc-` and `xoxd-`.
  - Reads credentials from argument → stdin → hidden interactive prompt; supports `--pretty` JSON.
  - Normalizes the `d` cookie (accepts bare value, `d=` prefix, URL-encoded) and prefix-checks both values before a request.

- **Bug Fixes**
  - QR sign-in detects SSO and names the IdP when known (Google, Okta, Microsoft, OneLogin, Ping Identity, Auth0); custom IdPs are reported generically, with next steps (`auth extract` or `auth token`).
  - Clear messages for expired/single-use links and device confirmation prompts.
  - `--debug` logs per-hop Set-Cookie names for easier troubleshooting.

SKILL.md/docs: not updated in this PR.

<sup>Written for commit aa00b4feece8da4027afa1ca23b1f31f04867192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

