### PR TITLE
fix(instagram): harden username/password login flow

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -74,6 +74,15 @@ function urlParamsBody(callIndex = 0): Record<string, string> {
   return Object.fromEntries(new URLSearchParams(raw))
 }
 
+function signedBody(callIndex = 0): Record<string, string> {
+  const raw = fetchCalls[callIndex]?.init?.body
+  if (!raw || typeof raw !== 'string') return {}
+  const signed = new URLSearchParams(raw).get('signed_body')
+  if (!signed) return {}
+  const json = signed.slice(signed.indexOf('.') + 1)
+  return JSON.parse(json) as Record<string, string>
+}
+
 async function loadedClient(): Promise<InstagramClient> {
   const client = new InstagramClient()
   await client.loadSession(sessionPath)
@@ -115,43 +124,39 @@ describe('InstagramClient', () => {
     })
   })
 
-  describe('plaintextPassword format', () => {
-    it('produces #PWD_INSTAGRAM:0:timestamp:rawpassword format', async () => {
-      fetchResponses.push(
-        new Response(null, {
-          status: 200,
-          headers: {},
-        }),
-      )
-      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
+  function encryptionKeyResponse(): Response {
+    return new Response(null, {
+      status: 200,
+      headers: new Headers({
+        'ig-set-password-encryption-pub-key': rsaPublicKeyBase64,
+        'ig-set-password-encryption-key-id': '7',
+      }),
+    })
+  }
+
+  describe('authenticate password encryption', () => {
+    it('fails closed when Instagram returns no encryption key', async () => {
+      fetchResponses.push(new Response(null, { status: 200, headers: {} }))
 
       const client = new InstagramClient()
-      const before = Math.floor(Date.now() / 1000)
-      await client.authenticate('user', 'mypassword')
-      const after = Math.floor(Date.now() / 1000)
+      const err = await client.authenticate('user', 'mypassword').catch((e: unknown) => e)
 
-      const loginBody = urlParamsBody(1)
-      const encPassword = loginBody['enc_password'] ?? ''
-
-      expect(encPassword).toMatch(/^#PWD_INSTAGRAM:0:\d+:/)
-      const [, , ts, raw] = encPassword.split(':')
-      expect(Number(ts)).toBeGreaterThanOrEqual(before)
-      expect(Number(ts)).toBeLessThanOrEqual(after)
-      expect(raw).toBe('mypassword')
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('encryption_key_missing')
     })
-  })
 
-  describe('encryptPassword format', () => {
+    it('never sends a plaintext password', async () => {
+      fetchResponses.push(new Response(null, { status: 200, headers: {} }))
+
+      const client = new InstagramClient()
+      await client.authenticate('user', 'supersecret').catch(() => undefined)
+
+      const preLoginBody = fetchCalls[0]?.init?.body
+      expect(String(preLoginBody ?? '')).not.toContain('supersecret')
+    })
+
     it('produces #PWD_INSTAGRAM:4:timestamp:base64 format when encryption key provided', async () => {
-      fetchResponses.push(
-        new Response(null, {
-          status: 200,
-          headers: new Headers({
-            'ig-set-password-encryption-pub-key': rsaPublicKeyBase64,
-            'ig-set-password-encryption-key-id': '7',
-          }),
-        }),
-      )
+      fetchResponses.push(encryptionKeyResponse())
       fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
 
       const client = new InstagramClient()
@@ -159,7 +164,7 @@ describe('InstagramClient', () => {
       await client.authenticate('user', 'secret')
       const after = Math.floor(Date.now() / 1000)
 
-      const loginBody = urlParamsBody(1)
+      const loginBody = signedBody(1)
       const encPassword = loginBody['enc_password'] ?? ''
 
       expect(encPassword).toMatch(/^#PWD_INSTAGRAM:4:\d+:.+/)
@@ -170,11 +175,50 @@ describe('InstagramClient', () => {
       expect(parts[3]).toBeTruthy()
       expect(() => Buffer.from(parts[3] ?? '', 'base64')).not.toThrow()
     })
+
+    it('signs the login body and includes anti-bot login fields', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
+
+      const client = new InstagramClient()
+      await client.authenticate('user', 'secret')
+
+      const raw = fetchCalls[1]?.init?.body
+      const params = new URLSearchParams(String(raw ?? ''))
+      const signedBodyRaw = params.get('signed_body') ?? ''
+
+      expect(params.get('ig_sig_key_version')).toBe('4')
+      expect(signedBodyRaw).toMatch(/^[a-f0-9]{64}\./)
+
+      const login = signedBody(1)
+      expect(login['jazoest']).toMatch(/^2\d+$/)
+      expect(login['google_tokens']).toBe('[]')
+      expect(login['adid']).toBeTruthy()
+      expect(login['country_codes']).toContain('country_code')
+    })
+
+    it.each(['7abc', '1.5', '-1', '256'])('rejects malformed encryption key id %p', async (keyId) => {
+      fetchResponses.push(
+        new Response(null, {
+          status: 200,
+          headers: new Headers({
+            'ig-set-password-encryption-pub-key': rsaPublicKeyBase64,
+            'ig-set-password-encryption-key-id': keyId,
+          }),
+        }),
+      )
+
+      const client = new InstagramClient()
+      const err = await client.authenticate('user', 'secret').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('encryption_key_invalid')
+    })
   })
 
   describe('buildHeaders', () => {
     it('includes required Instagram headers', async () => {
-      fetchResponses.push(new Response(null, { status: 200, headers: {} }))
+      fetchResponses.push(encryptionKeyResponse())
       fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
 
       const client = new InstagramClient()
@@ -186,6 +230,8 @@ describe('InstagramClient', () => {
       expect(headers['User-Agent']).toMatch(/^Instagram \d+\.\d+\.\d+\.\d+\.\d+ Android \(/)
       expect(headers['X-IG-Capabilities']).toBeTruthy()
       expect(headers['X-IG-Connection-Type']).toBe('WIFI')
+      expect(headers['X-Bloks-Version-Id']).toBeTruthy()
+      expect(headers['X-IG-WWW-Claim']).toBe('0')
       expect(headers['Content-Type']).toContain('application/x-www-form-urlencoded')
     })
 
@@ -386,6 +432,85 @@ describe('InstagramClient', () => {
       expect(body['text']).toBe('Hey there')
       expect(body['action']).toBe('send_item')
       expect(body['client_context']).toBeTruthy()
+    })
+  })
+
+  describe('twoFactorLogin', () => {
+    it('completes via the legacy endpoint and signs the body', async () => {
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '77' } }))
+
+      const client = await loadedClient()
+      const result = await client.twoFactorLogin('user', '123456', 'ident-1')
+
+      expect(result.userId).toBe('77')
+      expect(fetchCalls[0]?.url).toContain('/accounts/two_factor_login/')
+
+      const params = new URLSearchParams(String(fetchCalls[0]?.init?.body ?? ''))
+      expect(params.get('signed_body')).toMatch(/^[a-f0-9]{64}\./)
+      const body = signedBody(0)
+      expect(body['verification_code']).toBe('123456')
+      expect(body['two_factor_identifier']).toBe('ident-1')
+    })
+
+    it('falls back to the Bloks flow when the legacy endpoint rejects params', async () => {
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'Invalid parameters' }, 400))
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '88' } }))
+
+      const client = await loadedClient()
+      const result = await client.twoFactorLogin('user', '654321', 'ctx-9')
+
+      expect(result.userId).toBe('88')
+      expect(fetchCalls[1]?.url).toContain('two_step_verification.verify_code.async')
+
+      const params = new URLSearchParams(String(fetchCalls[1]?.init?.body ?? ''))
+      expect(params.get('signed_body')).toBeNull()
+      expect(params.get('params')).toContain('654321')
+    })
+
+    it('passes the Bloks context from the failed legacy response, not the legacy identifier', async () => {
+      fetchResponses.push(jsonResponse({ status: 'fail', two_step_verification_context: 'real-bloks-ctx' }, 400))
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '88' } }))
+
+      const client = await loadedClient()
+      await client.twoFactorLogin('user', '654321', 'legacy-ident')
+
+      const params = new URLSearchParams(String(fetchCalls[1]?.init?.body ?? ''))
+      const bloksParams = JSON.parse(params.get('params') ?? '{}') as {
+        server_params: { two_step_verification_context: string }
+      }
+      expect(bloksParams.server_params.two_step_verification_context).toBe('real-bloks-ctx')
+    })
+
+    it('resolves the Bloks 2FA user id from the ds_user_id cookie when no logged_in_user is returned', async () => {
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'Invalid parameters' }, 400))
+      fetchResponses.push(
+        jsonResponse({ status: 'ok' }, 200, {
+          'ig-set-authorization': 'Bearer IGT:2:token',
+          'set-cookie': 'ds_user_id=555',
+        }),
+      )
+
+      const client = await loadedClient()
+      client.getSessionState().user_id = undefined
+      const result = await client.twoFactorLogin('user', '654321', 'ctx-9')
+
+      expect(result.userId).toBe('555')
+    })
+
+    it('fails the Bloks 2FA flow when no user id can be resolved', async () => {
+      const noUserSession: InstagramSessionState = { ...SESSION, cookies: '', user_id: undefined }
+      const noUserPath = join(testDir, 'no-user-session.json')
+      writeFileSync(noUserPath, JSON.stringify(noUserSession))
+
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'Invalid parameters' }, 400))
+      fetchResponses.push(jsonResponse({ status: 'ok' }, 200, { 'ig-set-authorization': 'Bearer IGT:2:token' }))
+
+      const client = new InstagramClient()
+      await client.loadSession(noUserPath)
+      const err = await client.twoFactorLogin('user', '654321', 'ctx-9').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('two_factor_failed')
     })
   })
 })

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -1,4 +1,4 @@
-import { constants, createCipheriv, publicEncrypt, randomBytes, randomUUID } from 'node:crypto'
+import { constants, createCipheriv, createHmac, publicEncrypt, randomBytes, randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 
@@ -15,18 +15,43 @@ import {
 
 const IG_BASE_URL = 'https://i.instagram.com/api/v1'
 const IG_APP_ID = '567067343352427'
-const IG_VERSION = '312.1.0.34.111'
-const IG_VERSION_CODE = '556927984'
-const ANDROID_VERSION = '13.0'
-const ANDROID_RELEASE = '33'
+const IG_VERSION = '428.0.0.47.67'
+const IG_VERSION_CODE = '719358530'
+// HMAC-SHA256 key for signing request bodies (signed_body); mandated by the private mobile API.
+const IG_SIGNATURE_KEY = '9193488027538fd3450b83b7d05286d4ca9599a0f7eeed90d8c85925698a05dc'
+const IG_SIGNATURE_VERSION = '4'
+// Bloks client versioning id; required header for Bloks endpoints (2FA / CAA flows).
+const IG_BLOKS_VERSION_ID = '5f56efad68e1edec7801f630b5c122704ec5378adbee6609a448f105f34a9c73'
+const IG_CAPABILITIES = '3brTv10='
+const ANDROID_VERSION = '14'
+const ANDROID_RELEASE = '34'
 const DEVICE_DPI = '480dpi'
-const DEVICE_RESOLUTION = '1080x2340'
-const DEVICE_MANUFACTURER = 'samsung'
-const DEVICE_MODEL = 'SM-S911B'
-const DEVICE_CHIPSET = 'qcom'
+const DEVICE_RESOLUTION = '1344x2992'
+const DEVICE_MANUFACTURER = 'Google/google'
+const DEVICE_MODEL = 'Pixel 8 Pro'
+const DEVICE_NAME = 'husky'
+const DEVICE_CHIPSET = 'husky'
 
 export function generateDeviceString(): string {
-  return `${ANDROID_VERSION}/${ANDROID_RELEASE}; ${DEVICE_DPI}; ${DEVICE_RESOLUTION}; ${DEVICE_MANUFACTURER}; ${DEVICE_MODEL}; ${DEVICE_MODEL}; ${DEVICE_CHIPSET}; en_US; ${IG_VERSION_CODE}`
+  return `${ANDROID_RELEASE}/${ANDROID_VERSION}; ${DEVICE_DPI}; ${DEVICE_RESOLUTION}; ${DEVICE_MANUFACTURER}; ${DEVICE_MODEL}; ${DEVICE_NAME}; ${DEVICE_CHIPSET}; en_US; ${IG_VERSION_CODE}`
+}
+
+function signBody(payload: Record<string, unknown>): Record<string, string> {
+  const json = JSON.stringify(payload)
+  const signature = createHmac('sha256', IG_SIGNATURE_KEY).update(json).digest('hex')
+  return {
+    signed_body: `${signature}.${json}`,
+    ig_sig_key_version: IG_SIGNATURE_VERSION,
+  }
+}
+
+// jazoest = "2" + sum of ASCII byte values of the input; an anti-bot checksum expected by login.
+function createJazoest(input: string): string {
+  let sum = 0
+  for (let i = 0; i < input.length; i++) {
+    sum += input.charCodeAt(i)
+  }
+  return `2${sum}`
 }
 
 function buildUserAgent(deviceString: string): string {
@@ -114,28 +139,34 @@ export class InstagramClient {
     this.session = { cookies: '', device }
 
     const encryptionKey = await this.preLoginFlow()
-    let encPassword: string
-    try {
-      if (encryptionKey) {
-        this.debugLog?.(`encrypting password with key_id=${encryptionKey.keyId}`)
-        encPassword = this.encryptPassword(password, encryptionKey)
-      } else {
-        this.debugLog?.('no encryption key, using plaintext password format')
-        encPassword = this.plaintextPassword(password)
-      }
-    } catch (err) {
-      this.debugLog?.(`encryption failed: ${err}, falling back to plaintext`)
-      encPassword = this.plaintextPassword(password)
+    if (!encryptionKey) {
+      throw new InstagramError(
+        'Instagram did not return a password encryption key. Login cannot proceed safely.',
+        'encryption_key_missing',
+      )
     }
 
-    const { status, data } = await this.request('POST', '/accounts/login/', {
-      username,
-      enc_password: encPassword,
-      guid: device.uuid,
-      phone_id: device.phone_id,
-      device_id: device.android_device_id,
-      login_attempt_count: '0',
-    })
+    this.debugLog?.(`encrypting password with key_id=${encryptionKey.keyId}`)
+    const encPassword = this.encryptPassword(password, encryptionKey)
+
+    const { status, data } = await this.request(
+      'POST',
+      '/accounts/login/',
+      {
+        username,
+        enc_password: encPassword,
+        guid: device.uuid,
+        phone_id: device.phone_id,
+        _csrftoken: this.cookies.get('csrftoken') ?? 'missing',
+        device_id: device.android_device_id,
+        adid: device.advertising_id,
+        google_tokens: '[]',
+        login_attempt_count: '0',
+        country_codes: JSON.stringify([{ country_code: '1', source: ['default'] }]),
+        jazoest: createJazoest(device.phone_id),
+      },
+      { signed: true },
+    )
 
     this.debugLog?.(`login response status=${status} body=${JSON.stringify(data)}`)
 
@@ -166,14 +197,32 @@ export class InstagramClient {
   }
 
   async twoFactorLogin(username: string, code: string, twoFactorIdentifier: string): Promise<{ userId: string }> {
-    const { status, data } = await this.request('POST', '/accounts/two_factor_login/', {
-      username,
-      verification_code: code,
-      two_factor_identifier: twoFactorIdentifier,
-      trust_this_device: '1',
-      guid: this.session?.device.uuid ?? '',
-      device_id: this.session?.device.android_device_id ?? '',
-    })
+    const device = this.session?.device
+    const { status, data } = await this.request(
+      'POST',
+      '/accounts/two_factor_login/',
+      {
+        username,
+        verification_code: code,
+        two_factor_identifier: twoFactorIdentifier,
+        trust_this_device: '1',
+        verification_method: '3',
+        _csrftoken: this.cookies.get('csrftoken') ?? 'missing',
+        guid: device?.uuid ?? '',
+        phone_id: device?.phone_id ?? '',
+        device_id: device?.android_device_id ?? '',
+      },
+      { signed: true },
+    )
+
+    if (this.isBloksTwoFactorFallback(status, data)) {
+      this.debugLog?.('legacy two_factor_login rejected, retrying via Bloks flow')
+      const bloksContext =
+        typeof data['two_step_verification_context'] === 'string'
+          ? data['two_step_verification_context']
+          : twoFactorIdentifier
+      return this.bloksTwoFactorLogin(code, bloksContext)
+    }
 
     if (status !== 200 || data['status'] !== 'ok') {
       const message = (data['message'] as string) ?? 'Two-factor authentication failed'
@@ -182,6 +231,60 @@ export class InstagramClient {
 
     await this.finalizeLogin(data)
     return { userId: this.userId ?? '' }
+  }
+
+  private isBloksTwoFactorFallback(status: number, data: Record<string, unknown>): boolean {
+    if (status === 200 && data['status'] === 'ok') return false
+    const message = ((data['message'] as string) ?? '').trim().toLowerCase()
+    return message === 'invalid parameters' || data['two_step_verification_context'] != null
+  }
+
+  private async bloksTwoFactorLogin(code: string, twoFactorIdentifier: string): Promise<{ userId: string }> {
+    const device = this.session?.device
+    const params = {
+      client_input_params: {
+        code,
+        should_trust_device: 1,
+        family_device_id: device?.phone_id ?? '',
+        device_id: device?.android_device_id ?? '',
+        machine_id: this.session?.mid ?? '',
+      },
+      server_params: {
+        challenge: 'totp',
+        two_step_verification_context: twoFactorIdentifier,
+        flow_source: 'two_factor_login',
+      },
+    }
+
+    const { status, data } = await this.request(
+      'POST',
+      '/bloks/async_action/com.bloks.www.two_step_verification.verify_code.async/',
+      { params: JSON.stringify(params), bk_client_context: JSON.stringify({ bloks_version: IG_BLOKS_VERSION_ID }) },
+    )
+
+    if (status !== 200 || (data['status'] != null && data['status'] !== 'ok')) {
+      const message = (data['message'] as string) ?? 'Two-factor authentication failed'
+      throw new InstagramError(message, 'two_factor_failed')
+    }
+
+    const loggedInUser = data['logged_in_user'] as Record<string, unknown> | undefined
+    if (loggedInUser) {
+      await this.finalizeLogin(data)
+      return { userId: this.userId ?? '' }
+    }
+
+    if (this.session?.authorization) {
+      const userId = this.session.user_id ?? this.cookies.get('ds_user_id')
+      if (!userId) {
+        throw new InstagramError('Two-factor authentication failed', 'two_factor_failed')
+      }
+      this.userId = userId
+      this.session.user_id = userId
+      await this.saveSession()
+      return { userId }
+    }
+
+    throw new InstagramError('Two-factor authentication failed', 'two_factor_failed')
   }
 
   async challengeSendCode(
@@ -453,12 +556,20 @@ export class InstagramClient {
     const response = await fetch(url, {
       method: 'POST',
       headers,
-      body: new URLSearchParams({
-        id: this.session!.device.uuid,
-        experiments: 'ig_android_fci,ig_android_device_detection_info_upload,ig_android_device_verification_fb_signup',
-      }).toString(),
+      body: new URLSearchParams(
+        signBody({
+          id: this.session!.device.uuid,
+          experiments:
+            'ig_android_fci,ig_android_device_detection_info_upload,ig_android_device_verification_fb_signup',
+        }),
+      ).toString(),
     })
     this.extractResponseCookies(response.headers)
+
+    const wwwClaim = response.headers.get('x-ig-set-www-claim')
+    if (wwwClaim && this.session) {
+      this.session.www_claim = wwwClaim
+    }
 
     const pubKeyHeader = response.headers.get('ig-set-password-encryption-pub-key')
     const keyIdHeader = response.headers.get('ig-set-password-encryption-key-id')
@@ -487,8 +598,15 @@ export class InstagramClient {
     const pubKeyPem = Buffer.from(key.publicKey, 'base64').toString('utf-8')
     const rsaEncrypted = publicEncrypt({ key: pubKeyPem, padding: constants.RSA_PKCS1_PADDING }, aesKey)
 
+    if (!/^(?:0|[1-9]\d*)$/.test(key.keyId)) {
+      throw new InstagramError(`Invalid password encryption key id: ${key.keyId}`, 'encryption_key_invalid')
+    }
+    const keyIdNum = Number(key.keyId)
+    if (keyIdNum > 255) {
+      throw new InstagramError(`Invalid password encryption key id: ${key.keyId}`, 'encryption_key_invalid')
+    }
+
     // Wire format: version(1) | keyId(1) | iv(12) | rsaLen(2 LE) | rsaEncrypted | tag(16) | aesEncrypted
-    const keyIdNum = Number.parseInt(key.keyId, 10)
     const buf = Buffer.alloc(1 + 1 + 12 + 2 + rsaEncrypted.length + 16 + encrypted.length)
     let offset = 0
     buf.writeUInt8(1, offset)
@@ -508,30 +626,32 @@ export class InstagramClient {
     return `#PWD_INSTAGRAM:4:${timestamp}:${buf.toString('base64')}`
   }
 
-  private plaintextPassword(password: string): string {
-    const timestamp = Math.floor(Date.now() / 1000).toString()
-    return `#PWD_INSTAGRAM:0:${timestamp}:${password}`
-  }
-
   private async request(
     method: string,
     path: string,
     body?: Record<string, string>,
+    options?: { signed?: boolean },
   ): Promise<{ status: number; data: Record<string, unknown> }> {
     const url = `${IG_BASE_URL}${path}`
     const headers = this.buildHeaders()
 
-    const options: RequestInit = { method, headers }
+    const requestInit: RequestInit = { method, headers }
     if (body) {
-      options.body = new URLSearchParams(body).toString()
+      const payload = options?.signed ? signBody(body) : body
+      requestInit.body = new URLSearchParams(payload).toString()
     }
 
-    const response = await fetch(url, options)
+    const response = await fetch(url, requestInit)
     this.extractResponseCookies(response.headers)
 
     const authHeader = response.headers.get('ig-set-authorization')
     if (authHeader && this.session) {
       this.session.authorization = authHeader
+    }
+
+    const wwwClaim = response.headers.get('x-ig-set-www-claim')
+    if (wwwClaim && this.session) {
+      this.session.www_claim = wwwClaim
     }
 
     if (response.status === 429) {
@@ -553,17 +673,22 @@ export class InstagramClient {
     const headers: Record<string, string> = {
       'User-Agent': buildUserAgent(deviceString),
       'X-IG-App-ID': IG_APP_ID,
-      'X-IG-Capabilities': '3brTv10=',
+      'X-IG-Capabilities': IG_CAPABILITIES,
       'X-IG-Connection-Type': 'WIFI',
       'X-IG-Timezone-Offset': String(new Date().getTimezoneOffset() * -60),
+      'X-Bloks-Version-Id': IG_BLOKS_VERSION_ID,
+      'X-FB-HTTP-Engine': 'Liger',
       'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
       Accept: '*/*',
       'Accept-Language': 'en-US,en;q=0.9',
     }
 
+    headers['X-IG-WWW-Claim'] = this.session?.www_claim ?? '0'
+
     if (this.session) {
       headers['X-IG-Device-ID'] = this.session.device.uuid
       headers['X-IG-Android-ID'] = this.session.device.android_device_id
+      headers['X-IG-Family-Device-ID'] = this.session.device.phone_id
       if (this.session.authorization) {
         headers['Authorization'] = this.session.authorization
       }

--- a/src/platforms/instagram/types.ts
+++ b/src/platforms/instagram/types.ts
@@ -73,6 +73,7 @@ export interface InstagramSessionState {
   authorization?: string
   user_id?: string
   mid?: string
+  www_claim?: string
   challenge_path?: string
 }
 


### PR DESCRIPTION
## Summary

Audited the Instagram username/password login path and brought it in line with the current private mobile-API requirements (cross-checked against `dilame/instagram-private-api` and `subzeroid/instagrapi`). The most important change removes an **unsafe plaintext-password fallback**; the rest close correctness gaps that cause the mobile API to challenge or reject logins.

The browser cookie-extraction path (`auth extract`) was already correct and is unchanged — it remains the recommended auth method.

## What was wrong

| Severity | Issue |
| --- | --- |
| 🔴 Safety | On any encryption hiccup, login fell back to `#PWD_INSTAGRAM:0:` — sending the **raw password** in the request body (leaks to logs/proxies/crash dumps). The mobile API rejects `:0:` anyway. |
| 🔴 Correctness | POST bodies were **not signed** — the mobile API requires the `signed_body` HMAC-SHA256 wrapper. |
| 🟠 Correctness | Login body was missing mandatory fields: `jazoest`, `_csrftoken`, `adid`, `google_tokens`, `country_codes`. |
| 🟠 Correctness | No **Bloks-based 2FA fallback** — accounts on Instagram's newer flow reject the legacy `two_factor_login` endpoint. |
| 🟡 Correctness | Missing headers: `X-Bloks-Version-Id`, `X-IG-WWW-Claim`, `X-FB-HTTP-Engine`, `X-IG-Family-Device-ID`. |
| 🟡 Hygiene | Stale app version / device fingerprint; `keyId` not range-validated. |

## Changes

- **Fail closed** when Instagram returns no password encryption key — no more plaintext fallback.
- **Sign** `login`, `two_factor_login`, and `qe/sync` bodies with `signed_body` + `ig_sig_key_version`. `direct_v2` broadcast and other endpoints remain **unsigned** (matches reference libraries — signing them would break message sending).
- Add mandatory login fields (`jazoest`, `_csrftoken`, `adid`, `google_tokens`, `country_codes`).
- Add a **Bloks 2FA fallback** (`com.bloks.www.two_step_verification.verify_code.async`) triggered when the legacy endpoint returns `invalid parameters` / a `two_step_verification_context`.
- Send the missing headers and track the rotating `X-IG-WWW-Claim`.
- Validate the encryption `keyId` is within `0..255` and fail closed.
- Bump app version / device fingerprint to a current build.

## Note on encryption algorithm

The existing AES-256-GCM + RSA-PKCS1v1.5 envelope and the `version|keyId|iv|rsaLen(2 LE)|rsaEncrypted|tag|aesEncrypted` wire format are **correct** for the mobile API — verified byte-for-byte against both reference libraries. No change needed there.

## Testing

- Added tests: fail-closed on missing key, no-plaintext guarantee, signed login body + anti-bot fields, legacy 2FA signing, and Bloks 2FA fallback.
- `bun lint` ✅ · `bun typecheck` ✅ · `bun run test` ✅ (3375 pass, 0 fail)
- `format:check` fails only on a **pre-existing** unrelated `docs/` CSS import issue present on `main` (`fumadocs-ui/css/neutral.css`); the three changed files pass `oxfmt --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Instagram username/password login to match current mobile private-API requirements. Removes the unsafe plaintext fallback, signs login and 2FA requests, and adds a Bloks-based 2FA fallback.

- **Bug Fixes**
  - Fail closed when the encryption key is missing; never send plaintext passwords.
  - Sign `login`, `two_factor_login`, and `qe/sync` bodies with `signed_body` + `ig_sig_key_version`.
  - Include required fields: `jazoest`, `_csrftoken`, `adid`, `google_tokens`, `country_codes`.
  - Add Bloks 2FA fallback (`two_step_verification.verify_code.async`) when legacy 2FA is rejected; resolve user id from `ds_user_id` if needed.
  - Send required headers (`X-Bloks-Version-Id`, `X-IG-WWW-Claim`, `X-FB-HTTP-Engine`, `X-IG-Family-Device-ID`) and track `X-IG-WWW-Claim`.
  - Validate encryption `keyId` range (`0..255`) and update app/device fingerprint.

- **Migration**
  - No action needed. SKILL.md/docs: not updated.

<sup>Written for commit 963e35ff7d55486c7f22036b125ec76c96031d40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

