### PR TITLE
feat(imessage): add iMessage support via BlueBubbles

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,7 @@
     "channel-talk",
     "line",
     "instagram",
+    "imessage",
     "messaging",
     "workspace",
     "guild",
@@ -44,6 +45,7 @@
     "./skills/agent-instagram",
     "./skills/agent-kakaotalk",
     "./skills/agent-channeltalk",
-    "./skills/agent-channeltalkbot"
+    "./skills/agent-channeltalkbot",
+    "./skills/agent-imessage"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Multi-platform messaging CLI for AI agents (Slack, Discord, Teams).
 
+## Platform Notes
+
+Each platform lives in `src/platforms/<name>/` and follows the same convention (cli, index, client, types, credential-manager, ensure-auth, commands). **iMessage (`agent-imessage`) is the one exception that requires a self-hosted relay:** Apple has no public API, so it connects over HTTP to a BlueBubbles server the user runs on their own Mac. Its client (`BlueBubblesClient`) is a plain REST client with a provider-aware `{ serverUrl, password }` credential, and it receives messages by polling (no inbound webhook server).
+
 ## TypeScript Execution Model
 
 ### Local Development

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This installs:
 - `agent-kakaotalk` — KakaoTalk CLI (sub-device login, LOCO protocol)
 - `agent-channeltalk` — Channel Talk CLI (beta, zero-config, extracted cookies)
 - `agent-channeltalkbot` — Channel Talk Bot CLI (beta, API credentials, for server-side/CI/CD)
+- `agent-imessage` — iMessage CLI (via a self-hosted [BlueBubbles](https://bluebubbles.app) server on your Mac)
 
 ## Agent Skills
 
@@ -210,6 +211,7 @@ const slack = await new SlackClient().login({ token: 'xoxc-...', cookie: 'xoxd-.
 | `agent-messenger/kakaotalk` | `KakaoTalkClient` |
 | `agent-messenger/channeltalk` | `ChannelClient` |
 | `agent-messenger/channeltalkbot` | `ChannelBotClient` |
+| `agent-messenger/imessage` | `BlueBubblesClient` |
 
 Each module also exports its credential manager, Zod schemas, and TypeScript types:
 
@@ -429,6 +431,8 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 
 > ⚠️ **Teams tokens expire in 60-90 minutes.** Re-run `agent-teams auth extract` to refresh. See [Teams Guide](skills/agent-teams/SKILL.md) for details.
 
+> 💬 **iMessage** is supported via a self-hosted [BlueBubbles](https://bluebubbles.app) relay (`agent-imessage`), not the table above. v1 covers send & list messages, direct & group chats, chat listing, real-time watch (polling), and multi-account. Reactions, typing indicators, and edit/unsend are a later tier that requires BlueBubbles' Private API. See the [iMessage Guide](skills/agent-imessage/SKILL.md).
+
 ## Platform Guides
 
 - **[Slack Guide](https://agent-messenger.dev/docs/cli/slack)** — Full command reference for Slack
@@ -448,6 +452,11 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 - **[KakaoTalk Guide](https://agent-messenger.dev/docs/cli/kakaotalk)** — Sub-device login and LOCO protocol integration
 - **[Channel Talk Guide](https://agent-messenger.dev/docs/cli/channeltalk)** — Full command reference for Channel Talk (beta, zero-config)
 - **[Channel Talk Bot Guide](https://agent-messenger.dev/docs/cli/channeltalkbot)** — Bot API integration for Channel Talk (beta)
+- **[iMessage Guide](skills/agent-imessage/SKILL.md)** — iMessage via a self-hosted BlueBubbles relay on your Mac
+
+### iMessage is different
+
+Most agent-messenger platforms run directly from the CLI with no server. **iMessage is the exception:** Apple provides no public API, so `agent-imessage` connects to **your own Mac** running the free, open-source [BlueBubbles](https://bluebubbles.app) server. You still act as yourself with your own Apple ID, keep control of your credentials, and run one shell command per action — but you (or your team) must keep one Mac running BlueBubbles. The CLI itself runs anywhere that can reach that Mac, including Docker containers. See the [setup guide](skills/agent-imessage/references/setup.md).
 
 ## Use Cases
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "agent-channeltalkbot": "./src/platforms/channeltalkbot/cli.ts",
     "agent-discord": "./src/platforms/discord/cli.ts",
     "agent-discordbot": "./src/platforms/discordbot/cli.ts",
+    "agent-imessage": "./src/platforms/imessage/cli.ts",
     "agent-instagram": "./src/platforms/instagram/cli.ts",
     "agent-kakaotalk": "./src/platforms/kakaotalk/cli.ts",
     "agent-line": "./src/platforms/line/cli.ts",
@@ -79,6 +80,9 @@
       ],
       "telegrambot": [
         "./src/platforms/telegrambot/index.ts"
+      ],
+      "imessage": [
+        "./src/platforms/imessage/index.ts"
       ]
     }
   },
@@ -151,6 +155,10 @@
     "./telegrambot": {
       "types": "./src/platforms/telegrambot/index.ts",
       "default": "./src/platforms/telegrambot/index.ts"
+    },
+    "./imessage": {
+      "types": "./src/platforms/imessage/index.ts",
+      "default": "./src/platforms/imessage/index.ts"
     }
   },
   "scripts": {

--- a/skills/agent-imessage/SKILL.md
+++ b/skills/agent-imessage/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: agent-imessage
+description: Interact with iMessage via BlueBubbles - send messages, read chats, watch for new messages
+version: 2.27.1
+allowed-tools: Bash(agent-imessage:*)
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - agent-imessage
+    install:
+      - kind: node
+        package: agent-messenger
+        bins: [agent-imessage]
+---
+
+# Agent iMessage
+
+An iMessage CLI for AI agents, backed by [BlueBubbles](https://bluebubbles.app). Apple provides no public iMessage API, so this integration connects to **your own Mac** running the free, open-source BlueBubbles server. You still act as yourself with your own Apple ID; the CLI just talks HTTP to your Mac.
+
+Use one of these entrypoints:
+- Global install: `agent-imessage ...`
+- One-off execution: `bunx --package agent-messenger agent-imessage ...`
+
+## Key Concepts
+
+- **BlueBubbles relay** = a free macOS app that bridges iMessage and exposes a REST API (default port `1234`). It runs on a Mac signed into iMessage. The CLI connects to it over HTTP — same Mac, LAN, or container.
+- **Chat GUID** = iMessage's chat identifier (e.g. `iMessage;-;+15551234567` for a DM, or a group GUID). Get GUIDs from `chat list`.
+- **serverUrl + password** = the only credentials. There is no Apple login in this CLI. You set a password in BlueBubbles and point the CLI at the server URL.
+- **Polling receive** = the CLI pulls new messages (`message watch`) rather than receiving webhooks, so it works from anywhere that can reach the Mac, including Docker containers (outbound-only).
+- **Multi-account** = each account is one BlueBubbles endpoint `(serverUrl, password)`. Use `auth list`/`auth use` to switch. Multiple accounts = multiple BlueBubbles instances (different ports or Macs).
+- **Private API tier** = reactions, typing indicators, and edit/unsend require BlueBubbles' Private API (SIP disabled). Basic text send/receive does NOT.
+
+## Quick Start
+
+```bash
+# Guided setup: verifies the connection and saves credentials
+agent-imessage setup
+
+# Or set credentials non-interactively (validated before saving)
+agent-imessage auth set --url http://host.docker.internal:1234 --password "$BB_PASSWORD" --current
+
+# List chats (get GUIDs here)
+agent-imessage chat list
+
+# Send a message
+agent-imessage message send "iMessage;-;+15551234567" "Hello from agent-imessage"
+
+# Watch for new messages (polling, JSON lines)
+agent-imessage message watch --chat all --interval 5s --jsonl
+
+# Diagnose connection problems
+agent-imessage doctor
+```
+
+## Server URL by location
+
+| Where the CLI runs | serverUrl |
+| --- | --- |
+| Same Mac (native) | `http://localhost:1234` |
+| Docker on the same Mac | `http://host.docker.internal:1234` |
+| Another machine / LAN | `http://<mac-lan-ip>:1234` |
+
+> Inside a container, `localhost` refers to the container itself — use `host.docker.internal` (same-Mac) or the Mac's LAN IP.
+
+## Authentication
+
+iMessage authentication is about reaching your BlueBubbles server, not logging into Apple.
+
+- `agent-imessage setup` — guided: pick your topology, enter the password, verifies, saves.
+- `agent-imessage auth set --url <url> --password <pw> [--account <id>] [--label <label>] [--current]` — scriptable. Validates before saving.
+- `agent-imessage auth login` — interactive prompt; validates before saving.
+
+Environment variables override stored credentials at runtime (never persisted to disk):
+`AGENT_IMESSAGE_URL` / `AGENT_IMESSAGE_PASSWORD` (aliases: `BLUEBUBBLES_URL` / `BLUEBUBBLES_PASSWORD`).
+
+Resolution order: explicit flags → `AGENT_IMESSAGE_*` → `BLUEBUBBLES_*` → stored current account.
+
+See [setup reference](references/setup.md) for the one-time Mac/BlueBubbles host setup and [docker reference](references/docker.md) for container topologies.
+
+### Agent Behavior (MANDATORY)
+
+When a command fails because no account is configured, the agent MUST drive setup itself rather than telling the user to run commands. If the user has a BlueBubbles server, run `auth set` with the URL/password they provide. If a command returns a `code` of `unreachable`, `auth_rejected`, or `localhost_in_container`, run `agent-imessage doctor` and act on the `suggestion` field before retrying. Never silently retry the same failing call.
+
+## Commands
+
+- `setup` — Guided connection setup and verification.
+- `doctor [--account <id>] [--test-chat <guid>]` — Diagnose the connection; surfaces actionable fixes.
+- `auth set|login|status|list|use|remove|logout` — Manage credentials/accounts.
+- `chat list [--limit <n>]` — List chats (source of chat GUIDs).
+- `chat search <query> [--limit <n>]` — Filter chats by name/identifier.
+- `message list <chat> [--limit <n>]` — Read recent messages from a chat GUID (oldest-last).
+- `message send <chat> <text>` — Send a text message.
+- `message watch [--chat <guid|all>] [--interval 5s] [--since <iso>] [--jsonl]` — Stream new messages via polling.
+- `whoami` — Show the active server/account and Private API status.
+
+All commands accept `--account <id>` (pick a specific account) and `--pretty` (human-readable JSON).
+
+## Output Format
+
+JSON by default (for tool use); `--pretty` for indented output. `message watch --jsonl` emits one JSON object per line.
+
+## Feature Tiers
+
+| Feature | Available | Requires |
+| --- | --- | --- |
+| List/search chats, send text, read/watch messages | ✅ | BlueBubbles (no SIP) |
+| Reactions / typing / edit / unsend | ⏳ planned | BlueBubbles Private API (SIP disabled) |
+
+## Error Handling
+
+Errors are JSON with a `code` and often a `suggestion`. Map them to actions:
+
+| Code | Meaning | Action |
+| --- | --- | --- |
+| `no_credentials` | No server configured | Run `agent-imessage setup` or `auth set`. |
+| `not_authenticated` | Client used before login | Resolve credentials first (env or `auth set`). |
+| `unreachable` | Server not responding | Is the BlueBubbles Mac app running? Check URL/port (default 1234). Run `doctor`. |
+| `auth_rejected` | Wrong password | Check the BlueBubbles server password; rerun `auth login`. |
+| `localhost_in_container` | `localhost` used inside Docker | Use `http://host.docker.internal:1234` (same Mac) or the Mac's LAN IP. |
+| `private_api_required` | Feature needs Private API | Text send/receive works without it; enable Private API in BlueBubbles for reactions/typing/edit. |
+| `invalid_limit` | Bad `--limit`/`--interval` | Use an integer 1–100 for `--limit`; `--interval` ≥ 1s. |
+| `send_failed` | BlueBubbles rejected the send | Run `doctor`; check the chat GUID and server health. |
+
+## Troubleshooting
+
+- **Inbound messages delayed by minutes** — macOS (especially Sequoia/macOS 26) idles Messages.app. Keep the Mac awake and BlueBubbles active (Amphetamine/Caffeine). `doctor` warns when it detects this.
+- **Connection refused from a container** — almost always the `localhost` trap; use `host.docker.internal` or the LAN IP.
+- **`agent-imessage doctor`** is the fastest way to see backend version, auth status, Private API status, and inbound freshness.
+
+## Configuration
+
+Credentials are stored in `~/.config/agent-messenger/imessage-credentials.json` (mode `0600`). Relocate via `AGENT_MESSENGER_CONFIG_DIR`.

--- a/skills/agent-imessage/references/docker.md
+++ b/skills/agent-imessage/references/docker.md
@@ -1,0 +1,38 @@
+# Running agent-imessage in Docker
+
+`agent-imessage` is outbound-only: it makes HTTP calls to BlueBubbles and polls for new messages. It never needs an inbound server, so it runs cleanly inside containers.
+
+## Topologies
+
+| Topology | serverUrl | Notes |
+| --- | --- | --- |
+| Container on the same Mac (Docker Desktop) | `http://host.docker.internal:1234` | Built-in on Docker Desktop; no `--add-host`. |
+| Container on another LAN machine | `http://<mac-lan-ip>:1234` | Allow port 1234 in the macOS firewall. |
+| Many containers, one shared Mac | `host.docker.internal` or LAN IP | Each container polls independently — no coordination needed. |
+
+> **The `localhost` trap:** inside a container, `localhost`/`127.0.0.1` is the container itself, not the Mac. Use `host.docker.internal` (same Mac) or the Mac's LAN IP. `agent-imessage` detects this and returns a `localhost_in_container` error with the fix.
+>
+> mDNS `.local` names do **not** resolve inside containers — use the LAN IP.
+
+## Configuration via environment variables
+
+Pass credentials as env vars (overrides stored credentials at runtime, never persisted):
+
+```bash
+docker run \
+  -e AGENT_IMESSAGE_URL=http://host.docker.internal:1234 \
+  -e AGENT_IMESSAGE_PASSWORD=your-password \
+  -e AGENT_MESSENGER_CONFIG_DIR=/config \
+  -v am-config:/config \
+  your-image \
+  agent-imessage message send "iMessage;-;+15551234567" "hello from a container"
+```
+
+`BLUEBUBBLES_URL` / `BLUEBUBBLES_PASSWORD` are accepted as aliases.
+
+## Notes
+
+- For non-Docker-Desktop runtimes (Colima, Rancher Desktop), `host.docker.internal` may require `--add-host=host.docker.internal:host-gateway`.
+- If Docker Desktop ≥ 4.31 resolves `host.docker.internal` to IPv6 and your server is IPv4-only, set the Docker network mode to "IPv4 only".
+- Mount a volume at `AGENT_MESSENGER_CONFIG_DIR` to persist credentials across container restarts (or just use env vars).
+- Use the Node build (`dist/`) in production images; Bun is only required for local development.

--- a/skills/agent-imessage/references/setup.md
+++ b/skills/agent-imessage/references/setup.md
@@ -1,0 +1,55 @@
+# BlueBubbles Host Setup (Operator Guide)
+
+iMessage has no public API. To send and receive iMessages programmatically you run [BlueBubbles Server](https://bluebubbles.app) on a Mac signed into iMessage, then point `agent-imessage` at it. This is a one-time host setup of roughly 5 minutes, part of which requires the macOS GUI.
+
+## Hardware & OS
+
+- **Any Mac that stays awake 24/7.** A used Mac Mini is the common choice. Runs headless fine.
+- **macOS version matters:**
+  - **Ventura (13)** — recommended, most stable, all features work.
+  - **Sonoma (14)** — good.
+  - **Sequoia (15)** — works, but Messages.app idle-throttling can delay inbound messages 8–15 min. Mitigate with a keep-alive app (Amphetamine/Caffeine).
+  - **macOS 26 (Tahoe)** — AppleScript send and the Private API helper are currently broken. Not recommended.
+- Use a **dedicated Apple ID** (e.g. `your-bot@icloud.com`), not your personal one. This avoids ban-risk bleed-over and echo loops.
+
+## One-time setup steps
+
+Some steps require the GUI (do them physically or via Screen Sharing/VNC once):
+
+1. **Install BlueBubbles Server** from https://bluebubbles.app. The app is unsigned (Apple revoked the dev cert) — right-click the app → Open to bypass Gatekeeper. *(CLI: `brew install --cask bluebubbles` also works.)*
+2. **Sign Messages.app into iMessage** with the dedicated Apple ID. *(GUI only — cannot be scripted.)*
+3. **Grant Full Disk Access** to BlueBubbles in System Settings → Privacy & Security → Full Disk Access. *(GUI only on unmanaged Macs.)* This lets it read `~/Library/Messages/chat.db`.
+4. **Set a strong server password** in BlueBubbles settings (default port `1234`).
+5. **Keep it running:** enable auto-login (System Settings → Users & Groups) and a keep-alive app so Messages.app stays warm. Optionally install a LaunchAgent for crash/reboot recovery.
+
+Basic text send/receive needs **no SIP changes**. Reactions, typing indicators, and edit/unsend require BlueBubbles' Private API (which requires disabling SIP) — treat that as an advanced, optional tier.
+
+## Networking
+
+- **Same Mac / LAN:** bind is `0.0.0.0` by default. Allow port `1234` through the macOS firewall for LAN access.
+- **Remote/internet:** use BlueBubbles' built-in Cloudflare Tunnel, ngrok, or Tailscale for HTTPS. The server password is the only auth layer — keep it strong and prefer HTTPS off-LAN.
+
+## Connect the CLI
+
+```bash
+agent-imessage setup     # guided
+# or
+agent-imessage auth set --url http://<mac-host>:1234 --password "$BB_PASSWORD" --current
+agent-imessage doctor    # verify
+```
+
+## Reliability checklist
+
+- Mac stays awake and logged in (keep-alive + auto-login).
+- macOS auto-updates pinned/deferred (updates can break sending).
+- `agent-imessage doctor` returns `connection: ok` and reasonable inbound freshness.
+
+## Multi-account
+
+One BlueBubbles instance = one Apple ID. For multiple iMessage identities, run multiple instances (separate macOS user sessions via Fast User Switching on different ports, or separate Macs), then add each as its own account:
+
+```bash
+agent-imessage auth set --url http://mac:1234 --password ... --account alice
+agent-imessage auth set --url http://mac:5678 --password ... --account bob
+agent-imessage auth use alice
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,10 @@ program.command('channeltalk', 'Interact with Channel Talk', {
   executableFile: join(__dirname, 'platforms', 'channeltalk', `cli${ext}`),
 })
 
+program.command('imessage', 'Interact with iMessage via BlueBubbles', {
+  executableFile: join(__dirname, 'platforms', 'imessage', `cli${ext}`),
+})
+
 program.command('channeltalkbot', 'Interact with Channel Talk using API credentials', {
   executableFile: join(__dirname, 'platforms', 'channeltalkbot', `cli${ext}`),
 })

--- a/src/platforms/imessage/cli.ts
+++ b/src/platforms/imessage/cli.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+
+import type { Command as CommandType } from 'commander'
+import { Command } from 'commander'
+
+import pkg from '../../../package.json' with { type: 'json' }
+import { authCommand, chatCommand, doctorCommand, messageCommand, setupCommand, whoamiCommand } from './commands/index'
+import { ensureIMessageAuth } from './ensure-auth'
+
+const UNGUARDED = new Set(['auth', 'setup', 'doctor'])
+
+function isUnguarded(command: CommandType): boolean {
+  let cmd: CommandType | null = command
+  while (cmd) {
+    if (UNGUARDED.has(cmd.name())) return true
+    cmd = cmd.parent
+  }
+  return false
+}
+
+const program = new Command()
+
+program.name('agent-imessage').description('CLI tool for iMessage via BlueBubbles').version(pkg.version)
+
+program.hook('preAction', async (_thisCommand, actionCommand) => {
+  if (isUnguarded(actionCommand)) return
+  await ensureIMessageAuth()
+})
+
+program.addCommand(authCommand)
+program.addCommand(setupCommand)
+program.addCommand(doctorCommand)
+program.addCommand(chatCommand)
+program.addCommand(messageCommand)
+program.addCommand(whoamiCommand)
+
+program.parse(process.argv)
+
+export default program

--- a/src/platforms/imessage/client.test.ts
+++ b/src/platforms/imessage/client.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { BlueBubblesClient } from './client'
+import { IMessageError } from './types'
+
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+type Handler = (url: URL, req: Request) => Response | Promise<Response>
+
+function startServer(handler: Handler): { url: string; stop: () => void } {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return handler(new URL(req.url), req)
+    },
+  })
+  return { url: `http://localhost:${server.port}`, stop: () => server.stop(true) }
+}
+
+function envelope(data: unknown, status = 200): Response {
+  return Response.json({ status, message: 'ok', data }, { status })
+}
+
+describe('BlueBubblesClient', () => {
+  it('connect resolves on 200 ping', async () => {
+    const srv = startServer((url) =>
+      url.pathname === '/api/v1/ping' ? envelope('pong') : new Response('x', { status: 404 }),
+    )
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: srv.url, password: 'pw' })
+      await expect(client.connect()).resolves.toBeUndefined()
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('connect on refused connection throws unreachable with suggestion', async () => {
+    const client = await new BlueBubblesClient().login({ serverUrl: 'http://127.0.0.1:1', password: 'pw' })
+    try {
+      await client.connect()
+      throw new Error('should have thrown')
+    } catch (error) {
+      const e = error as IMessageError
+      expect(e.code).toBe('unreachable')
+      expect(e.suggestion).toContain('port')
+    }
+  })
+
+  it('detects localhost-in-container and suggests host.docker.internal', async () => {
+    const prev = process.env.AGENT_MESSENGER_IN_CONTAINER
+    process.env.AGENT_MESSENGER_IN_CONTAINER = '1'
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: 'http://localhost:1', password: 'pw' })
+      await client.connect()
+      throw new Error('should have thrown')
+    } catch (error) {
+      const e = error as IMessageError
+      expect(e.code).toBe('localhost_in_container')
+      expect(e.suggestion).toContain('host.docker.internal')
+    } finally {
+      if (prev === undefined) delete process.env.AGENT_MESSENGER_IN_CONTAINER
+      else process.env.AGENT_MESSENGER_IN_CONTAINER = prev
+    }
+  })
+
+  it('maps 401 to auth_rejected', async () => {
+    const srv = startServer(() => new Response('no', { status: 401 }))
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: srv.url, password: 'pw' })
+      await client.connect()
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('auth_rejected')
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('listChats classifies group vs individual and maps fields', async () => {
+    const srv = startServer((url) => {
+      if (url.pathname === '/api/v1/ping') return envelope('pong')
+      if (url.pathname === '/api/v1/chat/query')
+        return envelope([
+          {
+            guid: 'g1',
+            chatIdentifier: 'c1',
+            displayName: 'Group A',
+            style: 43,
+            participants: [{ address: 'a' }, { address: 'b' }],
+          },
+          {
+            guid: 'i1',
+            chatIdentifier: '+15551112222',
+            displayName: null,
+            style: 45,
+            participants: [{ address: '+15551112222' }],
+          },
+        ])
+      return new Response('x', { status: 404 })
+    })
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: srv.url, password: 'pw' })
+      const chats = await client.listChats(10)
+      expect(chats[0]).toMatchObject({ id: 'g1', name: 'Group A', type: 'group' })
+      expect(chats[1]).toMatchObject({ id: 'i1', name: '+15551112222', type: 'individual' })
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('getMessages returns oldest-first ISO timestamps and is_outgoing', async () => {
+    const t = Date.now()
+    const srv = startServer((url) => {
+      if (url.pathname === '/api/v1/ping') return envelope('pong')
+      if (url.pathname === '/api/v1/message/query')
+        return envelope([
+          { guid: 'm2', text: 'second', dateCreated: t, isFromMe: true, handle: null },
+          { guid: 'm1', text: 'first', dateCreated: t - 1000, isFromMe: false, handle: { address: 'x' } },
+        ])
+      return new Response('x', { status: 404 })
+    })
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: srv.url, password: 'pw' })
+      const msgs = await client.getMessages('chat1', 10)
+      expect(msgs.map((m) => m.id)).toEqual(['m1', 'm2'])
+      expect(msgs[0]?.is_outgoing).toBe(false)
+      expect(msgs[1]?.is_outgoing).toBe(true)
+      expect(msgs[0]?.timestamp).toBe(new Date(t - 1000).toISOString())
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('countMessages returns the total', async () => {
+    const srv = startServer((url) =>
+      url.pathname === '/api/v1/message/count' ? envelope({ total: 3 }) : new Response('x', { status: 404 }),
+    )
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: srv.url, password: 'pw' })
+      expect(await client.countMessages(0)).toBe(3)
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('sendMessage returns the sent summary; 500 maps to send_failed', async () => {
+    const okSrv = startServer((url) => {
+      if (url.pathname === '/api/v1/ping') return envelope('pong')
+      if (url.pathname === '/api/v1/message/text')
+        return envelope({ guid: 'sent1', text: 'hi', dateCreated: Date.now(), isFromMe: true, handle: null })
+      return new Response('x', { status: 404 })
+    })
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: okSrv.url, password: 'pw' })
+      const sent = await client.sendMessage('chat1', 'hi')
+      expect(sent).toMatchObject({ id: 'sent1', is_outgoing: true, text: 'hi' })
+    } finally {
+      okSrv.stop()
+    }
+
+    const failSrv = startServer((url) =>
+      url.pathname === '/api/v1/message/text' ? new Response('err', { status: 500 }) : envelope('pong'),
+    )
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: failSrv.url, password: 'pw' })
+      await client.sendMessage('chat1', 'hi')
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('send_failed')
+    } finally {
+      failSrv.stop()
+    }
+  })
+
+  it('getServerInfo reflects private_api flag', async () => {
+    const srv = startServer((url) =>
+      url.pathname === '/api/v1/server/info'
+        ? envelope({ server_version: '1.9.9', os_version: '13.6', private_api: false })
+        : new Response('x', { status: 404 }),
+    )
+    try {
+      const client = await new BlueBubblesClient().login({ serverUrl: srv.url, password: 'pw' })
+      const info = await client.getServerInfo()
+      expect(info).toMatchObject({ backend: 'bluebubbles', version: '1.9.9', private_api_enabled: false })
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('throws not_authenticated when used before login', async () => {
+    const client = new BlueBubblesClient()
+    await expect(client.connect()).rejects.toMatchObject({ code: 'not_authenticated' })
+  })
+})

--- a/src/platforms/imessage/client.ts
+++ b/src/platforms/imessage/client.ts
@@ -1,0 +1,251 @@
+import { existsSync } from 'node:fs'
+
+import { type IMessageChatSummary, type IMessageMessageSummary, type IMessageServerInfo, IMessageError } from './types'
+
+interface BlueBubblesEnvelope<T> {
+  status: number
+  message: string
+  data: T
+}
+
+interface BlueBubblesHandle {
+  address?: string
+}
+
+interface BlueBubblesMessage {
+  guid: string
+  text?: string | null
+  dateCreated?: number
+  isFromMe?: boolean
+  handle?: BlueBubblesHandle | null
+}
+
+interface BlueBubblesChat {
+  guid: string
+  chatIdentifier?: string
+  displayName?: string | null
+  style?: number
+  participants?: BlueBubblesHandle[]
+  lastMessage?: BlueBubblesMessage | null
+}
+
+interface BlueBubblesServerInfo {
+  server_version?: string
+  os_version?: string
+  private_api?: boolean
+  detected_icloud?: string
+}
+
+const GROUP_CHAT_STYLE = 43
+
+function looksLikeContainer(): boolean {
+  if (process.env.AGENT_MESSENGER_IN_CONTAINER === '1') return true
+  try {
+    return existsSync('/.dockerenv')
+  } catch {
+    return false
+  }
+}
+
+function hostIsLoopback(serverUrl: string): boolean {
+  try {
+    const host = new URL(serverUrl).hostname
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+  } catch {
+    return false
+  }
+}
+
+function toIsoTimestamp(dateCreated?: number): string {
+  if (!dateCreated || Number.isNaN(dateCreated)) return new Date(0).toISOString()
+  return new Date(dateCreated).toISOString()
+}
+
+function summarizeMessage(msg: BlueBubblesMessage, chatGuid: string): IMessageMessageSummary {
+  return {
+    id: msg.guid,
+    chat_id: chatGuid,
+    from: msg.isFromMe ? '' : (msg.handle?.address ?? ''),
+    from_name: msg.handle?.address ?? undefined,
+    timestamp: toIsoTimestamp(msg.dateCreated),
+    is_outgoing: Boolean(msg.isFromMe),
+    text: msg.text ?? undefined,
+  }
+}
+
+function summarizeChat(chat: BlueBubblesChat): IMessageChatSummary {
+  const type = chat.style === GROUP_CHAT_STYLE || (chat.participants?.length ?? 0) > 1 ? 'group' : 'individual'
+  const fallbackName = chat.chatIdentifier ?? chat.guid
+  return {
+    id: chat.guid,
+    name: chat.displayName?.trim() || fallbackName,
+    type,
+    last_message: chat.lastMessage ? summarizeMessage(chat.lastMessage, chat.guid) : undefined,
+  }
+}
+
+export class BlueBubblesClient {
+  private serverUrl: string | null = null
+  private password: string | null = null
+
+  async login(credentials?: { serverUrl: string; password: string }): Promise<this> {
+    if (credentials) {
+      this.serverUrl = credentials.serverUrl.replace(/\/+$/, '')
+      this.password = credentials.password
+      return this
+    }
+
+    const { IMessageCredentialManager } = await import('./credential-manager')
+    const manager = new IMessageCredentialManager()
+    const resolved = await manager.resolveCredentials()
+    if (!resolved) {
+      throw new IMessageError(
+        'No iMessage credentials found. Run "agent-imessage auth login" or "agent-imessage setup" first.',
+        'no_credentials',
+        { doctorCommand: 'agent-imessage setup' },
+      )
+    }
+    return this.login({ serverUrl: resolved.server_url, password: resolved.password })
+  }
+
+  private ensureAuth(): void {
+    if (this.serverUrl === null || this.password === null) {
+      throw new IMessageError('Not authenticated. Call .login() first.', 'not_authenticated')
+    }
+  }
+
+  private buildUrl(path: string, query: Record<string, string | number | undefined> = {}): string {
+    const url = new URL(`${this.serverUrl}${path}`)
+    url.searchParams.set('password', this.password!)
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) url.searchParams.set(key, String(value))
+    }
+    return url.toString()
+  }
+
+  private async request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    options: { query?: Record<string, string | number | undefined>; body?: unknown } = {},
+  ): Promise<T> {
+    this.ensureAuth()
+
+    const init: RequestInit = { method }
+    if (method === 'POST' && options.body !== undefined) {
+      init.headers = { 'Content-Type': 'application/json' }
+      init.body = JSON.stringify(options.body)
+    }
+
+    let response: Response
+    try {
+      response = await fetch(this.buildUrl(path, options.query), init)
+    } catch {
+      throw this.normalizeNetworkError()
+    }
+
+    if (response.status === 401) {
+      throw new IMessageError('Password rejected by BlueBubbles.', 'auth_rejected', {
+        suggestion: 'Check the server password in BlueBubbles settings, then rerun "agent-imessage auth login".',
+        doctorCommand: 'agent-imessage doctor',
+      })
+    }
+
+    if (!response.ok) {
+      throw new IMessageError(`BlueBubbles request failed (HTTP ${response.status}).`, 'send_failed', {
+        doctorCommand: 'agent-imessage doctor',
+      })
+    }
+
+    const envelope = (await response.json()) as BlueBubblesEnvelope<T>
+    return envelope.data
+  }
+
+  private normalizeNetworkError(): IMessageError {
+    if (this.serverUrl && hostIsLoopback(this.serverUrl) && looksLikeContainer()) {
+      return new IMessageError(
+        'Cannot reach BlueBubbles at a loopback address from inside a container.',
+        'localhost_in_container',
+        {
+          suggestion:
+            'Inside Docker, localhost is the container itself. Use "http://host.docker.internal:1234" (same-Mac) or the Mac\'s LAN IP.',
+          doctorCommand: 'agent-imessage doctor',
+        },
+      )
+    }
+    return new IMessageError(`BlueBubbles is not reachable at ${this.serverUrl}.`, 'unreachable', {
+      suggestion: 'Is the BlueBubbles Mac app running and is the port correct (default 1234)?',
+      doctorCommand: 'agent-imessage doctor',
+    })
+  }
+
+  async connect(): Promise<void> {
+    await this.request<unknown>('GET', '/api/v1/ping')
+  }
+
+  async getServerInfo(): Promise<IMessageServerInfo> {
+    const info = await this.request<BlueBubblesServerInfo>('GET', '/api/v1/server/info')
+    return {
+      backend: 'bluebubbles',
+      version: info.server_version ?? null,
+      private_api_enabled: Boolean(info.private_api),
+      macos_version: info.os_version ?? null,
+    }
+  }
+
+  async listChats(limit = 25): Promise<IMessageChatSummary[]> {
+    const chats = await this.request<BlueBubblesChat[]>('POST', '/api/v1/chat/query', {
+      body: { limit, offset: 0, with: ['lastMessage', 'participants'], sort: 'lastmessage' },
+    })
+    return chats.map(summarizeChat)
+  }
+
+  async searchChats(query: string, limit = 25): Promise<IMessageChatSummary[]> {
+    const all = await this.listChats(Math.max(limit, 100))
+    const lower = query.toLowerCase()
+    const filtered = all.filter((c) => c.name.toLowerCase().includes(lower) || c.id.toLowerCase().includes(lower))
+    return filtered.slice(0, limit)
+  }
+
+  async getMessages(chatGuid: string, limit = 25): Promise<IMessageMessageSummary[]> {
+    const messages = await this.request<BlueBubblesMessage[]>('POST', '/api/v1/message/query', {
+      body: {
+        chatGuid,
+        limit,
+        offset: 0,
+        with: ['handle'],
+        sort: 'DESC',
+      },
+    })
+    return messages
+      .map((msg) => summarizeMessage(msg, chatGuid))
+      .sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp))
+  }
+
+  async countMessages(after: number, chatGuid?: string): Promise<number> {
+    const result = await this.request<{ total: number }>('GET', '/api/v1/message/count', {
+      query: { after, chatGuid },
+    })
+    return result.total
+  }
+
+  async sendMessage(chatGuid: string, text: string): Promise<IMessageMessageSummary> {
+    const message = await this.request<BlueBubblesMessage>('POST', '/api/v1/message/text', {
+      body: { chatGuid, message: text, method: 'apple-script' },
+    })
+    return summarizeMessage(message, chatGuid)
+  }
+
+  async getProfile(): Promise<{ id: string; backend: string; private_api_enabled: boolean }> {
+    const info = await this.getServerInfo()
+    return {
+      id: this.serverUrl ?? '',
+      backend: info.backend,
+      private_api_enabled: info.private_api_enabled,
+    }
+  }
+
+  async close(): Promise<void> {
+    this.serverUrl = null
+    this.password = null
+  }
+}

--- a/src/platforms/imessage/commands/auth.ts
+++ b/src/platforms/imessage/commands/auth.ts
@@ -1,0 +1,291 @@
+import { createInterface } from 'node:readline/promises'
+
+import { Command } from 'commander'
+
+import { formatOutput } from '@/shared/utils/output'
+
+import { BlueBubblesClient } from '../client'
+import { IMessageCredentialManager } from '../credential-manager'
+import { createAccountId, type IMessageAccount, IMessageError } from '../types'
+
+interface SetOptions {
+  url?: string
+  password?: string
+  account?: string
+  label?: string
+  current?: boolean
+  pretty?: boolean
+  _manager?: IMessageCredentialManager
+}
+
+async function validateAndBuildAccount(
+  serverUrl: string,
+  password: string,
+  label: string | undefined,
+  accountIdHint: string | undefined,
+): Promise<IMessageAccount> {
+  const client = await new BlueBubblesClient().login({ serverUrl, password })
+  await client.connect()
+  await client.getServerInfo()
+  await client.close()
+
+  const now = new Date().toISOString()
+  const accountId = createAccountId(accountIdHint ?? label ?? serverUrl)
+
+  return {
+    account_id: accountId,
+    provider: 'bluebubbles',
+    server_url: serverUrl.replace(/\/+$/, ''),
+    password,
+    label: label ?? undefined,
+    created_at: now,
+    updated_at: now,
+  }
+}
+
+async function persistAccount(
+  manager: IMessageCredentialManager,
+  account: IMessageAccount,
+  makeCurrent: boolean,
+): Promise<void> {
+  await manager.setAccount(account)
+  if (makeCurrent) {
+    await manager.setCurrent(account.account_id)
+  }
+}
+
+async function runSet(options: SetOptions): Promise<void> {
+  if (!options.url || !options.password) {
+    throw new IMessageError('Both --url and --password are required for "auth set".', 'no_credentials')
+  }
+
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const account = await validateAndBuildAccount(options.url, options.password, options.label, options.account)
+  await persistAccount(manager, account, options.current ?? false)
+
+  console.log(
+    formatOutput(
+      { success: true, account_id: account.account_id, server_url: account.server_url, label: account.label },
+      options.pretty,
+    ),
+  )
+  process.exit(0)
+}
+
+async function runLogin(options: { pretty?: boolean; _manager?: IMessageCredentialManager }): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    console.error('iMessage connects to your own Mac running BlueBubbles.')
+    console.error('Same-Mac Docker: http://host.docker.internal:1234 — remote: http://<mac-lan-ip>:1234\n')
+
+    const url = (await rl.question('BlueBubbles server URL: ')).trim()
+    const password = (await rl.question('Server password: ')).trim()
+    const label = (await rl.question('Account label (optional): ')).trim() || undefined
+
+    const manager = options._manager ?? new IMessageCredentialManager()
+    const account = await validateAndBuildAccount(url, password, label, label)
+    await persistAccount(manager, account, true)
+
+    console.log(
+      formatOutput(
+        { success: true, account_id: account.account_id, server_url: account.server_url, label: account.label },
+        options.pretty,
+      ),
+    )
+    process.exit(0)
+  } finally {
+    rl.close()
+  }
+}
+
+async function runStatus(options: {
+  account?: string
+  pretty?: boolean
+  _manager?: IMessageCredentialManager
+}): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const resolved = await manager.resolveCredentials(options.account)
+
+  if (!resolved) {
+    console.log(formatOutput({ valid: false, error: 'No credentials configured.' }, options.pretty))
+    process.exit(1)
+  }
+
+  let valid = false
+  let info: Awaited<ReturnType<BlueBubblesClient['getServerInfo']>> | null = null
+  try {
+    const client = await new BlueBubblesClient().login({
+      serverUrl: resolved.server_url,
+      password: resolved.password,
+    })
+    await client.connect()
+    info = await client.getServerInfo()
+    await client.close()
+    valid = true
+  } catch {
+    valid = false
+  }
+
+  console.log(
+    formatOutput(
+      { valid, server_url: resolved.server_url, backend: info?.backend, version: info?.version },
+      options.pretty,
+    ),
+  )
+  if (!valid) process.exit(1)
+}
+
+async function runList(options: { pretty?: boolean; _manager?: IMessageCredentialManager }): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const accounts = await manager.listAccounts()
+  console.log(
+    formatOutput(
+      accounts.map((a) => ({
+        account_id: a.account_id,
+        server_url: a.server_url,
+        label: a.label,
+        is_current: a.is_current,
+      })),
+      options.pretty,
+    ),
+  )
+  process.exit(0)
+}
+
+async function runUse(
+  accountId: string,
+  options: { pretty?: boolean; _manager?: IMessageCredentialManager },
+): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const found = await manager.setCurrent(accountId)
+  if (!found) {
+    console.log(formatOutput({ error: `Account "${accountId}" not found. Run "auth list".` }, options.pretty))
+    process.exit(1)
+  }
+  console.log(formatOutput({ success: true, account_id: createAccountId(accountId) }, options.pretty))
+  process.exit(0)
+}
+
+async function runRemove(
+  accountId: string,
+  options: { pretty?: boolean; _manager?: IMessageCredentialManager },
+): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const removed = await manager.removeAccount(accountId)
+  if (!removed) {
+    console.log(formatOutput({ error: `Account "${accountId}" not found. Run "auth list".` }, options.pretty))
+    process.exit(1)
+  }
+  console.log(formatOutput({ success: true }, options.pretty))
+  process.exit(0)
+}
+
+async function runLogout(options: { pretty?: boolean; _manager?: IMessageCredentialManager }): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  await manager.clearCredentials()
+  console.log(formatOutput({ success: true }, options.pretty))
+  process.exit(0)
+}
+
+function reportError(error: unknown, pretty?: boolean): never {
+  const payload = error instanceof IMessageError ? error.toJSON() : { error: (error as Error).message }
+  console.log(formatOutput(payload, pretty))
+  process.exit(1)
+}
+
+export const authCommand = new Command('auth')
+  .description('Authentication commands')
+  .addCommand(
+    new Command('login')
+      .description('Interactively configure and validate a BlueBubbles connection')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => {
+        try {
+          await runLogin(opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+  .addCommand(
+    new Command('set')
+      .description('Set BlueBubbles credentials non-interactively (validated before saving)')
+      .requiredOption('--url <url>', 'BlueBubbles server URL (e.g. http://host.docker.internal:1234)')
+      .requiredOption('--password <password>', 'BlueBubbles server password')
+      .option('--account <id>', 'Account id/alias')
+      .option('--label <label>', 'Human-friendly label')
+      .option('--current', 'Set as the active account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: SetOptions) => {
+        try {
+          await runSet(opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+  .addCommand(
+    new Command('status')
+      .description('Show authentication status')
+      .option('--account <id>', 'Check a specific account (default: current)')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { account?: string; pretty?: boolean }) => {
+        try {
+          await runStatus(opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+  .addCommand(
+    new Command('list')
+      .description('List configured accounts')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => {
+        try {
+          await runList(opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+  .addCommand(
+    new Command('use')
+      .description('Switch the active account')
+      .argument('<account-id>', 'Account id')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (accountId: string, opts: { pretty?: boolean }) => {
+        try {
+          await runUse(accountId, opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+  .addCommand(
+    new Command('remove')
+      .description('Remove a configured account')
+      .argument('<account-id>', 'Account id')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (accountId: string, opts: { pretty?: boolean }) => {
+        try {
+          await runRemove(accountId, opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+  .addCommand(
+    new Command('logout')
+      .description('Clear all stored credentials')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => {
+        try {
+          await runLogout(opts)
+        } catch (error) {
+          reportError(error, opts.pretty)
+        }
+      }),
+  )
+
+export { runSet, runLogin, runStatus, runList, runUse, runRemove, runLogout }

--- a/src/platforms/imessage/commands/chat.ts
+++ b/src/platforms/imessage/commands/chat.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { parseLimitOption, withIMessageClient } from './shared'
+
+async function listAction(options: { account?: string; pretty?: boolean; limit?: string }): Promise<void> {
+  try {
+    const limit = parseLimitOption(options.limit, 25)
+    const chats = await withIMessageClient(options, (client) => client.listChats(limit))
+    console.log(formatOutput(chats, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function searchAction(
+  query: string,
+  options: { account?: string; pretty?: boolean; limit?: string },
+): Promise<void> {
+  try {
+    const limit = parseLimitOption(options.limit, 25)
+    const chats = await withIMessageClient(options, (client) => client.searchChats(query, limit))
+    console.log(formatOutput(chats, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const chatCommand = new Command('chat')
+  .description('iMessage chat commands')
+  .addCommand(
+    new Command('list')
+      .description('List chats')
+      .option('--limit <n>', 'Number of chats to fetch', '25')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(listAction),
+  )
+  .addCommand(
+    new Command('search')
+      .description('Search chats by name or identifier')
+      .argument('<query>', 'Search query')
+      .option('--limit <n>', 'Number of results to return', '25')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(searchAction),
+  )

--- a/src/platforms/imessage/commands/doctor.test.ts
+++ b/src/platforms/imessage/commands/doctor.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { IMessageCredentialManager } from '../credential-manager'
+
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+  globalThis.fetch = realFetch
+})
+import { runDoctor } from './doctor'
+
+type Handler = (url: URL) => Response | Promise<Response>
+
+function startServer(handler: Handler): { url: string; stop: () => void } {
+  const server = Bun.serve({ port: 0, fetch: (req) => handler(new URL(req.url)) })
+  return { url: `http://localhost:${server.port}`, stop: () => server.stop(true) }
+}
+
+function envelope(data: unknown): Response {
+  return Response.json({ status: 200, message: 'ok', data })
+}
+
+const testDirs: string[] = []
+
+async function managerWith(serverUrl: string): Promise<IMessageCredentialManager> {
+  const dir = join(import.meta.dir, `.test-doctor-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  testDirs.push(dir)
+  const manager = new IMessageCredentialManager(dir)
+  const now = new Date().toISOString()
+  await manager.setAccount({
+    account_id: 'home',
+    provider: 'bluebubbles',
+    server_url: serverUrl,
+    password: 'pw',
+    created_at: now,
+    updated_at: now,
+  })
+  return manager
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  for (const dir of testDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('runDoctor', () => {
+  it('reports no_credentials when nothing configured', async () => {
+    const dir = join(import.meta.dir, `.test-doctor-empty-${Date.now()}`)
+    testDirs.push(dir)
+    const report = await runDoctor({ manager: new IMessageCredentialManager(dir) })
+    expect(report.ok).toBe(false)
+    expect(report.code).toBe('no_credentials')
+  })
+
+  it('reports healthy connection with backend, version and private api note', async () => {
+    const srv = startServer((url) => {
+      if (url.pathname === '/api/v1/ping') return envelope('pong')
+      if (url.pathname === '/api/v1/server/info')
+        return envelope({ server_version: '1.9.9', os_version: '13.6', private_api: false })
+      if (url.pathname === '/api/v1/chat/query') return envelope([])
+      return new Response('x', { status: 404 })
+    })
+    try {
+      const report = await runDoctor({ manager: await managerWith(srv.url) })
+      expect(report.ok).toBe(true)
+      expect(report.connection).toBe('ok')
+      expect(report.backend).toBe('bluebubbles')
+      expect(report.version).toBe('1.9.9')
+      expect(report.private_api).toBe(false)
+      expect(report.warnings.some((w) => w.includes('Private API disabled'))).toBe(true)
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('reports unreachable for a dead server', async () => {
+    const report = await runDoctor({ manager: await managerWith('http://127.0.0.1:1') })
+    expect(report.ok).toBe(false)
+    expect(report.code).toBe('unreachable')
+    expect(report.suggestion).toContain('port')
+  })
+
+  it('warns about idle throttling on Sequoia with stale inbound', async () => {
+    const stale = Date.now() - 30 * 60 * 1000
+    const srv = startServer((url) => {
+      if (url.pathname === '/api/v1/ping') return envelope('pong')
+      if (url.pathname === '/api/v1/server/info')
+        return envelope({ server_version: '1.9.9', os_version: '15.1', private_api: true })
+      if (url.pathname === '/api/v1/chat/query')
+        return envelope([
+          {
+            guid: 'c1',
+            chatIdentifier: 'x',
+            displayName: 'X',
+            style: 45,
+            participants: [{ address: 'x' }],
+            lastMessage: { guid: 'm1', text: 'hi', dateCreated: stale, isFromMe: false, handle: { address: 'x' } },
+          },
+        ])
+      return new Response('x', { status: 404 })
+    })
+    try {
+      const report = await runDoctor({ manager: await managerWith(srv.url) })
+      expect(report.warnings.some((w) => w.includes('idle throttling'))).toBe(true)
+    } finally {
+      srv.stop()
+    }
+  })
+
+  it('runs a test-chat send when requested', async () => {
+    const srv = startServer((url) => {
+      if (url.pathname === '/api/v1/ping') return envelope('pong')
+      if (url.pathname === '/api/v1/server/info')
+        return envelope({ server_version: '1.9.9', os_version: '13.6', private_api: false })
+      if (url.pathname === '/api/v1/chat/query') return envelope([])
+      if (url.pathname === '/api/v1/message/text')
+        return envelope({ guid: 's1', text: 'x', dateCreated: Date.now(), isFromMe: true, handle: null })
+      return new Response('x', { status: 404 })
+    })
+    try {
+      const report = await runDoctor({ manager: await managerWith(srv.url), testChat: 'chat1' })
+      expect(report.test_chat).toBe('sent')
+    } finally {
+      srv.stop()
+    }
+  })
+})

--- a/src/platforms/imessage/commands/doctor.ts
+++ b/src/platforms/imessage/commands/doctor.ts
@@ -1,0 +1,134 @@
+import { Command } from 'commander'
+
+import { formatOutput } from '@/shared/utils/output'
+
+import { BlueBubblesClient } from '../client'
+import { IMessageCredentialManager } from '../credential-manager'
+import { IMessageError } from '../types'
+
+const STALE_INBOUND_MS = 15 * 60 * 1000
+
+export interface DoctorReport {
+  ok: boolean
+  connection: 'ok' | 'failed'
+  server_url?: string
+  backend?: string
+  version?: string | null
+  auth: 'ok' | 'rejected' | 'unknown'
+  private_api?: boolean
+  private_api_note?: string
+  inbound_freshness?: string
+  test_chat?: string
+  warnings: string[]
+  error?: string
+  code?: string
+  suggestion?: string
+}
+
+export async function runDoctor(options: {
+  account?: string
+  testChat?: string
+  manager?: IMessageCredentialManager
+}): Promise<DoctorReport> {
+  const manager = options.manager ?? new IMessageCredentialManager()
+  const resolved = await manager.resolveCredentials(options.account)
+
+  if (!resolved) {
+    return {
+      ok: false,
+      connection: 'failed',
+      auth: 'unknown',
+      warnings: [],
+      error: 'No credentials configured.',
+      code: 'no_credentials',
+      suggestion: 'Run "agent-imessage setup" or "agent-imessage auth login".',
+    }
+  }
+
+  const warnings: string[] = []
+  const client = await new BlueBubblesClient().login({
+    serverUrl: resolved.server_url,
+    password: resolved.password,
+  })
+
+  try {
+    await client.connect()
+  } catch (error) {
+    await client.close()
+    const e = error as IMessageError
+    return {
+      ok: false,
+      connection: 'failed',
+      server_url: resolved.server_url,
+      auth: e.code === 'auth_rejected' ? 'rejected' : 'unknown',
+      warnings,
+      error: e.message,
+      code: e.code,
+      suggestion: e.suggestion,
+    }
+  }
+
+  const info = await client.getServerInfo()
+
+  let inboundFreshness: string | undefined
+  try {
+    const chats = await client.listChats(10)
+    const latest = chats
+      .map((c) => c.last_message?.timestamp)
+      .filter((t): t is string => Boolean(t))
+      .map((t) => Date.parse(t))
+      .sort((a, b) => b - a)[0]
+    if (latest) {
+      const ageMs = Date.now() - latest
+      inboundFreshness = `${Math.round(ageMs / 60000)}m ago`
+      if (ageMs > STALE_INBOUND_MS && (info.macos_version?.startsWith('15') || info.macos_version?.startsWith('26'))) {
+        warnings.push(
+          'Inbound messages may be delayed by macOS idle throttling. Keep the Mac awake and BlueBubbles active (Amphetamine/Caffeine).',
+        )
+      }
+    }
+  } catch {
+    inboundFreshness = undefined
+  }
+
+  if (!info.private_api_enabled) {
+    warnings.push('Private API disabled — text send/receive works; reactions/typing/edit are unavailable.')
+  }
+
+  let testChatResult: string | undefined
+  if (options.testChat) {
+    try {
+      await client.sendMessage(options.testChat, 'agent-imessage doctor test message')
+      testChatResult = 'sent'
+    } catch (error) {
+      testChatResult = `failed: ${(error as Error).message}`
+    }
+  }
+
+  await client.close()
+
+  return {
+    ok: true,
+    connection: 'ok',
+    server_url: resolved.server_url,
+    backend: info.backend,
+    version: info.version,
+    auth: 'ok',
+    private_api: info.private_api_enabled,
+    private_api_note: info.private_api_enabled ? 'enabled' : 'disabled (basic send/receive still works)',
+    inbound_freshness: inboundFreshness,
+    test_chat: testChatResult,
+    warnings,
+  }
+}
+
+export const doctorCommand = new Command('doctor')
+  .description('Diagnose the BlueBubbles connection and surface actionable fixes')
+  .option('--account <id>', 'Check a specific account (default: current)')
+  .option('--test-chat <guid>', 'Send a test message to this chat GUID')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(async (opts: { account?: string; testChat?: string; pretty?: boolean }) => {
+    const report = await runDoctor({ account: opts.account, testChat: opts.testChat })
+    console.log(formatOutput(report, opts.pretty))
+    process.exit(report.ok ? 0 : 1)
+  })

--- a/src/platforms/imessage/commands/index.ts
+++ b/src/platforms/imessage/commands/index.ts
@@ -1,0 +1,6 @@
+export { authCommand } from './auth'
+export { chatCommand } from './chat'
+export { doctorCommand } from './doctor'
+export { messageCommand } from './message'
+export { setupCommand } from './setup'
+export { whoamiCommand } from './whoami'

--- a/src/platforms/imessage/commands/message.test.ts
+++ b/src/platforms/imessage/commands/message.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { BlueBubblesClient } from '../client'
+import { IMessageError, type IMessageMessageSummary } from '../types'
+import { parseInterval, pollOnce } from './message'
+
+function msg(id: string, ts: number, text = 't'): IMessageMessageSummary {
+  return { id, chat_id: 'chat1', from: 'x', timestamp: new Date(ts).toISOString(), is_outgoing: false, text }
+}
+
+describe('parseInterval', () => {
+  it('parses seconds, ms, and bare numbers', () => {
+    expect(parseInterval('5s')).toBe(5000)
+    expect(parseInterval('1500ms')).toBe(1500)
+    expect(parseInterval('3')).toBe(3000)
+  })
+
+  it('rejects sub-second intervals and garbage', () => {
+    expect(() => parseInterval('500ms')).toThrow(IMessageError)
+    expect(() => parseInterval('abc')).toThrow(IMessageError)
+  })
+})
+
+describe('pollOnce', () => {
+  it('skips query when count is zero', async () => {
+    let queryCalls = 0
+    const client = {
+      countMessages: async () => 0,
+      getMessages: async () => {
+        queryCalls++
+        return []
+      },
+    } as unknown as BlueBubblesClient
+
+    const result = await pollOnce(client, 'chat1', 0, new Set())
+    expect(result.emitted).toEqual([])
+    expect(queryCalls).toBe(0)
+  })
+
+  it('emits only new messages, dedups by GUID, and advances watermark', async () => {
+    const base = 1_000_000
+    const client = {
+      countMessages: async () => 2,
+      getMessages: async () => [msg('m1', base + 1000), msg('m2', base + 2000)],
+    } as unknown as BlueBubblesClient
+
+    const seen = new Set<string>()
+    const first = await pollOnce(client, 'chat1', base, seen)
+    expect(first.emitted.map((m) => m.id)).toEqual(['m1', 'm2'])
+    expect(first.watermark).toBe(base + 2000)
+
+    const second = await pollOnce(client, 'chat1', first.watermark, seen)
+    expect(second.emitted).toEqual([])
+  })
+
+  it('ignores messages at or before the watermark', async () => {
+    const base = 1_000_000
+    const client = {
+      countMessages: async () => 1,
+      getMessages: async () => [msg('old', base - 1000)],
+    } as unknown as BlueBubblesClient
+
+    const result = await pollOnce(client, 'chat1', base, new Set())
+    expect(result.emitted).toEqual([])
+    expect(result.watermark).toBe(base)
+  })
+})

--- a/src/platforms/imessage/commands/message.ts
+++ b/src/platforms/imessage/commands/message.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import type { BlueBubblesClient } from '../client'
+import { IMessageError, type IMessageMessageSummary } from '../types'
+import { parseLimitOption, withIMessageClient } from './shared'
+
+async function listAction(
+  chat: string,
+  options: { account?: string; pretty?: boolean; limit?: string },
+): Promise<void> {
+  try {
+    const limit = parseLimitOption(options.limit, 25)
+    const messages = await withIMessageClient(options, (client) => client.getMessages(chat, limit))
+    console.log(formatOutput(messages, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function sendAction(chat: string, text: string, options: { account?: string; pretty?: boolean }): Promise<void> {
+  try {
+    const message = await withIMessageClient(options, (client) => client.sendMessage(chat, text))
+    console.log(formatOutput(message, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+function parseInterval(raw: string | undefined): number {
+  const value = (raw ?? '5s').trim().toLowerCase()
+  const match = /^(\d+)(ms|s)?$/.exec(value)
+  if (!match) {
+    throw new IMessageError('--interval must look like "5s", "1500ms", or "3".', 'invalid_limit')
+  }
+  const amount = Number.parseInt(match[1], 10)
+  const ms = match[2] === 'ms' ? amount : amount * 1000
+  if (ms < 1000) {
+    throw new IMessageError('--interval must be at least 1s to avoid overloading BlueBubbles.', 'invalid_limit')
+  }
+  return ms
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function pollOnce(
+  client: BlueBubblesClient,
+  chatGuid: string | undefined,
+  watermark: number,
+  seen: Set<string>,
+): Promise<{ emitted: IMessageMessageSummary[]; watermark: number }> {
+  const count = await client.countMessages(watermark, chatGuid)
+  if (count <= 0) return { emitted: [], watermark }
+
+  const fetched = chatGuid
+    ? await client.getMessages(chatGuid, Math.min(count, 100))
+    : await recentAcrossChats(client, count)
+
+  const emitted: IMessageMessageSummary[] = []
+  let nextWatermark = watermark
+  for (const msg of fetched) {
+    const ts = Date.parse(msg.timestamp)
+    if (ts <= watermark || seen.has(msg.id)) continue
+    seen.add(msg.id)
+    emitted.push(msg)
+    if (ts > nextWatermark) nextWatermark = ts
+  }
+  return { emitted, watermark: nextWatermark }
+}
+
+async function recentAcrossChats(client: BlueBubblesClient, limit: number): Promise<IMessageMessageSummary[]> {
+  const chats = await client.listChats(Math.min(Math.max(limit, 10), 100))
+  const collected: IMessageMessageSummary[] = []
+  for (const chat of chats) {
+    if (chat.last_message) collected.push(chat.last_message)
+  }
+  return collected.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp))
+}
+
+async function watchAction(options: {
+  account?: string
+  pretty?: boolean
+  chat?: string
+  interval?: string
+  since?: string
+  jsonl?: boolean
+}): Promise<void> {
+  try {
+    const intervalMs = parseInterval(options.interval)
+    const chatGuid = options.chat && options.chat !== 'all' ? options.chat : undefined
+    let watermark = options.since ? Date.parse(options.since) : Date.now()
+    if (Number.isNaN(watermark)) {
+      throw new IMessageError('--since must be an ISO timestamp.', 'invalid_limit')
+    }
+    const seen = new Set<string>()
+    let running = true
+
+    const stop = (): void => {
+      running = false
+    }
+    process.on('SIGINT', stop)
+    process.on('SIGTERM', stop)
+
+    await withIMessageClient(options, async (client) => {
+      while (running) {
+        const result = await pollOnce(client, chatGuid, watermark, seen)
+        watermark = result.watermark
+        for (const msg of result.emitted) {
+          if (options.jsonl) {
+            console.log(JSON.stringify(msg))
+          } else {
+            console.log(formatOutput(msg, options.pretty))
+          }
+        }
+        if (!running) break
+        await sleep(intervalMs)
+      }
+    })
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const messageCommand = new Command('message')
+  .description('iMessage message commands')
+  .addCommand(
+    new Command('list')
+      .description('List messages from a chat')
+      .argument('<chat>', 'Chat GUID')
+      .option('--limit <n>', 'Number of messages to fetch', '25')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(listAction),
+  )
+  .addCommand(
+    new Command('send')
+      .description('Send a text message to a chat')
+      .argument('<chat>', 'Chat GUID')
+      .argument('<text>', 'Message text')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(sendAction),
+  )
+  .addCommand(
+    new Command('watch')
+      .description('Stream new messages via polling (outbound-only, container-friendly)')
+      .option('--chat <guid|all>', 'Watch a specific chat or "all"', 'all')
+      .option('--interval <duration>', 'Poll interval (e.g. 5s, 1500ms)', '5s')
+      .option('--since <iso>', 'Replay messages after this ISO timestamp (default: from now)')
+      .option('--jsonl', 'Emit one JSON object per line')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(watchAction),
+  )
+
+export { parseInterval, pollOnce }

--- a/src/platforms/imessage/commands/setup.ts
+++ b/src/platforms/imessage/commands/setup.ts
@@ -1,0 +1,105 @@
+import { createInterface } from 'node:readline/promises'
+
+import { Command } from 'commander'
+
+import { formatOutput } from '@/shared/utils/output'
+
+import { BlueBubblesClient } from '../client'
+import { IMessageCredentialManager } from '../credential-manager'
+import { createAccountId, IMessageError } from '../types'
+
+const CHECKLIST = `iMessage runs through your own Mac. One-time host setup (≈5 min, partly GUI):
+  1. Install BlueBubbles Server on a Mac that stays awake: https://bluebubbles.app
+  2. Sign Messages.app into a DEDICATED Apple ID (not your personal one).
+  3. Grant BlueBubbles "Full Disk Access" in System Settings > Privacy & Security.
+  4. Set a server password in BlueBubbles settings (default port 1234).
+  5. Start BlueBubbles and keep it running (enable auto-login + a keep-alive app).
+
+Basic text send/receive needs NO SIP changes. Reactions/typing/edit (Private API) are a later tier.`
+
+function suggestUrl(topology: string): string {
+  switch (topology) {
+    case 'same-mac':
+      return 'http://localhost:1234'
+    case 'docker-same-mac':
+      return 'http://host.docker.internal:1234'
+    case 'remote':
+      return 'http://<mac-lan-ip>:1234'
+    default:
+      return 'http://host.docker.internal:1234'
+  }
+}
+
+async function runSetup(options: { pretty?: boolean; manager?: IMessageCredentialManager }): Promise<void> {
+  console.error(CHECKLIST)
+  console.error('')
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    console.error('Where does this CLI run relative to the Mac?')
+    console.error('  [1] On the same Mac (native)')
+    console.error('  [2] In Docker on the same Mac')
+    console.error('  [3] On another machine / LAN')
+    const choice = (await rl.question('Choice [2]: ')).trim() || '2'
+    const topology = choice === '1' ? 'same-mac' : choice === '3' ? 'remote' : 'docker-same-mac'
+
+    const suggested = suggestUrl(topology)
+    const url = (await rl.question(`BlueBubbles server URL [${suggested}]: `)).trim() || suggested
+    if (url.includes('<mac-lan-ip>')) {
+      throw new IMessageError("Replace <mac-lan-ip> with your Mac's actual LAN IP address.", 'unreachable')
+    }
+    const password = (await rl.question('Server password: ')).trim()
+    const label = (await rl.question('Account label (optional): ')).trim() || undefined
+
+    const client = await new BlueBubblesClient().login({ serverUrl: url, password })
+    await client.connect()
+    const info = await client.getServerInfo()
+    await client.close()
+
+    const manager = options.manager ?? new IMessageCredentialManager()
+    const now = new Date().toISOString()
+    const accountId = createAccountId(label ?? url)
+    await manager.setAccount({
+      account_id: accountId,
+      provider: 'bluebubbles',
+      server_url: url.replace(/\/+$/, ''),
+      password,
+      label,
+      created_at: now,
+      updated_at: now,
+    })
+    await manager.setCurrent(accountId)
+
+    console.log(
+      formatOutput(
+        {
+          success: true,
+          account_id: accountId,
+          server_url: url.replace(/\/+$/, ''),
+          backend: info.backend,
+          version: info.version,
+          private_api: info.private_api_enabled,
+        },
+        options.pretty,
+      ),
+    )
+    process.exit(0)
+  } finally {
+    rl.close()
+  }
+}
+
+export const setupCommand = new Command('setup')
+  .description('Guided setup: verify a BlueBubbles connection and save credentials')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(async (opts: { pretty?: boolean }) => {
+    try {
+      await runSetup(opts)
+    } catch (error) {
+      const payload = error instanceof IMessageError ? error.toJSON() : { error: (error as Error).message }
+      console.log(formatOutput(payload, opts.pretty))
+      process.exit(1)
+    }
+  })
+
+export { runSetup, suggestUrl }

--- a/src/platforms/imessage/commands/shared.ts
+++ b/src/platforms/imessage/commands/shared.ts
@@ -1,0 +1,61 @@
+import { formatOutput } from '@/shared/utils/output'
+
+import { BlueBubblesClient } from '../client'
+import { IMessageCredentialManager } from '../credential-manager'
+import { IMessageError } from '../types'
+
+export interface AccountOption {
+  account?: string
+  pretty?: boolean
+}
+
+export function parseLimitOption(rawLimit: string | undefined, defaultValue: number, maxValue = 100): number {
+  const trimmed = (rawLimit ?? `${defaultValue}`).trim()
+
+  if (!/^\d+$/.test(trimmed)) {
+    throw new IMessageError(`--limit must be an integer between 1 and ${maxValue}.`, 'invalid_limit')
+  }
+
+  const parsed = Number.parseInt(trimmed, 10)
+
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > maxValue) {
+    throw new IMessageError(`--limit must be an integer between 1 and ${maxValue}.`, 'invalid_limit')
+  }
+
+  return parsed
+}
+
+export async function withIMessageClient<T>(
+  options: AccountOption,
+  fn: (client: BlueBubblesClient) => Promise<T>,
+): Promise<T> {
+  const manager = new IMessageCredentialManager()
+  const resolved = await manager.resolveCredentials(options.account)
+
+  if (!resolved) {
+    console.log(
+      formatOutput(
+        {
+          error: options.account
+            ? `iMessage account "${options.account}" not found. Run "agent-imessage auth list" to see accounts, or "agent-imessage setup".`
+            : 'Not authenticated. Run "agent-imessage setup" or "agent-imessage auth login" first.',
+          code: 'no_credentials',
+        },
+        options.pretty,
+      ),
+    )
+    process.exit(1)
+  }
+
+  const client = await new BlueBubblesClient().login({
+    serverUrl: resolved.server_url,
+    password: resolved.password,
+  })
+
+  try {
+    await client.connect()
+    return await fn(client)
+  } finally {
+    await client.close()
+  }
+}

--- a/src/platforms/imessage/commands/whoami.ts
+++ b/src/platforms/imessage/commands/whoami.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { withIMessageClient } from './shared'
+
+async function whoamiAction(options: { account?: string; pretty?: boolean }): Promise<void> {
+  try {
+    const profile = await withIMessageClient(options, (client) => client.getProfile())
+    console.log(formatOutput(profile, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const whoamiCommand = new Command('whoami')
+  .description('Show the active iMessage server and account')
+  .option('--account <id>', 'Use a specific iMessage account')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(whoamiAction)

--- a/src/platforms/imessage/credential-manager.test.ts
+++ b/src/platforms/imessage/credential-manager.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { IMessageCredentialManager } from './credential-manager'
+import type { IMessageAccount } from './types'
+
+const testDirs: string[] = []
+const savedEnv: Record<string, string | undefined> = {}
+
+function setup(): IMessageCredentialManager {
+  const dir = join(import.meta.dir, `.test-imessage-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  testDirs.push(dir)
+  return new IMessageCredentialManager(dir)
+}
+
+function makeAccount(overrides?: Partial<IMessageAccount>): IMessageAccount {
+  const now = new Date().toISOString()
+  return {
+    account_id: 'home',
+    provider: 'bluebubbles',
+    server_url: 'http://host.docker.internal:1234',
+    password: 'secret',
+    label: 'Home Mac',
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  }
+}
+
+function clearEnv(): void {
+  for (const key of ['AGENT_IMESSAGE_URL', 'AGENT_IMESSAGE_PASSWORD', 'BLUEBUBBLES_URL', 'BLUEBUBBLES_PASSWORD']) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+}
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+}
+
+afterEach(() => {
+  restoreEnv()
+  for (const dir of testDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('IMessageCredentialManager', () => {
+  it('persists provider-aware schema with 0600 mode', async () => {
+    clearEnv()
+    const manager = setup()
+    await manager.setAccount(makeAccount())
+
+    const dir = testDirs[testDirs.length - 1]!
+    const path = join(dir, 'imessage-credentials.json')
+    expect(existsSync(path)).toBe(true)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+
+    const config = await manager.loadConfig()
+    expect(config.accounts.home?.provider).toBe('bluebubbles')
+  })
+
+  it('resolution order: flags beat AGENT_IMESSAGE_* beat BLUEBUBBLES_* beat stored', async () => {
+    clearEnv()
+    const manager = setup()
+    await manager.setAccount(makeAccount({ server_url: 'http://stored:1234', password: 'stored-pw' }))
+
+    expect(await manager.resolveCredentials()).toEqual({ server_url: 'http://stored:1234', password: 'stored-pw' })
+
+    process.env.BLUEBUBBLES_URL = 'http://bb:1234'
+    process.env.BLUEBUBBLES_PASSWORD = 'bb-pw'
+    expect(await manager.resolveCredentials()).toEqual({ server_url: 'http://bb:1234', password: 'bb-pw' })
+
+    process.env.AGENT_IMESSAGE_URL = 'http://ai:1234'
+    process.env.AGENT_IMESSAGE_PASSWORD = 'ai-pw'
+    expect(await manager.resolveCredentials()).toEqual({ server_url: 'http://ai:1234', password: 'ai-pw' })
+
+    expect(await manager.resolveCredentials(undefined, { serverUrl: 'http://flag:1234', password: 'flag-pw' })).toEqual(
+      {
+        server_url: 'http://flag:1234',
+        password: 'flag-pw',
+      },
+    )
+  })
+
+  it('does not write env-derived credentials to disk', async () => {
+    clearEnv()
+    const manager = setup()
+    process.env.AGENT_IMESSAGE_URL = 'http://env:1234'
+    process.env.AGENT_IMESSAGE_PASSWORD = 'env-pw'
+
+    await manager.resolveCredentials()
+
+    const dir = testDirs[testDirs.length - 1]!
+    expect(existsSync(join(dir, 'imessage-credentials.json'))).toBe(false)
+  })
+
+  it('returns null when nothing is configured', async () => {
+    clearEnv()
+    const manager = setup()
+    expect(await manager.resolveCredentials()).toBeNull()
+  })
+
+  it('removeAccount reassigns current to first remaining or null', async () => {
+    clearEnv()
+    const manager = setup()
+    await manager.setAccount(makeAccount({ account_id: 'a' }))
+    await manager.setAccount(makeAccount({ account_id: 'b' }))
+
+    expect(await manager.removeAccount('a')).toBe(true)
+    expect((await manager.getAccount())?.account_id).toBe('b')
+
+    expect(await manager.removeAccount('b')).toBe(true)
+    expect(await manager.getAccount()).toBeNull()
+  })
+
+  it('setCurrent returns false for unknown account', async () => {
+    clearEnv()
+    const manager = setup()
+    expect(await manager.setCurrent('ghost')).toBe(false)
+  })
+})

--- a/src/platforms/imessage/credential-manager.ts
+++ b/src/platforms/imessage/credential-manager.ts
@@ -1,0 +1,130 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { getConfigDir } from '../../shared/utils/config-dir'
+import { createAccountId, type IMessageAccount, type IMessageConfig } from './types'
+
+export interface ResolvedCredentials {
+  server_url: string
+  password: string
+}
+
+export interface CredentialOverrides {
+  serverUrl?: string
+  password?: string
+}
+
+export class IMessageCredentialManager {
+  private configDir: string
+  private credentialsPath: string
+
+  constructor(configDir?: string) {
+    this.configDir = configDir ?? getConfigDir()
+    this.credentialsPath = join(this.configDir, 'imessage-credentials.json')
+  }
+
+  async loadConfig(): Promise<IMessageConfig> {
+    if (!existsSync(this.credentialsPath)) {
+      return { current: null, accounts: {} }
+    }
+
+    try {
+      const content = await readFile(this.credentialsPath, 'utf-8')
+      return JSON.parse(content) as IMessageConfig
+    } catch {
+      return { current: null, accounts: {} }
+    }
+  }
+
+  async saveConfig(config: IMessageConfig): Promise<void> {
+    await mkdir(this.configDir, { recursive: true })
+    await writeFile(this.credentialsPath, JSON.stringify(config, null, 2), { mode: 0o600 })
+  }
+
+  async getAccount(accountId?: string): Promise<IMessageAccount | null> {
+    const config = await this.loadConfig()
+
+    if (!accountId) {
+      return config.current ? (config.accounts[config.current] ?? null) : null
+    }
+
+    const direct = config.accounts[accountId]
+    if (direct) return direct
+
+    return config.accounts[createAccountId(accountId)] ?? null
+  }
+
+  async listAccounts(): Promise<Array<IMessageAccount & { is_current: boolean }>> {
+    const config = await this.loadConfig()
+
+    return Object.values(config.accounts).map((account) => ({
+      ...account,
+      is_current: account.account_id === config.current,
+    }))
+  }
+
+  async setAccount(account: IMessageAccount): Promise<void> {
+    const config = await this.loadConfig()
+    config.accounts[account.account_id] = account
+
+    if (!config.current) {
+      config.current = account.account_id
+    }
+
+    await this.saveConfig(config)
+  }
+
+  async setCurrent(accountId: string): Promise<boolean> {
+    const config = await this.loadConfig()
+    const account = config.accounts[accountId] ?? config.accounts[createAccountId(accountId)]
+
+    if (!account) return false
+
+    config.current = account.account_id
+    await this.saveConfig(config)
+    return true
+  }
+
+  async removeAccount(accountId: string): Promise<boolean> {
+    const config = await this.loadConfig()
+    const account = config.accounts[accountId] ?? config.accounts[createAccountId(accountId)]
+
+    if (!account) return false
+
+    delete config.accounts[account.account_id]
+
+    if (config.current === account.account_id) {
+      config.current = Object.keys(config.accounts)[0] ?? null
+    }
+
+    await this.saveConfig(config)
+    return true
+  }
+
+  async clearCredentials(): Promise<void> {
+    if (existsSync(this.credentialsPath)) {
+      await rm(this.credentialsPath, { force: true })
+    }
+  }
+
+  async resolveCredentials(accountId?: string, overrides?: CredentialOverrides): Promise<ResolvedCredentials | null> {
+    const envUrl = process.env.AGENT_IMESSAGE_URL ?? process.env.BLUEBUBBLES_URL
+    const envPassword = process.env.AGENT_IMESSAGE_PASSWORD ?? process.env.BLUEBUBBLES_PASSWORD
+
+    const serverUrl = overrides?.serverUrl ?? envUrl
+    const password = overrides?.password ?? envPassword
+
+    if (serverUrl && password) {
+      return { server_url: serverUrl, password }
+    }
+
+    const account = await this.getAccount(accountId)
+    if (!account) return null
+
+    return {
+      server_url: serverUrl ?? account.server_url,
+      password: password ?? account.password,
+    }
+  }
+}

--- a/src/platforms/imessage/ensure-auth.ts
+++ b/src/platforms/imessage/ensure-auth.ts
@@ -1,0 +1,19 @@
+import { formatOutput } from '@/shared/utils/output'
+
+import { IMessageCredentialManager } from './credential-manager'
+
+export async function ensureIMessageAuth(): Promise<void> {
+  const manager = new IMessageCredentialManager()
+  const resolved = await manager.resolveCredentials()
+
+  if (!resolved) {
+    console.log(
+      formatOutput({
+        error:
+          'Not authenticated. iMessage connects to your own Mac running BlueBubbles. Run "agent-imessage setup" for a guided walkthrough, or "agent-imessage auth login" if BlueBubbles is already running.',
+        code: 'no_credentials',
+      }),
+    )
+    process.exit(1)
+  }
+}

--- a/src/platforms/imessage/index.test.ts
+++ b/src/platforms/imessage/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test'
+
+import * as imessage from './index'
+
+describe('imessage SDK barrel', () => {
+  it('exports the client, credential manager, and error', () => {
+    expect(typeof imessage.BlueBubblesClient).toBe('function')
+    expect(typeof imessage.IMessageCredentialManager).toBe('function')
+    expect(typeof imessage.IMessageError).toBe('function')
+    expect(typeof imessage.createAccountId).toBe('function')
+  })
+})

--- a/src/platforms/imessage/index.ts
+++ b/src/platforms/imessage/index.ts
@@ -1,0 +1,14 @@
+export { BlueBubblesClient } from './client'
+export { IMessageCredentialManager } from './credential-manager'
+export type { CredentialOverrides, ResolvedCredentials } from './credential-manager'
+export {
+  createAccountId,
+  IMessageError,
+  type IMessageAccount,
+  type IMessageChatSummary,
+  type IMessageConfig,
+  type IMessageErrorCode,
+  type IMessageMessageSummary,
+  type IMessageProvider,
+  type IMessageServerInfo,
+} from './types'

--- a/src/platforms/imessage/types.test.ts
+++ b/src/platforms/imessage/types.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createAccountId, IMessageError, type IMessageErrorCode } from './types'
+
+describe('createAccountId', () => {
+  it('strips protocol and slugifies a URL deterministically', () => {
+    expect(createAccountId('http://Mac-1:1234')).toBe(createAccountId('http://Mac-1:1234'))
+    expect(createAccountId('http://Mac-1:1234')).toBe('mac-1-1234')
+  })
+
+  it('strips https and trailing junk', () => {
+    expect(createAccountId('https://my-mac.local:1234/')).toBe('my-mac-local-1234')
+  })
+
+  it('falls back to "default" for empty input', () => {
+    expect(createAccountId('   ')).toBe('default')
+  })
+})
+
+describe('IMessageError', () => {
+  const codes: IMessageErrorCode[] = [
+    'no_credentials',
+    'not_authenticated',
+    'unreachable',
+    'auth_rejected',
+    'private_api_required',
+    'invalid_limit',
+    'send_failed',
+    'localhost_in_container',
+    'imessage_error',
+  ]
+
+  it('is instantiable with every code and exposes .code', () => {
+    for (const code of codes) {
+      const err = new IMessageError('msg', code)
+      expect(err.code).toBe(code)
+      expect(err).toBeInstanceOf(Error)
+    }
+  })
+
+  it('serializes suggestion and doctorCommand only when present', () => {
+    const bare = new IMessageError('m', 'unreachable').toJSON()
+    expect(bare).toEqual({ error: 'm', code: 'unreachable' })
+
+    const rich = new IMessageError('m', 'unreachable', {
+      suggestion: 's',
+      doctorCommand: 'agent-imessage doctor',
+    }).toJSON()
+    expect(rich).toEqual({
+      error: 'm',
+      code: 'unreachable',
+      suggestion: 's',
+      doctorCommand: 'agent-imessage doctor',
+    })
+  })
+})

--- a/src/platforms/imessage/types.ts
+++ b/src/platforms/imessage/types.ts
@@ -1,0 +1,89 @@
+export type IMessageProvider = 'bluebubbles'
+
+export interface IMessageAccount {
+  account_id: string
+  provider: IMessageProvider
+  server_url: string
+  password: string
+  label?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface IMessageConfig {
+  current: string | null
+  accounts: Record<string, IMessageAccount>
+}
+
+export interface IMessageChatSummary {
+  id: string
+  name: string
+  type: 'individual' | 'group'
+  last_message?: IMessageMessageSummary
+}
+
+export interface IMessageMessageSummary {
+  id: string
+  chat_id: string
+  from: string
+  from_name?: string
+  timestamp: string
+  is_outgoing: boolean
+  text?: string
+}
+
+export interface IMessageServerInfo {
+  backend: IMessageProvider
+  version: string | null
+  private_api_enabled: boolean
+  macos_version?: string | null
+}
+
+export type IMessageErrorCode =
+  | 'no_credentials'
+  | 'not_authenticated'
+  | 'unreachable'
+  | 'auth_rejected'
+  | 'private_api_required'
+  | 'invalid_limit'
+  | 'send_failed'
+  | 'localhost_in_container'
+  | 'imessage_error'
+
+export class IMessageError extends Error {
+  code: IMessageErrorCode
+  suggestion?: string
+  doctorCommand?: string
+
+  constructor(
+    message: string,
+    code: IMessageErrorCode = 'imessage_error',
+    extra?: { suggestion?: string; doctorCommand?: string },
+  ) {
+    super(message)
+    this.name = 'IMessageError'
+    this.code = code
+    this.suggestion = extra?.suggestion
+    this.doctorCommand = extra?.doctorCommand
+  }
+
+  toJSON(): { error: string; code: IMessageErrorCode; suggestion?: string; doctorCommand?: string } {
+    return {
+      error: this.message,
+      code: this.code,
+      ...(this.suggestion ? { suggestion: this.suggestion } : {}),
+      ...(this.doctorCommand ? { doctorCommand: this.doctorCommand } : {}),
+    }
+  }
+}
+
+export function createAccountId(input: string): string {
+  const normalized = input
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || 'default'
+}

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -1571,6 +1571,7 @@ describe('KakaoTalkClient', () => {
 
   describe('getProfile', () => {
     const mockFetch = mock(() => Promise.resolve(new Response()))
+    const originalFetch = globalThis.fetch
 
     beforeEach(() => {
       mockFetch.mockReset()
@@ -1579,6 +1580,7 @@ describe('KakaoTalkClient', () => {
 
     afterEach(() => {
       mockFetch.mockReset()
+      globalThis.fetch = originalFetch
     })
 
     function makeJsonResponse(data: unknown, status = 200): Response {

--- a/src/tui/adapters/imessage-adapter.ts
+++ b/src/tui/adapters/imessage-adapter.ts
@@ -1,0 +1,154 @@
+import { BlueBubblesClient } from '@/platforms/imessage/client'
+import { IMessageCredentialManager } from '@/platforms/imessage/credential-manager'
+
+import type { AuthHint, AuthIO, PlatformAdapter, UnifiedChannel, UnifiedMessage, Workspace } from './types'
+
+const POLL_INTERVAL_MS = 5000
+
+export class IMessageAdapter implements PlatformAdapter {
+  readonly name = 'iMessage'
+
+  private client: BlueBubblesClient | null = null
+  private credManager = new IMessageCredentialManager()
+  private currentAccount: Workspace | null = null
+  private pollTimer: ReturnType<typeof setInterval> | null = null
+
+  async login(): Promise<void> {
+    const client = new BlueBubblesClient()
+    await client.login()
+    await client.connect()
+    this.client = client
+
+    const config = await this.credManager.loadConfig()
+    if (config.current && config.accounts[config.current]) {
+      const acct = config.accounts[config.current]
+      this.currentAccount = { id: acct.account_id, name: acct.label ?? acct.server_url }
+    }
+  }
+
+  async getChannels(): Promise<UnifiedChannel[]> {
+    const client = this.ensureClient()
+    const chats = await client.listChats(50)
+    return chats.map((chat) => ({ id: chat.id, name: chat.name || chat.id }))
+  }
+
+  async getMessages(channelId: string, limit = 50): Promise<UnifiedMessage[]> {
+    const client = this.ensureClient()
+    const messages = await client.getMessages(channelId, limit)
+    return messages.map((msg) => ({
+      id: msg.id,
+      channelId,
+      author: msg.is_outgoing ? 'you' : (msg.from_name ?? msg.from ?? 'unknown'),
+      content: msg.text ?? '',
+      timestamp: msg.timestamp,
+    }))
+  }
+
+  async sendMessage(channelId: string, text: string): Promise<void> {
+    const client = this.ensureClient()
+    await client.sendMessage(channelId, text)
+  }
+
+  async startListening(onMessage: (msg: UnifiedMessage) => void): Promise<void> {
+    const client = this.ensureClient()
+    let watermark = Date.now()
+    const seen = new Set<string>()
+
+    this.pollTimer = setInterval(() => {
+      void (async () => {
+        try {
+          const count = await client.countMessages(watermark)
+          if (count <= 0) return
+          const chats = await client.listChats(50)
+          for (const chat of chats) {
+            const last = chat.last_message
+            if (!last) continue
+            const ts = Date.parse(last.timestamp)
+            if (ts <= watermark || seen.has(last.id)) continue
+            seen.add(last.id)
+            if (ts > watermark) watermark = ts
+            onMessage({
+              id: last.id,
+              channelId: chat.id,
+              author: last.is_outgoing ? 'you' : (last.from_name ?? last.from ?? 'unknown'),
+              content: last.text ?? '',
+              timestamp: last.timestamp,
+            })
+          }
+        } catch {
+          this.stopListening()
+        }
+      })()
+    }, POLL_INTERVAL_MS)
+  }
+
+  stopListening(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
+  }
+
+  async getWorkspaces(): Promise<Workspace[]> {
+    const accounts = await this.credManager.listAccounts()
+    return accounts.map((acct) => ({ id: acct.account_id, name: acct.label ?? acct.server_url }))
+  }
+
+  async switchWorkspace(accountId: string): Promise<void> {
+    if (this.client) {
+      await this.client.close().catch(() => {})
+      this.client = null
+    }
+    const account = await this.credManager.getAccount(accountId)
+    if (!account) throw new Error(`Account ${accountId} not found`)
+
+    const client = new BlueBubblesClient()
+    await client.login({ serverUrl: account.server_url, password: account.password })
+    await client.connect()
+    this.client = client
+    this.currentAccount = { id: account.account_id, name: account.label ?? account.server_url }
+  }
+
+  getCurrentWorkspace(): Workspace | null {
+    return this.currentAccount
+  }
+
+  getAuthHint(): AuthHint {
+    return {
+      command: 'agent-imessage setup',
+      description: 'iMessage needs a Mac running BlueBubbles. Run the guided setup below.',
+    }
+  }
+
+  async authenticate(io: AuthIO): Promise<void> {
+    const url = await io.prompt('BlueBubbles server URL (e.g. http://host.docker.internal:1234)')
+    const password = await io.prompt('Server password', { secret: true })
+
+    const client = await new BlueBubblesClient().login({ serverUrl: url, password })
+    await client.connect()
+    await client.getServerInfo()
+
+    const { createAccountId } = await import('@/platforms/imessage/types')
+    const now = new Date().toISOString()
+    const accountId = createAccountId(url)
+    await this.credManager.setAccount({
+      account_id: accountId,
+      provider: 'bluebubbles',
+      server_url: url.replace(/\/+$/, ''),
+      password,
+      created_at: now,
+      updated_at: now,
+    })
+    await this.credManager.setCurrent(accountId)
+
+    this.client = client
+    this.currentAccount = { id: accountId, name: url }
+  }
+
+  private ensureClient(): BlueBubblesClient {
+    if (!this.client) {
+      throw new Error('Not logged in. Call login() first.')
+    }
+    return this.client
+  }
+}

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -184,6 +184,19 @@ export async function createApp(): Promise<void> {
     },
     {
       adapter: lazyAdapter(
+        'iMessage',
+        'agent-imessage setup',
+        async () => new (await import('./adapters/imessage-adapter')).IMessageAdapter(),
+      ),
+      label: 'iMessage',
+      enabled: false,
+      channels: null,
+      workspaces: null,
+      listening: false,
+      lastChannelId: null,
+    },
+    {
+      adapter: lazyAdapter(
         'LINE',
         'agent-line auth login',
         async () => new (await import('./adapters/line-adapter')).LineAdapter(),


### PR DESCRIPTION
## Summary

Adds **iMessage support** as a new `agent-imessage` platform.

Apple provides no public iMessage API, so — unlike every other platform here — iMessage can't talk to a cloud service directly. Instead, `agent-imessage` is a REST client (`BlueBubblesClient`) that connects to a free, open-source [**BlueBubbles**](https://bluebubbles.app) server running on a Mac signed into iMessage. The CLI runs anywhere that can reach that Mac, **including Docker containers**.

The public surface (CLI grammar, SDK shape, skill) matches the other platforms; the BlueBubbles/Mac reality is hidden behind a clean UX and surfaced honestly in setup, docs, and first-run errors.

## What's included

- **`BlueBubblesClient`** — outbound REST client (`connect`, `getServerInfo`, `listChats`, `getMessages`, `countMessages`, `sendMessage`, `getProfile`) with **error normalization** that maps raw network/HTTP failures to actionable `IMessageError`s.
- **Provider-aware credentials** — `{ provider: "bluebubbles", serverUrl, password }` in `~/.config/agent-messenger/imessage-credentials.json` (mode `0600`). Multi-account via the standard `{ current, accounts }` map. The `provider` field leaves room for a future managed backend (e.g. Sendblue) with no schema rework.
- **Env override for containers** — `AGENT_IMESSAGE_URL` / `AGENT_IMESSAGE_PASSWORD` (aliases `BLUEBUBBLES_*`). Resolution order: flags → `AGENT_IMESSAGE_*` → `BLUEBUBBLES_*` → stored. Env creds are used at runtime but **never persisted**.
- **Polling-based receive** — `message watch` (count → query, watermark, dedup by GUID, JSONL). Outbound-only; no inbound webhook server, so it works from containers and across a LAN.
- **`doctor`** (the flagship UX) — checks reachability, auth, backend/version, Private API status, and inbound freshness; detects the Docker **`localhost` trap** and Sequoia **idle-throttle** delays, each with a concrete suggestion.
- **`setup`** — guided verifier that suggests the right `serverUrl` per topology, validates, and saves. Does not attempt brittle host automation (Apple ID sign-in, FDA, SIP).
- **Commands** — `auth login/set/status/list/use/remove/logout`, `chat list/search`, `message list/send/watch`, `whoami`, `doctor`, `setup`.
- **TUI adapter** + SDK barrel (`agent-messenger/imessage`) + registration in `cli.ts`, `app.ts`, `package.json`, `.claude-plugin/plugin.json`.

## Feature tiers

| Feature | This PR | Requires |
| --- | :---: | --- |
| List/search chats, send text, read/watch messages, multi-account | ✅ | BlueBubbles (no SIP) |
| Reactions / typing / edit / unsend | ⏳ later | BlueBubbles Private API (SIP disabled) |

Basic send/receive needs **no SIP changes**; the Private API tier is intentionally deferred to keep onboarding simple.

## Docs

- `skills/agent-imessage/SKILL.md` — full skill incl. Agent Behavior + an Error Handling table covering every error code.
- `skills/agent-imessage/references/setup.md` — operator guide (the ~5-min one-time GUI host setup, Ventura sweet spot, dedicated Apple ID, keep-alive).
- `skills/agent-imessage/references/docker.md` — container topologies + the `localhost` trap.
- README (platform list, SDK table, Supported Platforms note, "iMessage is different" framing) and `AGENTS.md`.

## Also

- `test(kakaotalk)`: the `getProfile` suite replaced `globalThis.fetch` in `beforeEach` without restoring it, leaking the mock into later suites. Fixed by restoring in `afterEach` (exposed by the new real-`fetch` tests here).

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings / 0 errors
- `bun format` — clean on changed files
- `bun test` — **3347 pass / 0 fail** (32 new tests across 6 files; QA-1…QA-12 from the plan)
- Manual CLI smoke: `--help`, router dispatch, `doctor` against dead server + `localhost`-in-container detection, and a full send/list/chat/auth flow against a mock BlueBubbles server.

## Notes / follow-ups

- A managed-relay backend (Sendblue/Linq) can be added later under the same `agent-imessage` command via the `provider` field.
- Reactions/typing/edit (Private API tier) are scoped out of v1.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iMessage support via BlueBubbles as `agent-imessage`, enabling send, list, and watch via polling with multi-account auth and clear error handling. Includes CLI commands, SDK (`agent-messenger/imessage`), TUI adapter, and a guided `setup`/`doctor` flow; docs updated: SKILL.md, setup guide, Docker guide, README, and AGENTS.

- **New Features**
  - `BlueBubblesClient` with normalized `IMessageError`s and provider-aware credentials; env overrides `AGENT_IMESSAGE_URL`/`AGENT_IMESSAGE_PASSWORD` (aliases `BLUEBUBBLES_*`) are runtime-only.
  - Polling receive: `message watch` (watermark + GUID dedupe); detects Docker localhost trap; works in containers without inbound servers.
  - `doctor` checks reachability, auth, backend/version, Private API, and inbound freshness; `setup` verifies and saves credentials.
  - CLI: `auth`, `chat list/search`, `message list/send/watch`, `whoami`, `doctor`, `setup`. SDK barrel at `agent-messenger/imessage`; CLI and TUI integration; plugin and `package.json` registration.
  - Private API features (reactions/typing/edit/unsend) deferred for a later tier.

- **Bug Fixes**
  - KakaoTalk tests: restore `globalThis.fetch` in `afterEach` to prevent cross-suite leaks.

<sup>Written for commit 24ae47aa3c27e9b784ccf87ca8dcb3b980f94b40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

