### PR TITLE
feat(imessage): add iMessage support via imsg

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,7 @@
     "channel-talk",
     "line",
     "instagram",
+    "imessage",
     "messaging",
     "workspace",
     "guild",
@@ -44,6 +45,7 @@
     "./skills/agent-instagram",
     "./skills/agent-kakaotalk",
     "./skills/agent-channeltalk",
-    "./skills/agent-channeltalkbot"
+    "./skills/agent-channeltalkbot",
+    "./skills/agent-imessage"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Multi-platform messaging CLI for AI agents (Slack, Discord, Teams).
 
+## Platform Notes
+
+Each platform lives in `src/platforms/<name>/` and follows the same convention (cli, index, client, types, credential-manager, ensure-auth, commands). **iMessage (`agent-imessage`) is the one platform that must run on a Mac:** Apple has no public API, so it shells out to the local [imsg](https://github.com/openclaw/imsg) CLI and talks to it over JSON-RPC (stdin/stdout) — there is no network/server. Its client (`ImsgClient`, over an `ImsgRpc` transport) spawns a long-lived `imsg rpc` child for chats/history/watch/send, and shells out to `imsg react` for standard tapbacks. Credentials are provider-aware (`{ provider: "imsg", binaryPath?, region? }`) with no secrets — it relies on macOS Full Disk Access + Automation permissions.
+
 ## TypeScript Execution Model
 
 ### Local Development

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This installs:
 - `agent-kakaotalk` — KakaoTalk CLI (sub-device login, LOCO protocol)
 - `agent-channeltalk` — Channel Talk CLI (beta, zero-config, extracted cookies)
 - `agent-channeltalkbot` — Channel Talk Bot CLI (beta, API credentials, for server-side/CI/CD)
+- `agent-imessage` — iMessage CLI (runs on a Mac via the [imsg](https://github.com/openclaw/imsg) tool)
 
 ## Agent Skills
 
@@ -210,6 +211,7 @@ const slack = await new SlackClient().login({ token: 'xoxc-...', cookie: 'xoxd-.
 | `agent-messenger/kakaotalk` | `KakaoTalkClient` |
 | `agent-messenger/channeltalk` | `ChannelClient` |
 | `agent-messenger/channeltalkbot` | `ChannelBotClient` |
+| `agent-messenger/imessage` | `ImsgClient` |
 
 Each module also exports its credential manager, Zod schemas, and TypeScript types:
 
@@ -429,6 +431,8 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 
 > ⚠️ **Teams tokens expire in 60-90 minutes.** Re-run `agent-teams auth extract` to refresh. See [Teams Guide](skills/agent-teams/SKILL.md) for details.
 
+> 💬 **iMessage** is supported via the local [imsg](https://github.com/openclaw/imsg) tool (`agent-imessage`), not the table above. It runs **on a Mac** (Apple has no API). v1 covers send & list messages, direct & group chats, chat listing, real-time watch, and standard tapbacks. Typing, edit/unsend, group management, and targeted/custom reactions require imsg's bridge (SIP disabled) and are a later tier. See the [iMessage Guide](skills/agent-imessage/SKILL.md).
+
 ## Platform Guides
 
 - **[Slack Guide](https://agent-messenger.dev/docs/cli/slack)** — Full command reference for Slack
@@ -448,6 +452,11 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 - **[KakaoTalk Guide](https://agent-messenger.dev/docs/cli/kakaotalk)** — Sub-device login and LOCO protocol integration
 - **[Channel Talk Guide](https://agent-messenger.dev/docs/cli/channeltalk)** — Full command reference for Channel Talk (beta, zero-config)
 - **[Channel Talk Bot Guide](https://agent-messenger.dev/docs/cli/channeltalkbot)** — Bot API integration for Channel Talk (beta)
+- **[iMessage Guide](skills/agent-imessage/SKILL.md)** — iMessage on a Mac via the imsg tool
+
+### iMessage is different
+
+Most agent-messenger platforms run anywhere. **iMessage is the exception:** Apple provides no API, so `agent-imessage` runs **on a Mac** and drives Messages locally through the [imsg](https://github.com/openclaw/imsg) tool. You still act as yourself with your own Apple ID and run one shell command per action, but the agent must run on the Mac (imsg is local-only — no network or server) with Full Disk Access and Automation granted. See the [setup guide](skills/agent-imessage/references/setup.md).
 
 ## Use Cases
 

--- a/docs/content/docs/cli/imessage.mdx
+++ b/docs/content/docs/cli/imessage.mdx
@@ -1,0 +1,99 @@
+---
+title: iMessage
+description: Complete reference for the agent-imessage CLI.
+---
+
+> **Tip**: After `npm install -g agent-messenger`, `agent-imessage` is available directly. For one-off execution without a global install you can use `npm exec --package agent-messenger agent-imessage ...`, `pnpm dlx --package agent-messenger agent-imessage ...`, `yarn dlx agent-messenger agent-imessage ...`, or `bunx --package agent-messenger agent-imessage ...`.
+
+## Requirements
+
+Apple provides no public iMessage API, so `agent-imessage` runs **on a Mac** and drives Messages through [imsg](https://github.com/openclaw/imsg), a native Swift CLI:
+
+- The agent must run **on the Mac itself** — imsg is local-only (no network, no server).
+- `agent-imessage` spawns `imsg` and communicates over JSON-RPC (stdin/stdout).
+- Requires macOS 14+, imsg installed (`brew install steipete/tap/imsg`), **Full Disk Access** (read), and **Automation → Messages** (send). macOS grants these to the launching parent process.
+- Basic send/read/watch/standard tapbacks need **no SIP changes**. Typing, edit/unsend, group management, and targeted/custom reactions require imsg's bridge (`imsg launch` + SIP) and are a later tier.
+
+See the [setup guide](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-imessage/references/setup.md) and [permissions guide](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-imessage/references/permissions.md).
+
+## Quick Start
+
+```bash
+agent-imessage setup                 # guided check + save account
+agent-imessage doctor                # diagnose imsg + permissions
+
+agent-imessage chat list             # chat ids/guids
+agent-imessage message send 42 "Hello"
+agent-imessage message send "+15551234567" "Hi"
+agent-imessage message list 42 --limit 20
+agent-imessage message watch --chat all --jsonl
+agent-imessage message react 42 love
+```
+
+## Chat references
+
+What a `<chat>` argument accepts depends on the command:
+
+- **`message send`** — a **chat id** (integer rowid), a portable **guid/identifier** (e.g. `iMessage;-;+15551234567`, passed straight through to imsg), or a **phone/email recipient**.
+- **`message list` / `message react` / `message watch --chat`** — a **chat id** is recommended. A guid/identifier also works as a convenience, but since imsg exposes no guid→id lookup it is resolved by scanning the **1000 most recent chats**; an older chat outside that window returns `chat_not_found`. Use the numeric chat id from `chat list` for those.
+
+Get chat ids and guids from `agent-imessage chat list`.
+
+## Authentication
+
+iMessage uses macOS permissions, not tokens. Configure the imsg binary/region:
+
+```bash
+agent-imessage auth set --bin /opt/homebrew/bin/imsg --region US --current
+agent-imessage auth list
+agent-imessage auth use <account-id>
+agent-imessage auth remove <account-id>
+agent-imessage auth logout
+```
+
+Environment overrides (runtime only, never persisted): `AGENT_IMESSAGE_BIN`, `AGENT_IMESSAGE_REGION`.
+
+## Commands
+
+### chat
+
+```bash
+agent-imessage chat list [--limit <n>]
+agent-imessage chat search <query> [--limit <n>]
+```
+
+### message
+
+```bash
+agent-imessage message list <chat> [--limit <n>] [--start <iso>]
+agent-imessage message send <chat> <text>
+agent-imessage message react <chat> <love|like|dislike|laugh|emphasis|question>
+agent-imessage message watch [--chat <ref|all>] [--since-rowid <n>] [--jsonl]
+```
+
+`message react` reacts to the **most recent incoming message** in the chat (an imsg limitation without the bridge). `message watch` streams new messages; pass `--since-rowid` to replay from a message rowid then continue live.
+
+### whoami / doctor / setup
+
+```bash
+agent-imessage whoami
+agent-imessage doctor [--account <id>] [--test-chat <chatId>]
+agent-imessage setup
+```
+
+All commands accept `--account <id>` and `--pretty`.
+
+## Output Format
+
+JSON by default; `--pretty` for indented output. `message watch --jsonl` emits one JSON object per line.
+
+## Feature Tiers
+
+| Feature                                                     | Available  | Requires                          |
+| ----------------------------------------------------------- | :--------: | --------------------------------- |
+| List/search chats, send text, read/watch, standard tapbacks |     ✅     | imsg core (no SIP)                |
+| Targeted/custom reactions, typing, edit/unsend, group mgmt  | ⏳ planned | imsg bridge (`imsg launch` + SIP) |
+
+## Notes
+
+`agent-imessage` is backend-agnostic by design (the credential record carries a `provider` field). Today the only provider is the local imsg tool. Networked backends are intentionally out of scope for this on-Mac integration.

--- a/docs/content/docs/cli/meta.json
+++ b/docs/content/docs/cli/meta.json
@@ -17,6 +17,7 @@
     "instagram",
     "kakaotalk",
     "channeltalk",
-    "channeltalkbot"
+    "channeltalkbot",
+    "imessage"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "agent-channeltalkbot": "./src/platforms/channeltalkbot/cli.ts",
     "agent-discord": "./src/platforms/discord/cli.ts",
     "agent-discordbot": "./src/platforms/discordbot/cli.ts",
+    "agent-imessage": "./src/platforms/imessage/cli.ts",
     "agent-instagram": "./src/platforms/instagram/cli.ts",
     "agent-kakaotalk": "./src/platforms/kakaotalk/cli.ts",
     "agent-line": "./src/platforms/line/cli.ts",
@@ -79,6 +80,9 @@
       ],
       "telegrambot": [
         "./src/platforms/telegrambot/index.ts"
+      ],
+      "imessage": [
+        "./src/platforms/imessage/index.ts"
       ]
     }
   },
@@ -151,6 +155,10 @@
     "./telegrambot": {
       "types": "./src/platforms/telegrambot/index.ts",
       "default": "./src/platforms/telegrambot/index.ts"
+    },
+    "./imessage": {
+      "types": "./src/platforms/imessage/index.ts",
+      "default": "./src/platforms/imessage/index.ts"
     }
   },
   "scripts": {

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -1,24 +1,21 @@
-import { cpSync, readFileSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 
-const cliFiles = [
-  'dist/src/cli.js',
-  'dist/src/platforms/slack/cli.js',
-  'dist/src/platforms/discord/cli.js',
-  'dist/src/platforms/teams/cli.js',
-  'dist/src/platforms/slackbot/cli.js',
-  'dist/src/platforms/channeltalk/cli.js',
-  'dist/src/platforms/channeltalkbot/cli.js',
-  'dist/src/platforms/telegram/cli.js',
-  'dist/src/platforms/telegrambot/cli.js',
-]
+const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { bin?: Record<string, string> }
 
+const cliFiles = Object.values(pkg.bin ?? {}).map((entry) =>
+  entry.replace(/^\.\/src\//, 'dist/src/').replace(/\.ts$/, '.js'),
+)
+
+let updatedCount = 0
 for (const file of cliFiles) {
+  if (!existsSync(file)) continue
   const content = readFileSync(file, 'utf8')
-  const updated = content.replace('#!/usr/bin/env bun', '#!/usr/bin/env node')
-  writeFileSync(file, updated)
+  if (!content.startsWith('#!/usr/bin/env bun')) continue
+  writeFileSync(file, content.replace('#!/usr/bin/env bun', '#!/usr/bin/env node'))
+  updatedCount++
 }
 
-console.log(`Updated shebang in ${cliFiles.length} CLI files`)
+console.log(`Updated shebang in ${updatedCount} CLI files`)
 
 cpSync('src/vendor', 'dist/src/vendor', { recursive: true })
 

--- a/skills/agent-imessage/SKILL.md
+++ b/skills/agent-imessage/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: agent-imessage
+description: Interact with iMessage on a Mac via the imsg tool - send messages, read chats, watch for new messages
+version: 2.27.1
+allowed-tools: Bash(agent-imessage:*)
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - agent-imessage
+    install:
+      - kind: node
+        package: agent-messenger
+        bins: [agent-imessage]
+---
+
+# Agent iMessage
+
+An iMessage CLI for AI agents, backed by [imsg](https://github.com/openclaw/imsg) — a native macOS tool that reads the local Messages database and sends through Messages.app. Apple has no public iMessage API, so this integration runs **on a Mac** and drives Messages locally. You act as yourself with your own Apple ID; nothing leaves the machine.
+
+Use one of these entrypoints:
+- Global install: `agent-imessage ...`
+- One-off execution: `bunx --package agent-messenger agent-imessage ...`
+
+## Key Concepts
+
+- **imsg** = a local Swift CLI (`brew install steipete/tap/imsg`). `agent-imessage` spawns it and talks to it over JSON-RPC (stdin/stdout). There is **no network and no server** — it must run on the Mac signed into iMessage.
+- **On-Mac only** = unlike other agent-messenger platforms, this one cannot run remotely or in a container. The agent runs on the Mac itself.
+- **Permissions** = imsg needs **Full Disk Access** (to read the Messages database) and **Automation → Messages** (to send). macOS grants these to the **parent process** — the app/terminal that launches agent-messenger.
+- **Chat reference** = for `message send`, a chat id (integer rowid), a portable `guid`/`identifier` (e.g. `iMessage;-;+15551234567`), or a phone/email recipient. For `message list`/`react`/`watch --chat`, prefer a **chat id** — a guid also works but (since imsg has no guid→id lookup) is resolved against the 1000 most recent chats only.
+- **Watch** = streams new messages via imsg; resumable from a message rowid with `--since-rowid`.
+- **Multi-account** = each account is an imsg configuration (binary path / region). Send is single-account (Messages has no from-selector).
+- **Private API tier** = typing, edit/unsend, group management, custom/targeted reactions require `imsg launch` (SIP disabled). Basic send/read/watch/standard tapbacks do NOT.
+
+## Quick Start
+
+```bash
+# Guided setup: checks imsg + permissions, saves an account
+agent-imessage setup
+
+# Diagnose anytime
+agent-imessage doctor
+
+# List chats (source of chat ids/guids)
+agent-imessage chat list
+
+# Send (to a chat id, guid, or a phone/email)
+agent-imessage message send 42 "Hello from agent-imessage"
+agent-imessage message send "+15551234567" "Hi"
+
+# Read recent messages
+agent-imessage message list 42 --limit 20
+
+# Watch for new messages (resumable, JSON lines)
+agent-imessage message watch --chat all --jsonl
+
+# React to the most recent incoming message (standard tapbacks)
+agent-imessage message react 42 love
+```
+
+## Setup & Permissions
+
+iMessage runs on the Mac via imsg. One-time setup:
+
+1. `brew install steipete/tap/imsg`
+2. Sign Messages.app into your Apple ID (a dedicated Apple ID is recommended).
+3. Grant **Full Disk Access** to the app/terminal launching agent-messenger (System Settings → Privacy & Security → Full Disk Access). macOS grants to the **parent process**.
+4. Grant **Automation → Messages** when first prompted (needed to send).
+
+See [setup](references/setup.md) and [permissions](references/permissions.md) references for detail.
+
+Configuration is scriptable too:
+```bash
+agent-imessage auth set --bin /opt/homebrew/bin/imsg --region US --current
+```
+Environment overrides (runtime only, not persisted): `AGENT_IMESSAGE_BIN`, `AGENT_IMESSAGE_REGION`.
+
+### Agent Behavior (MANDATORY)
+
+When a command fails, the agent MUST run `agent-imessage doctor` and act on the `suggestion`/`code` rather than telling the user to run commands. If `code` is `imsg_not_found`, guide installing imsg. If `full_disk_access` or `automation_denied`, surface the exact System Settings path (and that macOS grants to the parent process). Never silently retry the same failing call.
+
+## Commands
+
+- `setup` — guided check + save account.
+- `doctor [--account <id>] [--test-chat <chatId>]` — diagnose imsg + permissions.
+- `auth set|list|use|remove|logout` — manage accounts (binary path / region).
+- `chat list [--limit]` / `chat search <query> [--limit]`.
+- `message list <chat> [--limit] [--start <iso>]` — read history (oldest-last). `<chat>` = chat id (recommended) or recent-chat guid.
+- `message send <chat> <text>` — `<chat>` = chat id/guid or phone/email.
+- `message react <chat> <reaction>` — standard tapback to the **most recent incoming** message.
+- `message watch [--chat <ref|all>] [--since-rowid <n>] [--jsonl]` — stream new messages.
+- `whoami` — active account + imsg status.
+
+All commands accept `--account <id>` and `--pretty`.
+
+## Output Format
+
+JSON by default; `--pretty` for indented output. `message watch --jsonl` emits one JSON object per line.
+
+## Feature Tiers
+
+| Feature | Available | Requires |
+| --- | --- | --- |
+| List/search chats, send text, read/watch messages | ✅ | imsg core (no SIP) |
+| Standard tapbacks, to the most recent incoming message | ✅ | imsg core (no SIP) |
+| React to a specific message / custom-emoji tapbacks | ⏳ planned | imsg bridge (`imsg launch` + SIP) |
+| Typing, read receipts, edit/unsend, group management | ⏳ planned | imsg bridge (`imsg launch` + SIP) |
+
+## Error Handling
+
+Errors are JSON with a `code` and often a `suggestion`:
+
+| Code | Meaning | Action |
+| --- | --- | --- |
+| `imsg_not_found` | imsg binary not runnable | `brew install steipete/tap/imsg` (or set `--bin`/`AGENT_IMESSAGE_BIN`). |
+| `full_disk_access` | Can't read Messages DB | Grant Full Disk Access to the launching app (parent process). |
+| `automation_denied` | Can't control Messages | Grant Automation → Messages in System Settings. |
+| `not_authenticated` | No account configured | Run `agent-imessage setup`. |
+| `chat_not_found` | Unknown chat ref | Use a chat id/guid from `chat list`. |
+| `private_api_required` | Feature needs the bridge | Standard send/read/watch/tapbacks work without it; targeted/custom reactions need `imsg launch` (SIP off). |
+| `invalid_limit` | Bad `--limit`/`--since-rowid` | Use an integer 1–100 for `--limit`; non-negative integer for `--since-rowid`. |
+| `send_failed` | imsg could not send | Run `doctor`; on macOS 26 group sends can fail (imsg reports honestly). |
+| `rpc_error` | imsg rpc problem | Run `doctor`; check the imsg version. |
+
+## Troubleshooting
+
+- **`agent-imessage doctor`** is the fastest diagnostic — it reports imsg version, Full Disk Access, and the bridge tier.
+- **Permissions denied** — remember macOS grants Full Disk Access / Automation to the **parent** process (the terminal or agent runtime), not just `imsg`.
+- **Reactions only hit the latest message** — that's an imsg/AppleScript limitation without the bridge; reacting to a specific message needs `imsg launch` + SIP off.
+
+## Configuration
+
+Account config is stored in `~/.config/agent-messenger/imessage-credentials.json` (mode `0600`). Relocate via `AGENT_MESSENGER_CONFIG_DIR`. No secrets are stored — imsg uses macOS permissions, not tokens.

--- a/skills/agent-imessage/references/authentication.md
+++ b/skills/agent-imessage/references/authentication.md
@@ -1,0 +1,66 @@
+# Authentication
+
+iMessage authentication is unlike the other platforms: there are **no tokens, cookies, or login flow**. `agent-imessage` drives the local [imsg](https://github.com/openclaw/imsg) tool, which relies on **macOS permissions** (Full Disk Access + Automation) granted to the process that launches it. "Authentication" here means: imsg is installed, Messages.app is signed into your Apple ID, and the permissions are granted.
+
+## What gets stored
+
+The credential manager stores an **account record with no secrets** in `~/.config/agent-messenger/imessage-credentials.json` (mode `0600`):
+
+```jsonc
+{
+  "current": "default",
+  "accounts": {
+    "default": {
+      "account_id": "default",
+      "provider": "imsg",          // backend-agnostic discriminator
+      "binary_path": "/opt/homebrew/bin/imsg",  // optional; defaults to "imsg" on PATH
+      "region": "US",               // optional; default region for local-format phone numbers
+      "created_at": "…",
+      "updated_at": "…"
+    }
+  }
+}
+```
+
+There is no password/token field — access is governed entirely by macOS TCC permissions.
+
+## Configuring an account
+
+Guided:
+```bash
+agent-imessage setup            # verifies imsg + permissions (honors --bin/--region), then saves
+```
+
+Scriptable:
+```bash
+agent-imessage auth set --bin /opt/homebrew/bin/imsg --region US --current
+agent-imessage auth status      # via: agent-imessage doctor
+agent-imessage auth list
+agent-imessage auth use <account-id>
+agent-imessage auth remove <account-id>
+agent-imessage auth logout      # clears all stored accounts
+```
+
+## Credential resolution order
+
+When a command runs, the active configuration is resolved as:
+
+1. `--account <id>` (explicit account selection), then
+2. `AGENT_IMESSAGE_BIN` / `AGENT_IMESSAGE_REGION` environment variables (runtime override — **never persisted to disk**), then
+3. the stored **current** account, then
+4. defaults (`imsg` on PATH, no region).
+
+If nothing resolves, commands exit with `{ "code": "not_authenticated" }` and point to `agent-imessage setup`.
+
+## Permissions (the real "auth")
+
+imsg needs two macOS permissions, granted to the **parent process** (the terminal / agent runtime that launches `agent-messenger`), not to `imsg` in isolation:
+
+- **Full Disk Access** — to read `~/Library/Messages/chat.db`. Missing → `{ "code": "full_disk_access" }`.
+- **Automation → Messages** — to send. Missing → `{ "code": "automation_denied" }`.
+
+These are user-consent TCC grants and **cannot be scripted**. See [permissions](permissions.md) for the exact steps and the parent-process caveat. Run `agent-imessage doctor` to check status.
+
+## Multi-account
+
+Each account is an imsg configuration (binary path + default region). Messages.app has no from-selector, so **send is single-account per Mac**; multiple accounts are only meaningful if you run distinct imsg setups.

--- a/skills/agent-imessage/references/permissions.md
+++ b/skills/agent-imessage/references/permissions.md
@@ -1,0 +1,31 @@
+# macOS Permissions for imsg
+
+`agent-imessage` drives [imsg](https://github.com/openclaw/imsg), which needs two macOS permissions. These are TCC (Transparency, Consent, and Control) grants that **cannot be scripted** — a human must approve them once in System Settings.
+
+## Full Disk Access (required for everything)
+
+imsg reads the Messages database at `~/Library/Messages/chat.db`, which macOS protects behind Full Disk Access.
+
+- **Grant to:** the app/terminal/agent-runtime that launches `agent-messenger` — **the parent process**, not `imsg` alone.
+- **Where:** System Settings → Privacy & Security → Full Disk Access → enable your terminal/app → restart it.
+- **Symptom when missing:** `agent-imessage doctor` reports `full_disk_access: denied`; commands return `{ "code": "full_disk_access" }`.
+
+## Automation → Messages (required to send)
+
+Sending uses AppleScript automation of Messages.app.
+
+- **Grant to:** same parent process.
+- **Where:** System Settings → Privacy & Security → Automation → (your app) → enable **Messages**. macOS prompts automatically on the first send attempt.
+- **Symptom when missing:** sends fail with `{ "code": "automation_denied" }`.
+
+## Contacts (optional)
+
+Used only to resolve sender names. Nothing breaks without it; `from_name` is simply absent.
+
+## Why these can't be automated
+
+TCC grants are deliberately user-consent-only. `tccutil` can reset permissions but cannot grant them, and the TCC database is protected by SIP. There is no supported way to grant Full Disk Access or Automation programmatically on an unmanaged Mac — plan for a one-time manual approval (a quick Screen Sharing/VNC session works for a headless Mac).
+
+## SIP and the advanced bridge
+
+Core features (send/read/watch/standard tapbacks) need **no SIP changes**. Only the advanced bridge (`imsg launch`: typing, edit/unsend, group management, targeted/custom reactions) requires **disabling SIP**, which is a separate, deliberate step and out of scope for the core `agent-imessage` features.

--- a/skills/agent-imessage/references/setup.md
+++ b/skills/agent-imessage/references/setup.md
@@ -1,0 +1,49 @@
+# imsg Setup (Operator Guide)
+
+iMessage has no public API. `agent-imessage` runs **on a Mac** and uses [imsg](https://github.com/openclaw/imsg) — a native Swift CLI — to read the local Messages database and send through Messages.app. The agent must run on the same Mac (imsg is local-only; there is no network/server).
+
+## Requirements
+
+- **macOS 14+** (Sonoma or newer). imsg supports macOS 26/Tahoe with caveats (group sends via AppleScript can fail; imsg reports the failure honestly rather than lying).
+- **Messages.app signed in** to your Apple ID. A **dedicated Apple ID** is recommended to avoid mixing automated traffic with your personal account.
+- **imsg installed**: `brew install steipete/tap/imsg`.
+- **Full Disk Access** and **Automation → Messages** permissions (see below).
+
+## One-time setup
+
+1. **Install imsg**
+   ```bash
+   brew install steipete/tap/imsg
+   imsg --version
+   ```
+2. **Sign Messages.app into iMessage** with your (dedicated) Apple ID.
+3. **Grant Full Disk Access** — System Settings → Privacy & Security → Full Disk Access → add the app/terminal that will launch `agent-messenger`. This is required to read `~/Library/Messages/chat.db`.
+4. **Grant Automation → Messages** — triggered on first send; approve the prompt (System Settings → Privacy & Security → Automation → Messages).
+5. **Verify and save an account**
+   ```bash
+   agent-imessage setup      # guided: checks imsg + permissions, saves account
+   agent-imessage doctor     # re-check anytime
+   ```
+
+### The parent-process permission caveat (important)
+
+macOS grants Full Disk Access and Automation to the **process that launches imsg** — i.e. the terminal, IDE, or agent runtime that runs `agent-imessage`, not `imsg` in isolation. If `doctor` reports `full_disk_access: denied`, grant Full Disk Access to **that launching app** and restart it.
+
+## Feature tiers
+
+- **Core (no SIP):** list/search chats, read history, send text, watch new messages, standard tapbacks (to the most recent incoming message). This is all that `agent-imessage` v1 uses.
+- **Bridge (advanced):** typing indicators, read receipts, edit/unsend, group create/rename/members, and reacting to a *specific* message or with custom emoji. These require `imsg launch` (which injects into IMCore) and **disabling SIP**. Not used by v1; documented for completeness.
+
+## Multi-account
+
+Each `agent-imessage` account is an imsg configuration (binary path + default region). Messages.app has no from-selector, so **send is single-account** per Mac. Configure additional accounts only if you run multiple imsg binaries/setups:
+```bash
+agent-imessage auth set --bin /opt/homebrew/bin/imsg --region US --account home --current
+agent-imessage auth use home
+```
+
+## Reliability notes
+
+- The Mac must stay awake and logged in for live `watch` to keep receiving.
+- imsg's watcher uses filesystem events + polling and re-arms across Messages database (WAL) rotation, so it keeps up on busy/iCloud-synced databases.
+- Pin macOS updates if stability matters — major updates can change AppleScript/IMCore behavior.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,10 @@ program.command('channeltalk', 'Interact with Channel Talk', {
   executableFile: join(__dirname, 'platforms', 'channeltalk', `cli${ext}`),
 })
 
+program.command('imessage', 'Interact with iMessage via imsg (local, on-Mac)', {
+  executableFile: join(__dirname, 'platforms', 'imessage', `cli${ext}`),
+})
+
 program.command('channeltalkbot', 'Interact with Channel Talk using API credentials', {
   executableFile: join(__dirname, 'platforms', 'channeltalkbot', `cli${ext}`),
 })

--- a/src/platforms/imessage/cli.ts
+++ b/src/platforms/imessage/cli.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+
+import type { Command as CommandType } from 'commander'
+import { Command } from 'commander'
+
+import pkg from '../../../package.json' with { type: 'json' }
+import { authCommand, chatCommand, doctorCommand, messageCommand, setupCommand, whoamiCommand } from './commands/index'
+import { ensureIMessageAuth } from './ensure-auth'
+
+const UNGUARDED = new Set(['auth', 'setup', 'doctor'])
+
+function isUnguarded(command: CommandType): boolean {
+  let cmd: CommandType | null = command
+  while (cmd) {
+    if (UNGUARDED.has(cmd.name())) return true
+    cmd = cmd.parent
+  }
+  return false
+}
+
+const program = new Command()
+
+program.name('agent-imessage').description('CLI tool for iMessage via imsg (local, on-Mac)').version(pkg.version)
+
+program.hook('preAction', async (_thisCommand, actionCommand) => {
+  if (isUnguarded(actionCommand)) return
+  await ensureIMessageAuth()
+})
+
+program.addCommand(authCommand)
+program.addCommand(setupCommand)
+program.addCommand(doctorCommand)
+program.addCommand(chatCommand)
+program.addCommand(messageCommand)
+program.addCommand(whoamiCommand)
+
+program.parse(process.argv)
+
+export default program

--- a/src/platforms/imessage/client.test.ts
+++ b/src/platforms/imessage/client.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+
+import { ImsgClient } from './client'
+import { IMessageError } from './types'
+
+const STUB = join(import.meta.dir, 'test-stub-imsg.mjs')
+
+function clientWith(mode = 'ok'): ImsgClient {
+  process.env.IMSG_STUB_MODE = mode
+  return new ImsgClient()
+}
+
+describe('ImsgClient (against stub imsg binary)', () => {
+  it('getVersion returns the imsg version', async () => {
+    const c = await clientWith().login({ binaryPath: STUB })
+    expect(await c.getVersion()).toBe('0.11.1')
+    await c.close()
+  })
+
+  it('connect succeeds and listChats maps group/individual + fields', async () => {
+    const c = await clientWith().login({ binaryPath: STUB })
+    await c.connect()
+    const chats = await c.listChats(10)
+    expect(chats[0]).toMatchObject({ id: 42, name: 'Jane', is_group: false, service: 'iMessage' })
+    expect(chats[1]).toMatchObject({ id: 43, name: 'Crew', is_group: true })
+    expect(chats[1]?.participants).toHaveLength(2)
+    await c.close()
+  })
+
+  it('connect throws full_disk_access when the DB is not readable', async () => {
+    const c = await clientWith('fda_denied').login({ binaryPath: STUB })
+    try {
+      await c.connect()
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('full_disk_access')
+      expect((error as IMessageError).suggestion).toContain('Full Disk Access')
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('getMessages maps fields oldest-first with is_outgoing', async () => {
+    const c = await clientWith().login({ binaryPath: STUB })
+    await c.connect()
+    const msgs = await c.getMessages(42, 10)
+    expect(msgs.map((m) => m.guid)).toEqual(['m1', 'm2'])
+    expect(msgs[0]?.is_outgoing).toBe(false)
+    expect(msgs[1]?.is_outgoing).toBe(true)
+    await c.close()
+  })
+
+  it('sendMessage returns guid/id; send failure maps to send_failed', async () => {
+    const ok = await clientWith('ok').login({ binaryPath: STUB })
+    await ok.connect()
+    expect(await ok.sendMessage({ chatId: 42 }, 'hi')).toMatchObject({ guid: 'sent-guid', id: 99, is_outgoing: true })
+    await ok.close()
+
+    const fail = await clientWith('send_fail').login({ binaryPath: STUB })
+    await fail.connect()
+    try {
+      await fail.sendMessage({ chatId: 42 }, 'hi')
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('send_failed')
+    } finally {
+      await fail.close()
+    }
+  })
+
+  it('watch delivers live notifications', async () => {
+    const c = await clientWith().login({ binaryPath: STUB })
+    await c.connect()
+    const received: string[] = []
+    const stop = await c.watch((m) => received.push(m.guid), { chatId: 42 })
+    await new Promise((r) => setTimeout(r, 120))
+    await stop()
+    await c.close()
+    expect(received).toContain('m3')
+  })
+
+  it('sendReaction: standard via CLI; custom + message-target rejected', async () => {
+    const c = await clientWith().login({ binaryPath: STUB })
+    await c.connect()
+    await expect(c.sendReaction(42, 'love')).resolves.toBeUndefined()
+    await expect(c.sendReaction(42, 'sparkles')).rejects.toMatchObject({ code: 'private_api_required' })
+    await expect(c.sendReaction(42, 'love', 'some-guid')).rejects.toMatchObject({ code: 'private_api_required' })
+    await c.close()
+  })
+
+  it('maps an Automation-denied "imsg react" failure to automation_denied (not send_failed)', async () => {
+    const c = await clientWith('react_automation_denied').login({ binaryPath: STUB })
+    await c.connect()
+    try {
+      await c.sendReaction(42, 'love')
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('automation_denied')
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('maps AppleScript "not authorized" send error to automation_denied (not send_failed)', async () => {
+    const c = await clientWith('automation_denied').login({ binaryPath: STUB })
+    await c.connect()
+    try {
+      await c.sendMessage({ chatId: 42 }, 'hi')
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('automation_denied')
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('close() rejects in-flight requests instead of hanging', async () => {
+    const c = await clientWith().login({ binaryPath: STUB })
+    await c.connect()
+    const pending = c.listChats(1)
+    await c.close()
+    await expect(pending).rejects.toMatchObject({ code: 'rpc_error' })
+  })
+
+  it('imsg_not_found when the binary does not exist', async () => {
+    const c = await new ImsgClient().login({ binaryPath: '/nonexistent/imsg-xyz' })
+    try {
+      await c.connect()
+      throw new Error('should have thrown')
+    } catch (error) {
+      expect((error as IMessageError).code).toBe('imsg_not_found')
+    } finally {
+      await c.close()
+    }
+  })
+})

--- a/src/platforms/imessage/client.ts
+++ b/src/platforms/imessage/client.ts
@@ -1,0 +1,253 @@
+import { spawn } from 'node:child_process'
+
+import { classifyImsgFailure } from './errors'
+import { ImsgRpc } from './rpc'
+import { type IMessageChatSummary, type IMessageMessageSummary, type IMessageStatus, IMessageError } from './types'
+
+interface ImsgChat {
+  id: number
+  name?: string | null
+  identifier?: string | null
+  guid?: string | null
+  service?: string | null
+  is_group?: boolean
+  participants?: string[] | null
+  last_message?: ImsgMessage | null
+}
+
+interface ImsgMessage {
+  id: number
+  chat_id: number
+  guid: string
+  sender?: string | null
+  sender_name?: string | null
+  is_from_me?: boolean
+  text?: string | null
+  created_at?: string | null
+}
+
+const STANDARD_REACTIONS = new Set(['love', 'like', 'dislike', 'laugh', 'emphasis', 'question'])
+
+export interface SendTarget {
+  chatId?: number
+  chatGuid?: string
+  chatIdentifier?: string
+  to?: string
+}
+
+export type OneShotRunner = (
+  binaryPath: string,
+  args: string[],
+) => Promise<{ code: number; stdout: string; stderr: string }>
+
+const defaultRunner: OneShotRunner = (binaryPath, args) =>
+  new Promise((resolve, reject) => {
+    let proc: ReturnType<typeof spawn>
+    try {
+      proc = spawn(binaryPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    } catch {
+      reject(new IMessageError(`Could not run "${binaryPath}".`, 'imsg_not_found'))
+      return
+    }
+    let stdout = ''
+    let stderr = ''
+    proc.stdout?.on('data', (c: Buffer) => (stdout += c.toString()))
+    proc.stderr?.on('data', (c: Buffer) => (stderr += c.toString()))
+    proc.once('error', (err: NodeJS.ErrnoException) => {
+      reject(
+        err.code === 'ENOENT'
+          ? new IMessageError(`Could not run "${binaryPath}".`, 'imsg_not_found', {
+              suggestion: 'Install imsg: "brew install steipete/tap/imsg".',
+              doctorCommand: 'agent-imessage doctor',
+            })
+          : err,
+      )
+    })
+    proc.once('close', (code) => resolve({ code: code ?? 0, stdout, stderr }))
+  })
+
+function summarizeMessage(msg: ImsgMessage): IMessageMessageSummary {
+  return {
+    id: msg.id,
+    guid: msg.guid,
+    chat_id: msg.chat_id,
+    from: msg.is_from_me ? '' : (msg.sender ?? ''),
+    from_name: msg.sender_name ?? undefined,
+    is_outgoing: Boolean(msg.is_from_me),
+    timestamp: msg.created_at ?? new Date(0).toISOString(),
+    text: msg.text ?? undefined,
+  }
+}
+
+function summarizeChat(chat: ImsgChat): IMessageChatSummary {
+  return {
+    id: chat.id,
+    guid: chat.guid ?? null,
+    identifier: chat.identifier ?? null,
+    name: chat.name?.trim() || chat.identifier || chat.guid || String(chat.id),
+    service: chat.service ?? 'iMessage',
+    is_group: Boolean(chat.is_group),
+    participants: chat.participants ?? [],
+    last_message: chat.last_message ? summarizeMessage(chat.last_message) : undefined,
+  }
+}
+
+export class ImsgClient {
+  private binaryPath = 'imsg'
+  private region: string | undefined
+  private rpc: ImsgRpc
+  private runner: OneShotRunner
+
+  constructor(deps?: { rpc?: ImsgRpc; runner?: OneShotRunner }) {
+    this.rpc = deps?.rpc ?? new ImsgRpc()
+    this.runner = deps?.runner ?? defaultRunner
+  }
+
+  async login(credentials?: { binaryPath?: string; region?: string }): Promise<this> {
+    if (credentials) {
+      this.binaryPath = credentials.binaryPath ?? 'imsg'
+      this.region = credentials.region
+      return this
+    }
+    const { IMessageCredentialManager } = await import('./credential-manager')
+    const resolved = await new IMessageCredentialManager().resolveAccount()
+    this.binaryPath = resolved?.binary_path ?? 'imsg'
+    this.region = resolved?.region
+    return this
+  }
+
+  async connect(): Promise<void> {
+    await this.rpc.start(this.binaryPath)
+    await this.rpc.request('chats.list', { limit: 1 })
+  }
+
+  async getVersion(): Promise<string | null> {
+    const result = await this.runner(this.binaryPath, ['--version'])
+    if (result.code !== 0) return null
+    return result.stdout.trim() || null
+  }
+
+  async getStatus(): Promise<IMessageStatus> {
+    let version: string | null = null
+    let fullDiskAccess = false
+    try {
+      version = await this.getVersion()
+    } catch {
+      version = null
+    }
+    try {
+      await this.rpc.request('chats.list', { limit: 1 })
+      fullDiskAccess = true
+    } catch {
+      fullDiskAccess = false
+    }
+    return {
+      imsg_version: version,
+      binary_path: this.binaryPath,
+      full_disk_access: fullDiskAccess,
+      automation: 'unknown',
+      bridge_available: false,
+    }
+  }
+
+  async listChats(limit = 25): Promise<IMessageChatSummary[]> {
+    const result = await this.rpc.request<{ chats: ImsgChat[] }>('chats.list', { limit })
+    return result.chats.map(summarizeChat)
+  }
+
+  async searchChats(query: string, limit = 25): Promise<IMessageChatSummary[]> {
+    const all = await this.listChats(Math.max(limit, 100))
+    const lower = query.toLowerCase()
+    return all
+      .filter((c) => c.name.toLowerCase().includes(lower) || (c.identifier ?? '').toLowerCase().includes(lower))
+      .slice(0, limit)
+  }
+
+  async getMessages(chatId: number, limit = 25, start?: string): Promise<IMessageMessageSummary[]> {
+    const result = await this.rpc.request<{ messages: ImsgMessage[] }>('messages.history', {
+      chat_id: chatId,
+      limit,
+      ...(start ? { start } : {}),
+    })
+    return result.messages.map(summarizeMessage).sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp))
+  }
+
+  async sendMessage(target: SendTarget, text: string): Promise<IMessageMessageSummary> {
+    const params: Record<string, unknown> = { text }
+    if (target.chatId !== undefined) params.chat_id = target.chatId
+    else if (target.chatGuid) params.chat_guid = target.chatGuid
+    else if (target.chatIdentifier) params.chat_identifier = target.chatIdentifier
+    else if (target.to) params.to = target.to
+    else throw new IMessageError('A chat id, guid, or recipient is required to send.', 'chat_not_found')
+    if (this.region) params.region = this.region
+
+    const result = await this.rpc.request<{ ok?: boolean; guid?: string; id?: number; service?: string }>(
+      'send',
+      params,
+    )
+    return {
+      id: result.id ?? 0,
+      guid: result.guid ?? '',
+      chat_id: target.chatId ?? 0,
+      from: '',
+      is_outgoing: true,
+      timestamp: new Date().toISOString(),
+      text,
+    }
+  }
+
+  async sendReaction(chatId: number, reaction: string, messageGuid?: string): Promise<void> {
+    if (messageGuid) {
+      throw new IMessageError(
+        'Reacting to a specific message requires the imsg Private API bridge.',
+        'private_api_required',
+        { suggestion: 'Enable the bridge with "imsg launch" (requires SIP disabled).' },
+      )
+    }
+    if (!STANDARD_REACTIONS.has(reaction)) {
+      throw new IMessageError(
+        `Custom reactions require the imsg Private API bridge. Standard tapbacks: ${[...STANDARD_REACTIONS].join(', ')}.`,
+        'private_api_required',
+        { suggestion: 'Enable the bridge with "imsg launch" (requires SIP disabled).' },
+      )
+    }
+    const result = await this.runner(this.binaryPath, [
+      'react',
+      '--chat-id',
+      String(chatId),
+      '--reaction',
+      reaction,
+      '--json',
+    ])
+    if (result.code !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() || 'Reaction failed.'
+      throw classifyImsgFailure(detail, 'send_failed')
+    }
+  }
+
+  async watch(
+    onMessage: (msg: IMessageMessageSummary) => void,
+    options: { chatId?: number; sinceRowId?: number; onError?: (msg: string) => void } = {},
+  ): Promise<() => Promise<void>> {
+    const params: Record<string, unknown> = { include_reactions: false }
+    if (options.chatId !== undefined) params.chat_id = options.chatId
+    if (options.sinceRowId !== undefined) params.since_rowid = options.sinceRowId
+
+    const subscription = await this.rpc.subscribe(
+      params,
+      (raw) => onMessage(summarizeMessage(raw as ImsgMessage)),
+      options.onError,
+    )
+    return async () => {
+      await this.rpc.unsubscribe(subscription)
+    }
+  }
+
+  async getProfile(): Promise<IMessageStatus> {
+    return this.getStatus()
+  }
+
+  async close(): Promise<void> {
+    this.rpc.close()
+  }
+}

--- a/src/platforms/imessage/commands/auth.ts
+++ b/src/platforms/imessage/commands/auth.ts
@@ -1,0 +1,142 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { IMessageCredentialManager } from '../credential-manager'
+import { createAccountId } from '../types'
+
+async function guard(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn()
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+interface SetOptions {
+  bin?: string
+  region?: string
+  account?: string
+  label?: string
+  current?: boolean
+  pretty?: boolean
+  _manager?: IMessageCredentialManager
+}
+
+async function runSet(options: SetOptions): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const now = new Date().toISOString()
+  const accountId = createAccountId(options.account ?? options.label ?? options.bin ?? 'default')
+
+  await manager.setAccount({
+    account_id: accountId,
+    provider: 'imsg',
+    label: options.label,
+    binary_path: options.bin,
+    region: options.region,
+    created_at: now,
+    updated_at: now,
+  })
+  if (options.current) await manager.setCurrent(accountId)
+
+  console.log(
+    formatOutput({ success: true, account_id: accountId, binary_path: options.bin ?? 'imsg' }, options.pretty),
+  )
+  process.exit(0)
+}
+
+async function runList(options: { pretty?: boolean; _manager?: IMessageCredentialManager }): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const accounts = await manager.listAccounts()
+  console.log(
+    formatOutput(
+      accounts.map((a) => ({
+        account_id: a.account_id,
+        label: a.label,
+        binary_path: a.binary_path ?? 'imsg',
+        region: a.region,
+        is_current: a.is_current,
+      })),
+      options.pretty,
+    ),
+  )
+  process.exit(0)
+}
+
+async function runUse(
+  accountId: string,
+  options: { pretty?: boolean; _manager?: IMessageCredentialManager },
+): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const found = await manager.setCurrent(accountId)
+  if (!found) {
+    console.log(formatOutput({ error: `Account "${accountId}" not found. Run "auth list".` }, options.pretty))
+    process.exit(1)
+  }
+  console.log(formatOutput({ success: true, account_id: createAccountId(accountId) }, options.pretty))
+  process.exit(0)
+}
+
+async function runRemove(
+  accountId: string,
+  options: { pretty?: boolean; _manager?: IMessageCredentialManager },
+): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  const removed = await manager.removeAccount(accountId)
+  if (!removed) {
+    console.log(formatOutput({ error: `Account "${accountId}" not found. Run "auth list".` }, options.pretty))
+    process.exit(1)
+  }
+  console.log(formatOutput({ success: true }, options.pretty))
+  process.exit(0)
+}
+
+async function runLogout(options: { pretty?: boolean; _manager?: IMessageCredentialManager }): Promise<void> {
+  const manager = options._manager ?? new IMessageCredentialManager()
+  await manager.clearCredentials()
+  console.log(formatOutput({ success: true }, options.pretty))
+  process.exit(0)
+}
+
+export const authCommand = new Command('auth')
+  .description('Account configuration commands')
+  .addCommand(
+    new Command('set')
+      .description('Configure an iMessage account (imsg binary path / region)')
+      .option('--bin <path>', 'Path to the imsg binary (default: imsg on PATH)')
+      .option('--region <code>', 'Default region for local-format phone numbers (e.g. US)')
+      .option('--account <id>', 'Account id/alias')
+      .option('--label <label>', 'Human-friendly label')
+      .option('--current', 'Set as the active account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: SetOptions) => guard(() => runSet(opts))),
+  )
+  .addCommand(
+    new Command('list')
+      .description('List configured accounts')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => guard(() => runList(opts))),
+  )
+  .addCommand(
+    new Command('use')
+      .description('Switch the active account')
+      .argument('<account-id>', 'Account id')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (accountId: string, opts: { pretty?: boolean }) => guard(() => runUse(accountId, opts))),
+  )
+  .addCommand(
+    new Command('remove')
+      .description('Remove a configured account')
+      .argument('<account-id>', 'Account id')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (accountId: string, opts: { pretty?: boolean }) => guard(() => runRemove(accountId, opts))),
+  )
+  .addCommand(
+    new Command('logout')
+      .description('Clear all stored accounts')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(async (opts: { pretty?: boolean }) => guard(() => runLogout(opts))),
+  )
+
+export { runSet, runList, runUse, runRemove, runLogout }

--- a/src/platforms/imessage/commands/chat.ts
+++ b/src/platforms/imessage/commands/chat.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { parseLimitOption, withImsgClient } from './shared'
+
+async function listAction(options: { account?: string; pretty?: boolean; limit?: string }): Promise<void> {
+  try {
+    const limit = parseLimitOption(options.limit, 25)
+    const chats = await withImsgClient(options, (client) => client.listChats(limit))
+    console.log(formatOutput(chats, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function searchAction(
+  query: string,
+  options: { account?: string; pretty?: boolean; limit?: string },
+): Promise<void> {
+  try {
+    const limit = parseLimitOption(options.limit, 25)
+    const chats = await withImsgClient(options, (client) => client.searchChats(query, limit))
+    console.log(formatOutput(chats, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const chatCommand = new Command('chat')
+  .description('iMessage chat commands')
+  .addCommand(
+    new Command('list')
+      .description('List chats')
+      .option('--limit <n>', 'Number of chats to fetch', '25')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(listAction),
+  )
+  .addCommand(
+    new Command('search')
+      .description('Search chats by name or identifier')
+      .argument('<query>', 'Search query')
+      .option('--limit <n>', 'Number of results to return', '25')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(searchAction),
+  )

--- a/src/platforms/imessage/commands/doctor.test.ts
+++ b/src/platforms/imessage/commands/doctor.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+
+import { runDoctor } from './doctor'
+
+const STUB = join(import.meta.dir, '..', 'test-stub-imsg.mjs')
+const saved: Record<string, string | undefined> = {}
+
+function setMode(mode: string, bin = STUB): void {
+  saved.IMSG_STUB_MODE = process.env.IMSG_STUB_MODE
+  saved.AGENT_IMESSAGE_BIN = process.env.AGENT_IMESSAGE_BIN
+  process.env.IMSG_STUB_MODE = mode
+  process.env.AGENT_IMESSAGE_BIN = bin
+}
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+})
+
+describe('runDoctor', () => {
+  it('reports imsg_not_found when the binary is missing', async () => {
+    setMode('ok', '/nonexistent/imsg-xyz')
+    const report = await runDoctor({})
+    expect(report.ok).toBe(false)
+    expect(report.code).toBe('imsg_not_found')
+    expect(report.suggestion).toContain('brew install')
+  })
+
+  it('reports full_disk_access denied with Settings guidance', async () => {
+    setMode('fda_denied')
+    const report = await runDoctor({})
+    expect(report.ok).toBe(false)
+    expect(report.full_disk_access).toBe('denied')
+    expect(report.code).toBe('full_disk_access')
+    expect(report.suggestion).toContain('Full Disk Access')
+  })
+
+  it('reports healthy with version, FDA ok, and bridge note', async () => {
+    setMode('ok')
+    const report = await runDoctor({})
+    expect(report.ok).toBe(true)
+    expect(report.imsg).toBe('found')
+    expect(report.imsg_version).toBe('0.11.1')
+    expect(report.full_disk_access).toBe('ok')
+    expect(report.bridge).toBe('disabled')
+    expect(report.warnings.some((w) => w.includes('Private API bridge'))).toBe(true)
+  })
+
+  it('does not mislabel a non-FDA connect failure as Full Disk Access denied', async () => {
+    setMode('connect_rpc_fail')
+    const report = await runDoctor({})
+    expect(report.ok).toBe(false)
+    expect(report.full_disk_access).toBe('unknown')
+    expect(report.code).toBe('rpc_error')
+  })
+
+  it('honors an explicit --bin override (verifies the supplied binary, not the default)', async () => {
+    setMode('ok', '/nonexistent/default-imsg')
+    const report = await runDoctor({ bin: STUB })
+    expect(report.ok).toBe(true)
+    expect(report.binary_path).toBe(STUB)
+  })
+
+  it('fails on an invalid --bin even when the default/env binary is valid', async () => {
+    setMode('ok', STUB)
+    const report = await runDoctor({ bin: '/nonexistent/custom-imsg' })
+    expect(report.ok).toBe(false)
+    expect(report.code).toBe('imsg_not_found')
+    expect(report.binary_path).toBe('/nonexistent/custom-imsg')
+  })
+
+  it('runs a test-chat send when requested', async () => {
+    setMode('ok')
+    const report = await runDoctor({ testChat: 42 })
+    expect(report.test_chat).toBe('sent')
+  })
+})

--- a/src/platforms/imessage/commands/doctor.ts
+++ b/src/platforms/imessage/commands/doctor.ts
@@ -1,0 +1,139 @@
+import { Command } from 'commander'
+
+import { formatOutput } from '@/shared/utils/output'
+
+import { ImsgClient } from '../client'
+import { IMessageCredentialManager } from '../credential-manager'
+import { IMessageError } from '../types'
+
+export interface DoctorReport {
+  ok: boolean
+  imsg: 'found' | 'missing'
+  imsg_version?: string | null
+  binary_path: string
+  full_disk_access: 'ok' | 'denied' | 'unknown'
+  automation: string
+  bridge: 'enabled' | 'disabled'
+  test_chat?: string
+  warnings: string[]
+  error?: string
+  code?: string
+  suggestion?: string
+}
+
+export async function runDoctor(options: {
+  account?: string
+  bin?: string
+  region?: string
+  testChat?: number
+  client?: ImsgClient
+}): Promise<DoctorReport> {
+  const resolved = await new IMessageCredentialManager().resolveAccount(options.account)
+  const binaryPath = options.bin ?? resolved?.binary_path ?? process.env.AGENT_IMESSAGE_BIN ?? 'imsg'
+  const region = options.region ?? resolved?.region
+
+  const client = options.client ?? new ImsgClient()
+  await client.login({ binaryPath, region })
+
+  const warnings: string[] = []
+
+  let version: string | null = null
+  let versionError: IMessageError | undefined
+  try {
+    version = await client.getVersion()
+  } catch (error) {
+    versionError = error as IMessageError
+  }
+
+  if (version === null) {
+    const code = versionError?.code ?? 'imsg_not_found'
+    return {
+      ok: false,
+      imsg: 'missing',
+      binary_path: binaryPath,
+      full_disk_access: 'unknown',
+      automation: 'unknown',
+      bridge: 'disabled',
+      warnings,
+      error: versionError?.message ?? `Could not run "${binaryPath} --version".`,
+      code,
+      suggestion:
+        versionError?.suggestion ??
+        (code === 'imsg_not_found' ? 'Install imsg: "brew install steipete/tap/imsg".' : undefined),
+    }
+  }
+
+  let connectError: IMessageError | undefined
+  try {
+    await client.connect()
+  } catch (error) {
+    connectError = error as IMessageError
+  }
+
+  if (connectError) {
+    await client.close()
+    const isFda = connectError.code === 'full_disk_access'
+    return {
+      ok: false,
+      imsg: 'found',
+      imsg_version: version,
+      binary_path: binaryPath,
+      full_disk_access: isFda ? 'denied' : 'unknown',
+      automation: 'unknown',
+      bridge: 'disabled',
+      warnings,
+      error: connectError.message,
+      code: connectError.code,
+      suggestion:
+        connectError.suggestion ??
+        (isFda
+          ? 'Grant Full Disk Access to the app/terminal launching agent-messenger (System Settings → Privacy & Security → Full Disk Access). macOS grants to the parent process.'
+          : undefined),
+    }
+  }
+
+  warnings.push(
+    'Automation (Messages) is verified on first send. If sends fail, grant Privacy → Automation → Messages.',
+  )
+  warnings.push(
+    'Private API bridge disabled — send/read/watch/standard tapbacks work; typing/edit/group mgmt need "imsg launch" (SIP off).',
+  )
+
+  let testChatResult: string | undefined
+  if (options.testChat !== undefined) {
+    try {
+      await client.sendMessage({ chatId: options.testChat }, 'agent-imessage doctor test message')
+      testChatResult = 'sent'
+    } catch (error) {
+      testChatResult = `failed: ${(error as Error).message}`
+    }
+  }
+
+  await client.close()
+
+  return {
+    ok: true,
+    imsg: 'found',
+    imsg_version: version,
+    binary_path: binaryPath,
+    full_disk_access: 'ok',
+    automation: 'unknown',
+    bridge: 'disabled',
+    test_chat: testChatResult,
+    warnings,
+  }
+}
+
+export const doctorCommand = new Command('doctor')
+  .description('Diagnose imsg availability and macOS permissions')
+  .option('--account <id>', 'Check a specific account (default: current)')
+  .option('--bin <path>', 'Check a specific imsg binary path')
+  .option('--region <code>', 'Default region for local-format phone numbers')
+  .option('--test-chat <chatId>', 'Send a test message to this chat id')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(async (opts: { account?: string; bin?: string; region?: string; testChat?: string; pretty?: boolean }) => {
+    const testChat = opts.testChat && /^\d+$/.test(opts.testChat) ? Number.parseInt(opts.testChat, 10) : undefined
+    const report = await runDoctor({ account: opts.account, bin: opts.bin, region: opts.region, testChat })
+    console.log(formatOutput(report, opts.pretty))
+    process.exit(report.ok ? 0 : 1)
+  })

--- a/src/platforms/imessage/commands/index.ts
+++ b/src/platforms/imessage/commands/index.ts
@@ -1,0 +1,6 @@
+export { authCommand } from './auth'
+export { chatCommand } from './chat'
+export { doctorCommand } from './doctor'
+export { messageCommand } from './message'
+export { setupCommand } from './setup'
+export { whoamiCommand } from './whoami'

--- a/src/platforms/imessage/commands/message.test.ts
+++ b/src/platforms/imessage/commands/message.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+
+import { IMessageError } from '../types'
+import { parseRowId } from './message'
+
+describe('parseRowId', () => {
+  it('parses a non-negative integer', () => {
+    expect(parseRowId('9000')).toBe(9000)
+    expect(parseRowId('0')).toBe(0)
+  })
+
+  it('returns undefined when absent', () => {
+    expect(parseRowId(undefined)).toBeUndefined()
+  })
+
+  it('rejects non-integers', () => {
+    expect(() => parseRowId('abc')).toThrow(IMessageError)
+    expect(() => parseRowId('-5')).toThrow(IMessageError)
+  })
+})

--- a/src/platforms/imessage/commands/message.ts
+++ b/src/platforms/imessage/commands/message.ts
@@ -1,0 +1,151 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { IMessageError, type IMessageMessageSummary } from '../types'
+import { parseLimitOption, resolveChatId, resolveChatTarget, withImsgClient } from './shared'
+
+async function listAction(
+  chat: string,
+  options: { account?: string; pretty?: boolean; limit?: string; start?: string },
+): Promise<void> {
+  try {
+    const limit = parseLimitOption(options.limit, 25)
+    const messages = await withImsgClient(options, async (client) => {
+      const chatId = await resolveChatId(client, chat)
+      return client.getMessages(chatId, limit, options.start)
+    })
+    console.log(formatOutput(messages, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function sendAction(chat: string, text: string, options: { account?: string; pretty?: boolean }): Promise<void> {
+  try {
+    const message = await withImsgClient(options, (client) => client.sendMessage(resolveChatTarget(chat), text))
+    console.log(formatOutput(message, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+async function reactAction(
+  chat: string,
+  reaction: string,
+  options: { account?: string; pretty?: boolean },
+): Promise<void> {
+  try {
+    await withImsgClient(options, async (client) => {
+      const chatId = await resolveChatId(client, chat)
+      await client.sendReaction(chatId, reaction)
+    })
+    console.log(formatOutput({ success: true, chat, reaction }, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+function parseRowId(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  if (!/^\d+$/.test(raw.trim())) {
+    throw new IMessageError('--since-rowid must be a non-negative integer.', 'invalid_limit')
+  }
+  return Number.parseInt(raw.trim(), 10)
+}
+
+async function watchAction(options: {
+  account?: string
+  pretty?: boolean
+  chat?: string
+  sinceRowid?: string
+  jsonl?: boolean
+}): Promise<void> {
+  try {
+    const sinceRowId = parseRowId(options.sinceRowid)
+    await withImsgClient(options, async (client) => {
+      const chatId = options.chat && options.chat !== 'all' ? await resolveChatId(client, options.chat) : undefined
+      const seen = new Set<string>()
+      const SEEN_CAP = 2000
+      let running = true
+
+      const emit = (msg: IMessageMessageSummary): void => {
+        if (msg.guid) {
+          if (seen.has(msg.guid)) return
+          seen.add(msg.guid)
+          if (seen.size > SEEN_CAP) {
+            const oldest = seen.values().next().value
+            if (oldest !== undefined) seen.delete(oldest)
+          }
+        }
+        console.log(options.jsonl ? JSON.stringify(msg) : formatOutput(msg, options.pretty))
+      }
+
+      const stop = await client.watch(emit, {
+        chatId,
+        sinceRowId,
+        onError: (m) => console.error(JSON.stringify({ warning: m })),
+      })
+
+      await new Promise<void>((resolve) => {
+        const shutdown = (): void => {
+          if (!running) return
+          running = false
+          void stop().finally(resolve)
+        }
+        process.on('SIGINT', shutdown)
+        process.on('SIGTERM', shutdown)
+      })
+    })
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const messageCommand = new Command('message')
+  .description('iMessage message commands')
+  .addCommand(
+    new Command('list')
+      .description('List messages from a chat')
+      .argument('<chat>', 'Chat id, guid, or identifier')
+      .option('--limit <n>', 'Number of messages to fetch', '25')
+      .option('--start <iso>', 'Only messages on/after this ISO timestamp')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(listAction),
+  )
+  .addCommand(
+    new Command('send')
+      .description('Send a text message to a chat or recipient')
+      .argument('<chat>', 'Chat id/guid, or a phone/email recipient')
+      .argument('<text>', 'Message text')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(sendAction),
+  )
+  .addCommand(
+    new Command('react')
+      .description('React to the most recent incoming message in a chat (standard tapbacks)')
+      .argument('<chat>', 'Chat id, guid, or identifier')
+      .argument('<reaction>', 'love | like | dislike | laugh | emphasis | question')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(reactAction),
+  )
+  .addCommand(
+    new Command('watch')
+      .description('Stream new messages via imsg (resumable with --since-rowid)')
+      .option('--chat <ref|all>', 'Watch a specific chat or "all"', 'all')
+      .option('--since-rowid <n>', 'Replay messages after this message rowid, then stream live')
+      .option('--jsonl', 'Emit one JSON object per line')
+      .option('--account <id>', 'Use a specific iMessage account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(watchAction),
+  )
+
+export { parseRowId }

--- a/src/platforms/imessage/commands/setup.test.ts
+++ b/src/platforms/imessage/commands/setup.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { IMessageCredentialManager } from '../credential-manager'
+import { performSetup } from './setup'
+
+const STUB = join(import.meta.dir, '..', 'test-stub-imsg.mjs')
+const testDirs: string[] = []
+const saved: Record<string, string | undefined> = {}
+
+function freshManager(): { manager: IMessageCredentialManager; dir: string } {
+  const dir = join(import.meta.dir, `.test-setup-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  testDirs.push(dir)
+  return { manager: new IMessageCredentialManager(dir), dir }
+}
+
+function setEnv(bin?: string): void {
+  saved.IMSG_STUB_MODE = process.env.IMSG_STUB_MODE
+  saved.AGENT_IMESSAGE_BIN = process.env.AGENT_IMESSAGE_BIN
+  process.env.IMSG_STUB_MODE = 'ok'
+  if (bin === undefined) delete process.env.AGENT_IMESSAGE_BIN
+  else process.env.AGENT_IMESSAGE_BIN = bin
+}
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+  for (const dir of testDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('performSetup', () => {
+  it('saves the account when the supplied --bin verifies', async () => {
+    setEnv()
+    const { manager, dir } = freshManager()
+    const result = await performSetup({ bin: STUB, manager })
+    expect(result.ok).toBe(true)
+    expect(existsSync(join(dir, 'imessage-credentials.json'))).toBe(true)
+    expect((await manager.resolveAccount())?.binary_path).toBe(STUB)
+  })
+
+  it('does NOT persist an account when an invalid --bin fails, even if the default binary is valid', async () => {
+    setEnv(STUB)
+    const { manager, dir } = freshManager()
+    const result = await performSetup({ bin: '/nonexistent/custom-imsg', manager })
+    expect(result.ok).toBe(false)
+    expect(result.report.code).toBe('imsg_not_found')
+    expect(existsSync(join(dir, 'imessage-credentials.json'))).toBe(false)
+  })
+})

--- a/src/platforms/imessage/commands/setup.ts
+++ b/src/platforms/imessage/commands/setup.ts
@@ -1,0 +1,76 @@
+import { Command } from 'commander'
+
+import { formatOutput } from '@/shared/utils/output'
+
+import { IMessageCredentialManager } from '../credential-manager'
+import { createAccountId } from '../types'
+import { runDoctor } from './doctor'
+
+const CHECKLIST = `iMessage runs on THIS Mac through the "imsg" tool. One-time setup:
+  1. Install imsg:  brew install steipete/tap/imsg
+  2. Sign Messages.app into your Apple ID (a dedicated Apple ID is recommended).
+  3. Grant Full Disk Access to the app/terminal that launches agent-messenger
+     (System Settings > Privacy & Security > Full Disk Access). macOS grants to the parent process.
+  4. Grant Automation > Messages when first prompted (needed to send).
+
+Basic send / read / watch / standard tapbacks need NO SIP changes.
+Typing, edit/unsend, group management need "imsg launch" (SIP disabled) — a later tier.`
+
+export async function performSetup(options: {
+  bin?: string
+  region?: string
+  manager?: IMessageCredentialManager
+}): Promise<{ ok: boolean; report: Awaited<ReturnType<typeof runDoctor>>; account_id?: string }> {
+  const report = await runDoctor({ bin: options.bin, region: options.region })
+  if (!report.ok) {
+    return { ok: false, report }
+  }
+
+  const manager = options.manager ?? new IMessageCredentialManager()
+  const now = new Date().toISOString()
+  const accountId = createAccountId(options.bin ?? 'default')
+  await manager.setAccount({
+    account_id: accountId,
+    provider: 'imsg',
+    binary_path: options.bin,
+    region: options.region,
+    created_at: now,
+    updated_at: now,
+  })
+  await manager.setCurrent(accountId)
+
+  return { ok: true, report, account_id: accountId }
+}
+
+async function runSetup(options: { bin?: string; region?: string; pretty?: boolean }): Promise<void> {
+  console.error(CHECKLIST)
+  console.error('')
+
+  const result = await performSetup({ bin: options.bin, region: options.region })
+  if (!result.ok) {
+    console.log(formatOutput(result.report, options.pretty))
+    process.exit(1)
+  }
+
+  console.log(
+    formatOutput(
+      {
+        success: true,
+        account_id: result.account_id,
+        imsg_version: result.report.imsg_version,
+        full_disk_access: result.report.full_disk_access,
+      },
+      options.pretty,
+    ),
+  )
+  process.exit(0)
+}
+
+export const setupCommand = new Command('setup')
+  .description('Guided setup: verify imsg + permissions and save an account')
+  .option('--bin <path>', 'Path to the imsg binary (default: imsg on PATH)')
+  .option('--region <code>', 'Default region for local-format phone numbers')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(async (opts: { bin?: string; region?: string; pretty?: boolean }) => runSetup(opts))
+
+export { runSetup }

--- a/src/platforms/imessage/commands/shared.test.ts
+++ b/src/platforms/imessage/commands/shared.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test'
+
+import { resolveChatTarget } from './shared'
+
+describe('resolveChatTarget', () => {
+  it('treats a digits-only ref as a chat id (rowid)', () => {
+    expect(resolveChatTarget('42')).toEqual({ chatId: 42 })
+  })
+
+  it('passes a portable guid/identifier through as chat_guid', () => {
+    expect(resolveChatTarget('iMessage;-;+15551234567')).toEqual({ chatGuid: 'iMessage;-;+15551234567' })
+    expect(resolveChatTarget('iMessage;+;chat99')).toEqual({ chatGuid: 'iMessage;+;chat99' })
+  })
+
+  it('treats a non-numeric, non-guid ref as a recipient handle', () => {
+    expect(resolveChatTarget('+15551234567')).toEqual({ to: '+15551234567' })
+    expect(resolveChatTarget('jane@icloud.com')).toEqual({ to: 'jane@icloud.com' })
+  })
+})

--- a/src/platforms/imessage/commands/shared.ts
+++ b/src/platforms/imessage/commands/shared.ts
@@ -1,0 +1,69 @@
+import { formatOutput } from '@/shared/utils/output'
+
+import { ImsgClient, type SendTarget } from '../client'
+import { IMessageCredentialManager } from '../credential-manager'
+import { IMessageError } from '../types'
+
+export interface AccountOption {
+  account?: string
+  pretty?: boolean
+}
+
+export function parseLimitOption(rawLimit: string | undefined, defaultValue: number, maxValue = 100): number {
+  const trimmed = (rawLimit ?? `${defaultValue}`).trim()
+  if (!/^\d+$/.test(trimmed)) {
+    throw new IMessageError(`--limit must be an integer between 1 and ${maxValue}.`, 'invalid_limit')
+  }
+  const parsed = Number.parseInt(trimmed, 10)
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > maxValue) {
+    throw new IMessageError(`--limit must be an integer between 1 and ${maxValue}.`, 'invalid_limit')
+  }
+  return parsed
+}
+
+export function resolveChatTarget(chatRef: string): SendTarget {
+  if (/^\d+$/.test(chatRef)) return { chatId: Number.parseInt(chatRef, 10) }
+  if (chatRef.includes(';')) return { chatGuid: chatRef }
+  return { to: chatRef }
+}
+
+const CHAT_RESOLVE_LIMIT = 1000
+
+export async function resolveChatId(client: ImsgClient, chatRef: string): Promise<number> {
+  if (/^\d+$/.test(chatRef)) return Number.parseInt(chatRef, 10)
+
+  if (chatRef.includes(';')) {
+    const chats = await client.listChats(CHAT_RESOLVE_LIMIT)
+    const match = chats.find((c) => c.guid === chatRef || c.identifier === chatRef)
+    if (match) return match.id
+  }
+
+  throw new IMessageError(
+    `Could not resolve "${chatRef}" to a chat id (searched the ${CHAT_RESOLVE_LIMIT} most recent chats). Use a numeric chat id from "agent-imessage chat list".`,
+    'chat_not_found',
+  )
+}
+
+export async function withImsgClient<T>(options: AccountOption, fn: (client: ImsgClient) => Promise<T>): Promise<T> {
+  const resolved = await new IMessageCredentialManager().resolveAccount(options.account)
+  if (!resolved) {
+    console.log(
+      formatOutput(
+        {
+          error: 'Not configured. Run "agent-imessage setup" first.',
+          code: 'not_authenticated',
+        },
+        options.pretty,
+      ),
+    )
+    process.exit(1)
+  }
+
+  const client = await new ImsgClient().login({ binaryPath: resolved.binary_path, region: resolved.region })
+  try {
+    await client.connect()
+    return await fn(client)
+  } finally {
+    await client.close()
+  }
+}

--- a/src/platforms/imessage/commands/whoami.ts
+++ b/src/platforms/imessage/commands/whoami.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander'
+
+import { handleError } from '@/shared/utils/error-handler'
+import { formatOutput } from '@/shared/utils/output'
+
+import { withImsgClient } from './shared'
+
+async function whoamiAction(options: { account?: string; pretty?: boolean }): Promise<void> {
+  try {
+    const status = await withImsgClient(options, (client) => client.getStatus())
+    console.log(formatOutput(status, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export const whoamiCommand = new Command('whoami')
+  .description('Show the active iMessage account and imsg status')
+  .option('--account <id>', 'Use a specific iMessage account')
+  .option('--pretty', 'Pretty print JSON output')
+  .action(whoamiAction)

--- a/src/platforms/imessage/credential-manager.test.ts
+++ b/src/platforms/imessage/credential-manager.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { IMessageCredentialManager } from './credential-manager'
+import type { IMessageAccount } from './types'
+
+const testDirs: string[] = []
+const saved: Record<string, string | undefined> = {}
+
+function setup(): IMessageCredentialManager {
+  const dir = join(import.meta.dir, `.test-imsg-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  testDirs.push(dir)
+  return new IMessageCredentialManager(dir)
+}
+
+function makeAccount(overrides?: Partial<IMessageAccount>): IMessageAccount {
+  const now = new Date().toISOString()
+  return {
+    account_id: 'home',
+    provider: 'imsg',
+    binary_path: '/opt/homebrew/bin/imsg',
+    region: 'US',
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  }
+}
+
+function clearEnv(): void {
+  for (const k of ['AGENT_IMESSAGE_BIN', 'AGENT_IMESSAGE_REGION']) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+}
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+  for (const dir of testDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('IMessageCredentialManager', () => {
+  it('persists provider-aware schema with enforced 0600', async () => {
+    clearEnv()
+    const manager = setup()
+    await manager.setAccount(makeAccount())
+    const path = join(testDirs[testDirs.length - 1]!, 'imessage-credentials.json')
+    expect(existsSync(path)).toBe(true)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+    const config = await manager.loadConfig()
+    expect(config.accounts.home?.provider).toBe('imsg')
+  })
+
+  it('resolveAccount: env AGENT_IMESSAGE_BIN/REGION override stored, not persisted', async () => {
+    clearEnv()
+    const manager = setup()
+    await manager.setAccount(makeAccount({ binary_path: '/stored/imsg', region: 'GB' }))
+
+    expect(await manager.resolveAccount()).toEqual({ binary_path: '/stored/imsg', region: 'GB' })
+
+    process.env.AGENT_IMESSAGE_BIN = '/env/imsg'
+    process.env.AGENT_IMESSAGE_REGION = 'US'
+    expect(await manager.resolveAccount()).toEqual({ binary_path: '/env/imsg', region: 'US' })
+
+    const fresh = await manager.getAccount('home')
+    expect(fresh?.binary_path).toBe('/stored/imsg')
+  })
+
+  it('resolveAccount returns env-only when no account but AGENT_IMESSAGE_BIN set', async () => {
+    clearEnv()
+    const manager = setup()
+    expect(await manager.resolveAccount()).toBeNull()
+    process.env.AGENT_IMESSAGE_BIN = '/env/imsg'
+    expect(await manager.resolveAccount()).toEqual({ binary_path: '/env/imsg', region: undefined })
+  })
+
+  it('coerces malformed config and drops invalid accounts', async () => {
+    clearEnv()
+    const dir = join(import.meta.dir, `.test-imsg-bad-${Date.now()}`)
+    testDirs.push(dir)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'imessage-credentials.json'),
+      JSON.stringify({ current: 'missing', accounts: { good: { account_id: 'good' }, junk: 'x' } }),
+    )
+    const config = await new IMessageCredentialManager(dir).loadConfig()
+    expect(Object.keys(config.accounts)).toEqual(['good'])
+    expect(config.current).toBe('good')
+  })
+
+  it('re-indexes accounts by validated account_id when the persisted key differs', async () => {
+    clearEnv()
+    const dir = join(import.meta.dir, `.test-imsg-reindex-${Date.now()}`)
+    testDirs.push(dir)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'imessage-credentials.json'),
+      JSON.stringify({
+        current: 'home',
+        accounts: { 'stale-key': { account_id: 'home', server_url: undefined, binary_path: '/x/imsg' } },
+      }),
+    )
+    const manager = new IMessageCredentialManager(dir)
+    const config = await manager.loadConfig()
+    expect(Object.keys(config.accounts)).toEqual(['home'])
+    expect(config.current).toBe('home')
+    expect((await manager.getAccount('home'))?.binary_path).toBe('/x/imsg')
+  })
+
+  it('removeAccount reassigns current; setCurrent false for unknown', async () => {
+    clearEnv()
+    const manager = setup()
+    await manager.setAccount(makeAccount({ account_id: 'a' }))
+    await manager.setAccount(makeAccount({ account_id: 'b' }))
+    expect(await manager.removeAccount('a')).toBe(true)
+    expect((await manager.getAccount())?.account_id).toBe('b')
+    expect(await manager.setCurrent('ghost')).toBe(false)
+  })
+})

--- a/src/platforms/imessage/credential-manager.ts
+++ b/src/platforms/imessage/credential-manager.ts
@@ -1,0 +1,123 @@
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { getConfigDir } from '../../shared/utils/config-dir'
+import { createAccountId, type IMessageAccount, type IMessageConfig } from './types'
+
+export interface ResolvedAccount {
+  binary_path: string
+  region?: string
+}
+
+function coerceConfig(raw: unknown): IMessageConfig {
+  if (typeof raw !== 'object' || raw === null) return { current: null, accounts: {} }
+
+  const obj = raw as Record<string, unknown>
+  const accounts: Record<string, IMessageAccount> = {}
+
+  if (typeof obj.accounts === 'object' && obj.accounts !== null) {
+    for (const value of Object.values(obj.accounts as Record<string, unknown>)) {
+      if (typeof value !== 'object' || value === null) continue
+      const a = value as Record<string, unknown>
+      if (typeof a.account_id !== 'string' || a.account_id.length === 0) continue
+      accounts[a.account_id] = {
+        account_id: a.account_id,
+        provider: 'imsg',
+        label: typeof a.label === 'string' ? a.label : undefined,
+        binary_path: typeof a.binary_path === 'string' ? a.binary_path : undefined,
+        region: typeof a.region === 'string' ? a.region : undefined,
+        created_at: typeof a.created_at === 'string' ? a.created_at : new Date().toISOString(),
+        updated_at: typeof a.updated_at === 'string' ? a.updated_at : new Date().toISOString(),
+      }
+    }
+  }
+
+  const current =
+    typeof obj.current === 'string' && accounts[obj.current] ? obj.current : (Object.keys(accounts)[0] ?? null)
+  return { current, accounts }
+}
+
+export class IMessageCredentialManager {
+  private configDir: string
+  private credentialsPath: string
+
+  constructor(configDir?: string) {
+    this.configDir = configDir ?? getConfigDir()
+    this.credentialsPath = join(this.configDir, 'imessage-credentials.json')
+  }
+
+  async loadConfig(): Promise<IMessageConfig> {
+    if (!existsSync(this.credentialsPath)) return { current: null, accounts: {} }
+    try {
+      return coerceConfig(JSON.parse(await readFile(this.credentialsPath, 'utf-8')))
+    } catch {
+      return { current: null, accounts: {} }
+    }
+  }
+
+  async saveConfig(config: IMessageConfig): Promise<void> {
+    await mkdir(this.configDir, { recursive: true })
+    await writeFile(this.credentialsPath, JSON.stringify(config, null, 2), { mode: 0o600 })
+    await chmod(this.credentialsPath, 0o600)
+  }
+
+  async getAccount(accountId?: string): Promise<IMessageAccount | null> {
+    const config = await this.loadConfig()
+    if (!accountId) return config.current ? (config.accounts[config.current] ?? null) : null
+    return config.accounts[accountId] ?? config.accounts[createAccountId(accountId)] ?? null
+  }
+
+  async listAccounts(): Promise<Array<IMessageAccount & { is_current: boolean }>> {
+    const config = await this.loadConfig()
+    return Object.values(config.accounts).map((account) => ({
+      ...account,
+      is_current: account.account_id === config.current,
+    }))
+  }
+
+  async setAccount(account: IMessageAccount): Promise<void> {
+    const config = await this.loadConfig()
+    config.accounts[account.account_id] = account
+    if (!config.current) config.current = account.account_id
+    await this.saveConfig(config)
+  }
+
+  async setCurrent(accountId: string): Promise<boolean> {
+    const config = await this.loadConfig()
+    const account = config.accounts[accountId] ?? config.accounts[createAccountId(accountId)]
+    if (!account) return false
+    config.current = account.account_id
+    await this.saveConfig(config)
+    return true
+  }
+
+  async removeAccount(accountId: string): Promise<boolean> {
+    const config = await this.loadConfig()
+    const account = config.accounts[accountId] ?? config.accounts[createAccountId(accountId)]
+    if (!account) return false
+    delete config.accounts[account.account_id]
+    if (config.current === account.account_id) {
+      config.current = Object.keys(config.accounts)[0] ?? null
+    }
+    await this.saveConfig(config)
+    return true
+  }
+
+  async clearCredentials(): Promise<void> {
+    if (existsSync(this.credentialsPath)) await rm(this.credentialsPath, { force: true })
+  }
+
+  async resolveAccount(accountId?: string): Promise<ResolvedAccount | null> {
+    const envBin = process.env.AGENT_IMESSAGE_BIN
+    const envRegion = process.env.AGENT_IMESSAGE_REGION
+
+    const account = await this.getAccount(accountId)
+    if (!account && !envBin) return null
+
+    return {
+      binary_path: envBin ?? account?.binary_path ?? 'imsg',
+      region: envRegion ?? account?.region,
+    }
+  }
+}

--- a/src/platforms/imessage/ensure-auth.ts
+++ b/src/platforms/imessage/ensure-auth.ts
@@ -1,0 +1,18 @@
+import { formatOutput } from '@/shared/utils/output'
+
+import { IMessageCredentialManager } from './credential-manager'
+
+export async function ensureIMessageAuth(): Promise<void> {
+  const resolved = await new IMessageCredentialManager().resolveAccount()
+
+  if (!resolved) {
+    console.log(
+      formatOutput({
+        error:
+          'Not configured. iMessage runs on this Mac via the "imsg" tool. Run "agent-imessage setup" for a guided walkthrough, or "agent-imessage doctor" to check requirements.',
+        code: 'not_authenticated',
+      }),
+    )
+    process.exit(1)
+  }
+}

--- a/src/platforms/imessage/errors.ts
+++ b/src/platforms/imessage/errors.ts
@@ -1,0 +1,27 @@
+import { IMessageError, type IMessageErrorCode } from './types'
+
+const FULL_DISK_ACCESS = /full disk access|cannot access messages database|unable to open database/i
+const AUTOMATION_DENIED = /automation|not authorized|not allowed to send/i
+const APPLESCRIPT_SEND = /unjoined empty outgoing row|delivery to the target chat was not confirmed|applescript/i
+
+export function classifyImsgFailure(text: string, fallback: IMessageErrorCode = 'rpc_error'): IMessageError {
+  if (FULL_DISK_ACCESS.test(text)) {
+    return new IMessageError('imsg cannot read the Messages database.', 'full_disk_access', {
+      suggestion:
+        'Grant Full Disk Access to the app/terminal that launches agent-messenger (System Settings → Privacy & Security → Full Disk Access).',
+      doctorCommand: 'agent-imessage doctor',
+    })
+  }
+  if (AUTOMATION_DENIED.test(text)) {
+    return new IMessageError('imsg is not allowed to control Messages.app.', 'automation_denied', {
+      suggestion: 'Grant Automation → Messages in System Settings → Privacy & Security.',
+      doctorCommand: 'agent-imessage doctor',
+    })
+  }
+  if (APPLESCRIPT_SEND.test(text)) {
+    return new IMessageError(text || 'imsg could not send the message.', 'send_failed', {
+      doctorCommand: 'agent-imessage doctor',
+    })
+  }
+  return new IMessageError(text || 'imsg request failed.', fallback, { doctorCommand: 'agent-imessage doctor' })
+}

--- a/src/platforms/imessage/index.test.ts
+++ b/src/platforms/imessage/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'bun:test'
+
+import * as imessage from './index'
+
+describe('imessage SDK barrel', () => {
+  it('exports client, rpc, credential manager, error, helper', () => {
+    expect(typeof imessage.ImsgClient).toBe('function')
+    expect(typeof imessage.ImsgRpc).toBe('function')
+    expect(typeof imessage.IMessageCredentialManager).toBe('function')
+    expect(typeof imessage.IMessageError).toBe('function')
+    expect(typeof imessage.createAccountId).toBe('function')
+  })
+})

--- a/src/platforms/imessage/index.ts
+++ b/src/platforms/imessage/index.ts
@@ -1,0 +1,16 @@
+export { ImsgClient } from './client'
+export type { OneShotRunner } from './client'
+export { ImsgRpc } from './rpc'
+export { IMessageCredentialManager } from './credential-manager'
+export type { ResolvedAccount } from './credential-manager'
+export {
+  createAccountId,
+  IMessageError,
+  type IMessageAccount,
+  type IMessageChatSummary,
+  type IMessageConfig,
+  type IMessageErrorCode,
+  type IMessageMessageSummary,
+  type IMessageProvider,
+  type IMessageStatus,
+} from './types'

--- a/src/platforms/imessage/rpc.ts
+++ b/src/platforms/imessage/rpc.ts
@@ -1,0 +1,157 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { createInterface, type Interface } from 'node:readline'
+
+import { classifyImsgFailure } from './errors'
+import { IMessageError } from './types'
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id?: string | number
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+  method?: string
+  params?: { subscription?: number; message?: unknown; error?: { message?: string } }
+}
+
+type Pending = { resolve: (value: unknown) => void; reject: (err: Error) => void }
+type MessageHandler = (message: unknown) => void
+type ErrorHandler = (message: string) => void
+
+function normalizeRpcError(error: { code: number; message: string; data?: unknown }): IMessageError {
+  const detail = typeof error.data === 'string' ? error.data : error.message
+  const text = `${error.message}${typeof error.data === 'string' ? `: ${error.data}` : ''}`
+  return classifyImsgFailure(detail.length > 0 ? `${detail} ${text}` : text, 'rpc_error')
+}
+
+export class ImsgRpc {
+  private child: ChildProcessWithoutNullStreams | null = null
+  private reader: Interface | null = null
+  private nextId = 1
+  private pending = new Map<string | number, Pending>()
+  private subscriptions = new Map<number, { onMessage: MessageHandler; onError?: ErrorHandler }>()
+  private stderrBuffer = ''
+
+  async start(binaryPath = 'imsg'): Promise<void> {
+    if (this.child) return
+
+    const child = await new Promise<ChildProcessWithoutNullStreams>((resolve, reject) => {
+      let proc: ChildProcessWithoutNullStreams
+      try {
+        proc = spawn(binaryPath, ['rpc'], { stdio: ['pipe', 'pipe', 'pipe'] })
+      } catch {
+        reject(this.spawnError(binaryPath))
+        return
+      }
+      proc.once('error', (err: NodeJS.ErrnoException) => {
+        reject(err.code === 'ENOENT' ? this.spawnError(binaryPath) : err)
+      })
+      proc.once('spawn', () => resolve(proc))
+    })
+
+    this.child = child
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => {
+      this.stderrBuffer = (this.stderrBuffer + chunk).slice(-4096)
+    })
+
+    this.reader = createInterface({ input: child.stdout })
+    this.reader.on('line', (line: string) => this.handleLine(line))
+
+    child.once('exit', () => this.handleExit())
+  }
+
+  private spawnError(binaryPath: string): IMessageError {
+    return new IMessageError(`Could not run "${binaryPath}".`, 'imsg_not_found', {
+      suggestion: 'Install imsg: "brew install steipete/tap/imsg", or set --bin / AGENT_IMESSAGE_BIN.',
+      doctorCommand: 'agent-imessage doctor',
+    })
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim()
+    if (!trimmed) return
+
+    let frame: JsonRpcResponse
+    try {
+      frame = JSON.parse(trimmed) as JsonRpcResponse
+    } catch {
+      return
+    }
+
+    if (frame.method === 'message' && frame.params?.subscription !== undefined) {
+      this.subscriptions.get(frame.params.subscription)?.onMessage(frame.params.message)
+      return
+    }
+    if (frame.method === 'error' && frame.params?.subscription !== undefined) {
+      this.subscriptions.get(frame.params.subscription)?.onError?.(frame.params.error?.message ?? 'watch error')
+      return
+    }
+
+    if (frame.id === undefined) return
+    const pending = this.pending.get(frame.id)
+    if (!pending) return
+    this.pending.delete(frame.id)
+
+    if (frame.error) {
+      pending.reject(normalizeRpcError(frame.error))
+    } else {
+      pending.resolve(frame.result)
+    }
+  }
+
+  private handleExit(): void {
+    const err = new IMessageError(
+      `imsg rpc process exited.${this.stderrBuffer ? ` ${this.stderrBuffer.trim()}` : ''}`,
+      'rpc_error',
+    )
+    for (const pending of this.pending.values()) pending.reject(err)
+    this.pending.clear()
+    this.child = null
+    this.reader?.close()
+    this.reader = null
+  }
+
+  async request<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    if (!this.child) throw new IMessageError('imsg rpc is not running. Call start() first.', 'rpc_error')
+    const id = this.nextId++
+    const frame = `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`
+
+    return await new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject })
+      this.child!.stdin.write(frame, (err) => {
+        if (err) {
+          this.pending.delete(id)
+          reject(err)
+        }
+      })
+    })
+  }
+
+  async subscribe(params: Record<string, unknown>, onMessage: MessageHandler, onError?: ErrorHandler): Promise<number> {
+    const result = await this.request<{ subscription: number }>('watch.subscribe', params)
+    this.subscriptions.set(result.subscription, { onMessage, onError })
+    return result.subscription
+  }
+
+  async unsubscribe(subscription: number): Promise<void> {
+    this.subscriptions.delete(subscription)
+    try {
+      await this.request('watch.unsubscribe', { subscription })
+    } catch {
+      this.subscriptions.delete(subscription)
+    }
+  }
+
+  close(): void {
+    const err = new IMessageError('imsg rpc connection closed.', 'rpc_error')
+    for (const pending of this.pending.values()) pending.reject(err)
+    this.pending.clear()
+    this.subscriptions.clear()
+    if (this.child) {
+      this.child.stdin.end()
+      this.child = null
+    }
+    this.reader?.close()
+    this.reader = null
+  }
+}

--- a/src/platforms/imessage/test-stub-imsg.mjs
+++ b/src/platforms/imessage/test-stub-imsg.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Test stub for the imsg binary. Behavior controlled by IMSG_STUB_MODE.
+// Modes: ok (default), fda_denied, send_fail
+const mode = process.env.IMSG_STUB_MODE || 'ok'
+const arg = process.argv[2]
+
+if (arg === '--version') {
+  if (mode === 'novers') {
+    process.exit(1)
+  }
+  process.stdout.write('0.11.1\n')
+  process.exit(0)
+}
+
+if (arg === 'react') {
+  if (mode === 'react_automation_denied') {
+    process.stderr.write('AppleScript error: Messages got an error: Not authorized to send Apple events\n')
+    process.exit(1)
+  }
+  if (mode === 'react_fail') {
+    process.stdout.write('error: could not react\n')
+    process.exit(1)
+  }
+  process.stdout.write(JSON.stringify({ success: true, chat_id: 42, reaction_type: 'love' }) + '\n')
+  process.exit(0)
+}
+
+if (arg === 'rpc') {
+  let buf = ''
+  process.stdin.on('data', (d) => {
+    buf += d
+    let i
+    while ((i = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, i).trim()
+      buf = buf.slice(i + 1)
+      if (!line) continue
+      const req = JSON.parse(line)
+      const reply = (result) => process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: req.id, result }) + '\n')
+      const fail = (code, message, data) =>
+        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: req.id, error: { code, message, data } }) + '\n')
+
+      if (req.method === 'chats.list') {
+        if (mode === 'fda_denied') {
+          fail(-32603, 'Internal error', 'Permission Error: Cannot access Messages database')
+        } else if (mode === 'connect_rpc_fail') {
+          fail(-32603, 'Internal error', 'some unexpected internal failure')
+        } else {
+          reply({
+            chats: [
+              {
+                id: 42,
+                name: 'Jane',
+                identifier: 'iMessage;-;+15551234567',
+                guid: 'iMessage;-;+15551234567',
+                service: 'iMessage',
+                is_group: false,
+                participants: ['+15551234567'],
+                last_message: {
+                  id: 1,
+                  chat_id: 42,
+                  guid: 'm1',
+                  sender: '+15551234567',
+                  is_from_me: false,
+                  text: 'hi',
+                  created_at: '2026-06-24T00:00:00.000Z',
+                },
+              },
+              {
+                id: 43,
+                name: 'Crew',
+                identifier: 'iMessage;+;chat99',
+                guid: 'iMessage;+;chat99',
+                service: 'iMessage',
+                is_group: true,
+                participants: ['+15551111111', '+15552222222'],
+              },
+            ],
+          })
+        }
+      } else if (req.method === 'messages.history') {
+        reply({
+          messages: [
+            {
+              id: 2,
+              chat_id: 42,
+              guid: 'm2',
+              sender: '',
+              is_from_me: true,
+              text: 'yo',
+              created_at: '2026-06-24T00:01:00.000Z',
+            },
+            {
+              id: 1,
+              chat_id: 42,
+              guid: 'm1',
+              sender: '+15551234567',
+              is_from_me: false,
+              text: 'hi',
+              created_at: '2026-06-24T00:00:00.000Z',
+            },
+          ],
+        })
+      } else if (req.method === 'send') {
+        if (mode === 'send_fail') {
+          fail(-32603, 'Internal error', 'Messages accepted the chat send but wrote an unjoined empty outgoing row')
+        } else if (mode === 'automation_denied') {
+          fail(
+            -32603,
+            'Internal error',
+            'AppleScript error: Messages got an error: Not authorized to send Apple events',
+          )
+        } else {
+          reply({ ok: true, id: 99, guid: 'sent-guid', service: 'iMessage' })
+        }
+      } else if (req.method === 'watch.subscribe') {
+        reply({ subscription: 1 })
+        setTimeout(
+          () =>
+            process.stdout.write(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'message',
+                params: {
+                  subscription: 1,
+                  message: {
+                    id: 3,
+                    chat_id: 42,
+                    guid: 'm3',
+                    sender: '+15551234567',
+                    is_from_me: false,
+                    text: 'new!',
+                    created_at: '2026-06-24T00:02:00.000Z',
+                  },
+                },
+              }) + '\n',
+            ),
+          30,
+        )
+      } else if (req.method === 'watch.unsubscribe') {
+        reply({ ok: true })
+      } else {
+        fail(-32601, 'Method not found')
+      }
+    }
+  })
+  process.stdin.on('end', () => process.exit(0))
+}

--- a/src/platforms/imessage/types.test.ts
+++ b/src/platforms/imessage/types.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createAccountId, IMessageError, type IMessageErrorCode } from './types'
+
+describe('createAccountId', () => {
+  it('slugifies deterministically and is filesystem-safe', () => {
+    expect(createAccountId('/opt/homebrew/bin/imsg')).toBe(createAccountId('/opt/homebrew/bin/imsg'))
+    expect(createAccountId('My Mac')).toBe('my-mac')
+  })
+
+  it('falls back to default for empty input', () => {
+    expect(createAccountId('   ')).toBe('default')
+  })
+})
+
+describe('IMessageError', () => {
+  const codes: IMessageErrorCode[] = [
+    'imsg_not_found',
+    'full_disk_access',
+    'automation_denied',
+    'rpc_error',
+    'send_failed',
+    'not_authenticated',
+    'invalid_limit',
+    'chat_not_found',
+    'private_api_required',
+    'imessage_error',
+  ]
+
+  it('is instantiable with every code and exposes .code', () => {
+    for (const code of codes) {
+      const err = new IMessageError('m', code)
+      expect(err.code).toBe(code)
+      expect(err).toBeInstanceOf(Error)
+    }
+  })
+
+  it('toJSON includes suggestion/doctorCommand only when present', () => {
+    expect(new IMessageError('m', 'rpc_error').toJSON()).toEqual({ error: 'm', code: 'rpc_error' })
+    expect(new IMessageError('m', 'imsg_not_found', { suggestion: 's', doctorCommand: 'd' }).toJSON()).toEqual({
+      error: 'm',
+      code: 'imsg_not_found',
+      suggestion: 's',
+      doctorCommand: 'd',
+    })
+  })
+})

--- a/src/platforms/imessage/types.ts
+++ b/src/platforms/imessage/types.ts
@@ -1,0 +1,95 @@
+export type IMessageProvider = 'imsg'
+
+export interface IMessageAccount {
+  account_id: string
+  provider: IMessageProvider
+  label?: string
+  binary_path?: string
+  region?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface IMessageConfig {
+  current: string | null
+  accounts: Record<string, IMessageAccount>
+}
+
+export interface IMessageChatSummary {
+  id: number
+  guid: string | null
+  identifier: string | null
+  name: string
+  service: string
+  is_group: boolean
+  participants: string[]
+  last_message?: IMessageMessageSummary
+}
+
+export interface IMessageMessageSummary {
+  id: number
+  guid: string
+  chat_id: number
+  from: string
+  from_name?: string
+  is_outgoing: boolean
+  timestamp: string
+  text?: string
+}
+
+export interface IMessageStatus {
+  imsg_version: string | null
+  binary_path: string
+  full_disk_access: boolean
+  automation: 'ok' | 'unknown' | 'denied'
+  bridge_available: boolean
+}
+
+export type IMessageErrorCode =
+  | 'imsg_not_found'
+  | 'full_disk_access'
+  | 'automation_denied'
+  | 'rpc_error'
+  | 'send_failed'
+  | 'not_authenticated'
+  | 'invalid_limit'
+  | 'chat_not_found'
+  | 'private_api_required'
+  | 'imessage_error'
+
+export class IMessageError extends Error {
+  code: IMessageErrorCode
+  suggestion?: string
+  doctorCommand?: string
+
+  constructor(
+    message: string,
+    code: IMessageErrorCode = 'imessage_error',
+    extra?: { suggestion?: string; doctorCommand?: string },
+  ) {
+    super(message)
+    this.name = 'IMessageError'
+    this.code = code
+    this.suggestion = extra?.suggestion
+    this.doctorCommand = extra?.doctorCommand
+  }
+
+  toJSON(): { error: string; code: IMessageErrorCode; suggestion?: string; doctorCommand?: string } {
+    return {
+      error: this.message,
+      code: this.code,
+      ...(this.suggestion ? { suggestion: this.suggestion } : {}),
+      ...(this.doctorCommand ? { doctorCommand: this.doctorCommand } : {}),
+    }
+  }
+}
+
+export function createAccountId(input: string): string {
+  const normalized = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || 'default'
+}

--- a/src/tui/adapters/imessage-adapter.ts
+++ b/src/tui/adapters/imessage-adapter.ts
@@ -1,0 +1,131 @@
+import { ImsgClient } from '@/platforms/imessage/client'
+import { IMessageCredentialManager } from '@/platforms/imessage/credential-manager'
+
+import type { AuthHint, AuthIO, PlatformAdapter, UnifiedChannel, UnifiedMessage, Workspace } from './types'
+
+export class IMessageAdapter implements PlatformAdapter {
+  readonly name = 'iMessage'
+
+  private client: ImsgClient | null = null
+  private credManager = new IMessageCredentialManager()
+  private currentAccount: Workspace | null = null
+  private stopWatch: (() => Promise<void>) | null = null
+
+  async login(): Promise<void> {
+    const resolved = await this.credManager.resolveAccount()
+    if (!resolved) {
+      throw new Error('iMessage is not configured. Run "agent-imessage setup" or set AGENT_IMESSAGE_BIN.')
+    }
+    const client = new ImsgClient()
+    await client.login({ binaryPath: resolved.binary_path, region: resolved.region })
+    await client.connect()
+    this.client = client
+
+    const config = await this.credManager.loadConfig()
+    if (config.current && config.accounts[config.current]) {
+      const acct = config.accounts[config.current]
+      this.currentAccount = { id: acct.account_id, name: acct.label ?? acct.account_id }
+    }
+  }
+
+  async getChannels(): Promise<UnifiedChannel[]> {
+    const client = this.ensureClient()
+    const chats = await client.listChats(50)
+    return chats.map((chat) => ({ id: String(chat.id), name: chat.name }))
+  }
+
+  async getMessages(channelId: string, limit = 50): Promise<UnifiedMessage[]> {
+    const client = this.ensureClient()
+    const messages = await client.getMessages(Number.parseInt(channelId, 10), limit)
+    return messages.map((msg) => ({
+      id: msg.guid,
+      channelId,
+      author: msg.is_outgoing ? 'you' : (msg.from_name ?? msg.from ?? 'unknown'),
+      content: msg.text ?? '',
+      timestamp: msg.timestamp,
+    }))
+  }
+
+  async sendMessage(channelId: string, text: string): Promise<void> {
+    const client = this.ensureClient()
+    await client.sendMessage({ chatId: Number.parseInt(channelId, 10) }, text)
+  }
+
+  async startListening(onMessage: (msg: UnifiedMessage) => void): Promise<void> {
+    const client = this.ensureClient()
+    this.stopWatch = await client.watch(
+      (msg) =>
+        onMessage({
+          id: msg.guid,
+          channelId: String(msg.chat_id),
+          author: msg.is_outgoing ? 'you' : (msg.from_name ?? msg.from ?? 'unknown'),
+          content: msg.text ?? '',
+          timestamp: msg.timestamp,
+        }),
+      { onError: () => undefined },
+    )
+  }
+
+  stopListening(): void {
+    void this.stopWatch?.()
+    this.stopWatch = null
+  }
+
+  async getWorkspaces(): Promise<Workspace[]> {
+    const accounts = await this.credManager.listAccounts()
+    return accounts.map((acct) => ({ id: acct.account_id, name: acct.label ?? acct.account_id }))
+  }
+
+  async switchWorkspace(accountId: string): Promise<void> {
+    if (this.client) {
+      await this.client.close().catch(() => {})
+      this.client = null
+    }
+    const account = await this.credManager.getAccount(accountId)
+    if (!account) throw new Error(`Account ${accountId} not found`)
+
+    const client = new ImsgClient()
+    await client.login({ binaryPath: account.binary_path, region: account.region })
+    await client.connect()
+    this.client = client
+    this.currentAccount = { id: account.account_id, name: account.label ?? account.account_id }
+  }
+
+  getCurrentWorkspace(): Workspace | null {
+    return this.currentAccount
+  }
+
+  getAuthHint(): AuthHint {
+    return {
+      command: 'agent-imessage setup',
+      description: 'iMessage runs on this Mac via the imsg tool. Run the guided setup below.',
+    }
+  }
+
+  async authenticate(io: AuthIO): Promise<void> {
+    const bin = (await io.prompt('Path to imsg binary (blank for "imsg" on PATH)')).trim() || undefined
+    const client = new ImsgClient()
+    await client.login({ binaryPath: bin })
+    await client.connect()
+
+    const { createAccountId } = await import('@/platforms/imessage/types')
+    const now = new Date().toISOString()
+    const accountId = createAccountId(bin ?? 'default')
+    await this.credManager.setAccount({
+      account_id: accountId,
+      provider: 'imsg',
+      binary_path: bin,
+      created_at: now,
+      updated_at: now,
+    })
+    await this.credManager.setCurrent(accountId)
+
+    this.client = client
+    this.currentAccount = { id: accountId, name: accountId }
+  }
+
+  private ensureClient(): ImsgClient {
+    if (!this.client) throw new Error('Not logged in. Call login() first.')
+    return this.client
+  }
+}

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -184,6 +184,19 @@ export async function createApp(): Promise<void> {
     },
     {
       adapter: lazyAdapter(
+        'iMessage',
+        'agent-imessage setup',
+        async () => new (await import('./adapters/imessage-adapter')).IMessageAdapter(),
+      ),
+      label: 'iMessage',
+      enabled: false,
+      channels: null,
+      workspaces: null,
+      listening: false,
+      lastChannelId: null,
+    },
+    {
+      adapter: lazyAdapter(
         'LINE',
         'agent-line auth login',
         async () => new (await import('./adapters/line-adapter')).LineAdapter(),


### PR DESCRIPTION
## Summary

Adds **iMessage support** as a new `agent-imessage` platform, backed by the local [imsg](https://github.com/openclaw/imsg) CLI.

Apple has no public iMessage API, so — unlike every other platform here — this one runs **on a Mac** and drives Messages locally. `agent-imessage` spawns `imsg` and talks to it over **JSON-RPC (stdin/stdout)**; there is no network or server. You act as yourself with your own Apple ID, and nothing leaves the machine.

> Supersedes #264 (a BlueBubbles/HTTP approach), closed in favor of this lighter, on-Mac, agent-native design.

## What's included

- **`ImsgRpc` transport** — manages one long-lived `imsg rpc` child process, frames JSON-RPC, routes responses by `id` and watch notifications by `subscription`, and normalizes failures into `IMessageError`s (`full_disk_access`, `automation_denied`, `send_failed`, `imsg_not_found`, `rpc_error`).
- **`ImsgClient`** — `chats.list` / `messages.history` / `send` / `watch.subscribe` over RPC; `getVersion` via one-shot spawn; standard tapbacks via CLI `imsg react`. Maps imsg JSON to unified summaries (group detection, `is_from_me`→`is_outgoing`, ISO timestamps).
- **Provider-aware credentials** — `{ provider: "imsg", binaryPath?, region? }` in `~/.config/agent-messenger/imessage-credentials.json` (mode `0600`, enforced). **No secrets** — imsg uses macOS permissions, not tokens. Env override `AGENT_IMESSAGE_BIN` / `AGENT_IMESSAGE_REGION` (runtime only, never persisted).
- **`watch`** — RPC subscription streamed as JSONL, resumable via `--since-rowid`, dedup by message GUID, clean SIGINT shutdown.
- **`doctor`** (flagship UX) — reports imsg presence/version, Full Disk Access (probed via `chats.list`), and the bridge tier; maps each failure to an actionable suggestion, including the macOS **parent-process** permission caveat.
- **`setup`** — guided verifier (checks imsg + permissions, saves an account); prints the one-time System Settings steps (it cannot toggle TCC/SIP).
- **Commands** — `auth set/list/use/remove/logout`, `chat list/search`, `message list/send/react/watch`, `whoami`, `doctor`, `setup`.
- **TUI adapter** + SDK barrel (`agent-messenger/imessage`) + registration in `cli.ts`, `app.ts`, `package.json`, `.claude-plugin/plugin.json`, docs `meta.json`.

## Feature tiers

| Feature | This PR | Requires |
| --- | :---: | --- |
| List/search chats, send text, read/watch messages | ✅ | imsg core (no SIP) |
| Standard tapbacks (to the most recent incoming message) | ✅ | imsg core (no SIP) |
| React to a *specific* message / custom-emoji tapbacks | ⏳ later | imsg bridge (`imsg launch` + SIP) |
| Typing, read receipts, edit/unsend, group management | ⏳ later | imsg bridge (`imsg launch` + SIP) |

Two imsg-API constraints are honored deliberately (verified against imsg source): `messages.history` has **no rowid cursor** (backfill uses `watch.subscribe --since_rowid` or `--start <ISO>`), and no-SIP `imsg react` targets only the **most recent incoming message** (specific/custom reactions are bridge-tier, returning `private_api_required`).

## Docs

- `skills/agent-imessage/SKILL.md` — full skill incl. Agent Behavior + an Error Handling table for every code.
- `skills/agent-imessage/references/setup.md` + `references/permissions.md` — install, Full Disk Access + Automation (with the parent-process caveat), the SIP/bridge tier.
- `docs/content/docs/cli/imessage.mdx` (+ `meta.json`), README (install list, SDK table, Supported Platforms note, "iMessage is different" framing), `AGENTS.md`.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 warnings / 0 errors
- `bun run build` — succeeds; compiled Node CLI runs; the test stub is **not** shipped to `dist`
- `bun test` — **3340 pass / 0 fail** (25 new tests across 6 files; QA-1…QA-12)
- Tests run against a stub `imsg` binary (real subprocess + JSON-RPC) and injected fakes — **no live Messages.app or imsg install needed in CI**.
- Manual: `agent-imessage doctor` with imsg absent → `imsg_not_found`; with the stub → healthy report; full send/list/chat/watch/react flow against the stub.

> Note on `format:check`: the docs subproject's `globals.css` references `fumadocs-ui` (not installed in a bare worktree) — this failure is pre-existing on `main` and unrelated to this PR. All changed files are format-clean.

## Notes / follow-ups

- **Local-only by design.** The agent must run on the Mac (imsg has no network surface). Networked backends remain out of scope; the `provider` field leaves room for them later.
- The bridge tier (typing/edit/groups/targeted reactions) is scoped out of v1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iMessage support as a new `agent-imessage` platform using the local `imsg` CLI on macOS. It lists chats, reads/sends messages, watches in real time, and supports standard tapbacks with no server.

- **New Features**
  - `ImsgRpc` transport: long‑lived `imsg rpc`, JSON‑RPC framing, normalized `IMessageError` codes (`imsg_not_found`, `full_disk_access`, `automation_denied`, `send_failed`, `private_api_required`, `rpc_error`).
  - `ImsgClient`: chats/history/send/watch; standard tapbacks via `imsg react`; unified maps for chats/messages/status.
  - Credential manager + auth guard: provider‑aware, secret‑free config; env overrides `AGENT_IMESSAGE_BIN`/`AGENT_IMESSAGE_REGION`; SDK export `agent-messenger/imessage`.
  - CLI/TUI: `auth`, `setup`, `doctor`, `chat list/search`, `message list/send/react/watch`, `whoami`; `agent-imessage` entrypoint; TUI adapter; wired into `src/cli.ts`, `.claude-plugin/plugin.json`.
  - Build/exports: `package.json` bin and `./imessage` export; postbuild auto‑detects bins for shebang swap; documentation site wired.

- **Migration**
  - Requires macOS with `imsg` installed; grant Full Disk Access and Automation → Messages; run `agent-imessage setup`, then `agent-imessage doctor`.
  - Advanced features (typing, edit/unsend, group management, targeted/custom reactions) require the `imsg` bridge (`imsg launch`, SIP disabled); not in v1.
  - Docs/SKILL updated: `skills/agent-imessage/SKILL.md`, setup/permissions/auth references, CLI docs (`docs/content/docs/cli/imessage.mdx`), README/`AGENTS.md`, plugin keywords.

<sup>Written for commit 8be220a0713e32e667e01a1961fc8534552a52e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

