### PR TITLE
fix(kakaotalk): normalize Long-like chat ids in chat list pagination

### DIFF
--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -540,6 +540,121 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    // Regression for #266: LCHATLIST pages can return chat.c as a BSON Long-like
+    // {low, high} object. String(chat.c) collapses it to "[object Object]", breaking
+    // dedupe/format/title-resolution. longToString must normalize it to a decimal id.
+    // LONG_CHAT_ID encodes 9876543210 as (high << 32) | low.
+    const LONG_CHAT_ID = { low: 1286608618, high: 2 }
+    const LONG_CHAT_ID_DECIMAL = '9876543210'
+
+    it('includes paginated LCHATLIST chats whose id is a Long-like {low, high} object', async () => {
+      // given
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList.mockResolvedValueOnce({
+        body: {
+          chatDatas: [
+            {
+              c: LONG_CHAT_ID,
+              t: 1,
+              k: ['티머니'],
+              i: [9],
+              a: 1,
+              n: 0,
+              o: 1698000000,
+              l: null,
+              ll: makeLong(100),
+            },
+          ],
+          lastTokenId: makeLong(1),
+          lastChatId: LONG_CHAT_ID,
+          eof: true,
+        },
+      })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const chats = await client.getChats({ all: true })
+
+      // then
+      expect(chats).toHaveLength(3)
+      const paginated = chats.find((c) => c.display_name === '티머니')
+      expect(paginated).toBeDefined()
+      expect(paginated!.chat_id).toBe(LONG_CHAT_ID_DECIMAL)
+
+      client.close()
+    })
+
+    it('deduplicates a Long-like LCHATLIST id against a numeric login-snapshot id', async () => {
+      // given
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList.mockResolvedValueOnce({
+        body: {
+          chatDatas: [
+            {
+              c: { low: 100, high: 0 },
+              t: 1,
+              k: ['Alice', 'Bob'],
+              a: 2,
+              n: 0,
+              o: 1700000000,
+              l: null,
+              ll: makeLong(999),
+            },
+          ],
+          lastTokenId: makeLong(1),
+          lastChatId: makeLong(100),
+          eof: true,
+        },
+      })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const chats = await client.getChats({ all: true })
+
+      // then
+      expect(chats).toHaveLength(2)
+      client.close()
+    })
+
+    it('resolves titles without crashing for Long-like LCHATLIST chat ids', async () => {
+      // given
+      mockLogin.mockResolvedValue({ ...DEFAULT_LOGIN_RESULT, eof: false })
+      mockGetChatList.mockResolvedValueOnce({
+        body: {
+          chatDatas: [
+            {
+              c: LONG_CHAT_ID,
+              t: 1,
+              k: ['티머니'],
+              i: [9],
+              a: 1,
+              n: 0,
+              o: 1698000000,
+              l: null,
+              ll: makeLong(100),
+            },
+          ],
+          lastTokenId: makeLong(1),
+          lastChatId: LONG_CHAT_ID,
+          eof: true,
+        },
+      })
+      mockGetChannelInfo.mockResolvedValue({
+        body: { chatInfo: { chatMetas: [{ type: 3, content: 'PlusChat' }] } },
+      })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      // when
+      const chats = await client.getChats({ all: true, resolveTitles: true })
+
+      // then
+      const paginated = chats.find((c) => c.chat_id === LONG_CHAT_ID_DECIMAL)
+      expect(paginated).toBeDefined()
+      expect(paginated!.title).toBe('PlusChat')
+
+      client.close()
+    })
+
     it('wraps errors as KakaoTalkError', async () => {
       mockLogin.mockRejectedValue(new Error('Connection refused'))
 

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -62,7 +62,7 @@ class MemberNameCache {
       const names = chat.k as string[] | undefined
       if (!Array.isArray(ids) || !Array.isArray(names)) continue
 
-      const chatId = String(chat.c)
+      const chatId = longToString(chat.c)
       let map = this.byChatId.get(chatId)
       if (!map) {
         map = new Map()
@@ -176,7 +176,7 @@ function formatChat(chat: ChatData, title: string | null, nameCache: MemberNameC
   const memberNames = (chat.k ?? []) as string[]
   const lastLog = chat.l as Record<string, unknown> | null
   const displayName = memberNames.join(', ') || null
-  const chatId = String(chat.c)
+  const chatId = longToString(chat.c)
 
   return {
     chat_id: chatId,
@@ -256,7 +256,7 @@ function findMaxLogId(logs: Array<Record<string, unknown>>, field: string): Long
 
 function collectChats(chatDatas: ChatData[], into: ChatData[], seen: Set<string>): void {
   for (const chat of chatDatas) {
-    const id = String(chat.c)
+    const id = longToString(chat.c)
     if (!seen.has(id)) {
       seen.add(id)
       into.push(chat)
@@ -771,7 +771,9 @@ export class KakaoTalkClient {
         }
 
         const titles = options?.resolveTitles
-          ? await Promise.all(results.map((chat) => this.fetchChatTitle(session, parseLong(String(chat.c)), chat)))
+          ? await Promise.all(
+              results.map((chat) => this.fetchChatTitle(session, parseLong(longToString(chat.c)), chat)),
+            )
           : null
 
         return results.map((chat, i) => formatChat(chat, titles ? titles[i] : null, this.nameCache))


### PR DESCRIPTION
## Summary

`agent-kakaotalk chat list --all` could stop after the initial `LOGINLIST` snapshot and silently drop chats returned by later `LCHATLIST` pages (e.g. `PlusChat` rooms like `티머니`). In the reported repro the CLI returned 100 chats while direct pagination surfaced 52 more.

Root cause: some KakaoTalk chat ids arrive as BSON `Long`-like `{ low, high }` objects in paginated `LCHATLIST` responses. The `LOGINLIST` snapshot uses plain numbers, but the code keyed/formatted/searched chats with `String(chat.c)`, which collapses a `{ low, high }` object to the literal string `"[object Object]"`. That single bad key then poisoned every downstream path.

## What was broken

`String(chat.c)` was used at four chat-id boundaries in `src/platforms/kakaotalk/client.ts`:

| Location | Impact when `chat.c` is `{ low, high }` |
| --- | --- |
| `MemberNameCache.ingest` | member-name cache keyed under `"[object Object]"` → wrong/empty author names |
| `formatChat` | emitted `chat_id: "[object Object]"` in CLI output |
| `collectChats` (dedupe) | every Long-id chat shared the same key → broken dedupe |
| `getChats` title resolution | `parseLong(String(chat.c))` → `BigInt("[object Object]")` **throws**, failing the whole `--resolve-titles` call |

## The fix

Use the existing `longToString` helper (already present in the same file and used in ~35 other places) at all four boundaries. It normalizes both numeric snapshot ids and Long-like paginated ids to a stable decimal string, so dedupe, formatting, caching, and title resolution all agree on the same id.

```diff
- const id = String(chat.c)
+ const id = longToString(chat.c)
```

## Tests

Added three co-located regression tests in `client.test.ts` (inside `describe('getChats')`), each seeding a numeric-id `LOGINLIST` snapshot plus an `LCHATLIST` page with a Long-like `{ low: 1286608618, high: 2 }` id (= `9876543210`):

1. paginated Long-id chat is included with the correct decimal `chat_id`
2. a Long-like id dedupes against the same numeric login-snapshot id
3. `--resolve-titles` resolves the Long-id chat without throwing

All three **fail on `main`** (confirmed by reverting the fix → 3 failures) and **pass with the fix**.

## Verification

- `bun test` — 3318 pass / 0 fail
- `bun typecheck` — clean
- `bun lint` — 0 warnings / 0 errors
- `bunx oxfmt --check` on changed files — clean

Fixes #266

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize KakaoTalk chat IDs in paginated chat lists to prevent dropped chats and crashes during title resolution. Ensures `agent-kakaotalk chat list --all` returns all chats with correct decimal `chat_id`. Fixes #266.

- **Bug Fixes**
  - Use `longToString` instead of `String(chat.c)` for member-name cache keys, chat formatting, dedupe, and title lookup.
  - Stops `"[object Object]"` keys and BigInt parse errors; paginated `LCHATLIST` chats (e.g., PlusChat) are now included and deduped, and the CLI emits stable decimal IDs.
  - Added regression tests for inclusion, dedupe, and `--resolve-titles`; SKILL.md/docs: no updates needed.

<sup>Written for commit 7b1ebabcd736328901b9784e6fcfc44263ef252a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

