### PR TITLE
fix(instagram): stop trimming interactive password input

### DIFF
--- a/src/platforms/instagram/commands/auth.test.ts
+++ b/src/platforms/instagram/commands/auth.test.ts
@@ -10,7 +10,7 @@ const mockListAccounts = mock(() => Promise.resolve([]))
 const mockSetCurrent = mock(() => Promise.resolve(true))
 const mockRemoveAccount = mock(() => Promise.resolve(true))
 
-import { authCommand } from './auth'
+import { authCommand, sanitizePassword } from './auth'
 
 function resetCommandState(cmd: Command): void {
   for (const sub of cmd.commands) {
@@ -214,6 +214,31 @@ describe('auth commands', () => {
 
       const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(output.error).toContain('missing_account')
+    })
+  })
+
+  describe('sanitizePassword', () => {
+    it('preserves leading and trailing whitespace', () => {
+      expect(sanitizePassword('  pass word  ')).toBe('  pass word  ')
+      expect(sanitizePassword('\tpw\t')).toBe('\tpw\t')
+    })
+
+    it('preserves internal characters exactly', () => {
+      expect(sanitizePassword('p@$$ w0rd!#')).toBe('p@$$ w0rd!#')
+    })
+
+    it('strips only a trailing carriage return', () => {
+      expect(sanitizePassword('secret\r')).toBe('secret')
+      expect(sanitizePassword('sec\rret')).toBe('sec\rret')
+    })
+
+    it('returns undefined for empty input', () => {
+      expect(sanitizePassword('')).toBeUndefined()
+      expect(sanitizePassword('\r')).toBeUndefined()
+    })
+
+    it('keeps a whitespace-only password (not treated as empty)', () => {
+      expect(sanitizePassword('   ')).toBe('   ')
     })
   })
 })

--- a/src/platforms/instagram/commands/auth.ts
+++ b/src/platforms/instagram/commands/auth.ts
@@ -26,6 +26,13 @@ async function promptText(message: string): Promise<string | undefined> {
   }
 }
 
+// Never trim passwords: they may contain leading/trailing spaces. Trimming corrupts them and
+// Instagram rejects the login as bad_password. Only strip the trailing CR some terminals add.
+export function sanitizePassword(raw: string): string | undefined {
+  const password = raw.replace(/\r$/, '')
+  return password.length > 0 ? password : undefined
+}
+
 async function promptHidden(message: string): Promise<string | undefined> {
   const { createInterface } = await import('node:readline/promises')
   const hiddenOutput = new (class extends Writable {
@@ -41,7 +48,7 @@ async function promptHidden(message: string): Promise<string | undefined> {
     process.stdout.write(`${message}: `)
     const answer = await rl.question('')
     process.stdout.write('\n')
-    return answer.trim() || undefined
+    return sanitizePassword(answer)
   } finally {
     hiddenOutput.muted = false
     rl.close()


### PR DESCRIPTION
## Summary

Defensive hardening for the interactive password prompt. **Note: this is not the fix for the Facebook-linked-account login failure** that motivated the investigation — that turned out to be an account-policy rejection (Instagram steers Facebook-linked accounts away from private-API password login), tracked separately. This PR is a standalone correctness fix worth landing on its own merits.

## What was wrong

The hidden password prompt ran `answer.trim()`:

```ts
const answer = await rl.question('')
return answer.trim() || undefined   // corrupts passwords with leading/trailing whitespace
```

`readline.question()` already strips the trailing newline, so `.trim()` only serves to mutate valid passwords that contain leading or trailing whitespace — the wrong password would then be encrypted and sent. Usernames and 2FA codes are still trimmed (correct for those).

## Changes

- Extract a pure, exported `sanitizePassword()` helper that:
  - **never trims** — preserves the password verbatim, including leading/trailing spaces
  - strips only a trailing `\r` (some terminals append CR)
  - returns `undefined` for empty input
- `promptHidden()` delegates to it.

## Testing

- Added `sanitizePassword` unit tests: preserves leading/trailing whitespace, preserves internal special chars, strips only a trailing CR (not internal), returns `undefined` for empty/CR-only, keeps whitespace-only passwords.
- `bun lint` ✅ · `bun typecheck` ✅ · `bun run test` ✅ (3389 pass, 0 fail) · changed files pass `oxfmt --check` ✅
- `format:check` fails only on the pre-existing unrelated `docs/` CSS import issue, same as #272/#273.

Follow-up to #273.