### PR TITLE
fix(kakaotalk): normalize paginated chat ids

### DIFF
--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -540,6 +540,46 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('normalizes Long-like chat ids from LCHATLIST pages', async () => {
+      const loginResult = {
+        ...DEFAULT_LOGIN_RESULT,
+        eof: false,
+      }
+      mockLogin.mockResolvedValue(loginResult)
+
+      mockGetChatList.mockResolvedValueOnce({
+        body: {
+          chatDatas: [
+            {
+              c: makeLong(300),
+              t: 1,
+              k: ['Dave'],
+              i: [4],
+              a: 1,
+              n: 0,
+              o: 1698000000,
+              l: { authorId: 4, message: 'from paginated chat', sendAt: 1698000000 },
+              ll: makeLong(100),
+            },
+          ],
+          lastTokenId: makeLong(1),
+          lastChatId: makeLong(300),
+          eof: true,
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const chats = await client.getChats({ all: true })
+
+      const paginatedChat = chats.find((chat) => chat.chat_id === '300')
+      expect(paginatedChat?.chat_id).toBe('300')
+      expect(paginatedChat?.display_name).toBe('Dave')
+      expect(paginatedChat?.last_message?.author_name).toBe('Dave')
+      expect(chats.some((chat) => chat.chat_id === '[object Object]')).toBe(false)
+
+      client.close()
+    })
+
     it('wraps errors as KakaoTalkError', async () => {
       mockLogin.mockRejectedValue(new Error('Connection refused'))
 

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -62,7 +62,7 @@ class MemberNameCache {
       const names = chat.k as string[] | undefined
       if (!Array.isArray(ids) || !Array.isArray(names)) continue
 
-      const chatId = String(chat.c)
+      const chatId = longToString(chat.c)
       let map = this.byChatId.get(chatId)
       if (!map) {
         map = new Map()
@@ -176,7 +176,7 @@ function formatChat(chat: ChatData, title: string | null, nameCache: MemberNameC
   const memberNames = (chat.k ?? []) as string[]
   const lastLog = chat.l as Record<string, unknown> | null
   const displayName = memberNames.join(', ') || null
-  const chatId = String(chat.c)
+  const chatId = longToString(chat.c)
 
   return {
     chat_id: chatId,
@@ -256,7 +256,7 @@ function findMaxLogId(logs: Array<Record<string, unknown>>, field: string): Long
 
 function collectChats(chatDatas: ChatData[], into: ChatData[], seen: Set<string>): void {
   for (const chat of chatDatas) {
-    const id = String(chat.c)
+    const id = longToString(chat.c)
     if (!seen.has(id)) {
       seen.add(id)
       into.push(chat)
@@ -771,7 +771,9 @@ export class KakaoTalkClient {
         }
 
         const titles = options?.resolveTitles
-          ? await Promise.all(results.map((chat) => this.fetchChatTitle(session, parseLong(String(chat.c)), chat)))
+          ? await Promise.all(
+              results.map((chat) => this.fetchChatTitle(session, parseLong(longToString(chat.c)), chat)),
+            )
           : null
 
         return results.map((chat, i) => formatChat(chat, titles ? titles[i] : null, this.nameCache))


### PR DESCRIPTION
## Summary

- normalize KakaoTalk chat ids with the existing Long-aware helper when ingesting member names, formatting chat output, deduplicating paginated chats, and resolving titles
- add a regression test for LCHATLIST pages that return `chat.c` as a BSON Long-like `{ low, high }` value
- ensure paginated chats no longer surface as `[object Object]` ids and still resolve cached author names

Fixes #266.

## Testing

- `bun test src/platforms/kakaotalk/client.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run lint`
- `./node_modules/.bin/oxfmt --write src/platforms/kakaotalk/client.ts src/platforms/kakaotalk/client.test.ts`

Note: `bun run format` currently fails before touching this change because `oxfmt --write .` cannot resolve `fumadocs-ui/css/neutral.css` from `docs/src/app/globals.css` in this checkout. The modified files were formatted directly with `oxfmt`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize KakaoTalk chat IDs from paginated LCHATLIST pages by converting Long-like `chat.c` values to strings, preventing “[object Object]” IDs and keeping title/name resolution working. Adds a regression test for `{ low, high }` IDs. Fixes #266.

- **Bug Fixes**
  - Use Long-aware normalization for `chat.c` across member-name caching, chat formatting, pagination dedupe, and title resolution.
  - Paginated chats now return correct `chat_id` (e.g., "300"), display_name, and cached author names.

- **Docs**
  - No changes to SKILL.md or docs.

<sup>Written for commit f064ceeb570580ee0b099589e4433580d97d82dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

