### PR TITLE
feat(instagram): add real-time DM delivery via MQTToT

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,28 @@ listener.on('slash_commands', ({ ack, body }) => {
 await listener.start()
 ```
 
+### Real-time Events (Instagram)
+
+Stream Instagram DMs in real time over Instagram's MQTToT transport (a persistent TLS connection to `edge-mqtt.facebook.com`), with automatic fallback to polling if the connection can't be established.
+
+```typescript
+import { InstagramClient, InstagramHybridListener } from 'agent-messenger/instagram'
+
+const client = await new InstagramClient().login()
+const listener = new InstagramHybridListener(client)
+
+listener.on('message', (msg) => {
+  if (msg.is_outgoing) return
+  console.log(`New DM in ${msg.thread_id}: ${msg.text}`)
+})
+
+listener.on('connected', ({ userId, transport }) => {
+  console.log(`Listening as ${userId} via ${transport}`)
+})
+
+await listener.start()
+```
+
 ## TUI (Experimental)
 
 A unified terminal interface for all your messaging platforms in one screen. Navigate between Slack, Discord, Teams, Webex, Telegram, WhatsApp, iMessage, LINE, Instagram, KakaoTalk, and Channel Talk — all from your terminal.

--- a/docs/content/docs/cli/instagram.mdx
+++ b/docs/content/docs/cli/instagram.mdx
@@ -182,7 +182,7 @@ Thread IDs are numeric strings returned by `chat list` (e.g. `340282366841710300
 
 ## Limitations
 
-- **HTTP on demand**: Each command makes HTTP requests and returns. No persistent daemon or WebSocket connection.
+- **HTTP on demand**: Each command makes HTTP requests and returns. No persistent daemon or WebSocket connection. The CLI does not expose real-time events, but the SDK does — via `InstagramHybridListener` (realtime over MQTToT with polling fallback) and `InstagramRealtimeListener`. See the [SDK reference](../sdk/instagram#real-time-events).
 - **Ban risk**: Instagram monitors for automated behavior. Avoid high-volume messaging, rapid-fire sends, or bulk operations. Space out commands when sending multiple messages.
 - **No file uploads or downloads**
 - **No voice or video calls**

--- a/docs/content/docs/sdk/instagram.mdx
+++ b/docs/content/docs/sdk/instagram.mdx
@@ -13,6 +13,8 @@ npm install agent-messenger
 import {
   InstagramClient,
   InstagramListener,
+  InstagramRealtimeListener,
+  InstagramHybridListener,
   InstagramError,
   InstagramCredentialManager,
 } from 'agent-messenger/instagram'
@@ -122,7 +124,83 @@ client.setDebugLog((msg) => console.error(`[debug] ${msg}`))
 
 ## Real-Time Events
 
-`InstagramListener` polls the Instagram inbox for new messages at a configurable interval.
+### InstagramHybridListener (Recommended)
+
+`InstagramHybridListener` tries to connect over Instagram's MQTToT transport first (a persistent TLS connection to `edge-mqtt.facebook.com` — the same protocol Instagram's own app uses). If that fails, it falls back to polling automatically and retries the realtime connection with capped exponential backoff.
+
+```typescript
+import { InstagramClient, InstagramHybridListener } from 'agent-messenger/instagram'
+
+const client = await new InstagramClient().login()
+const listener = new InstagramHybridListener(client, {
+  pollInterval: 5000, // fallback poll interval in ms (default: 5000)
+  realtimeRetryBaseMs: 2000, // backoff base for realtime reconnect attempts
+  realtimeRetryMaxMs: 60000, // backoff cap
+  disableRealtime: false, // set true to force polling-only mode
+})
+
+listener.on('message', (msg) => {
+  console.log(`[${msg.thread_id}] ${msg.from}: ${msg.text}`)
+})
+
+listener.on('connected', ({ userId, transport }) => {
+  // transport is 'realtime' or 'polling'
+  console.log(`Listening as ${userId} via ${transport}`)
+})
+
+listener.on('error', (err) => console.error(err))
+listener.on('disconnected', () => console.log('Stopped'))
+
+await listener.start()
+// listener.stop() to disconnect
+```
+
+#### Events
+
+| Event          | Payload                                                  | Description                                   |
+| -------------- | -------------------------------------------------------- | --------------------------------------------- |
+| `message`      | `InstagramMessageSummary`                                | New message received                          |
+| `connected`    | `{ userId: string; transport: 'realtime' \| 'polling' }` | Listener active; `transport` shows which path |
+| `disconnected` | —                                                        | Listener stopped                              |
+| `error`        | `Error`                                                  | Network or API error                          |
+
+### InstagramRealtimeListener
+
+`InstagramRealtimeListener` connects directly over MQTToT with no polling fallback. Use this when you want pure realtime and prefer to handle reconnection yourself.
+
+```typescript
+import { InstagramClient, InstagramRealtimeListener } from 'agent-messenger/instagram'
+
+const client = await new InstagramClient().login()
+const listener = new InstagramRealtimeListener(client)
+
+listener.on('message', (msg) => {
+  console.log(`[${msg.thread_id}] ${msg.from}: ${msg.text}`)
+})
+
+listener.on('connected', ({ userId }) => {
+  console.log(`Listening as ${userId}`)
+})
+
+listener.on('error', (err) => console.error(err))
+listener.on('disconnected', () => console.log('Disconnected'))
+
+await listener.start()
+// listener.stop() to disconnect
+```
+
+#### Events
+
+| Event          | Payload                   | Description                   |
+| -------------- | ------------------------- | ----------------------------- |
+| `message`      | `InstagramMessageSummary` | New message received          |
+| `connected`    | `{ userId: string }`      | MQTToT connection established |
+| `disconnected` | —                         | Connection closed             |
+| `error`        | `Error`                   | Connection or protocol error  |
+
+### InstagramListener (Polling Only)
+
+`InstagramListener` polls the Instagram inbox for new messages at a configurable interval. It's the original listener and remains available for environments where a persistent connection isn't suitable.
 
 ```typescript
 import { InstagramClient, InstagramListener } from 'agent-messenger/instagram'
@@ -145,7 +223,7 @@ await listener.start()
 // listener.stop() to disconnect
 ```
 
-### Events
+#### Events
 
 | Event          | Payload                   | Description                             |
 | -------------- | ------------------------- | --------------------------------------- |
@@ -220,6 +298,9 @@ import type {
   InstagramMessageSummary,
   InstagramSessionState,
   InstagramListenerEventMap,
+  InstagramRealtimeListenerEventMap,
+  InstagramHybridListenerEventMap,
+  InstagramHybridListenerOptions,
 } from 'agent-messenger/instagram'
 ```
 
@@ -304,17 +385,21 @@ if (alice) {
 
 ### Message Monitor
 
-Watch for new DMs using the real-time listener.
+Watch for new DMs using the hybrid listener, which tries realtime first and falls back to polling automatically.
 
 ```typescript
-import { InstagramClient, InstagramListener } from 'agent-messenger/instagram'
+import { InstagramClient, InstagramHybridListener } from 'agent-messenger/instagram'
 
 const client = await new InstagramClient().login()
-const listener = new InstagramListener(client, { pollInterval: 10_000 })
+const listener = new InstagramHybridListener(client)
 
 listener.on('message', (msg) => {
   if (msg.is_outgoing) return
   console.log(`New DM from ${msg.from}: ${msg.text ?? `[${msg.type}]`}`)
+})
+
+listener.on('connected', ({ userId, transport }) => {
+  console.log(`Listening as ${userId} via ${transport}`)
 })
 
 listener.on('error', (err) => {

--- a/skills/agent-instagram/SKILL.md
+++ b/skills/agent-instagram/SKILL.md
@@ -27,7 +27,7 @@ Use one of these entrypoints:
 - **Thread ID** = Instagram's identifier for a DM conversation. Numeric string returned by `chat list`.
 - **Browser cookie extraction** = recommended auth method. Extracts cookies from Chromium browsers (Chrome, Chrome Canary, Edge, Arc, Brave, Vivaldi, Chromium) where you're logged into instagram.com. Zero-config.
 - **Username/password auth** = fallback method. Authenticates using Instagram credentials. Supports two-factor authentication via SMS or authenticator app.
-- **HTTP-based** = each command makes HTTP requests and returns. No persistent connection or background process.
+- **HTTP-based** = each CLI command makes HTTP requests and returns. No persistent connection or background process. The SDK additionally offers real-time listeners (`InstagramHybridListener`, `InstagramRealtimeListener`) for streaming DMs — see [SDK: Real-Time Events](#sdk-real-time-events) below.
 - **Multi-account** = multiple Instagram accounts can be stored. Use `auth list` and `auth use` to switch between them.
 - **DM-only** = this CLI focuses on Instagram Direct Messages. It does not manage posts, stories, or followers.
 
@@ -440,3 +440,73 @@ Instagram invalidates sessions based on device fingerprinting and activity patte
 1. Avoid frequent re-authentication
 2. Space out API calls
 3. Don't switch between multiple IP addresses rapidly
+
+## SDK: Real-Time Events
+
+`InstagramHybridListener` connects over Instagram's MQTToT transport (a persistent TLS connection to `edge-mqtt.facebook.com`) and falls back to polling automatically if the connection fails. It retries realtime with capped exponential backoff. This is the recommended listener for most use cases.
+
+`InstagramRealtimeListener` is the pure-realtime option with no polling fallback — use it when you want direct MQTToT and prefer to handle reconnection yourself.
+
+Both use the unofficial private API, the same risk surface as the existing polling listener.
+
+### Setup
+
+```typescript
+import { InstagramClient, InstagramHybridListener } from 'agent-messenger/instagram'
+
+const client = await new InstagramClient().login()
+const listener = new InstagramHybridListener(client, {
+  pollInterval: 5000,         // fallback poll interval in ms
+  realtimeRetryBaseMs: 2000,  // backoff base for realtime reconnect
+  realtimeRetryMaxMs: 60000,  // backoff cap
+})
+```
+
+Or for pure realtime:
+
+```typescript
+import { InstagramClient, InstagramRealtimeListener } from 'agent-messenger/instagram'
+
+const client = await new InstagramClient().login()
+const listener = new InstagramRealtimeListener(client)
+```
+
+### Listening for Events
+
+```typescript
+listener.on('connected', ({ userId, transport }) => {
+  // transport is 'realtime' or 'polling' (hybrid only)
+  console.log(`Listening as ${userId} via ${transport}`)
+})
+
+listener.on('message', (msg) => {
+  // msg.id, msg.thread_id, msg.from, msg.timestamp
+  // msg.is_outgoing, msg.type, msg.text, msg.media_url
+  if (msg.is_outgoing) return
+  console.log(`[${msg.thread_id}] ${msg.from}: ${msg.text}`)
+})
+
+listener.on('error', (err) => {
+  console.error(err.message)
+})
+
+listener.on('disconnected', () => {
+  // hybrid listener retries realtime automatically
+})
+```
+
+### Lifecycle
+
+```typescript
+await listener.start()  // connects via MQTToT (or starts polling fallback)
+listener.stop()         // clean shutdown
+```
+
+### Event Types
+
+| Event          | Payload (Hybrid)                                          | Payload (Realtime / Polling) | Description                    |
+| -------------- | --------------------------------------------------------- | ---------------------------- | ------------------------------ |
+| `message`      | `InstagramMessageSummary`                                 | `InstagramMessageSummary`    | New DM received                |
+| `connected`    | `{ userId: string; transport: 'realtime' \| 'polling' }` | `{ userId: string }`         | Listener active                |
+| `disconnected` | —                                                         | —                            | Connection closed              |
+| `error`        | `Error`                                                   | `Error`                      | Connection or API error        |

--- a/skills/agent-instagram/references/common-patterns.md
+++ b/skills/agent-instagram/references/common-patterns.md
@@ -323,6 +323,39 @@ agent-instagram message send-to alice "Hello!"
 agent-instagram message send 12345678901 "Hello!"
 ```
 
+## Pattern 11: Real-Time DM Monitor (SDK)
+
+**Use case**: Receive new DMs as they arrive, without polling
+
+The SDK's `InstagramHybridListener` is the right tool for continuous DM monitoring. It connects over Instagram's MQTToT transport and falls back to polling automatically — no manual loop or `sleep` needed.
+
+```typescript
+import { InstagramClient, InstagramHybridListener } from 'agent-messenger/instagram'
+
+const client = await new InstagramClient().login()
+const listener = new InstagramHybridListener(client)
+
+listener.on('connected', ({ userId, transport }) => {
+  console.log(`Listening as ${userId} via ${transport}`)
+})
+
+listener.on('message', (msg) => {
+  if (msg.is_outgoing) return
+  console.log(`[${msg.thread_id}] ${msg.from}: ${msg.text ?? `[${msg.type}]`}`)
+})
+
+listener.on('error', (err) => {
+  console.error('Listener error:', err.message)
+})
+
+await listener.start()
+// Runs until listener.stop() is called
+```
+
+**When to use**: Any time you need to react to incoming DMs in real time — notifications, bots, monitoring dashboards. Prefer this over a polling shell loop.
+
+**Contrast with shell polling**: The `monitor-chat.sh` template uses `sleep` + `message list` in a loop. That works for simple scripts but makes one HTTP request per interval and can't react faster than the interval. The SDK listener holds a persistent connection and delivers messages as they arrive.
+
 ## Anti-Patterns
 
 ### Don't Poll Too Frequently
@@ -340,6 +373,8 @@ while true; do
   sleep 30
 done
 ```
+
+For real-time monitoring, the SDK's `InstagramHybridListener` is a better alternative — it holds a persistent connection and avoids repeated HTTP requests entirely. See [Pattern 11](#pattern-11-real-time-dm-monitor-sdk) above.
 
 ### Don't Spam Threads
 
@@ -360,3 +395,4 @@ agent-instagram message send "$THREAD" "$MESSAGE"
 ## See Also
 
 - [Authentication Guide](authentication.md) - Setting up credentials
+- For real-time events, use the `InstagramHybridListener` SDK (see SKILL.md → SDK: Real-Time Events)

--- a/skills/agent-instagram/templates/monitor-chat.sh
+++ b/skills/agent-instagram/templates/monitor-chat.sh
@@ -12,6 +12,11 @@
 # Example:
 #   ./monitor-chat.sh 340282366841710300949128138443434234567
 #   ./monitor-chat.sh 340282366841710300949128138443434234567 10
+#
+# NOTE: For real-time monitoring, prefer the SDK's InstagramHybridListener over
+# this poll-based approach. It connects over Instagram's MQTToT transport and
+# delivers messages as they arrive, with automatic fallback to polling if needed.
+# See SKILL.md -> SDK: Real-Time Events for setup and usage.
 
 set -euo pipefail
 

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -298,6 +298,24 @@ export class InstagramClient {
     return threads.map((t) => this.mapThread(t))
   }
 
+  async fetchIrisBootstrap(): Promise<{ seqId: number; snapshotAtMs: number }> {
+    this.ensureSession()
+    const { data } = await this.request('GET', '/direct_v2/inbox/?limit=1')
+
+    if (data['status'] !== 'ok') {
+      throw new InstagramError('Failed to fetch iris bootstrap', 'inbox_error')
+    }
+
+    const seqId = data['seq_id'] as number | undefined
+    const snapshotAtMs = data['snapshot_at_ms'] as number | undefined
+
+    if (typeof seqId !== 'number' || typeof snapshotAtMs !== 'number') {
+      throw new InstagramError('Iris bootstrap missing seq_id or snapshot_at_ms', 'iris_bootstrap_missing')
+    }
+
+    return { seqId, snapshotAtMs }
+  }
+
   async searchChats(query: string, limit = 20): Promise<InstagramChatSummary[]> {
     const allChats = await this.listChats(Math.max(limit, 50))
     const lower = query.toLowerCase()
@@ -403,6 +421,11 @@ export class InstagramClient {
 
   getUserId(): string | null {
     return this.userId
+  }
+
+  getSessionState(): InstagramSessionState {
+    this.ensureSession()
+    return this.session!
   }
 
   async getProfile(): Promise<{

--- a/src/platforms/instagram/hybrid-listener.test.ts
+++ b/src/platforms/instagram/hybrid-listener.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { EventEmitter } from 'node:events'
+
+import { InstagramHybridListener } from '@/platforms/instagram/hybrid-listener'
+import type { InstagramRealtimeListener } from '@/platforms/instagram/realtime-listener'
+
+function makeRealtimeFailingClient() {
+  return {
+    getUserId: () => '123',
+    getSessionState: () => {
+      throw new Error('realtime bootstrap failed')
+    },
+    fetchIrisBootstrap: async () => {
+      throw new Error('realtime bootstrap failed')
+    },
+    listChats: mock(async () => []),
+  } as never
+}
+
+class FakeRealtimeListener {
+  private emitter = new EventEmitter()
+  stopped = false
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    this.emitter.on(event, handler)
+    return this
+  }
+  off() {
+    return this
+  }
+  once() {
+    return this
+  }
+  async start() {
+    this.emitter.emit('connected', { userId: '123' })
+  }
+  stop() {
+    this.stopped = true
+    this.emitter.emit('disconnected')
+  }
+  fail() {
+    this.emitter.emit('error', new Error('realtime connection lost'))
+  }
+}
+
+class TestableHybridListener extends InstagramHybridListener {
+  lastFake: FakeRealtimeListener | null = null
+  protected override createRealtimeListener(): InstagramRealtimeListener {
+    const fake = new FakeRealtimeListener()
+    this.lastFake = fake
+    return fake as unknown as InstagramRealtimeListener
+  }
+}
+
+describe('InstagramHybridListener', () => {
+  let listener: InstagramHybridListener
+
+  afterEach(() => {
+    listener?.stop()
+  })
+
+  it('falls back to polling and emits a single error when realtime startup fails', async () => {
+    const client = makeRealtimeFailingClient()
+    listener = new InstagramHybridListener(client, {
+      pollInterval: 60_000,
+      realtimeRetryBaseMs: 60_000,
+      realtimeRetryMaxMs: 60_000,
+    })
+
+    const errors: Error[] = []
+    listener.on('error', (err) => errors.push(err))
+
+    const connected = new Promise<{ userId: string; transport: string }>((resolve) => {
+      listener.on('connected', resolve)
+    })
+
+    await listener.start()
+    const info = await connected
+
+    // given a realtime failure, when startup fails, then it falls back to polling
+    expect(info.transport).toBe('polling')
+    // and the failure is reported exactly once (no recursive re-entry)
+    expect(errors).toHaveLength(1)
+  })
+
+  it('falls back to polling exactly once when a connected realtime listener fails', async () => {
+    const client = {
+      getUserId: () => '123',
+      listChats: mock(async () => []),
+    } as never
+    const testable = new TestableHybridListener(client, {
+      pollInterval: 60_000,
+      realtimeRetryBaseMs: 60_000,
+      realtimeRetryMaxMs: 60_000,
+    })
+    listener = testable
+
+    const errors: Error[] = []
+    const transports: string[] = []
+    testable.on('error', (err) => errors.push(err))
+    testable.on('connected', ({ transport }) => transports.push(transport))
+
+    await testable.start()
+    // given an established realtime connection
+    expect(transports).toContain('realtime')
+
+    const pollingConnected = new Promise<void>((resolve) => {
+      testable.on('connected', ({ transport }) => {
+        if (transport === 'polling') resolve()
+      })
+    })
+
+    // when the connected realtime listener fails
+    testable.lastFake!.fail()
+    await pollingConnected
+
+    // then the failure is reported once and it falls back to polling without recursion
+    expect(errors).toHaveLength(1)
+    expect(transports.filter((t) => t === 'polling')).toHaveLength(1)
+  })
+
+  it('uses polling directly when realtime is disabled', async () => {
+    const client = makeRealtimeFailingClient()
+    listener = new InstagramHybridListener(client, { pollInterval: 60_000, disableRealtime: true })
+
+    const connected = new Promise<{ transport: string }>((resolve) => {
+      listener.on('connected', resolve)
+    })
+
+    await listener.start()
+    const info = await connected
+
+    expect(info.transport).toBe('polling')
+  })
+})

--- a/src/platforms/instagram/hybrid-listener.ts
+++ b/src/platforms/instagram/hybrid-listener.ts
@@ -1,0 +1,196 @@
+import { EventEmitter } from 'node:events'
+
+import type { InstagramClient } from './client'
+import { InstagramListener } from './listener'
+import { InstagramRealtimeListener } from './realtime-listener'
+import type { InstagramMessageSummary } from './types'
+
+export interface InstagramHybridListenerEventMap {
+  message: [InstagramMessageSummary]
+  error: [Error]
+  connected: [{ userId: string; transport: 'realtime' | 'polling' }]
+  disconnected: []
+}
+
+type EventKey = keyof InstagramHybridListenerEventMap
+
+const DEFAULT_REALTIME_RETRY_BASE_MS = 30_000
+const DEFAULT_REALTIME_RETRY_MAX_MS = 5 * 60_000
+
+export interface InstagramHybridListenerOptions {
+  pollInterval?: number
+  realtimeRetryBaseMs?: number
+  realtimeRetryMaxMs?: number
+  disableRealtime?: boolean
+  connackTimeoutMs?: number
+}
+
+export class InstagramHybridListener {
+  private client: InstagramClient
+  private emitter = new EventEmitter()
+  private realtime: InstagramRealtimeListener | null = null
+  private poller: InstagramListener | null = null
+  private options: Required<
+    Pick<InstagramHybridListenerOptions, 'realtimeRetryBaseMs' | 'realtimeRetryMaxMs' | 'disableRealtime'>
+  > &
+    Pick<InstagramHybridListenerOptions, 'pollInterval' | 'connackTimeoutMs'>
+  private running = false
+  private realtimeRetryTimer: ReturnType<typeof setTimeout> | null = null
+  private realtimeFailures = 0
+  private activeTransport: 'realtime' | 'polling' | null = null
+  private tearingDownRealtime = false
+
+  constructor(client: InstagramClient, options: InstagramHybridListenerOptions = {}) {
+    this.client = client
+    this.options = {
+      pollInterval: options.pollInterval,
+      realtimeRetryBaseMs: options.realtimeRetryBaseMs ?? DEFAULT_REALTIME_RETRY_BASE_MS,
+      realtimeRetryMaxMs: options.realtimeRetryMaxMs ?? DEFAULT_REALTIME_RETRY_MAX_MS,
+      disableRealtime: options.disableRealtime ?? false,
+      connackTimeoutMs: options.connackTimeoutMs,
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+
+    if (this.options.disableRealtime) {
+      this.startPolling()
+      return
+    }
+
+    await this.tryRealtime()
+  }
+
+  stop(): void {
+    this.running = false
+    this.activeTransport = null
+    this.clearRealtimeRetry()
+    this.teardownRealtime()
+    this.teardownPolling()
+    this.emitter.emit('disconnected')
+  }
+
+  on<K extends EventKey>(event: K, listener: (...args: InstagramHybridListenerEventMap[K]) => void): this {
+    this.emitter.on(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  off<K extends EventKey>(event: K, listener: (...args: InstagramHybridListenerEventMap[K]) => void): this {
+    this.emitter.off(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  once<K extends EventKey>(event: K, listener: (...args: InstagramHybridListenerEventMap[K]) => void): this {
+    this.emitter.once(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  protected createRealtimeListener(): InstagramRealtimeListener {
+    return new InstagramRealtimeListener(this.client, { connackTimeoutMs: this.options.connackTimeoutMs })
+  }
+
+  private async tryRealtime(): Promise<void> {
+    const realtime = this.createRealtimeListener()
+    this.realtime = realtime
+
+    realtime.on('message', (message) => this.emitter.emit('message', message))
+    realtime.on('connected', ({ userId }) => {
+      this.realtimeFailures = 0
+      this.activeTransport = 'realtime'
+      this.teardownPolling()
+      this.emitter.emit('connected', { userId, transport: 'realtime' })
+    })
+    realtime.on('error', (error) => this.onRealtimeFailure(error))
+    realtime.on('disconnected', () => {
+      // Ignore the 'disconnected' that our own teardown triggers; only an
+      // unexpected close (still marked realtime-active) is a real failure.
+      if (this.tearingDownRealtime) return
+      if (this.running && this.activeTransport === 'realtime') {
+        this.onRealtimeFailure(new Error('Realtime connection closed'))
+      }
+    })
+
+    try {
+      await realtime.start()
+      // stop() may have run during the bootstrap await; if so, don't leave an MQTT
+      // connection alive after the hybrid listener was already torn down.
+      if (!this.running) {
+        realtime.stop()
+        if (this.realtime === realtime) this.realtime = null
+      }
+    } catch (error) {
+      this.onRealtimeFailure(error instanceof Error ? error : new Error(String(error)))
+    }
+  }
+
+  private onRealtimeFailure(error: Error): void {
+    if (!this.running) return
+
+    this.activeTransport = null
+    this.emitter.emit('error', error)
+    this.realtimeFailures++
+    // teardownRealtime() suppresses the 'disconnected' it triggers, so this path
+    // does not re-enter via the realtime disconnected handler.
+    this.teardownRealtime()
+    this.startPolling()
+    this.scheduleRealtimeRetry()
+  }
+
+  private scheduleRealtimeRetry(): void {
+    if (!this.running || this.realtimeRetryTimer) return
+
+    const delay = Math.min(
+      this.options.realtimeRetryBaseMs * 2 ** (this.realtimeFailures - 1),
+      this.options.realtimeRetryMaxMs,
+    )
+
+    this.realtimeRetryTimer = setTimeout(() => {
+      this.realtimeRetryTimer = null
+      if (this.running) void this.tryRealtime()
+    }, delay)
+  }
+
+  private startPolling(): void {
+    if (this.poller) return
+
+    const poller = new InstagramListener(this.client, { pollInterval: this.options.pollInterval })
+    this.poller = poller
+
+    poller.on('message', (message) => this.emitter.emit('message', message))
+    poller.on('error', (error) => this.emitter.emit('error', error))
+    poller.on('connected', ({ userId }) => {
+      this.activeTransport = 'polling'
+      this.emitter.emit('connected', { userId, transport: 'polling' })
+    })
+
+    void poller.start()
+  }
+
+  private teardownRealtime(): void {
+    if (this.realtime) {
+      this.tearingDownRealtime = true
+      try {
+        this.realtime.stop()
+      } finally {
+        this.tearingDownRealtime = false
+      }
+      this.realtime = null
+    }
+  }
+
+  private teardownPolling(): void {
+    if (this.poller) {
+      this.poller.stop()
+      this.poller = null
+    }
+  }
+
+  private clearRealtimeRetry(): void {
+    if (this.realtimeRetryTimer) {
+      clearTimeout(this.realtimeRetryTimer)
+      this.realtimeRetryTimer = null
+    }
+  }
+}

--- a/src/platforms/instagram/index.ts
+++ b/src/platforms/instagram/index.ts
@@ -1,6 +1,16 @@
 export { InstagramClient } from './client'
 export { InstagramCredentialManager } from './credential-manager'
+export {
+  InstagramHybridListener,
+  type InstagramHybridListenerEventMap,
+  type InstagramHybridListenerOptions,
+} from './hybrid-listener'
 export { InstagramListener, type InstagramListenerEventMap } from './listener'
+export {
+  InstagramRealtimeListener,
+  type InstagramRealtimeListenerEventMap,
+  type InstagramRealtimeListenerOptions,
+} from './realtime-listener'
 export { InstagramTokenExtractor, type ExtractedInstagramCookies } from './token-extractor'
 export {
   createAccountId,

--- a/src/platforms/instagram/mqtt/connection.ts
+++ b/src/platforms/instagram/mqtt/connection.ts
@@ -1,0 +1,72 @@
+import { deflateSync } from 'node:zlib'
+
+import type { InstagramSessionState } from '../types'
+import { ThriftCompactWriter } from './thrift'
+
+const IG_APP_ID = 567067343352427n
+const IG_VERSION = '312.1.0.34.111'
+const CLIENT_CAPABILITIES = 183n
+const PUBLISH_FORMAT = 1
+const NETWORK_TYPE_WIFI = 1
+const CLIENT_STACK = 3
+const CLIENT_IDENTIFIER_MAX_LENGTH = 20
+const SESSION_ID_MASK = 0xffffffffn
+
+const CONNECT_SUBSCRIBE_TOPIC_IDS = [88, 135, 149, 150, 133, 146]
+
+export function extractSessionId(session: InstagramSessionState): string {
+  const authorization = session.authorization ?? ''
+  const igTokenMatch = authorization.match(/^Bearer IGT:2:(.+)$/)
+  if (igTokenMatch) {
+    try {
+      const decoded = JSON.parse(Buffer.from(igTokenMatch[1]!, 'base64').toString('utf8')) as { sessionid?: string }
+      if (decoded.sessionid) return decoded.sessionid
+    } catch {
+      // Malformed/stale token: fall through to the cookie-based sessionid below.
+    }
+  }
+
+  const cookieMatch = session.cookies.match(/sessionid=([^;]+)/)
+  if (cookieMatch) return cookieMatch[1]!
+
+  throw new Error('No sessionid found in Instagram session (checked authorization token and cookies)')
+}
+
+export function buildConnectPayload(session: InstagramSessionState): Buffer {
+  const sessionId = extractSessionId(session)
+  const userId = BigInt(session.user_id ?? '0')
+  const deviceId = session.device.phone_id
+  const userAgent = `Instagram ${IG_VERSION} Android (${session.device.device_string})`
+
+  const thrift = new ThriftCompactWriter()
+    .binary(1, deviceId.substring(0, CLIENT_IDENTIFIER_MAX_LENGTH))
+    .structStart(4)
+    .i64(1, userId)
+    .binary(2, userAgent)
+    .i64(3, CLIENT_CAPABILITIES)
+    .i64(4, 0)
+    .i32(5, PUBLISH_FORMAT)
+    .bool(6, false)
+    .bool(7, true)
+    .binary(8, deviceId)
+    .bool(9, true)
+    .i32(10, NETWORK_TYPE_WIFI)
+    .i32(11, 0)
+    .i64(12, BigInt(Date.now()) & SESSION_ID_MASK)
+    .listOfI32(14, CONNECT_SUBSCRIBE_TOPIC_IDS)
+    .binary(15, 'cookie_auth')
+    .i64(16, IG_APP_ID)
+    .binary(20, '')
+    .byte(21, CLIENT_STACK)
+    .structEnd()
+    .binary(5, `sessionid=${sessionId}`)
+    .mapBinaryBinary(10, {
+      platform: 'android',
+      ig_mqtt_route: 'django',
+      pubsub_msg_type_blacklist: 'direct, typing_type',
+      auth_cache_enabled: '0',
+    })
+    .finish()
+
+  return deflateSync(thrift, { level: 9 })
+}

--- a/src/platforms/instagram/mqtt/thrift.test.ts
+++ b/src/platforms/instagram/mqtt/thrift.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test'
+
+import { ThriftCompactWriter } from '@/platforms/instagram/mqtt/thrift'
+
+describe('ThriftCompactWriter', () => {
+  it('encodes a true bool as a packed field header with a trailing stop byte', () => {
+    // field id 1 (delta 1) << 4 | TYPE_TRUE(0x01) = 0x11, then struct stop 0x00
+    const out = new ThriftCompactWriter().bool(1, true).finish()
+    expect([...out]).toEqual([0x11, 0x00])
+  })
+
+  it('encodes a false bool with the false type code', () => {
+    // field id 1 (delta 1) << 4 | TYPE_FALSE(0x02) = 0x12
+    const out = new ThriftCompactWriter().bool(1, false).finish()
+    expect([...out]).toEqual([0x12, 0x00])
+  })
+
+  it('encodes i32 using zigzag varint', () => {
+    // field 1 i32(0x05) = 0x15, zigzag(1) = 2
+    const out = new ThriftCompactWriter().i32(1, 1).finish()
+    expect([...out]).toEqual([0x15, 0x02, 0x00])
+  })
+
+  it('encodes negative i32 via zigzag', () => {
+    // zigzag(-1) = 1
+    const out = new ThriftCompactWriter().i32(1, -1).finish()
+    expect([...out]).toEqual([0x15, 0x01, 0x00])
+  })
+
+  it('encodes a large positive i32 as an unsigned <=5-byte varint', () => {
+    // 0x40000000: zigzag(1073741824) = 2147483648 = 0x80000000 -> varint 80 80 80 80 08
+    const out = new ThriftCompactWriter().i32(1, 0x40000000).finish()
+    expect([...out]).toEqual([0x15, 0x80, 0x80, 0x80, 0x80, 0x08, 0x00])
+  })
+
+  it('encodes INT32_MIN without overflowing into a 64-bit varint', () => {
+    // zigzag(-2147483648) = 4294967295 = 0xFFFFFFFF -> varint ff ff ff ff 0f (5 bytes, not 9)
+    const out = new ThriftCompactWriter().i32(1, -2147483648).finish()
+    expect([...out]).toEqual([0x15, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x00])
+  })
+
+  it('encodes binary as length-prefixed utf8', () => {
+    // field 1 binary(0x08) = 0x18, length 2, "hi"
+    const out = new ThriftCompactWriter().binary(1, 'hi').finish()
+    expect([...out]).toEqual([0x18, 0x02, 0x68, 0x69, 0x00])
+  })
+
+  it('packs small field-id deltas across multiple fields', () => {
+    // field 1 binary = 0x18, then field 3 binary uses delta 2 = 0x28
+    const out = new ThriftCompactWriter().binary(1, 'a').binary(3, 'b').finish()
+    expect([...out]).toEqual([0x18, 0x01, 0x61, 0x28, 0x01, 0x62, 0x00])
+  })
+
+  it('falls back to explicit zigzag id when delta exceeds 15', () => {
+    // field 20 binary: delta 20 > 15, so type byte 0x08 then zigzag(20)=40=0x28
+    const out = new ThriftCompactWriter().binary(20, 'x').finish()
+    expect([...out]).toEqual([0x08, 0x28, 0x01, 0x78, 0x00])
+  })
+
+  it('encodes a short i32 list with size packed into the header nibble', () => {
+    // field 1 list = 0x19, list header size 2 << 4 | i32(0x05) = 0x25, zigzag(88)=176=0xb0 0x01, zigzag(146)=292=0xa4 0x02
+    const out = new ThriftCompactWriter().listOfI32(1, [88, 146]).finish()
+    expect([...out]).toEqual([0x19, 0x25, 0xb0, 0x01, 0xa4, 0x02, 0x00])
+  })
+
+  it('encodes an empty map as a single zero byte', () => {
+    // field 1 map = 0x1b, empty map size 0x00
+    const out = new ThriftCompactWriter().mapBinaryBinary(1, {}).finish()
+    expect([...out]).toEqual([0x1b, 0x00, 0x00])
+  })
+
+  it('encodes a binary->binary map with the key/value type byte', () => {
+    // field 1 map = 0x1b, size 1, types (binary<<4|binary)=0x88, key "k", value "v"
+    const out = new ThriftCompactWriter().mapBinaryBinary(1, { k: 'v' }).finish()
+    expect([...out]).toEqual([0x1b, 0x01, 0x88, 0x01, 0x6b, 0x01, 0x76, 0x00])
+  })
+
+  it('resets field-id delta tracking inside nested structs', () => {
+    // field 4 struct = 0x4c, inner field 1 binary = 0x18 "a", inner stop 0x00, outer stop 0x00
+    const out = new ThriftCompactWriter().structStart(4).binary(1, 'a').structEnd().finish()
+    expect([...out]).toEqual([0x4c, 0x18, 0x01, 0x61, 0x00, 0x00])
+  })
+
+  it('encodes i64 values larger than 32 bits', () => {
+    // field 16 i64: delta 16 > 15 -> type 0x06, zigzag id(16)=32=0x20, then zigzag64(567067343352427)
+    const out = new ThriftCompactWriter().i64(16, 567067343352427n).finish()
+    expect(out[0]).toBe(0x06)
+    expect(out[1]).toBe(0x20)
+    expect(out[out.length - 1]).toBe(0x00)
+  })
+})

--- a/src/platforms/instagram/mqtt/thrift.ts
+++ b/src/platforms/instagram/mqtt/thrift.ts
@@ -1,0 +1,159 @@
+const TYPE_TRUE = 0x01
+const TYPE_FALSE = 0x02
+const TYPE_BYTE = 0x03
+const TYPE_I16 = 0x04
+const TYPE_I32 = 0x05
+const TYPE_I64 = 0x06
+const TYPE_BINARY = 0x08
+const TYPE_LIST = 0x09
+const TYPE_MAP = 0x0b
+const TYPE_STRUCT = 0x0c
+
+const VARINT_CONTINUE = 0x80
+const VARINT_MASK = 0x7f
+const U64_MASK = 0xffffffffffffffffn
+
+export class ThriftCompactWriter {
+  private bytes: number[] = []
+  private parentFieldStack: number[] = []
+  private lastFieldId = 0
+
+  bool(id: number, value: boolean): this {
+    this.writeFieldHeader(value ? TYPE_TRUE : TYPE_FALSE, id)
+    return this
+  }
+
+  byte(id: number, value: number): this {
+    this.writeFieldHeader(TYPE_BYTE, id)
+    this.bytes.push(value & 0xff)
+    return this
+  }
+
+  i16(id: number, value: number): this {
+    this.writeFieldHeader(TYPE_I16, id)
+    this.writeVarint(zigzag32(value))
+    return this
+  }
+
+  i32(id: number, value: number): this {
+    this.writeFieldHeader(TYPE_I32, id)
+    this.writeVarint(zigzag32(value))
+    return this
+  }
+
+  i64(id: number, value: number | bigint): this {
+    this.writeFieldHeader(TYPE_I64, id)
+    this.writeVarint(zigzag64(BigInt(value)))
+    return this
+  }
+
+  binary(id: number, value: string | Buffer): this {
+    this.writeFieldHeader(TYPE_BINARY, id)
+    this.writeBinaryValue(value)
+    return this
+  }
+
+  listOfI32(id: number, values: number[]): this {
+    this.writeFieldHeader(TYPE_LIST, id)
+    this.writeListHeader(TYPE_I32, values.length)
+    for (const value of values) this.writeVarint(zigzag32(value))
+    return this
+  }
+
+  listOfBinary(id: number, values: string[]): this {
+    this.writeFieldHeader(TYPE_LIST, id)
+    this.writeListHeader(TYPE_BINARY, values.length)
+    for (const value of values) this.writeBinaryValue(value)
+    return this
+  }
+
+  mapBinaryBinary(id: number, entries: Record<string, string>): this {
+    this.writeFieldHeader(TYPE_MAP, id)
+    const keys = Object.keys(entries)
+
+    // Compact protocol encodes an empty map as a single zero byte (size only).
+    if (keys.length === 0) {
+      this.bytes.push(0)
+      return this
+    }
+
+    this.writeVarint(keys.length)
+    this.bytes.push((TYPE_BINARY << 4) | TYPE_BINARY)
+    for (const key of keys) {
+      this.writeBinaryValue(key)
+      this.writeBinaryValue(entries[key]!)
+    }
+    return this
+  }
+
+  structStart(id: number): this {
+    this.writeFieldHeader(TYPE_STRUCT, id)
+    this.parentFieldStack.push(this.lastFieldId)
+    this.lastFieldId = 0
+    return this
+  }
+
+  structEnd(): this {
+    this.bytes.push(0)
+    this.lastFieldId = this.parentFieldStack.pop() ?? 0
+    return this
+  }
+
+  finish(): Buffer {
+    this.bytes.push(0)
+    return Buffer.from(this.bytes)
+  }
+
+  // Compact protocol packs a small field-id delta and the type into one byte
+  // (delta << 4 | type); deltas outside 1..15 fall back to a zigzag varint id.
+  private writeFieldHeader(type: number, id: number): void {
+    const delta = id - this.lastFieldId
+    if (delta > 0 && delta <= 15) {
+      this.bytes.push((delta << 4) | type)
+    } else {
+      this.bytes.push(type)
+      this.writeVarint(zigzag32(id))
+    }
+    this.lastFieldId = id
+  }
+
+  // Lists with fewer than 15 elements pack size into the header nibble;
+  // larger lists set the nibble to 0xf and append the size as a varint.
+  private writeListHeader(elementType: number, size: number): void {
+    if (size < 15) {
+      this.bytes.push((size << 4) | elementType)
+    } else {
+      this.bytes.push(0xf0 | elementType)
+      this.writeVarint(size)
+    }
+  }
+
+  private writeBinaryValue(value: string | Buffer): void {
+    const buf = Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8')
+    this.writeVarint(buf.length)
+    for (const b of buf) this.bytes.push(b)
+  }
+
+  private writeVarint(value: number | bigint): void {
+    let remaining = BigInt(value) & U64_MASK
+    while (true) {
+      const chunk = Number(remaining & BigInt(VARINT_MASK))
+      remaining >>= 7n
+      if (remaining === 0n) {
+        this.bytes.push(chunk)
+        return
+      }
+      this.bytes.push(chunk | VARINT_CONTINUE)
+    }
+  }
+}
+
+function zigzag32(value: number): number {
+  // `>>> 0` coerces the signed int32 bitwise result to an unsigned 32-bit value,
+  // so large positives and INT32_MIN encode as a <=5-byte varint, not a 64-bit one.
+  return ((value << 1) ^ (value >> 31)) >>> 0
+}
+
+function zigzag64(value: bigint): bigint {
+  return BigInt.asUintN(64, value << 1n) ^ (value >> 63n)
+}

--- a/src/platforms/instagram/mqtt/transport.ts
+++ b/src/platforms/instagram/mqtt/transport.ts
@@ -1,0 +1,285 @@
+import { EventEmitter } from 'node:events'
+import tls from 'node:tls'
+
+const MQTTOT_HOST = 'edge-mqtt.facebook.com'
+const MQTTOT_PORT = 443
+const PROTOCOL_NAME = 'MQTToT'
+const PROTOCOL_LEVEL = 3
+
+// CONNECT flags 0xC2 = username present + clean session; the "password" travels
+// inside the Thrift payload rather than the standard MQTT password field.
+const CONNECT_FLAGS = 0xc2
+const KEEPALIVE_SECONDS = 60
+const CONNACK_TIMEOUT_MS = 15_000
+
+const PacketType = {
+  Connect: 1,
+  ConnAck: 2,
+  Publish: 3,
+  PubAck: 4,
+  Subscribe: 8,
+  PingReq: 12,
+  PingResp: 13,
+  Disconnect: 14,
+} as const
+
+export interface MqttPublish {
+  topic: string
+  payload: Buffer
+}
+
+export interface MqttTransportEventMap {
+  connect: []
+  publish: [MqttPublish]
+  error: [Error]
+  close: []
+}
+
+type EventKey = keyof MqttTransportEventMap
+
+export class MqttTransport {
+  private socket: tls.TLSSocket | null = null
+  private emitter = new EventEmitter()
+  private buffer = Buffer.alloc(0)
+  private nextPacketId = 1
+  private pingTimer: ReturnType<typeof setInterval> | null = null
+  private connackTimer: ReturnType<typeof setTimeout> | null = null
+  private connackTimeoutMs: number
+
+  constructor(options: { connackTimeoutMs?: number } = {}) {
+    this.connackTimeoutMs = options.connackTimeoutMs ?? CONNACK_TIMEOUT_MS
+  }
+
+  connect(connectPayload: Buffer): void {
+    const socket = tls.connect({ host: MQTTOT_HOST, port: MQTTOT_PORT, servername: MQTTOT_HOST }, () => {
+      socket.write(this.buildConnectPacket(connectPayload))
+    })
+    this.socket = socket
+
+    // Guard against a peer that accepts TLS but never sends CONNACK, which would
+    // otherwise leave a hybrid caller waiting forever instead of failing over.
+    this.connackTimer = setTimeout(() => {
+      this.connackTimer = null
+      this.emitter.emit('error', new Error('MQTToT CONNACK timed out'))
+      socket.destroy()
+    }, this.connackTimeoutMs)
+
+    socket.on('data', (chunk: Buffer) => this.onData(chunk))
+    socket.on('error', (err: Error) => this.emitter.emit('error', err))
+    socket.on('close', () => {
+      this.clearConnackTimer()
+      this.stopPing()
+      this.emitter.emit('close')
+    })
+  }
+
+  publish(topic: string, payload: Buffer, qos: 0 | 1 = 1): void {
+    if (!this.socket) throw new Error('MQTT transport not connected')
+    this.socket.write(this.buildPublishPacket(topic, payload, qos))
+  }
+
+  subscribe(topics: string[]): void {
+    if (!this.socket) throw new Error('MQTT transport not connected')
+    this.socket.write(this.buildSubscribePacket(topics))
+  }
+
+  disconnect(): void {
+    this.clearConnackTimer()
+    this.stopPing()
+    if (this.socket) {
+      try {
+        this.socket.write(Buffer.from([PacketType.Disconnect << 4, 0]))
+      } catch {
+        // socket may already be torn down; closing below is sufficient
+      }
+      this.socket.destroy()
+      this.socket = null
+    }
+  }
+
+  on<K extends EventKey>(event: K, listener: (...args: MqttTransportEventMap[K]) => void): this {
+    this.emitter.on(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    this.drainPackets()
+  }
+
+  private drainPackets(): void {
+    while (this.buffer.length >= 2) {
+      const decoded = decodeRemainingLength(this.buffer, 1)
+      if (!decoded) return
+
+      const { length: remainingLength, bytesUsed } = decoded
+      const totalLength = 1 + bytesUsed + remainingLength
+      if (this.buffer.length < totalLength) return
+
+      const packet = this.buffer.subarray(0, totalLength)
+      this.buffer = this.buffer.subarray(totalLength)
+      this.handlePacket(packet, 1 + bytesUsed)
+    }
+  }
+
+  private handlePacket(packet: Buffer, bodyStart: number): void {
+    const type = (packet[0]! >> 4) & 0x0f
+
+    switch (type) {
+      case PacketType.ConnAck: {
+        this.clearConnackTimer()
+        const returnCode = packet[bodyStart + 1]
+        if (returnCode === 0) {
+          this.startPing()
+          this.emitter.emit('connect')
+        } else {
+          this.emitter.emit('error', new Error(`MQTToT CONNACK refused with return code ${returnCode}`))
+        }
+        break
+      }
+      case PacketType.Publish:
+        this.handlePublish(packet, bodyStart)
+        break
+      case PacketType.PingResp:
+      case PacketType.PubAck:
+      case PacketType.Subscribe + 1:
+        break
+    }
+  }
+
+  private handlePublish(packet: Buffer, bodyStart: number): void {
+    const qos = (packet[0]! >> 1) & 0x03
+
+    // A truncated/malformed frame must not throw out of the data handler, or it
+    // would crash the process instead of letting the listener fail over.
+    if (bodyStart + 2 > packet.length) return
+    const topicLength = packet.readUInt16BE(bodyStart)
+    let offset = bodyStart + 2
+    if (offset + topicLength > packet.length) return
+    const topic = packet.toString('utf8', offset, offset + topicLength)
+    offset += topicLength
+
+    let packetId: number | null = null
+    if (qos > 0) {
+      if (offset + 2 > packet.length) return
+      packetId = packet.readUInt16BE(offset)
+      offset += 2
+    }
+
+    const payload = packet.subarray(offset)
+    this.emitter.emit('publish', { topic, payload })
+
+    if (qos === 1 && packetId !== null) {
+      this.sendPubAck(packetId)
+    }
+  }
+
+  private sendPubAck(packetId: number): void {
+    const packet = Buffer.from([PacketType.PubAck << 4, 2, (packetId >> 8) & 0xff, packetId & 0xff])
+    this.socket?.write(packet)
+  }
+
+  private startPing(): void {
+    this.stopPing()
+    this.pingTimer = setInterval(() => {
+      this.socket?.write(Buffer.from([PacketType.PingReq << 4, 0]))
+    }, KEEPALIVE_SECONDS * 1000)
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer)
+      this.pingTimer = null
+    }
+  }
+
+  private clearConnackTimer(): void {
+    if (this.connackTimer) {
+      clearTimeout(this.connackTimer)
+      this.connackTimer = null
+    }
+  }
+
+  private buildConnectPacket(payload: Buffer): Buffer {
+    const variableHeader: number[] = []
+    appendString(variableHeader, PROTOCOL_NAME)
+    variableHeader.push(PROTOCOL_LEVEL, CONNECT_FLAGS)
+    variableHeader.push((KEEPALIVE_SECONDS >> 8) & 0xff, KEEPALIVE_SECONDS & 0xff)
+
+    const body = Buffer.concat([Buffer.from(variableHeader), payload])
+    return Buffer.concat([Buffer.from([PacketType.Connect << 4, ...encodeRemainingLength(body.length)]), body])
+  }
+
+  private buildPublishPacket(topic: string, payload: Buffer, qos: 0 | 1): Buffer {
+    const variableHeader: number[] = []
+    appendString(variableHeader, topic)
+    if (qos > 0) {
+      const packetId = this.allocatePacketId()
+      variableHeader.push((packetId >> 8) & 0xff, packetId & 0xff)
+    }
+
+    const body = Buffer.concat([Buffer.from(variableHeader), payload])
+    const flags = qos << 1
+    return Buffer.concat([
+      Buffer.from([(PacketType.Publish << 4) | flags, ...encodeRemainingLength(body.length)]),
+      body,
+    ])
+  }
+
+  private buildSubscribePacket(topics: string[]): Buffer {
+    const packetId = this.allocatePacketId()
+    const body: number[] = [(packetId >> 8) & 0xff, packetId & 0xff]
+    for (const topic of topics) {
+      appendString(body, topic)
+      body.push(0)
+    }
+    // SUBSCRIBE has reserved flags 0010 in the fixed-header low nibble.
+    return Buffer.concat([
+      Buffer.from([(PacketType.Subscribe << 4) | 0x02, ...encodeRemainingLength(body.length)]),
+      Buffer.from(body),
+    ])
+  }
+
+  private allocatePacketId(): number {
+    const id = this.nextPacketId
+    this.nextPacketId = (this.nextPacketId % 0xffff) + 1
+    return id
+  }
+}
+
+function appendString(target: number[], value: string): void {
+  const buf = Buffer.from(value, 'utf8')
+  target.push((buf.length >> 8) & 0xff, buf.length & 0xff)
+  for (const b of buf) target.push(b)
+}
+
+function encodeRemainingLength(length: number): number[] {
+  const bytes: number[] = []
+  let value = length
+  do {
+    let digit = value & 0x7f
+    value >>= 7
+    if (value > 0) digit |= 0x80
+    bytes.push(digit)
+  } while (value > 0)
+  return bytes
+}
+
+function decodeRemainingLength(buffer: Buffer, offset: number): { length: number; bytesUsed: number } | null {
+  let length = 0
+  let multiplier = 1
+  let bytesUsed = 0
+
+  while (offset + bytesUsed < buffer.length) {
+    const byte = buffer[offset + bytesUsed]!
+    length += (byte & 0x7f) * multiplier
+    bytesUsed++
+    if ((byte & 0x80) === 0) {
+      return { length, bytesUsed }
+    }
+    multiplier *= 128
+    if (bytesUsed > 4) return null
+  }
+
+  return null
+}

--- a/src/platforms/instagram/realtime-listener.test.ts
+++ b/src/platforms/instagram/realtime-listener.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test'
+
+import { InstagramRealtimeListener } from '@/platforms/instagram/realtime-listener'
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    getUserId: () => '123',
+    getSessionState: () => ({}) as never,
+    fetchIrisBootstrap: async () => ({ seqId: 1, snapshotAtMs: 1 }),
+    ...overrides,
+  } as never
+}
+
+describe('InstagramRealtimeListener', () => {
+  it('stays restartable after a bootstrap failure', async () => {
+    let calls = 0
+    const client = makeClient({
+      fetchIrisBootstrap: async () => {
+        calls++
+        throw new Error('bootstrap failed')
+      },
+    })
+    const listener = new InstagramRealtimeListener(client)
+
+    // given a failing bootstrap, when start() rejects, then running must be reset
+    await expect(listener.start()).rejects.toThrow('bootstrap failed')
+
+    // when start() is called again, then it must retry rather than no-op at the guard
+    await expect(listener.start()).rejects.toThrow('bootstrap failed')
+    expect(calls).toBe(2)
+
+    listener.stop()
+  })
+})

--- a/src/platforms/instagram/realtime-listener.ts
+++ b/src/platforms/instagram/realtime-listener.ts
@@ -1,0 +1,201 @@
+import { EventEmitter } from 'node:events'
+import { deflateSync, inflateSync } from 'node:zlib'
+
+import type { InstagramClient } from './client'
+import { buildConnectPayload } from './mqtt/connection'
+import { MqttTransport } from './mqtt/transport'
+import { extractMediaUrl, extractMessageText, getMessageType, type InstagramMessageSummary } from './types'
+
+export interface InstagramRealtimeListenerEventMap {
+  message: [InstagramMessageSummary]
+  error: [Error]
+  connected: [{ userId: string }]
+  disconnected: []
+}
+
+export interface InstagramRealtimeListenerOptions {
+  connackTimeoutMs?: number
+}
+
+type EventKey = keyof InstagramRealtimeListenerEventMap
+
+const TOPIC_PUBSUB = '88'
+const TOPIC_REALTIME_SUB = '149'
+const TOPIC_IRIS_SUB = '134'
+const TOPIC_MESSAGE_SYNC = '146'
+
+const ZLIB_MAGIC_BYTE = 0x78
+
+const DM_THREAD_PATH_PATTERN = /^\/direct_v2\/(?:inbox\/)?threads\//
+const THREAD_ID_PATTERN = /^\/direct_v2\/(?:inbox\/)?threads\/(\d+)/
+
+interface IrisEnvelope {
+  data?: IrisPatch[]
+}
+
+interface IrisPatch {
+  op?: string
+  path?: string
+  value?: string
+}
+
+export class InstagramRealtimeListener {
+  private client: InstagramClient
+  private transport: MqttTransport | null = null
+  private emitter = new EventEmitter()
+  private running = false
+  private userId: string
+  private connackTimeoutMs: number | undefined
+
+  constructor(client: InstagramClient, options: InstagramRealtimeListenerOptions = {}) {
+    this.client = client
+    this.userId = client.getUserId() ?? ''
+    this.connackTimeoutMs = options.connackTimeoutMs
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+
+    try {
+      const session = this.client.getSessionState()
+      const iris = await this.client.fetchIrisBootstrap()
+
+      if (!this.running) return
+
+      const connectPayload = buildConnectPayload(session)
+
+      const transport = new MqttTransport({ connackTimeoutMs: this.connackTimeoutMs })
+      this.transport = transport
+
+      transport.on('connect', () => {
+        this.sendSubscriptions(iris)
+        this.emitter.emit('connected', { userId: this.userId })
+      })
+      transport.on('publish', ({ topic, payload }) => this.handlePublish(topic, payload))
+      transport.on('error', (err) => this.emitter.emit('error', err))
+      transport.on('close', () => {
+        if (this.running) this.emitter.emit('disconnected')
+      })
+
+      transport.connect(connectPayload)
+    } catch (error) {
+      // Any setup failure must leave the listener cleanly restartable: reset running
+      // and discard the partial transport so a later start() does not no-op at the guard.
+      this.running = false
+      if (this.transport) {
+        this.transport.disconnect()
+        this.transport = null
+      }
+      throw error
+    }
+  }
+
+  stop(): void {
+    this.running = false
+    if (this.transport) {
+      this.transport.disconnect()
+      this.transport = null
+    }
+    this.emitter.emit('disconnected')
+  }
+
+  on<K extends EventKey>(event: K, listener: (...args: InstagramRealtimeListenerEventMap[K]) => void): this {
+    this.emitter.on(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  off<K extends EventKey>(event: K, listener: (...args: InstagramRealtimeListenerEventMap[K]) => void): this {
+    this.emitter.off(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  once<K extends EventKey>(event: K, listener: (...args: InstagramRealtimeListenerEventMap[K]) => void): this {
+    this.emitter.once(event, listener as (...args: unknown[]) => void)
+    return this
+  }
+
+  private sendSubscriptions(iris: { seqId: number; snapshotAtMs: number }): void {
+    const transport = this.transport
+    if (!transport) return
+
+    transport.publish(
+      TOPIC_IRIS_SUB,
+      deflateJson({
+        seq_id: iris.seqId,
+        snapshot_at_ms: iris.snapshotAtMs,
+        snapshot_app_version: APP_VERSION,
+      }),
+    )
+
+    transport.publish(TOPIC_PUBSUB, deflateJson({ sub: [`ig/u/v1/${this.userId}`] }))
+
+    transport.publish(
+      TOPIC_REALTIME_SUB,
+      deflateJson({
+        sub: [`1/graphqlsubscriptions/17867973967082385/{"input_data":{"user_id":"${this.userId}"}}`],
+      }),
+    )
+  }
+
+  private handlePublish(topic: string, payload: Buffer): void {
+    if (topic !== TOPIC_MESSAGE_SYNC) return
+
+    let envelopes: IrisEnvelope[]
+    try {
+      envelopes = JSON.parse(inflateIfNeeded(payload).toString('utf8')) as IrisEnvelope[]
+    } catch (error) {
+      this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+      return
+    }
+
+    for (const envelope of envelopes) {
+      for (const patch of envelope.data ?? []) {
+        const message = this.decodeDmPatch(patch)
+        if (message) this.emitter.emit('message', message)
+      }
+    }
+  }
+
+  private decodeDmPatch(patch: IrisPatch): InstagramMessageSummary | null {
+    if (patch.op !== 'add') return null
+    if (!patch.path || !patch.value || !DM_THREAD_PATH_PATTERN.test(patch.path)) return null
+
+    const threadId = patch.path.match(THREAD_ID_PATTERN)?.[1] ?? ''
+
+    let item: Record<string, unknown>
+    try {
+      item = JSON.parse(patch.value) as Record<string, unknown>
+    } catch {
+      return null
+    }
+
+    const itemId = String(item['item_id'] ?? '')
+    const fromUserId = String(item['user_id'] ?? '')
+    const timestampUs = item['timestamp'] as number | string | undefined
+
+    return {
+      id: itemId,
+      thread_id: threadId,
+      from: fromUserId,
+      timestamp: timestampUs ? new Date(Number(timestampUs) / 1000).toISOString() : new Date().toISOString(),
+      is_outgoing: fromUserId === this.userId,
+      type: getMessageType(item),
+      text: extractMessageText(item),
+      media_url: extractMediaUrl(item),
+    }
+  }
+}
+
+const APP_VERSION = '312.1.0.34.111'
+
+function deflateJson(value: unknown): Buffer {
+  return deflateSync(JSON.stringify(value), { level: 9 })
+}
+
+function inflateIfNeeded(payload: Buffer): Buffer {
+  if (payload.length > 0 && payload[0] === ZLIB_MAGIC_BYTE) {
+    return inflateSync(payload)
+  }
+  return payload
+}


### PR DESCRIPTION
## Summary

Adds **real-time Instagram DM delivery** to the SDK. Until now, Instagram was polling-only (`InstagramListener` hitting the inbox every 5s). This PR adds a listener that streams DMs over Instagram's native **MQTToT** transport — the same protocol Instagram's own app uses — built from scratch over Node's `tls` with **no third-party SDK** (no `instagram-private-api`, no `instagram_mqtt`, no `mqtts`), in keeping with this repo's hand-rolled-client convention.

The new `InstagramHybridListener` is the recommended entry point: it connects over MQTToT first and **falls back to polling automatically** if realtime can't be established, retrying realtime with capped backoff. The existing polling `InstagramListener` is unchanged and still exported.

> Same auth model and same private-API risk surface as the existing poller — no new credential flow. Realtime is driven entirely by the session this codebase already has.

## What's included

**MQTToT wire layer** (`src/platforms/instagram/mqtt/`)
- `thrift.ts` — Thrift Compact encoder (zigzag varints, delta field IDs, packed list/map/struct headers) for the CONNECT payload, with unit tests against hand-derived byte vectors
- `transport.ts` — minimal MQTT3 framing over TLS to `edge-mqtt.facebook.com` (CONNECT/CONNACK/PUBLISH/PUBACK/PINGREQ/SUBSCRIBE), QoS-1 acks, 60s keepalive
- `connection.ts` — builds the CONNECT payload from the existing session; extracts `sessionid` from the `Bearer IGT:2` authorization token (falls back to the cookie jar)

**Listeners**
- `InstagramRealtimeListener` — iris/skywalker/graphql subscriptions, decodes the `/ig_message_sync` topic into `InstagramMessageSummary`, same event contract as the poller
- `InstagramHybridListener` — tries realtime, falls back to polling with capped exponential backoff; its `connected` event reports `{ userId, transport: 'realtime' | 'polling' }`

**Client support** (`client.ts`)
- `fetchIrisBootstrap()` — pulls `seq_id` + `snapshot_at_ms` from `/direct_v2/inbox/` to seed the realtime sync (realtime startup fails over to polling if these are missing)
- `getSessionState()` — exposes the session for the CONNECT handshake

**SDK surface** — exports `InstagramRealtimeListener`, `InstagramHybridListener`, and their event-map / options types from `agent-messenger/instagram`.

## Architecture

```
InstagramListener         polling (existing, unchanged) — the fallback
InstagramRealtimeListener  MQTToT realtime, same event contract
InstagramHybridListener    tries realtime → falls back to polling + backoff
```

All three share the identical EventEmitter contract (`message` / `error` / `connected` / `disconnected`), so realtime is a drop-in for polling. The risky transport is isolated: a protocol bug degrades to polling rather than breaking the platform.

## Docs

- README: new **Real-time Events (Instagram)** section (the feature table already listed Instagram realtime as ✅; this backs it up)
- SDK reference (`docs/.../sdk/instagram.mdx`): documents the hybrid + realtime listeners; updated message-monitor example
- CLI reference + `skills/agent-instagram/SKILL.md`: corrected the stale "no persistent connection" claims to scope them to the CLI, and added an **SDK: Real-Time Events** section
- `common-patterns.md`, TUI docs, and the poll-based monitor template updated to point at the SDK listener

## Verification

- `bun lint` — 0 warnings / 0 errors
- `bun typecheck` — clean
- `bun run test` — **3365 pass / 0 fail** (12 new Thrift codec tests)
- **Validated against the live Instagram MQTT server**: cookie-driven CONNECT → CONNACK, subscribed, and received a real DM over the realtime stream end-to-end (decoded correctly to `InstagramMessageSummary`)

> Note on `format:check`: the docs subproject's `globals.css` references `fumadocs-ui` (not installed in a bare worktree) — this failure is **pre-existing on `main`** and unrelated to this PR (see #265, #267). All changed source files are format-clean (`oxfmt --check`).

## Notes

- **Unofficial API.** Like the existing poller, realtime uses Instagram's private mobile API — not the official Graph API. MQTT doesn't add a new risk category; done accurately it presents a more app-like footprint than 5s polling. The hybrid listener's polling fallback keeps the feature resilient if the protocol shifts.
- No CLI `watch` command is added — the listeners are SDK-only (same as the prior poller).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-time Instagram DM streaming over MQTToT with a new `InstagramRealtimeListener`, plus an `InstagramHybridListener` that falls back to polling with capped backoff. This delivers instant DMs while keeping the existing poller unchanged.

- **New Features**
  - Hand-rolled MQTToT stack: Thrift Compact encoder (with unit tests), MQTT3/TLS transport (QoS-1 acks, 60s keepalive, CONNACK timeout), CONNECT payload builder (extracts `sessionid` from IGT token or cookies).
  - `InstagramRealtimeListener`: streams DMs from topic 146 (`/ig_message_sync`); same event names as the poller.
  - `InstagramHybridListener`: prefers realtime, falls back to polling; `connected` includes `{ transport }`; capped exponential backoff.
  - Client: `fetchIrisBootstrap()` and `getSessionState()` for realtime bootstrap.
  - SDK exports updated in `agent-messenger/instagram`.

- **Docs**
  - README and SDK docs: new Real-time Events section and listener guides.
  - CLI docs: note that CLI remains HTTP-only; realtime is available via the SDK.
  - Skills: updated `skills/agent-instagram/SKILL.md`, `references/common-patterns.md`, and `templates/monitor-chat.sh` with realtime guidance.

<sup>Written for commit e943ac675c832527c64593dcfb0b0f27a9e72250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

