### PR TITLE
fix(instagram): use SIGNATURE. body format for username/password login

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -187,14 +187,41 @@ describe('InstagramClient', () => {
       const params = new URLSearchParams(String(raw ?? ''))
       const signedBodyRaw = params.get('signed_body') ?? ''
 
-      expect(params.get('ig_sig_key_version')).toBe('4')
-      expect(signedBodyRaw).toMatch(/^[a-f0-9]{64}\./)
+      expect(params.get('ig_sig_key_version')).toBeNull()
+      expect(signedBodyRaw).toMatch(/^SIGNATURE\./)
 
       const login = signedBody(1)
       expect(login['jazoest']).toMatch(/^2\d+$/)
       expect(login['google_tokens']).toBe('[]')
       expect(login['adid']).toBeTruthy()
       expect(login['country_codes']).toContain('country_code')
+      expect(login['_csrftoken']).toBeTruthy()
+      expect(login['_csrftoken']).not.toBe('missing')
+    })
+
+    it('signs bodies with the literal SIGNATURE. prefix and no key version', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
+
+      const client = new InstagramClient()
+      await client.authenticate('user', 'secret')
+
+      const preLogin = new URLSearchParams(String(fetchCalls[0]?.init?.body ?? ''))
+      expect(preLogin.get('signed_body')).toMatch(/^SIGNATURE\./)
+      expect(preLogin.get('ig_sig_key_version')).toBeNull()
+    })
+
+    it('uses the configured country code in the login body', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
+
+      const client = new InstagramClient()
+      client.setCountryCode('82')
+      await client.authenticate('user', 'secret')
+
+      const login = signedBody(1)
+      const countryCodes = JSON.parse(login['country_codes'] ?? '[]') as Array<{ country_code: string }>
+      expect(countryCodes[0]?.country_code).toBe('82')
     })
 
     it.each(['7abc', '1.5', '-1', '256'])('rejects malformed encryption key id %p', async (keyId) => {
@@ -446,7 +473,8 @@ describe('InstagramClient', () => {
       expect(fetchCalls[0]?.url).toContain('/accounts/two_factor_login/')
 
       const params = new URLSearchParams(String(fetchCalls[0]?.init?.body ?? ''))
-      expect(params.get('signed_body')).toMatch(/^[a-f0-9]{64}\./)
+      expect(params.get('signed_body')).toMatch(/^SIGNATURE\./)
+      expect(params.get('ig_sig_key_version')).toBeNull()
       const body = signedBody(0)
       expect(body['verification_code']).toBe('123456')
       expect(body['two_factor_identifier']).toBe('ident-1')

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -1,4 +1,4 @@
-import { constants, createCipheriv, createHmac, publicEncrypt, randomBytes, randomUUID } from 'node:crypto'
+import { constants, createCipheriv, publicEncrypt, randomBytes, randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 
@@ -17,9 +17,6 @@ const IG_BASE_URL = 'https://i.instagram.com/api/v1'
 const IG_APP_ID = '567067343352427'
 const IG_VERSION = '428.0.0.47.67'
 const IG_VERSION_CODE = '719358530'
-// HMAC-SHA256 key for signing request bodies (signed_body); mandated by the private mobile API.
-const IG_SIGNATURE_KEY = '9193488027538fd3450b83b7d05286d4ca9599a0f7eeed90d8c85925698a05dc'
-const IG_SIGNATURE_VERSION = '4'
 // Bloks client versioning id; required header for Bloks endpoints (2FA / CAA flows).
 const IG_BLOKS_VERSION_ID = '5f56efad68e1edec7801f630b5c122704ec5378adbee6609a448f105f34a9c73'
 const IG_CAPABILITIES = '3brTv10='
@@ -36,13 +33,12 @@ export function generateDeviceString(): string {
   return `${ANDROID_RELEASE}/${ANDROID_VERSION}; ${DEVICE_DPI}; ${DEVICE_RESOLUTION}; ${DEVICE_MANUFACTURER}; ${DEVICE_MODEL}; ${DEVICE_NAME}; ${DEVICE_CHIPSET}; en_US; ${IG_VERSION_CODE}`
 }
 
+// Instagram no longer verifies the body HMAC; the current mobile API expects a literal
+// "SIGNATURE." prefix (per subzeroid/instagrapi, subzeroid/aiograpi). Sending a real HMAC +
+// ig_sig_key_version is rejected as malformed on /accounts/login/, surfacing as a misleading
+// "account not found" error. URLSearchParams url-encodes the value exactly once.
 function signBody(payload: Record<string, unknown>): Record<string, string> {
-  const json = JSON.stringify(payload)
-  const signature = createHmac('sha256', IG_SIGNATURE_KEY).update(json).digest('hex')
-  return {
-    signed_body: `${signature}.${json}`,
-    ig_sig_key_version: IG_SIGNATURE_VERSION,
-  }
+  return { signed_body: `SIGNATURE.${JSON.stringify(payload)}` }
 }
 
 // jazoest = "2" + sum of ASCII byte values of the input; an anti-bot checksum expected by login.
@@ -52,6 +48,10 @@ function createJazoest(input: string): string {
     sum += input.charCodeAt(i)
   }
   return `2${sum}`
+}
+
+function generateToken(): string {
+  return randomBytes(16).toString('hex')
 }
 
 function buildUserAgent(deviceString: string): string {
@@ -73,9 +73,14 @@ export class InstagramClient {
   private sessionPath: string | null = null
   private userId: string | null = null
   private cookies: Map<string, string> = new Map()
+  private countryCode = '1'
 
   constructor(credentialManager?: InstagramCredentialManager) {
     this.credentialManager = credentialManager ?? new InstagramCredentialManager()
+  }
+
+  setCountryCode(code: string): void {
+    this.countryCode = code
   }
 
   async login(credentials?: { username: string; password: string }, accountId?: string): Promise<this> {
@@ -157,12 +162,12 @@ export class InstagramClient {
         enc_password: encPassword,
         guid: device.uuid,
         phone_id: device.phone_id,
-        _csrftoken: this.cookies.get('csrftoken') ?? 'missing',
+        _csrftoken: this.cookies.get('csrftoken') ?? generateToken(),
         device_id: device.android_device_id,
         adid: device.advertising_id,
         google_tokens: '[]',
         login_attempt_count: '0',
-        country_codes: JSON.stringify([{ country_code: '1', source: ['default'] }]),
+        country_codes: JSON.stringify([{ country_code: this.countryCode, source: ['default'] }]),
         jazoest: createJazoest(device.phone_id),
       },
       { signed: true },
@@ -207,7 +212,7 @@ export class InstagramClient {
         two_factor_identifier: twoFactorIdentifier,
         trust_this_device: '1',
         verification_method: '3',
-        _csrftoken: this.cookies.get('csrftoken') ?? 'missing',
+        _csrftoken: this.cookies.get('csrftoken') ?? generateToken(),
         guid: device?.uuid ?? '',
         phone_id: device?.phone_id ?? '',
         device_id: device?.android_device_id ?? '',


### PR DESCRIPTION
## Summary

Follow-up to #272. Fixes username/password login failing with a misleading **"We can't find an account with `<username>`"** error even for accounts that clearly exist.

## Root cause

#272 added real HMAC-SHA256 body signing (`signed_body=<hmac>.<json>` + `ig_sig_key_version=4`). But Instagram's current private mobile API **no longer verifies the body HMAC** — and sending a real HMAC with `ig_sig_key_version` is now *rejected as a malformed request* on `/accounts/login/`. Instagram surfaces that rejection as the generic **"account not found"** message rather than a signing error, which is why an existing account looks like it doesn't exist.

Verified against the current reference libraries:
- [`subzeroid/instagrapi`](https://github.com/subzeroid/instagrapi/blob/master/instagrapi/utils/auth.py) — `generate_signature()` returns `signed_body=SIGNATURE.<data>` (literal `SIGNATURE.`, no HMAC, no key version).
- [`subzeroid/aiograpi`](https://github.com/subzeroid/aiograpi/blob/main/aiograpi/utils/auth.py) — same.
- Multiple downstream clients (threads-api, etc.) send the same `SIGNATURE.` prefix.

## Changes

- **Signing**: `signBody()` now emits the literal `signed_body=SIGNATURE.<json>` prefix and drops `ig_sig_key_version` / the HMAC key. `URLSearchParams` URL-encodes the value exactly once, matching the reference wire format.
- **`_csrftoken`**: replaced the literal fallback string `'missing'` with a generated token when Instagram hasn't yet issued a `csrftoken` cookie (matches `instagrapi`). Applied to both `authenticate()` and `twoFactorLogin()`.
- **`country_codes`**: made the login country code configurable via `setCountryCode()` instead of hardcoding US (`'1'`); default unchanged.

The AES-256-GCM + RSA password envelope, the required headers (`X-Bloks-Version-Id`, `X-IG-WWW-Claim`, `X-FB-HTTP-Engine`, `X-IG-Family-Device-ID`), the anti-bot login fields (`jazoest`, `adid`, `google_tokens`, `country_codes`), and the Bloks 2FA fallback from #272 are all **unchanged**.

## Testing

- Updated the two signing assertions to expect the `SIGNATURE.` prefix and no `ig_sig_key_version`.
- Added tests: `SIGNATURE.` prefix on signed bodies, `setCountryCode()` reflected in the login body, and `_csrftoken` no longer being the literal `'missing'`.
- `bun lint` passes, `bun typecheck` passes, `bun run test` passes (3384 pass, 0 fail), changed files pass `oxfmt --check`.
- `format:check` fails only on the **pre-existing** unrelated `docs/` CSS import issue (`fumadocs-ui/css/neutral.css`), same as noted on #272.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Instagram username/password login by switching to the literal SIGNATURE.<json> body format, preventing false “account not found” errors. Also generates a real CSRF token and lets clients set the login country code.

- **Bug Fixes**
  - Sign request bodies as `signed_body=SIGNATURE.<json>` and remove `ig_sig_key_version`.
  - Generate a CSRF token when missing for login and 2FA instead of `'missing'`.
  - Add `setCountryCode()` to control `country_codes` (default `'1'`).
  - SKILL.md/docs not updated.

<sup>Written for commit 5a287bebaff97e57b0d0fc33a85c48a3777c41af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

