### PR TITLE
fix(instagram): detect Facebook-linked accounts and guide to auth extract

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -243,6 +243,51 @@ describe('InstagramClient', () => {
     })
   })
 
+  describe('authenticate Facebook-linked accounts', () => {
+    it('throws a clear facebook_linked error when Instagram offers login_with_facebook', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(
+        jsonResponse(
+          {
+            status: 'fail',
+            error_type: 'bad_password',
+            message: 'You can log in with your linked Facebook account.',
+            buttons: [
+              { title: 'Use Facebook', action: 'login_with_facebook' },
+              { title: 'Try again', action: 'dismiss' },
+            ],
+          },
+          400,
+        ),
+      )
+
+      const client = new InstagramClient()
+      const err = await client.authenticate('user', 'secret').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('facebook_linked')
+      expect((err as InstagramError).message).toContain('auth extract')
+      expect((err as InstagramError).message).toContain('password')
+      expect((err as InstagramError).message).toContain('unlink Facebook')
+    })
+
+    it('throws the generic login error for a real bad_password without the Facebook button', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(
+        jsonResponse(
+          { status: 'fail', error_type: 'bad_password', message: 'The password you entered is incorrect.' },
+          400,
+        ),
+      )
+
+      const client = new InstagramClient()
+      const err = await client.authenticate('user', 'secret').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('bad_password')
+    })
+  })
+
   describe('buildHeaders', () => {
     it('includes required Instagram headers', async () => {
       fetchResponses.push(encryptionKeyResponse())

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -192,6 +192,20 @@ export class InstagramClient {
       return { userId: '', challengeRequired: true, challengePath: challengeApiPath }
     }
 
+    if (this.isFacebookLinkedLogin(data)) {
+      throw new InstagramError(
+        'This account appears to sign in with Facebook and has no usable Instagram password for CLI login. ' +
+          'Most reliable fix: log in to instagram.com in your browser, then run "agent-instagram auth extract". ' +
+          'Alternatively, give the account its own password: in the Instagram app go to ' +
+          'Menu > Settings and privacy > Accounts Center > Password and security > Change password. ' +
+          'If it will not let you set one, unlink Facebook in the same app under ' +
+          'Menu > Settings and privacy > Accounts Center > Accounts > Remove (next to Facebook); ' +
+          'removing it prompts you to create an Instagram password. ' +
+          'Setting a password may enable "auth login", though Instagram can still reject automated logins from a new device.',
+        'facebook_linked',
+      )
+    }
+
     if (status !== 200 || data['status'] !== 'ok') {
       const message = (data['message'] as string) ?? 'Login failed'
       throw new InstagramError(message, errorType ?? 'login_failed')
@@ -236,6 +250,12 @@ export class InstagramClient {
 
     await this.finalizeLogin(data)
     return { userId: this.userId ?? '' }
+  }
+
+  private isFacebookLinkedLogin(data: Record<string, unknown>): boolean {
+    const buttons = data['buttons']
+    if (!Array.isArray(buttons)) return false
+    return buttons.some((button) => (button as Record<string, unknown>)?.['action'] === 'login_with_facebook')
   }
 
   private isBloksTwoFactorFallback(status: number, data: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary

Follow-up to #273. When a **Facebook-linked** Instagram account tries username/password login, Instagram's private `/accounts/login/` endpoint returns `error_type: bad_password` with a *"You can log in with your linked Facebook account"* payload — **even when the password is correct**. This PR detects that case and returns a clear, actionable error instead of the misleading `bad_password` message.

## Root cause

For accounts created via / linked to Facebook, Instagram steers login to Facebook OAuth and rejects the native password endpoint. The response is a **policy/flow rejection, not a credential failure**:

```json
{
  "message": "You can log in with your linked Facebook account.",
  "error_type": "bad_password",
  "buttons": [
    { "title": "Use Facebook", "action": "login_with_facebook" },
    { "title": "Try again", "action": "dismiss" }
  ]
}
```

Confirmed by investigation:
- The same password works in the browser and the official app; only the private-API path fails, consistently, after each password reset.
- Neither `subzeroid/instagrapi` nor `dilame/instagram-private-api` supports native password login for Facebook-linked accounts. See [dilame/instagram-private-api#1819 — "IgLoginBadPasswordError when password is actually right"](https://github.com/dilame/instagram-private-api/issues/1819).
- Bloks CAA login still needs a password and also rejects these accounts. FB OAuth (`/fb/facebook_signup/`) works but is interactive and a fragile legacy endpoint. Cookie extraction is the reliable path.
- The AES/RSA envelope, signing, headers, and anti-bot fields are all correct — the request reaches Instagram's credential logic and is rejected by policy.

## Changes

- Add `isFacebookLinkedLogin()` — detects a `login_with_facebook` action in the login response `buttons`.
- In `authenticate()`, when detected, throw `InstagramError(..., 'facebook_linked')` with guidance:
  1. **Reliable fix**: log in at instagram.com in the browser, then run `agent-instagram auth extract` (browser cookies).
  2. **Alternative**: set a native Instagram password (Accounts Center > Password and security, or the password-reset page). If Instagram won't let you set one while Facebook is linked, **unlink Facebook first** (Accounts Center > Connected experiences), then set a password. Worded as it **may** enable `auth login`, since Instagram can still reject automated logins from a new device.
- A genuine `bad_password` **without** the Facebook button still throws the normal error (unchanged).

## Testing

- Tests: FB-linked response throws `facebook_linked` with a message pointing to `auth extract`, setting a password, and unlinking Facebook; a plain `bad_password` (no Facebook button) still throws the generic `bad_password` error.
- `bun lint` ✅ · `bun typecheck` ✅ · `bun run test` ✅ (3386 pass, 0 fail) · changed files pass `oxfmt --check` ✅
- `format:check` fails only on the pre-existing unrelated `docs/` CSS import issue, same as #272/#273.