### PR TITLE
fix(discord): resolve listener start() only after gateway READY

### DIFF
--- a/src/platforms/discord/listener.test.ts
+++ b/src/platforms/discord/listener.test.ts
@@ -107,11 +107,40 @@ function createMockClient(overrides: Record<string, any> = {}) {
   } as any
 }
 
+// start() now resolves only once the gateway emits READY, so the handshake must be
+// driven concurrently while start() is pending. This waits for connect() to create the
+// socket (after the awaited gatewayConnect microtask) before the caller drives it.
+async function waitForSocket(): Promise<MockWs> {
+  for (let i = 0; i < 50 && !mockWsInstance; i++) {
+    await Promise.resolve()
+  }
+  return mockWsInstance
+}
+
+async function startAndReady(listener: DiscordListener): Promise<void> {
+  const started = listener.start()
+  const ws = await waitForSocket()
+  ws.simulateOpen()
+  ws.simulateHello()
+  ws.simulateReady()
+  await started
+}
+
+// For tests that exercise pre-READY behavior (Identify/heartbeat/close paths): start() stays
+// pending here. The start promise's rejection is swallowed; afterEach stop() clears its timer.
+async function startConnecting(listener: DiscordListener): Promise<MockWs> {
+  listener.start().catch(() => {})
+  const ws = await waitForSocket()
+  ws.simulateOpen()
+  return ws
+}
+
 describe('DiscordListener', () => {
   let listener: DiscordListener
 
   afterEach(() => {
     listener?.stop()
+    mockWsInstance = undefined as unknown as MockWs
   })
 
   describe('start', () => {
@@ -119,20 +148,74 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
+      await startAndReady(listener)
 
       expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not resolve until a READY dispatch is delivered', async () => {
+      const client = createMockClient()
+      listener = new DiscordListener(client)
+
+      let resolved = false
+      const started = listener.start().then(() => {
+        resolved = true
+      })
+
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+
+      // given: socket open + Hello (Identify sent) but no READY yet
+      await Promise.resolve()
+      expect(resolved).toBe(false)
+
+      // when: READY arrives
+      ws.simulateReady()
+      await started
+
+      expect(resolved).toBe(true)
     })
 
     it('is idempotent', async () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
+      await startAndReady(listener)
       await listener.start()
 
       expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('shares one readiness promise across concurrent start() calls', async () => {
+      const client = createMockClient()
+      listener = new DiscordListener(client)
+
+      const first = listener.start()
+      const second = listener.start()
+
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+      ws.simulateReady()
+
+      await Promise.all([first, second])
+      expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects an in-flight start() when stop() is called before READY', async () => {
+      const client = createMockClient()
+      listener = new DiscordListener(client)
+
+      const started = listener.start()
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+
+      // given: start() is still awaiting READY when the consumer stops the listener
+      listener.stop()
+
+      await expect(started).rejects.toThrow(/stopped before becoming ready/)
     })
   })
 
@@ -144,10 +227,7 @@ describe('DiscordListener', () => {
       const connected: any[] = []
       listener.on('connected', (info) => connected.push(info))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect(connected.length).toBe(1)
       expect(connected[0].user.id).toBe('U_SELF')
@@ -160,9 +240,8 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
+      const ws = await startConnecting(listener)
+      ws.simulateHello()
 
       const sentMessages = mockWsInstance.sent.map((s) => JSON.parse(s))
       const identifyMsg = sentMessages.find((m) => m.op === 2)
@@ -175,9 +254,8 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
+      const ws = await startConnecting(listener)
+      ws.simulateHello()
 
       const sentMessages = mockWsInstance.sent.map((s) => JSON.parse(s))
       const identifyMsg = sentMessages.find((m) => m.op === 2)
@@ -204,10 +282,7 @@ describe('DiscordListener', () => {
       const messages: DiscordGatewayMessageCreateEvent[] = []
       listener.on('message_create', (event) => messages.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         {
@@ -232,10 +307,7 @@ describe('DiscordListener', () => {
       const updates: DiscordGatewayMessageUpdateEvent[] = []
       listener.on('message_update', (event) => updates.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_UPDATE',
         { id: 'msg_1', channel_id: 'C123', content: 'edited', edited_timestamp: '2024-01-01T00:01:00Z' },
@@ -254,10 +326,7 @@ describe('DiscordListener', () => {
       const deletes: DiscordGatewayMessageDeleteEvent[] = []
       listener.on('message_delete', (event) => deletes.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch('MESSAGE_DELETE', { id: 'msg_1', channel_id: 'C123' }, 2)
 
       expect(deletes.length).toBe(1)
@@ -273,10 +342,7 @@ describe('DiscordListener', () => {
       const reactions: DiscordGatewayReactionEvent[] = []
       listener.on('message_reaction_add', (event) => reactions.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_REACTION_ADD',
         {
@@ -302,10 +368,7 @@ describe('DiscordListener', () => {
       const events: DiscordGatewayGenericEvent[] = []
       listener.on('discord_event', (event) => events.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         { id: 'm1', channel_id: 'C1', content: 'hi', timestamp: 't', author: { id: 'U1', username: 'u' } },
@@ -328,9 +391,8 @@ describe('DiscordListener', () => {
         const client = createMockClient()
         listener = new DiscordListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello(50)
+        const ws = await startConnecting(listener)
+        ws.simulateHello(50)
 
         await new Promise((r) => setTimeout(r, 150))
 
@@ -350,10 +412,7 @@ describe('DiscordListener', () => {
       const events: DiscordGatewayGenericEvent[] = []
       listener.on('discord_event', (event) => events.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateHeartbeatACK()
 
       expect(events.length).toBe(0)
@@ -370,9 +429,8 @@ describe('DiscordListener', () => {
         const disconnected: boolean[] = []
         listener.on('disconnected', () => disconnected.push(true))
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello(50)
+        const ws = await startConnecting(listener)
+        ws.simulateHello(50)
 
         await new Promise((r) => setTimeout(r, 300))
 
@@ -388,8 +446,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
+      await startConnecting(listener)
 
       listener.stop()
 
@@ -406,9 +463,8 @@ describe('DiscordListener', () => {
       const disconnected: boolean[] = []
       listener.on('disconnected', () => disconnected.push(true))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateClose()
+      const ws = await startConnecting(listener)
+      ws.simulateClose()
 
       expect(disconnected.length).toBe(1)
 
@@ -416,28 +472,20 @@ describe('DiscordListener', () => {
       expect(client.gatewayConnect.mock.calls.length).toBeGreaterThanOrEqual(2)
     })
 
-    it('emits error and reconnects on gatewayConnect failure', async () => {
-      let callCount = 0
+    it('rejects start() and stops on gatewayConnect failure during initial connect', async () => {
       const client = createMockClient({
-        gatewayConnect: mock(() => {
-          callCount++
-          if (callCount === 1) return Promise.reject(new Error('network_error'))
-          return Promise.resolve({ token: 'fake-token' })
-        }),
+        gatewayConnect: mock(() => Promise.reject(new Error('network_error'))),
       })
 
       listener = new DiscordListener(client)
+      listener.on('error', () => {})
 
-      const errors: Error[] = []
-      listener.on('error', (err) => errors.push(err))
+      await expect(listener.start()).rejects.toThrow('network_error')
 
-      await listener.start()
-
+      // given: a pre-READY connect error tears down the listener (no resurrected reconnect loop)
       await new Promise((r) => setTimeout(r, 1500))
-
-      expect(errors.length).toBe(1)
-      expect(errors[0].message).toBe('network_error')
-      expect(client.gatewayConnect.mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect((listener as any).running).toBe(false)
+      expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -450,10 +498,7 @@ describe('DiscordListener', () => {
       const handler = (event: DiscordGatewayMessageCreateEvent) => messages.push(event)
       listener.on('message_create', handler)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         { id: 'm1', channel_id: 'C1', content: 'a', timestamp: 't', author: { id: 'U1', username: 'u' } },
@@ -478,10 +523,7 @@ describe('DiscordListener', () => {
       const messages: DiscordGatewayMessageCreateEvent[] = []
       listener.once('message_create', (event) => messages.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         { id: 'm1', channel_id: 'C1', content: 'first', timestamp: 't', author: { id: 'U1', username: 'u' } },
@@ -503,10 +545,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       ;(listener as any).reconnectAttempts = 5
       mockWsInstance.simulateReconnect()
@@ -520,10 +559,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect((listener as any).sessionId).toBe('session_123')
 
@@ -538,10 +574,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       const sessionIdBefore = (listener as any).sessionId
 
@@ -556,10 +589,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateClose()
 
@@ -577,22 +607,38 @@ describe('DiscordListener', () => {
   })
 
   describe('non-recoverable close codes', () => {
-    it('emits error and stops on code 4004', async () => {
+    for (const code of [4004, 4013, 4014]) {
+      it(`rejects start() and stops on non-recoverable close ${code}`, async () => {
+        const client = createMockClient()
+        listener = new DiscordListener(client)
+        listener.on('error', () => {})
+
+        const started = listener.start()
+        const ws = await waitForSocket()
+        ws.simulateOpen()
+        ws.simulateClose(code)
+
+        await expect(started).rejects.toThrow(String(code))
+        expect((listener as any).running).toBe(false)
+        expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+      })
+    }
+  })
+
+  describe('connect timeout', () => {
+    it('rejects start() and tears down when READY never arrives', async () => {
       const client = createMockClient()
-      listener = new DiscordListener(client)
+      listener = new DiscordListener(client, { connectTimeoutMs: 100 })
+      listener.on('error', () => {})
 
-      const errors: Error[] = []
-      listener.on('error', (err) => errors.push(err))
+      const started = listener.start()
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+      // given: Identify sent but the gateway never delivers READY
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateClose(4004)
-
-      await new Promise((r) => setTimeout(r, 50))
-
-      expect(errors.length).toBe(1)
-      expect(errors[0].message).toContain('4004')
-      expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+      await expect(started).rejects.toThrow(/did not become ready/)
+      expect((listener as any).running).toBe(false)
     })
   })
 
@@ -601,10 +647,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect((listener as any).sessionId).toBe('session_123')
 
@@ -631,10 +674,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateClose(4009)
 
@@ -651,10 +691,12 @@ describe('DiscordListener', () => {
         const client = createMockClient()
         listener = new DiscordListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello(50)
-        mockWsInstance.simulateReady()
+        const started = listener.start()
+        const ws = await waitForSocket()
+        ws.simulateOpen()
+        ws.simulateHello(50)
+        ws.simulateReady()
+        await started
 
         mockWsInstance.simulateHello(50)
 
@@ -679,10 +721,7 @@ describe('DiscordListener', () => {
         const client = createMockClient()
         listener = new DiscordListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello()
-        mockWsInstance.simulateReady()
+        await startAndReady(listener)
 
         mockWsInstance.simulateInvalidSession(true)
 
@@ -698,10 +737,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateInvalidSession(false)
 
@@ -724,10 +760,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       const sentBefore = mockWsInstance.sent.length
       mockWsInstance.simulateMessage({ op: 1 })
@@ -744,10 +777,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
@@ -762,10 +792,7 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
@@ -789,11 +816,11 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
+      await startConnecting(listener)
       ;(listener as any).reconnectAttempts = 5
       listener.stop()
 
-      await listener.start()
+      await startConnecting(listener)
       expect((listener as any).reconnectAttempts).toBe(0)
     })
   })
@@ -803,10 +830,11 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateMessage({
+      const started = listener.start()
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+      ws.simulateMessage({
         op: 0,
         t: 'READY',
         s: 1,
@@ -816,6 +844,7 @@ describe('DiscordListener', () => {
           user: { id: 'U_SELF', username: 'user' },
         },
       })
+      await started
 
       mockWsInstance.simulateClose()
       await new Promise((r) => setTimeout(r, 1500))
@@ -829,10 +858,11 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
+      listener.start().catch(() => {})
+      const ws = await waitForSocket()
       ;(listener as any).reconnectAttempts = 5
 
-      mockWsInstance.simulateOpen()
+      ws.simulateOpen()
 
       expect((listener as any).reconnectAttempts).toBe(5)
     })
@@ -841,12 +871,14 @@ describe('DiscordListener', () => {
       const client = createMockClient()
       listener = new DiscordListener(client)
 
-      await listener.start()
+      const started = listener.start()
+      const ws = await waitForSocket()
       ;(listener as any).reconnectAttempts = 5
 
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      ws.simulateOpen()
+      ws.simulateHello()
+      ws.simulateReady()
+      await started
 
       expect((listener as any).reconnectAttempts).toBe(0)
     })

--- a/src/platforms/discord/listener.ts
+++ b/src/platforms/discord/listener.ts
@@ -13,6 +13,11 @@ const RECONNECT_MAX_DELAY = 30_000
 const NON_RECOVERABLE_CLOSE_CODES = [4004, 4010, 4011, 4012, 4013, 4014]
 const SESSION_RESET_CLOSE_CODES = [4007, 4009]
 
+// Hello arrives within milliseconds and READY within a few seconds on a healthy gateway;
+// 15s is generous for a successful handshake while still failing fast on bad tokens,
+// network stalls, or a gateway that accepts the socket but never delivers READY.
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
+
 // User (non-bot) gateway capabilities bitmask, mirroring discord.py-self's default set.
 // Capabilities shape the READY payload; bit 10 (client_state_v2) requires client_state.guild_versions.
 const USER_GATEWAY_CAPABILITIES = 16381
@@ -30,8 +35,13 @@ const USER_GATEWAY_BUILD_NUMBER = Number(process.env.AGENT_DISCORD_BUILD_NUMBER)
 
 type EventKey = keyof DiscordListenerEventMap
 
+export interface DiscordListenerOptions {
+  connectTimeoutMs?: number
+}
+
 export class DiscordListener {
   private client: DiscordClient
+  private connectTimeoutMs: number
   private running = false
   private ws: WebSocket | null = null
   private emitter = new EventEmitter()
@@ -40,6 +50,7 @@ export class DiscordListener {
   private heartbeatJitterTimer: ReturnType<typeof setTimeout> | null = null
   private invalidSessionTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
   private sequence: number | null = null
   private sessionId: string | null = null
@@ -47,23 +58,90 @@ export class DiscordListener {
   private token: string | null = null
   private cachedUser: { id: string; username: string } | null = null
   private generation = 0
+  private startPromise: Promise<void> | null = null
+  private pendingStartReject: ((error: Error) => void) | null = null
 
-  constructor(client: DiscordClient) {
+  constructor(client: DiscordClient, options?: DiscordListenerOptions) {
     this.client = client
+    this.connectTimeoutMs = options?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
   }
 
   async start(): Promise<void> {
+    if (this.startPromise) return this.startPromise
     if (this.running) return
+
     this.running = true
     this.reconnectAttempts = 0
-    this.generation++
-    await this.connect(this.generation)
+    const generation = ++this.generation
+
+    const ready = new Promise<void>((resolve, reject) => {
+      let settled = false
+
+      const cleanup = () => {
+        this.emitter.off('connected', onConnected)
+        this.emitter.off('error', onError)
+        this.pendingStartReject = null
+        if (this.connectTimeoutTimer) {
+          clearTimeout(this.connectTimeoutTimer)
+          this.connectTimeoutTimer = null
+        }
+      }
+
+      const onConnected = () => {
+        if (settled || !this.isCurrent(generation)) return
+        settled = true
+        cleanup()
+        resolve()
+      }
+
+      const onError = (error: Error) => {
+        if (settled || !this.isCurrent(generation)) return
+        settled = true
+        cleanup()
+        this.teardownFailedStart(generation)
+        reject(error)
+      }
+
+      this.emitter.once('connected', onConnected)
+      this.emitter.once('error', onError)
+
+      // Generation-agnostic on purpose: stop() invokes this to reject an in-flight start
+      // (after bumping generation) without leaking the once() handlers.
+      this.pendingStartReject = (error: Error) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        reject(error)
+      }
+
+      this.connectTimeoutTimer = setTimeout(() => {
+        onError(new Error(`Discord gateway did not become ready within ${this.connectTimeoutMs}ms`))
+      }, this.connectTimeoutMs)
+    })
+
+    const run = async (): Promise<void> => {
+      try {
+        await Promise.all([this.connect(generation), ready])
+      } finally {
+        if (this.generation === generation) this.startPromise = null
+      }
+    }
+    const startPromise = run()
+    this.startPromise = startPromise
+    return startPromise
   }
 
   stop(): void {
     this.running = false
     this.generation++
     this.clearTimers()
+    if (this.connectTimeoutTimer) {
+      clearTimeout(this.connectTimeoutTimer)
+      this.connectTimeoutTimer = null
+    }
+    const rejectStart = this.pendingStartReject
+    this.pendingStartReject = null
+    this.startPromise = null
     if (this.ws) {
       this.ws.close()
       this.ws = null
@@ -73,6 +151,12 @@ export class DiscordListener {
     this.resumeGatewayUrl = null
     this.token = null
     this.cachedUser = null
+    rejectStart?.(new Error('Discord gateway start was stopped before becoming ready'))
+  }
+
+  private teardownFailedStart(generation: number): void {
+    if (!this.isCurrent(generation)) return
+    this.stop()
   }
 
   on<K extends EventKey>(event: K, listener: (...args: DiscordListenerEventMap[K]) => void): this {

--- a/src/platforms/discordbot/listener.test.ts
+++ b/src/platforms/discordbot/listener.test.ts
@@ -107,11 +107,40 @@ function createMockClient(overrides: Record<string, any> = {}) {
   } as any
 }
 
+// start() now resolves only once the gateway emits READY, so the handshake must be
+// driven concurrently while start() is pending. This waits for connect() to create the
+// socket (after the awaited gatewayConnect microtask) before the caller drives it.
+async function waitForSocket(): Promise<MockWs> {
+  for (let i = 0; i < 50 && !mockWsInstance; i++) {
+    await Promise.resolve()
+  }
+  return mockWsInstance
+}
+
+async function startAndReady(listener: DiscordBotListener): Promise<void> {
+  const started = listener.start()
+  const ws = await waitForSocket()
+  ws.simulateOpen()
+  ws.simulateHello()
+  ws.simulateReady()
+  await started
+}
+
+// For tests that exercise pre-READY behavior (Identify/heartbeat/close paths): start() stays
+// pending here. The start promise's rejection is swallowed; afterEach stop() clears its timer.
+async function startConnecting(listener: DiscordBotListener): Promise<MockWs> {
+  listener.start().catch(() => {})
+  const ws = await waitForSocket()
+  ws.simulateOpen()
+  return ws
+}
+
 describe('DiscordBotListener', () => {
   let listener: DiscordBotListener
 
   afterEach(() => {
     listener?.stop()
+    mockWsInstance = undefined as unknown as MockWs
   })
 
   describe('start', () => {
@@ -119,20 +148,74 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
+      await startAndReady(listener)
 
       expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not resolve until a READY dispatch is delivered', async () => {
+      const client = createMockClient()
+      listener = new DiscordBotListener(client)
+
+      let resolved = false
+      const started = listener.start().then(() => {
+        resolved = true
+      })
+
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+
+      // given: socket open + Hello (Identify sent) but no READY yet
+      await Promise.resolve()
+      expect(resolved).toBe(false)
+
+      // when: READY arrives
+      ws.simulateReady()
+      await started
+
+      expect(resolved).toBe(true)
     })
 
     it('is idempotent', async () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
+      await startAndReady(listener)
       await listener.start()
 
       expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('shares one readiness promise across concurrent start() calls', async () => {
+      const client = createMockClient()
+      listener = new DiscordBotListener(client)
+
+      const first = listener.start()
+      const second = listener.start()
+
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+      ws.simulateReady()
+
+      await Promise.all([first, second])
+      expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects an in-flight start() when stop() is called before READY', async () => {
+      const client = createMockClient()
+      listener = new DiscordBotListener(client)
+
+      const started = listener.start()
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+
+      // given: start() is still awaiting READY when the consumer stops the listener
+      listener.stop()
+
+      await expect(started).rejects.toThrow(/stopped before becoming ready/)
     })
   })
 
@@ -144,10 +227,7 @@ describe('DiscordBotListener', () => {
       const connected: any[] = []
       listener.on('connected', (info) => connected.push(info))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect(connected.length).toBe(1)
       expect(connected[0].user.id).toBe('BOT_SELF')
@@ -160,9 +240,8 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
+      const ws = await startConnecting(listener)
+      ws.simulateHello()
 
       const sentMessages = mockWsInstance.sent.map((s) => JSON.parse(s))
       const identifyMsg = sentMessages.find((m) => m.op === 2)
@@ -176,9 +255,8 @@ describe('DiscordBotListener', () => {
       const customIntents = (1 << 9) | (1 << 15) // GuildMessages | MessageContent
       listener = new DiscordBotListener(client, { intents: customIntents })
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
+      const ws = await startConnecting(listener)
+      ws.simulateHello()
 
       const sentMessages = mockWsInstance.sent.map((s) => JSON.parse(s))
       const identifyMsg = sentMessages.find((m) => m.op === 2)
@@ -191,9 +269,8 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
+      const ws = await startConnecting(listener)
+      ws.simulateHello()
 
       const sentMessages = mockWsInstance.sent.map((s) => JSON.parse(s))
       const identifyMsg = sentMessages.find((m) => m.op === 2)
@@ -214,10 +291,7 @@ describe('DiscordBotListener', () => {
       const messages: DiscordGatewayMessageCreateEvent[] = []
       listener.on('message_create', (event) => messages.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         {
@@ -242,10 +316,7 @@ describe('DiscordBotListener', () => {
       const messages: DiscordGatewayMessageCreateEvent[] = []
       listener.on('message_create', (event) => messages.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         {
@@ -283,10 +354,7 @@ describe('DiscordBotListener', () => {
       const updates: DiscordGatewayMessageUpdateEvent[] = []
       listener.on('message_update', (event) => updates.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_UPDATE',
         { id: 'msg_1', channel_id: 'C123', content: 'edited', edited_timestamp: '2024-01-01T00:01:00Z' },
@@ -305,10 +373,7 @@ describe('DiscordBotListener', () => {
       const deletes: DiscordGatewayMessageDeleteEvent[] = []
       listener.on('message_delete', (event) => deletes.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch('MESSAGE_DELETE', { id: 'msg_1', channel_id: 'C123' }, 2)
 
       expect(deletes.length).toBe(1)
@@ -324,10 +389,7 @@ describe('DiscordBotListener', () => {
       const reactions: DiscordGatewayReactionEvent[] = []
       listener.on('message_reaction_add', (event) => reactions.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_REACTION_ADD',
         {
@@ -353,10 +415,7 @@ describe('DiscordBotListener', () => {
       const interactions: any[] = []
       listener.on('interaction_create', (event) => interactions.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'INTERACTION_CREATE',
         {
@@ -383,10 +442,7 @@ describe('DiscordBotListener', () => {
       const events: DiscordGatewayGenericEvent[] = []
       listener.on('discord_event', (event) => events.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         { id: 'm1', channel_id: 'C1', content: 'hi', timestamp: 't', author: { id: 'U1', username: 'u' } },
@@ -409,9 +465,8 @@ describe('DiscordBotListener', () => {
         const client = createMockClient()
         listener = new DiscordBotListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello(50)
+        const ws = await startConnecting(listener)
+        ws.simulateHello(50)
 
         await new Promise((r) => setTimeout(r, 150))
 
@@ -431,10 +486,7 @@ describe('DiscordBotListener', () => {
       const events: DiscordGatewayGenericEvent[] = []
       listener.on('discord_event', (event) => events.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateHeartbeatACK()
 
       expect(events.length).toBe(0)
@@ -451,9 +503,8 @@ describe('DiscordBotListener', () => {
         const disconnected: boolean[] = []
         listener.on('disconnected', () => disconnected.push(true))
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello(50)
+        const ws = await startConnecting(listener)
+        ws.simulateHello(50)
 
         await new Promise((r) => setTimeout(r, 300))
 
@@ -469,8 +520,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
+      await startConnecting(listener)
 
       listener.stop()
 
@@ -487,9 +537,8 @@ describe('DiscordBotListener', () => {
       const disconnected: boolean[] = []
       listener.on('disconnected', () => disconnected.push(true))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateClose()
+      const ws = await startConnecting(listener)
+      ws.simulateClose()
 
       expect(disconnected.length).toBe(1)
 
@@ -497,28 +546,20 @@ describe('DiscordBotListener', () => {
       expect(client.gatewayConnect.mock.calls.length).toBeGreaterThanOrEqual(2)
     })
 
-    it('emits error and reconnects on gatewayConnect failure', async () => {
-      let callCount = 0
+    it('rejects start() and stops on gatewayConnect failure during initial connect', async () => {
       const client = createMockClient({
-        gatewayConnect: mock(() => {
-          callCount++
-          if (callCount === 1) return Promise.reject(new Error('network_error'))
-          return Promise.resolve({ token: 'fake-bot-token' })
-        }),
+        gatewayConnect: mock(() => Promise.reject(new Error('network_error'))),
       })
 
       listener = new DiscordBotListener(client)
+      listener.on('error', () => {})
 
-      const errors: Error[] = []
-      listener.on('error', (err) => errors.push(err))
+      await expect(listener.start()).rejects.toThrow('network_error')
 
-      await listener.start()
-
+      // given: a pre-READY connect error tears down the listener (no resurrected reconnect loop)
       await new Promise((r) => setTimeout(r, 1500))
-
-      expect(errors.length).toBe(1)
-      expect(errors[0].message).toBe('network_error')
-      expect(client.gatewayConnect.mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect((listener as any).running).toBe(false)
+      expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -531,10 +572,7 @@ describe('DiscordBotListener', () => {
       const handler = (event: DiscordGatewayMessageCreateEvent) => messages.push(event)
       listener.on('message_create', handler)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         { id: 'm1', channel_id: 'C1', content: 'a', timestamp: 't', author: { id: 'U1', username: 'u' } },
@@ -559,10 +597,7 @@ describe('DiscordBotListener', () => {
       const messages: DiscordGatewayMessageCreateEvent[] = []
       listener.once('message_create', (event) => messages.push(event))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
         { id: 'm1', channel_id: 'C1', content: 'first', timestamp: 't', author: { id: 'U1', username: 'u' } },
@@ -584,10 +619,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       ;(listener as any).reconnectAttempts = 5
       mockWsInstance.simulateReconnect()
@@ -601,10 +633,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect((listener as any).sessionId).toBe('session_123')
 
@@ -619,10 +648,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       const sessionIdBefore = (listener as any).sessionId
 
@@ -637,10 +663,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateClose()
 
@@ -658,39 +681,38 @@ describe('DiscordBotListener', () => {
   })
 
   describe('non-recoverable close codes', () => {
-    it('emits error and stops on code 4014 (privileged intent not approved)', async () => {
+    for (const code of [4004, 4013, 4014]) {
+      it(`rejects start() and stops on non-recoverable close ${code}`, async () => {
+        const client = createMockClient()
+        listener = new DiscordBotListener(client)
+        listener.on('error', () => {})
+
+        const started = listener.start()
+        const ws = await waitForSocket()
+        ws.simulateOpen()
+        ws.simulateClose(code)
+
+        await expect(started).rejects.toThrow(String(code))
+        expect((listener as any).running).toBe(false)
+        expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
+      })
+    }
+  })
+
+  describe('connect timeout', () => {
+    it('rejects start() and tears down when READY never arrives', async () => {
       const client = createMockClient()
-      listener = new DiscordBotListener(client)
+      listener = new DiscordBotListener(client, { connectTimeoutMs: 100 })
+      listener.on('error', () => {})
 
-      const errors: Error[] = []
-      listener.on('error', (err) => errors.push(err))
+      const started = listener.start()
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+      // given: Identify sent but the gateway never delivers READY
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateClose(4014)
-
-      await new Promise((r) => setTimeout(r, 50))
-
-      expect(errors.length).toBe(1)
-      expect(errors[0].message).toContain('4014')
-      expect(client.gatewayConnect).toHaveBeenCalledTimes(1)
-    })
-
-    it('emits error and stops on code 4004 (invalid token)', async () => {
-      const client = createMockClient()
-      listener = new DiscordBotListener(client)
-
-      const errors: Error[] = []
-      listener.on('error', (err) => errors.push(err))
-
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateClose(4004)
-
-      await new Promise((r) => setTimeout(r, 50))
-
-      expect(errors.length).toBe(1)
-      expect(errors[0].message).toContain('4004')
+      await expect(started).rejects.toThrow(/did not become ready/)
+      expect((listener as any).running).toBe(false)
     })
   })
 
@@ -699,10 +721,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect((listener as any).sessionId).toBe('session_123')
 
@@ -729,10 +748,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateClose(4009)
 
@@ -749,10 +765,12 @@ describe('DiscordBotListener', () => {
         const client = createMockClient()
         listener = new DiscordBotListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello(50)
-        mockWsInstance.simulateReady()
+        const started = listener.start()
+        const ws = await waitForSocket()
+        ws.simulateOpen()
+        ws.simulateHello(50)
+        ws.simulateReady()
+        await started
 
         mockWsInstance.simulateHello(50)
 
@@ -777,10 +795,7 @@ describe('DiscordBotListener', () => {
         const client = createMockClient()
         listener = new DiscordBotListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello()
-        mockWsInstance.simulateReady()
+        await startAndReady(listener)
 
         mockWsInstance.simulateInvalidSession(true)
 
@@ -798,10 +813,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       const sentBefore = mockWsInstance.sent.length
       mockWsInstance.simulateMessage({ op: 1 })
@@ -818,10 +830,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
@@ -836,10 +845,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateDispatch(
         'MESSAGE_CREATE',
@@ -863,11 +869,11 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
+      await startConnecting(listener)
       ;(listener as any).reconnectAttempts = 5
       listener.stop()
 
-      await listener.start()
+      await startConnecting(listener)
       expect((listener as any).reconnectAttempts).toBe(0)
     })
   })
@@ -877,10 +883,11 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateMessage({
+      const started = listener.start()
+      const ws = await waitForSocket()
+      ws.simulateOpen()
+      ws.simulateHello()
+      ws.simulateMessage({
         op: 0,
         t: 'READY',
         s: 1,
@@ -890,6 +897,7 @@ describe('DiscordBotListener', () => {
           user: { id: 'BOT', username: 'bot' },
         },
       })
+      await started
 
       mockWsInstance.simulateClose()
       await new Promise((r) => setTimeout(r, 1500))
@@ -901,7 +909,8 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
+      listener.start().catch(() => {})
+      await waitForSocket()
 
       expect(MockWs.lastUrl).toBe('wss://gateway.discord.gg/?v=10&encoding=json')
     })
@@ -912,10 +921,11 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
+      listener.start().catch(() => {})
+      const ws = await waitForSocket()
       ;(listener as any).reconnectAttempts = 5
 
-      mockWsInstance.simulateOpen()
+      ws.simulateOpen()
 
       // given: a socket opens but no READY received yet
       // then: reconnectAttempts must NOT be reset (open alone is not a successful session)
@@ -926,12 +936,14 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
+      const started = listener.start()
+      const ws = await waitForSocket()
       ;(listener as any).reconnectAttempts = 5
 
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      ws.simulateOpen()
+      ws.simulateHello()
+      ws.simulateReady()
+      await started
 
       expect((listener as any).reconnectAttempts).toBe(0)
     })
@@ -940,10 +952,7 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       mockWsInstance.simulateClose()
       await new Promise((r) => setTimeout(r, 1500))
@@ -966,10 +975,7 @@ describe('DiscordBotListener', () => {
       const connectedEvents: any[] = []
       listener.on('connected', (info) => connectedEvents.push(info))
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       expect(connectedEvents.length).toBe(1)
 
@@ -991,15 +997,13 @@ describe('DiscordBotListener', () => {
       const client = createMockClient()
       listener = new DiscordBotListener(client)
 
-      await listener.start()
-      mockWsInstance.simulateOpen()
-      mockWsInstance.simulateHello()
-      mockWsInstance.simulateReady()
+      await startAndReady(listener)
 
       const oldWs = mockWsInstance
 
       listener.stop()
-      await listener.start()
+      mockWsInstance = undefined as unknown as MockWs
+      await startConnecting(listener)
 
       // given: a fresh socket from the second start()
       // when: the OLD socket fires a stale close event
@@ -1018,10 +1022,7 @@ describe('DiscordBotListener', () => {
         const client = createMockClient()
         listener = new DiscordBotListener(client)
 
-        await listener.start()
-        mockWsInstance.simulateOpen()
-        mockWsInstance.simulateHello()
-        mockWsInstance.simulateReady()
+        await startAndReady(listener)
 
         const initialGeneration = (listener as any).generation
 
@@ -1029,7 +1030,8 @@ describe('DiscordBotListener', () => {
 
         // when: stop()+start() before the d=true delay fires
         listener.stop()
-        await listener.start()
+        mockWsInstance = undefined as unknown as MockWs
+        await startConnecting(listener)
 
         await new Promise((r) => setTimeout(r, 1500))
 

--- a/src/platforms/discordbot/listener.ts
+++ b/src/platforms/discordbot/listener.ts
@@ -13,6 +13,11 @@ const RECONNECT_MAX_DELAY = 30_000
 const NON_RECOVERABLE_CLOSE_CODES = [4004, 4010, 4011, 4012, 4013, 4014]
 const SESSION_RESET_CLOSE_CODES = [4007, 4009]
 
+// Hello arrives within milliseconds and READY within a few seconds on a healthy gateway;
+// 15s is generous for a successful handshake while still failing fast on bad tokens,
+// network stalls, or a gateway that accepts the socket but never delivers READY.
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
+
 const DEFAULT_INTENTS =
   DiscordIntent.Guilds |
   DiscordIntent.GuildMessages |
@@ -26,11 +31,13 @@ type EventKey = keyof DiscordBotListenerEventMap
 
 export interface DiscordBotListenerOptions {
   intents?: number
+  connectTimeoutMs?: number
 }
 
 export class DiscordBotListener {
   private client: DiscordBotClient
   private intents: number
+  private connectTimeoutMs: number
   private running = false
   private ws: WebSocket | null = null
   private emitter = new EventEmitter()
@@ -39,6 +46,7 @@ export class DiscordBotListener {
   private heartbeatJitterTimer: ReturnType<typeof setTimeout> | null = null
   private invalidSessionTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
   private sequence: number | null = null
   private sessionId: string | null = null
@@ -46,24 +54,91 @@ export class DiscordBotListener {
   private token: string | null = null
   private cachedUser: { id: string; username: string } | null = null
   private generation = 0
+  private startPromise: Promise<void> | null = null
+  private pendingStartReject: ((error: Error) => void) | null = null
 
   constructor(client: DiscordBotClient, options?: DiscordBotListenerOptions) {
     this.client = client
     this.intents = options?.intents ?? DEFAULT_INTENTS
+    this.connectTimeoutMs = options?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
   }
 
   async start(): Promise<void> {
+    if (this.startPromise) return this.startPromise
     if (this.running) return
+
     this.running = true
     this.reconnectAttempts = 0
-    this.generation++
-    await this.connect(this.generation)
+    const generation = ++this.generation
+
+    const ready = new Promise<void>((resolve, reject) => {
+      let settled = false
+
+      const cleanup = () => {
+        this.emitter.off('connected', onConnected)
+        this.emitter.off('error', onError)
+        this.pendingStartReject = null
+        if (this.connectTimeoutTimer) {
+          clearTimeout(this.connectTimeoutTimer)
+          this.connectTimeoutTimer = null
+        }
+      }
+
+      const onConnected = () => {
+        if (settled || !this.isCurrent(generation)) return
+        settled = true
+        cleanup()
+        resolve()
+      }
+
+      const onError = (error: Error) => {
+        if (settled || !this.isCurrent(generation)) return
+        settled = true
+        cleanup()
+        this.teardownFailedStart(generation)
+        reject(error)
+      }
+
+      this.emitter.once('connected', onConnected)
+      this.emitter.once('error', onError)
+
+      // Generation-agnostic on purpose: stop() invokes this to reject an in-flight start
+      // (after bumping generation) without leaking the once() handlers.
+      this.pendingStartReject = (error: Error) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        reject(error)
+      }
+
+      this.connectTimeoutTimer = setTimeout(() => {
+        onError(new Error(`Discord gateway did not become ready within ${this.connectTimeoutMs}ms`))
+      }, this.connectTimeoutMs)
+    })
+
+    const run = async (): Promise<void> => {
+      try {
+        await Promise.all([this.connect(generation), ready])
+      } finally {
+        if (this.generation === generation) this.startPromise = null
+      }
+    }
+    const startPromise = run()
+    this.startPromise = startPromise
+    return startPromise
   }
 
   stop(): void {
     this.running = false
     this.generation++
     this.clearTimers()
+    if (this.connectTimeoutTimer) {
+      clearTimeout(this.connectTimeoutTimer)
+      this.connectTimeoutTimer = null
+    }
+    const rejectStart = this.pendingStartReject
+    this.pendingStartReject = null
+    this.startPromise = null
     if (this.ws) {
       this.ws.close()
       this.ws = null
@@ -73,6 +148,12 @@ export class DiscordBotListener {
     this.resumeGatewayUrl = null
     this.token = null
     this.cachedUser = null
+    rejectStart?.(new Error('Discord gateway start was stopped before becoming ready'))
+  }
+
+  private teardownFailedStart(generation: number): void {
+    if (!this.isCurrent(generation)) return
+    this.stop()
   }
 
   on<K extends EventKey>(event: K, listener: (...args: DiscordBotListenerEventMap[K]) => void): this {


### PR DESCRIPTION
## Problem

`DiscordListener.start()` (and `DiscordBotListener.start()`) is `async` but resolves as soon as the WebSocket is **created**, not when the gateway is actually connected. `start()` → `connect()` only awaits `client.gatewayConnect()` and `new WebSocket(url)`, then returns. The `'connected'` event fires much later, asynchronously, once the gateway completes **Hello → Identify → READY** (in `handleDispatch`, the `t === 'READY'` branch).

A consumer doing the idiomatic `await listener.start()` and then checking connection state finds it **disconnected**, because READY hasn't arrived yet — violating the `await start() ⇒ connected` contract. (Discovered in TypeClaw: adapter logs `listener.start()` returned without emitting `connected` even though auth and the gateway are fine.)

## Fix

`start()` now returns a **readiness-gated** promise that:

- **resolves** on the first `connected` (READY/RESUMED)
- **rejects** on an `error` raised before the first `connected` — connect-time error, ws `error`, or a non-recoverable close (`4004`/`4010`/`4011`/`4012`/`4013`/`4014`)
- **rejects** on a **connect timeout** (default **15s**, configurable via the new `connectTimeoutMs` option) and tears the socket down
- **detaches** its one-shot resolve/reject handlers after settling, so later reconnect errors during normal long-running operation never reject an already-settled promise

Additional lifecycle hardening (surfaced during review):

- `stop()` **rejects any in-flight `start()`** instead of leaving it pending forever
- **concurrent `start()` calls share a single readiness promise** (truly readiness-gated, not an early return)
- **recoverable** closes during the initial handshake keep retrying (bounded by the timeout) rather than rejecting — a transient blip rides the reconnect and still resolves on the eventual READY

This matches how the Slack and Webex listeners surface readiness (`connected` on `hello` / handler `connected`).

The same fix is applied identically to **`DiscordBotListener`**, which shared the exact pattern.

## Tests

New tests (both listeners):

- `start()` does **not** resolve until a READY dispatch is delivered
- `start()` **rejects** on non-recoverable close `4004` / `4013` / `4014`
- `start()` **rejects** on connect **timeout** when READY never arrives
- `start()` **rejects** when `stop()` is called before READY
- concurrent `start()` calls **share one readiness promise**
- `start()` rejects + tears down on `gatewayConnect()` failure during initial connect

Existing tests were updated to drive the handshake **concurrently** (`const p = start(); simulateOpen(); simulateHello(); simulateReady(); await p`) since the new contract makes the old `await start(); then simulateReady()` ordering logically impossible.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings, 0 errors
- `bun test` — **3315 pass / 0 fail** (+8 new tests)
- `oxfmt --check` on changed files — correctly formatted

> Note: repo-wide `format:check` fails on a pre-existing `docs/` CSS import resolution issue unrelated to this change (docs deps not installed in the dev worktree).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Discord listeners resolve start() only after the gateway sends READY, with a connect timeout and better failure handling. Applies to both `DiscordListener` and `DiscordBotListener`.

- **Bug Fixes**
  - `start()` resolves on first READY/RESUMED; rejects on pre-READY errors and non-recoverable close codes.
  - Added connect timeout (default 15s; configurable via `connectTimeoutMs`); failure tears down the socket.
  - `stop()` rejects any in-flight `start()`; concurrent `start()` calls share one readiness promise.
  - Recoverable closes during the initial handshake keep retrying until the timeout.

- **Migration**
  - No app changes expected; if you relied on `start()` resolving before READY, update call sites accordingly. Optional: set `connectTimeoutMs` as needed.
  - SKILL.md/docs: no updates required.

<sup>Written for commit e1e0809ca99aec97c92dd86d9182f5acc6347152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

