### PR TITLE
fix(instagram): correct Facebook unlink steps in linked-account error

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -269,6 +269,7 @@ describe('InstagramClient', () => {
       expect((err as InstagramError).message).toContain('auth extract')
       expect((err as InstagramError).message).toContain('password')
       expect((err as InstagramError).message).toContain('unlink Facebook')
+      expect((err as InstagramError).message).toContain('Move out of this Account Center')
     })
 
     it('throws the generic login error for a real bad_password without the Facebook button', async () => {

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -199,7 +199,8 @@ export class InstagramClient {
           'Alternatively, give the account its own password: in the Instagram app go to ' +
           'Menu > Settings and privacy > Accounts Center > Password and security > Change password. ' +
           'If it will not let you set one, unlink Facebook in the same app under ' +
-          'Menu > Settings and privacy > Accounts Center > Accounts > Remove (next to Facebook); ' +
+          'Menu > Settings and privacy > Accounts Center > Manage accounts > (your Facebook profile) Manage > ' +
+          'Move out of this Account Center > Move account > Continue; ' +
           'removing it prompts you to create an Instagram password. ' +
           'Setting a password may enable "auth login", though Instagram can still reject automated logins from a new device.',
         'facebook_linked',

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -196,12 +196,11 @@ export class InstagramClient {
       throw new InstagramError(
         'This account appears to sign in with Facebook and has no usable Instagram password for CLI login. ' +
           'Most reliable fix: log in to instagram.com in your browser, then run "agent-instagram auth extract". ' +
-          'Alternatively, give the account its own password: in the Instagram app go to ' +
-          'Menu > Settings and privacy > Accounts Center > Password and security > Change password. ' +
-          'If it will not let you set one, unlink Facebook in the same app under ' +
+          'Alternatively, give the account its own password. Most reliably, unlink Facebook first: in the Instagram app go to ' +
           'Menu > Settings and privacy > Accounts Center > Manage accounts > (your Facebook profile) Manage > ' +
-          'Move out of this Account Center > Move account > Continue; ' +
-          'removing it prompts you to create an Instagram password. ' +
+          'Move out of this Account Center > Move account > Continue; removing it prompts you to create an Instagram password. ' +
+          'If Facebook is already unlinked, set one directly under ' +
+          'Menu > Settings and privacy > Accounts Center > Password and security > Change password. ' +
           'Setting a password may enable "auth login", though Instagram can still reject automated logins from a new device.',
         'facebook_linked',
       )


### PR DESCRIPTION
## Summary

The `facebook_linked` error (shown when a Facebook-linked Instagram account has no usable password for CLI login) gave an **incorrect** unlink path (`Accounts Center > Accounts > Remove`), a screen that no longer exists. This corrects it to the working **Manage accounts** flow and reorders the guidance so users unlink Facebook **first** (which prompts creating a real Instagram password), with the direct password change as the fallback.

## Full error message (after this PR)

> This account appears to sign in with Facebook and has no usable Instagram password for CLI login. Most reliable fix: log in to instagram.com in your browser, then run `agent-instagram auth extract`. Alternatively, give the account its own password. Most reliably, unlink Facebook first: in the Instagram app go to **Menu > Settings and privacy > Accounts Center > Manage accounts > (your Facebook profile) Manage > Move out of this Account Center > Move account > Continue**; removing it prompts you to create an Instagram password. If Facebook is already unlinked, set one directly under **Menu > Settings and privacy > Accounts Center > Password and security > Change password**. Setting a password may enable `auth login`, though Instagram can still reject automated logins from a new device.

### Recommended paths, in order

1. **Extract from browser (most reliable):** log in at instagram.com, then `agent-instagram auth extract`.
2. **Unlink Facebook (creates a password):** `Menu > Settings and privacy > Accounts Center > Manage accounts > (your Facebook profile) Manage > Move out of this Account Center > Move account > Continue`. Removing it prompts you to create an Instagram password.
3. **Change password directly (if already unlinked):** `Menu > Settings and privacy > Accounts Center > Password and security > Change password`.

## Changes

- `src/platforms/instagram/client.ts` — corrected the unlink steps and reordered the guidance (unlink before change-password) in the `facebook_linked` `InstagramError` message.
- `src/platforms/instagram/client.test.ts` — assert the new "Move out of this Account Center" wording is present.

## Verification

- `bun typecheck` — pass
- `bun lint` — pass (0 warnings, 0 errors)
- `bun test` — 3391 pass, 0 fail

> Note: `bun run format:check` reports a pre-existing, unrelated failure in `docs/src/app/globals.css` (`fumadocs-ui/css/neutral.css` resolution). Not touched by this PR.
