### PR TITLE
docs(imessage): add missing iMessage entries to listings and badges

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,6 +1,6 @@
 # Agent Messenger - Claude Code Plugin
 
-Messaging platform interaction skills for AI agents and Claude Code. Supports Slack, Discord, Microsoft Teams, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta).
+Messaging platform interaction skills for AI agents and Claude Code. Supports Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, iMessage (Mac-only), Instagram, KakaoTalk, and Channel Talk (beta).
 
 ## Installation
 
@@ -108,6 +108,14 @@ Enables AI agents to interact with messaging platforms through CLI interfaces:
 - **QR code login** — authenticates as secondary device
 - **Multi-account support** with easy switching
 
+### iMessage (`agent-imessage`) — Mac-only
+- **Send messages** to chats, groups, and phone/email recipients
+- **Read chats** and message history
+- **List chats** (source of chat ids/guids)
+- **Watch for new messages** in real time (resumable JSON lines)
+- **Standard tapbacks** (love, like, dislike, etc.)
+- **Runs on a Mac** via the [imsg](https://github.com/openclaw/imsg) tool — no API, no network, no server
+
 ### Instagram (`agent-instagram`)
 - **Send messages** to DM conversations
 - **Read chats** and message history
@@ -190,6 +198,7 @@ All commands output JSON by default for easy AI consumption. Use `--pretty` for 
 
 - Desktop app installed and logged in for the platform(s) you want to use (Slack, Discord, Teams, KakaoTalk, and/or Channel Talk). For Slack and Discord, QR code sign-in is the recommended alternative — no desktop app required (Discord needs the mobile app to scan). Instagram uses username/password auth
 - For Telegram: TDLib is bundled; API credentials are auto-provisioned on first login
+- For iMessage: macOS only — requires [imsg](https://github.com/openclaw/imsg) installed, with Full Disk Access and Automation → Messages granted to the launching app/terminal (macOS grants these to the parent process, not the `imsg` binary)
 - Node.js 18+ or Bun runtime
 
 ## Quick Start
@@ -276,6 +285,7 @@ agent-discord file upload <channel-id> ./report.pdf
 - [WhatsApp Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-whatsapp/SKILL.md)
 - [WhatsApp Bot Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-whatsappbot/SKILL.md)
 - [LINE Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-line/SKILL.md)
+- [iMessage Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-imessage/SKILL.md)
 - [Instagram Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-instagram/SKILL.md)
 - [KakaoTalk Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-kakaotalk/SKILL.md)
 - [Channel Talk Skill Documentation](https://github.com/agent-messenger/agent-messenger/blob/main/skills/agent-channeltalk/SKILL.md)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-messenger",
-  "description": "Messaging platform interaction skills for AI agents - Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk",
+  "description": "Messaging platform interaction skills for AI agents - Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, and Channel Talk",
   "owner": {
     "name": "agent-messenger",
     "url": "https://github.com/agent-messenger"
@@ -136,6 +136,19 @@
       "category": "productivity",
       "homepage": "https://github.com/agent-messenger/agent-messenger",
       "keywords": ["channel-talk", "channeltalkbot", "bot", "messaging", "ai-agent", "cli", "ci-cd"]
+    },
+    {
+      "name": "agent-imessage",
+      "description": "Interact with iMessage on a Mac via the imsg tool. Apple has no public API, so it runs locally on macOS (no network, no server) and drives Messages.app through imsg over JSON-RPC. Supports send/list messages, direct & group chats, chat listing, real-time watch, and standard tapbacks. Requires Full Disk Access and Automation permissions.",
+      "version": "2.27.2",
+      "author": {
+        "name": "agent-messenger",
+        "url": "https://github.com/agent-messenger"
+      },
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/agent-messenger/agent-messenger",
+      "keywords": ["imessage", "imsg", "macos", "apple", "messaging", "ai-agent", "cli", "communication"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-messenger",
   "version": "2.27.2",
-  "description": "Messaging platform interaction skills for AI agents. Interact with Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk - send messages, read channels, manage reactions, upload files, and more through simple CLI interfaces.",
+  "description": "Messaging platform interaction skills for AI agents. Interact with Slack, Discord, Microsoft Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, and Channel Talk - send messages, read channels, manage reactions, upload files, and more through simple CLI interfaces.",
   "author": {
     "name": "agent-messenger",
     "url": "https://github.com/agent-messenger"
@@ -18,8 +18,8 @@
     "kakaotalk",
     "channel-talk",
     "line",
-    "instagram",
     "imessage",
+    "instagram",
     "messaging",
     "workspace",
     "guild",
@@ -42,10 +42,10 @@
     "./skills/agent-whatsapp",
     "./skills/agent-whatsappbot",
     "./skills/agent-line",
+    "./skills/agent-imessage",
     "./skills/agent-instagram",
     "./skills/agent-kakaotalk",
     "./skills/agent-channeltalk",
-    "./skills/agent-channeltalkbot",
-    "./skills/agent-imessage"
+    "./skills/agent-channeltalkbot"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Agent Messenger
 
-[![npm](https://img.shields.io/npm/v/agent-messenger?color=E67E22)](https://www.npmjs.com/package/agent-messenger) [![platform](https://img.shields.io/badge/platform-slack-4A154B)](https://agent-messenger.dev/docs/cli/slack) [![platform](https://img.shields.io/badge/platform-discord-5865F2)](https://agent-messenger.dev/docs/cli/discord) [![platform](https://img.shields.io/badge/platform-teams-6264A7)](https://agent-messenger.dev/docs/cli/teams) [![platform](https://img.shields.io/badge/platform-webex-00BCF2)](https://agent-messenger.dev/docs/cli/webex) [![platform](https://img.shields.io/badge/platform-telegram-2AABEE)](https://agent-messenger.dev/docs/cli/telegram) [![platform](https://img.shields.io/badge/platform-whatsapp-25D366)](https://agent-messenger.dev/docs/cli/whatsapp) [![platform](https://img.shields.io/badge/platform-line-06C755)](https://agent-messenger.dev/docs/cli/line) [![platform](https://img.shields.io/badge/platform-wechat-07C160)](https://agent-messenger.dev/docs/cli/wechatbot) [![platform](https://img.shields.io/badge/platform-instagram-E4405F)](https://agent-messenger.dev/docs/cli/instagram) [![platform](https://img.shields.io/badge/platform-kakaotalk-FEE500)](https://agent-messenger.dev/docs/cli/kakaotalk) [![platform](https://img.shields.io/badge/platform-channel_talk-3B3FE4)](https://agent-messenger.dev/docs/cli/channeltalk)
+[![npm](https://img.shields.io/npm/v/agent-messenger?color=E67E22)](https://www.npmjs.com/package/agent-messenger) [![platform](https://img.shields.io/badge/platform-slack-4A154B)](https://agent-messenger.dev/docs/cli/slack) [![platform](https://img.shields.io/badge/platform-discord-5865F2)](https://agent-messenger.dev/docs/cli/discord) [![platform](https://img.shields.io/badge/platform-teams-6264A7)](https://agent-messenger.dev/docs/cli/teams) [![platform](https://img.shields.io/badge/platform-webex-00BCF2)](https://agent-messenger.dev/docs/cli/webex) [![platform](https://img.shields.io/badge/platform-telegram-2AABEE)](https://agent-messenger.dev/docs/cli/telegram) [![platform](https://img.shields.io/badge/platform-whatsapp-25D366)](https://agent-messenger.dev/docs/cli/whatsapp) [![platform](https://img.shields.io/badge/platform-line-06C755)](https://agent-messenger.dev/docs/cli/line) [![platform](https://img.shields.io/badge/platform-wechat-07C160)](https://agent-messenger.dev/docs/cli/wechatbot) [![platform](https://img.shields.io/badge/platform-imessage-007AFF)](https://agent-messenger.dev/docs/cli/imessage) [![platform](https://img.shields.io/badge/platform-instagram-E4405F)](https://agent-messenger.dev/docs/cli/instagram) [![platform](https://img.shields.io/badge/platform-kakaotalk-FEE500)](https://agent-messenger.dev/docs/cli/kakaotalk) [![platform](https://img.shields.io/badge/platform-channel_talk-3B3FE4)](https://agent-messenger.dev/docs/cli/channeltalk)
 
 **Your agent messages as you — not as a bot**
 
 </div>
 
-One CLI for Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk. Credentials extracted from desktop apps and browsers, or authenticated in seconds — no API keys, no OAuth, no admin approval. TypeScript SDK included.
+One CLI for Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, WeChat, iMessage, Instagram, KakaoTalk, and Channel Talk. Credentials extracted from desktop apps and browsers, or authenticated in seconds — no API keys, no OAuth, no admin approval. TypeScript SDK included.
 
 > [!TIP]
 > 🎉 Agent Messenger powers multi-channel messaging in [TypeClaw](https://github.com/typeclaw/typeclaw), a TypeScript-native agent runtime.
@@ -51,7 +51,7 @@ Agent Messenger reads session tokens from your Slack, Discord, Teams, KakaoTalk,
 - **QR Code Sign-In (Slack & Discord)** — The recommended, safest auth: sign in through the platform's official flow, no credential extraction and no desktop app required (Discord scans with the mobile app)
 - **Auto-Extract Auth** — Reads tokens from Slack, Discord, Teams, KakaoTalk, and Channel Talk desktop apps, with browser fallback and custom Chromium profile paths via `--browser-profile`. Webex and Instagram tokens extracted from Chromium browsers. Telegram and WhatsApp authenticate with a one-time code — still under a minute
 - **Act As Yourself** — Extracts your user session — not a bot token. Your agent sends messages, reacts, and searches as you. Need bot mode? Bot CLIs are included too
-- **One Interface** — Consistent command style across 7 platforms for supported actions (e.g. message send, message search, channel list, snapshot). Learn once
+- **One Interface** — Consistent command style across 12 platforms for supported actions (e.g. message send, message search, channel list, snapshot). Learn once
 - **Agent-Native Output** — JSON by default for LLM tool use. `--pretty` for human-readable. Structured output your agent can parse and act on
 - **Token Efficient** — CLI, not MCP. One skill file, one shell command per action. No server to run, no tool registration. ([Why not MCP?](#philosophy))
 - **Persistent Memory** — Stores workspace IDs, channel mappings, and preferences in ~/.config so your agent never asks twice
@@ -88,11 +88,11 @@ This installs:
 - `agent-whatsappbot` — WhatsApp Bot CLI (Cloud API, for server-side/CI/CD)
 - `agent-line` — LINE CLI (QR code login, Thrift protocol)
 - `agent-wechatbot` — WeChat Bot CLI (Official Account API, for server-side/CI/CD)
+- `agent-imessage` — iMessage CLI (runs on a Mac via the [imsg](https://github.com/openclaw/imsg) tool)
 - `agent-instagram` — Instagram DM CLI (browser cookie extraction + username/password auth)
 - `agent-kakaotalk` — KakaoTalk CLI (sub-device login, LOCO protocol)
 - `agent-channeltalk` — Channel Talk CLI (beta, zero-config, extracted cookies)
 - `agent-channeltalkbot` — Channel Talk Bot CLI (beta, API credentials, for server-side/CI/CD)
-- `agent-imessage` — iMessage CLI (runs on a Mac via the [imsg](https://github.com/openclaw/imsg) tool)
 
 ## Agent Skills
 
@@ -102,7 +102,7 @@ Agent Messenger includes [Agent Skills](https://agentskills.io/) that teach your
 
 SkillPad is a GUI app for Agent Skills. See [skillpad.dev](https://skillpad.dev/) for more details.
 
-[![Available on SkillPad](https://badge.skillpad.dev/agent-slack/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slack) [![Available on SkillPad](https://badge.skillpad.dev/agent-slackbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slackbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-discord/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discord) [![Available on SkillPad](https://badge.skillpad.dev/agent-discordbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discordbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-teams/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-teams) [![Available on SkillPad](https://badge.skillpad.dev/agent-webex/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-webex) [![Available on SkillPad](https://badge.skillpad.dev/agent-webexbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-webexbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegram) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegrambot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegrambot) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsapp/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsapp) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsappbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsappbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-line/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-line) [![Available on SkillPad](https://badge.skillpad.dev/agent-wechatbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-wechatbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-instagram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-instagram) [![Available on SkillPad](https://badge.skillpad.dev/agent-kakaotalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-kakaotalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalkbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalkbot)
+[![Available on SkillPad](https://badge.skillpad.dev/agent-slack/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slack) [![Available on SkillPad](https://badge.skillpad.dev/agent-slackbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-slackbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-discord/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discord) [![Available on SkillPad](https://badge.skillpad.dev/agent-discordbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-discordbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-teams/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-teams) [![Available on SkillPad](https://badge.skillpad.dev/agent-webex/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-webex) [![Available on SkillPad](https://badge.skillpad.dev/agent-webexbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-webexbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegram) [![Available on SkillPad](https://badge.skillpad.dev/agent-telegrambot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-telegrambot) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsapp/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsapp) [![Available on SkillPad](https://badge.skillpad.dev/agent-whatsappbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-whatsappbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-line/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-line) [![Available on SkillPad](https://badge.skillpad.dev/agent-wechatbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-wechatbot) [![Available on SkillPad](https://badge.skillpad.dev/agent-imessage/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-imessage) [![Available on SkillPad](https://badge.skillpad.dev/agent-instagram/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-instagram) [![Available on SkillPad](https://badge.skillpad.dev/agent-kakaotalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-kakaotalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalk/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalk) [![Available on SkillPad](https://badge.skillpad.dev/agent-channeltalkbot/dark.svg)](https://skillpad.dev/install/agent-messenger/agent-messenger/agent-channeltalkbot)
 
 ### Skills CLI
 
@@ -156,7 +156,7 @@ export AGENT_MESSENGER_CONFIG_DIR="$HOME/.local/share/agent-messenger"
 agent-slack auth extract
 ```
 
-The variable is read on every CLI/SDK invocation and applies to all platforms (Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, WeChat, Instagram, KakaoTalk, Channel Talk, and their bot variants). Explicit `configDir` arguments to credential managers still take precedence.
+The variable is read on every CLI/SDK invocation and applies to all platforms (Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, WeChat, iMessage, Instagram, KakaoTalk, Channel Talk, and their bot variants). Explicit `configDir` arguments to credential managers still take precedence.
 
 ## Telegram Quick Start
 
@@ -207,13 +207,13 @@ const slack = await new SlackClient().login({ token: 'xoxc-...', cookie: 'xoxd-.
 | `agent-messenger/whatsappbot` | `WhatsAppBotClient` |
 | `agent-messenger/line` | `LineClient` |
 | `agent-messenger/wechatbot` | `WeChatBotClient` |
+| `agent-messenger/imessage` | `ImsgClient` |
 | `agent-messenger/instagram` | `InstagramClient` |
 | `agent-messenger/kakaotalk` | `KakaoTalkClient` |
 | `agent-messenger/channeltalk` | `ChannelClient` |
 | `agent-messenger/channeltalkbot` | `ChannelBotClient` |
-| `agent-messenger/imessage` | `ImsgClient` |
 
-Each module also exports its credential manager, Zod schemas, and TypeScript types:
+Each module also exports its credential manager, Zod schemas, and TypeScript types (except `imessage`, which exports its client, credential manager, and TypeScript types — no Zod schemas):
 
 ```typescript
 import { SlackClient, SlackCredentialManager, SlackMessageSchema } from 'agent-messenger/slack'
@@ -383,7 +383,7 @@ await listener.start()
 
 ## TUI (Experimental)
 
-A unified terminal interface for all your messaging platforms in one screen. Navigate between Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk — all from your terminal.
+A unified terminal interface for all your messaging platforms in one screen. Navigate between Slack, Discord, Teams, Webex, Telegram, WhatsApp, iMessage, LINE, Instagram, KakaoTalk, and Channel Talk — all from your terminal.
 
 > **Note**: The TUI is a showcase of what's possible with Agent Messenger's SDK. It demonstrates the power of having a unified adapter layer across all platforms.
 
@@ -394,7 +394,7 @@ agent-messenger tui
 ![Agent Messenger TUI](docs/public/tui.png)
 
 Key features:
-- **Multi-platform** — All 10 platforms in one sidebar, auto-login on startup
+- **Multi-platform** — All 11 platforms in one sidebar, auto-login on startup
 - **Real-time messages** — Live message streaming for supported platforms
 - **Fuzzy pickers** — `Ctrl+K` for channels, `Ctrl+W` for workspaces
 - **Interactive auth** — Authenticate platforms that aren't set up yet, right in the TUI
@@ -448,11 +448,11 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 - **[WhatsApp Bot Guide](https://agent-messenger.dev/docs/cli/whatsappbot)** — Cloud API integration for WhatsApp Business
 - **[LINE Guide](https://agent-messenger.dev/docs/cli/line)** — QR code login and Thrift protocol integration
 - **[WeChat Bot Guide](https://agent-messenger.dev/docs/cli/wechatbot)** — Official Account API integration for WeChat
+- **[iMessage Guide](skills/agent-imessage/SKILL.md)** — iMessage on a Mac via the imsg tool
 - **[Instagram Guide](https://agent-messenger.dev/docs/cli/instagram)** — Browser cookie extraction and Instagram DM integration
 - **[KakaoTalk Guide](https://agent-messenger.dev/docs/cli/kakaotalk)** — Sub-device login and LOCO protocol integration
 - **[Channel Talk Guide](https://agent-messenger.dev/docs/cli/channeltalk)** — Full command reference for Channel Talk (beta, zero-config)
 - **[Channel Talk Bot Guide](https://agent-messenger.dev/docs/cli/channeltalkbot)** — Bot API integration for Channel Talk (beta)
-- **[iMessage Guide](skills/agent-imessage/SKILL.md)** — iMessage on a Mac via the imsg tool
 
 ### iMessage is different
 
@@ -504,7 +504,7 @@ Wire messaging into your CI, scripts, or agent workflows.
 
 ### ...and More
 
-These are just starting points. Your agent has full read/write access to Slack, Discord, Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk — anything you'd do manually in a chat app, it can handle for you. If you build something cool with Agent Messenger, [let me know](https://x.com/devxoul)!
+These are just starting points. Your agent has full read/write access to Slack, Discord, Teams, Telegram, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, and Channel Talk — anything you'd do manually in a chat app, it can handle for you. If you build something cool with Agent Messenger, [let me know](https://x.com/devxoul)!
 
 ## Philosophy
 

--- a/docs/content/docs/agent-skills.mdx
+++ b/docs/content/docs/agent-skills.mdx
@@ -4,7 +4,7 @@ description: Teach your AI agent how to use Agent Messenger CLIs effectively.
 icon: Hexagon
 ---
 
-Agent Skills are instruction files that teach AI coding agents how to use tools effectively. Agent Messenger includes skills for Slack, Discord, Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta).
+Agent Skills are instruction files that teach AI coding agents how to use tools effectively. Agent Messenger includes skills for Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, iMessage (Mac-only), Instagram, KakaoTalk, and Channel Talk (beta).
 
 ## What Are Agent Skills?
 

--- a/docs/content/docs/cli/meta.json
+++ b/docs/content/docs/cli/meta.json
@@ -14,10 +14,10 @@
     "whatsappbot",
     "line",
     "wechatbot",
+    "imessage",
     "instagram",
     "kakaotalk",
     "channeltalk",
-    "channeltalkbot",
-    "imessage"
+    "channeltalkbot"
   ]
 }

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: What is Agent Messenger?
-description: Give your AI agent the power to read and send messages across Slack, Discord, Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, Channel Talk, and more
+description: Give your AI agent the power to read and send messages across Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, Channel Talk, and more
 icon: Info
 ---
 
-Agent Messenger is a unified, agent-friendly CLI for messaging platforms. Zero-config credential extraction from your desktop apps—no OAuth flows, no API keys, no admin approval needed. Works out of the box. Supports Slack, Discord, Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta).
+Agent Messenger is a unified, agent-friendly CLI for messaging platforms. Most platforms use zero-config credential extraction from your desktop apps or quick local auth—no OAuth flows, no API keys, no admin approval needed. Supports Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, iMessage (Mac-only via imsg setup), Instagram, KakaoTalk, and Channel Talk (beta).
 
 ## Why Agent Messenger?
 
@@ -12,14 +12,14 @@ Messaging platforms only offer Bot tokens for API access—your AI agent can nev
 
 - **Act as yourself, not a bot** — Extracted user tokens let your agent operate on your behalf
 - **No API keys needed** — Automatically extracts credentials from your installed desktop apps
-- **One interface, multiple platforms** — Learn once, use everywhere (Slack, Discord, Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, Channel Talk)
+- **One interface, multiple platforms** — Learn once, use everywhere (Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, Channel Talk)
 - **AI-agent friendly** — JSON output by default, perfect for LLM tool use
 - **Human friendly too** — Add `--pretty` for readable output
 - **Token efficient** — CLI, not MCP. Load only what you need
 
 ## How It Works
 
-Agent Messenger reads authentication tokens directly from your installed desktop apps (Slack, Discord, Teams, KakaoTalk, Channel Talk). Telegram uses TDLib with auto-provisioned API credentials. WhatsApp authenticates via pairing code. KakaoTalk supports both credential extraction and sub-device login. These apps store session tokens locally, and Agent Messenger safely extracts them.
+Agent Messenger reads authentication tokens directly from your installed desktop apps (Slack, Discord, Teams, KakaoTalk, Channel Talk). Telegram uses TDLib with auto-provisioned API credentials. WhatsApp authenticates via pairing code. KakaoTalk supports both credential extraction and sub-device login. iMessage is the exception — Apple has no API, so it runs locally on a Mac via the [imsg](https://github.com/openclaw/imsg) tool. These apps store session tokens locally, and Agent Messenger safely extracts them.
 
 ```bash
 # Extract credentials from Slack desktop app
@@ -36,7 +36,7 @@ No app creation. No admin approval. No waiting.
 | Feature             | Description                                                                                                                                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Auto-extraction** | Pulls tokens from desktop apps automatically                                                                                                                                                                       |
-| **Multi-platform**  | Slack, Discord, Microsoft Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk (beta)                                                                                                           |
+| **Multi-platform**  | Slack, Discord, Microsoft Teams, Webex, Telegram, WhatsApp, LINE, iMessage (Mac-only), Instagram, KakaoTalk, and Channel Talk (beta)                                                                               |
 | **Multi-workspace** | Switch between workspaces/servers easily                                                                                                                                                                           |
 | **JSON output**     | Machine-readable by default, `--pretty` for humans                                                                                                                                                                 |
 | **Comprehensive**   | Messages, channels, users, reactions, files                                                                                                                                                                        |
@@ -95,7 +95,7 @@ Default output is JSON for machines. Add `--pretty` for humans. Both are first-c
 
 ### Unified Interface
 
-Learn once, use everywhere. The same commands work across Slack, Discord, Teams, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk.
+Learn once, use everywhere. The same commands work across Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, and Channel Talk.
 
 ### Fail Fast, Fail Clear
 
@@ -113,11 +113,14 @@ Tokens stay on your machine. Nothing is sent to external servers. Your credentia
 - [Discord](/docs/cli/discord) - Full Discord command reference
 - [Discord Bot](/docs/cli/discordbot) - Bot token integration for server-side and CI/CD
 - [Teams](/docs/cli/teams) - Full Teams command reference
+- [Webex](/docs/cli/webex) - Full Webex command reference
+- [Webex Bot](/docs/cli/webexbot) - Bot token integration for server-side and CI/CD
 - [Telegram](/docs/cli/telegram) - TDLib setup and Telegram command reference
 - [Telegram Bot](/docs/cli/telegrambot) - Bot token integration for server-side and CI/CD
 - [WhatsApp](/docs/cli/whatsapp) - Full WhatsApp command reference
 - [WhatsApp Bot](/docs/cli/whatsappbot) - Cloud API integration for WhatsApp Business
 - [LINE](/docs/cli/line) - Full LINE command reference
+- [iMessage](/docs/cli/imessage) - iMessage on a Mac via the imsg tool
 - [Instagram](/docs/cli/instagram) - Instagram DM integration via private mobile API
 - [KakaoTalk](/docs/cli/kakaotalk) - Full KakaoTalk command reference
 - [Channel Talk](/docs/cli/channeltalk) - Full Channel Talk command reference (beta)

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -35,6 +35,7 @@ This installs these CLI tools:
 - `agent-whatsapp` — WhatsApp CLI (user account via Baileys, pairing code auth)
 - `agent-whatsappbot` — WhatsApp Bot CLI (Cloud API, for server-side/CI/CD)
 - `agent-line` — LINE CLI (QR code login, Thrift protocol)
+- `agent-imessage` — iMessage CLI (runs on a Mac via the [imsg](https://github.com/openclaw/imsg) tool)
 - `agent-instagram` — Instagram DM CLI (user account via private mobile API)
 - `agent-kakaotalk` — KakaoTalk CLI (sub-device login, LOCO protocol)
 - `agent-channeltalk` — Channel Talk CLI (beta, zero-config, extracted cookies)
@@ -127,6 +128,7 @@ agent-slack workspace current
 - [Telegram Bot Reference](/docs/cli/telegrambot) - Bot token for server-side/CI/CD
 - [WhatsApp Reference](/docs/cli/whatsapp) - Full command reference
 - [WhatsApp Bot Reference](/docs/cli/whatsappbot) - Cloud API for WhatsApp Business
+- [iMessage Reference](/docs/cli/imessage) - iMessage on a Mac via the imsg tool
 - [KakaoTalk Reference](/docs/cli/kakaotalk) - Full command reference
 - [Channel Talk Reference](/docs/cli/channeltalk) - Full command reference (beta)
 - [Channel Talk Bot Reference](/docs/cli/channeltalkbot) - Bot API for Channel Talk (beta)

--- a/docs/content/docs/tui.mdx
+++ b/docs/content/docs/tui.mdx
@@ -4,11 +4,11 @@ description: A unified terminal interface for all your messaging platforms in on
 icon: Monitor
 ---
 
-> **Experimental** — The TUI is a showcase of what's possible with Agent Messenger's SDK. It's not intended for production use, but demonstrates the power of having a unified adapter layer across 10 messaging platforms.
+> **Experimental** — The TUI is a showcase of what's possible with Agent Messenger's SDK. It's not intended for production use, but demonstrates the power of having a unified adapter layer across 11 messaging platforms.
 
 ## What Is It?
 
-The TUI (Terminal User Interface) is a `blessed`-based interactive terminal app that unifies all your messaging platforms into a single screen. Navigate between Slack, Discord, Teams, Webex, Telegram, WhatsApp, LINE, Instagram, KakaoTalk, and Channel Talk — all from your terminal.
+The TUI (Terminal User Interface) is a `blessed`-based interactive terminal app that unifies all your messaging platforms into a single screen. Navigate between Slack, Discord, Teams, Webex, Telegram, WhatsApp, iMessage, LINE, Instagram, KakaoTalk, and Channel Talk — all from your terminal.
 
 ![Agent Messenger TUI](/tui.png)
 
@@ -30,7 +30,7 @@ The TUI has three navigation levels and three input modes.
 
 | Level         | What it shows                                              | How to enter                               |
 | ------------- | ---------------------------------------------------------- | ------------------------------------------ |
-| **Platform**  | All 10 platforms with online/offline status                | Launch or press `Esc` from workspace level |
+| **Platform**  | All 11 platforms with online/offline status                | Launch or press `Esc` from workspace level |
 | **Workspace** | Workspaces for the selected platform (skipped if only one) | Select a platform                          |
 | **Channel**   | Channels in the current workspace                          | Select a workspace                         |
 
@@ -128,6 +128,7 @@ src/tui/
 │   ├── webex-adapter.ts
 │   ├── telegram-adapter.ts
 │   ├── whatsapp-adapter.ts
+│   ├── imessage-adapter.ts
 │   ├── line-adapter.ts
 │   ├── instagram-adapter.ts
 │   ├── kakaotalk-adapter.ts

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-messenger",
   "version": "2.27.2",
-  "description": "Multi-platform messaging CLI for AI agents (Slack, Discord, Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, Instagram, KakaoTalk, Channel Talk)",
+  "description": "Multi-platform messaging CLI for AI agents (Slack, Discord, Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, Channel Talk)",
   "repository": {
     "type": "git",
     "url": "https://github.com/agent-messenger/agent-messenger"
@@ -66,6 +66,9 @@
       "wechatbot": [
         "./src/platforms/wechatbot/index.ts"
       ],
+      "imessage": [
+        "./src/platforms/imessage/index.ts"
+      ],
       "instagram": [
         "./src/platforms/instagram/index.ts"
       ],
@@ -80,9 +83,6 @@
       ],
       "telegrambot": [
         "./src/platforms/telegrambot/index.ts"
-      ],
-      "imessage": [
-        "./src/platforms/imessage/index.ts"
       ]
     }
   },
@@ -136,6 +136,10 @@
       "types": "./src/platforms/wechatbot/index.ts",
       "default": "./src/platforms/wechatbot/index.ts"
     },
+    "./imessage": {
+      "types": "./src/platforms/imessage/index.ts",
+      "default": "./src/platforms/imessage/index.ts"
+    },
     "./instagram": {
       "types": "./src/platforms/instagram/index.ts",
       "default": "./src/platforms/instagram/index.ts"
@@ -155,10 +159,6 @@
     "./telegrambot": {
       "types": "./src/platforms/telegrambot/index.ts",
       "default": "./src/platforms/telegrambot/index.ts"
-    },
-    "./imessage": {
-      "types": "./src/platforms/imessage/index.ts",
-      "default": "./src/platforms/imessage/index.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

`iMessage` (`agent-imessage`) shipped in #265 but was missing from many of the places that enumerate supported platforms. This PR adds it consistently everywhere a platform list, badge, table, or guide link appears — and reorders it to sit **between WeChat/LINE and Instagram** in every listing (per the project's canonical platform order). Stale platform/TUI counts are refreshed at the same time.

No source/behavior changes — docs, badges, and manifest metadata only.

## What changed

**README + package metadata** (`dbbe690`)
- Platform badge row (Apple-blue `imessage` shields.io badge) and SkillPad badge row
- Install CLI list, SDK "Available Imports" table, config-dir platform list
- TUI description, "...and More" use-cases list, Platform Guides list
- `package.json` `description`, `exports`, and `typesVersions`
- Counts: "7 platforms" → 12, TUI "10 platforms" → 11

**Claude plugin manifests** (`890a413`)
- `plugin.json` description, `keywords`, and `skills` array
- `marketplace.json` description
- `.claude-plugin/README.md` intro list, new feature section, requirements, and skill-doc link

**Docs site** (`da9bf17`)
- `index.mdx` (frontmatter, feature table, prose listings, Next Steps), `agent-skills.mdx`, `quick-start.mdx` (install list + Next Steps), `tui.mdx` (description, nav table, adapter source tree), `cli/meta.json` nav order

## Intentionally left as-is
- **README Supported Platforms feature table** — iMessage stays out by design; the existing footnote explains it's Mac-only with no API. (Its CLI install entry, Platform Guides link, and "iMessage is different" section already existed.)
- **Credential-extraction sentences** — iMessage doesn't extract tokens (runs locally on a Mac); `index.mdx` now names it as the exception.
- **`package.json` `bin` map** — alphabetically sorted, so `agent-imessage` is already in place.

## Verification
- `bun run lint` ✅
- `bun typecheck` ✅
- `bun run format:check` ✅
- `bun run test` ✅ (3353 pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iMessage (`agent-imessage`) to all platform listings, badges, docs, plugin manifests, and `package.json` metadata so SDK imports include `imessage`. Keeps canonical order (between WeChat/LINE and Instagram) and refreshes platform/TUI counts.

- **Docs & Metadata**
  - README: iMessage badge; install list; SDK “Available Imports” table (notes no Zod schemas for `imessage`); config-dir list; TUI section; use-cases; Platform Guides; counts updated
  - Docs site: updated index, quick-start, agent-skills, TUI pages; CLI nav order; added iMessage references
  - Claude plugin: updated descriptions, `keywords`, and `skills`; added full marketplace entry for `agent-imessage`; expanded plugin README (feature section, requirements, skill link)
  - `package.json`: added iMessage to `description`, `exports`, and `typesVersions`; reordered entries to canonical platform order

Note: No platform source changes. Docs updated; SKILL.md unchanged (linked where relevant).

<sup>Written for commit e3f82e3ebf94780d3058702c7c51f1a132d9fa02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

