### PR TITLE
feat(instagram): persist a stable device per machine for login trust

### DIFF
--- a/docs/content/docs/cli/instagram.mdx
+++ b/docs/content/docs/cli/instagram.mdx
@@ -179,6 +179,7 @@ Thread IDs are numeric strings returned by `chat list` (e.g. `340282366841710300
 
 - Credentials stored in `~/.config/agent-messenger/instagram-credentials.json`
 - Session data stored in `~/.config/agent-messenger/instagram/<account-id>/`
+- A machine-level device profile (synthetic Android device identifiers, no secrets) stored in `~/.config/agent-messenger/instagram/device.json` and shared across all accounts, so repeat logins present a consistent device fingerprint
 
 ## Limitations
 

--- a/skills/agent-instagram/references/authentication.md
+++ b/skills/agent-instagram/references/authentication.md
@@ -196,10 +196,21 @@ Session data (cookies and tokens) is stored per account:
 ~/.config/agent-messenger/instagram/<account-id>/
 ```
 
+A device profile (randomized Android device identifiers) is generated once and
+shared across all accounts on this machine, so repeat logins present a
+consistent device fingerprint:
+
+```
+~/.config/agent-messenger/instagram/device.json
+```
+
 ### Security
 
 - Credentials file permissions: `0600` (owner read/write only)
 - Session cookies are stored in plaintext on disk
+- `device.json` holds no secrets — only synthetic device identifiers — but is
+  shared across accounts, so all accounts on this machine share one device
+  fingerprint
 - Keep these files secure. They grant full access to your Instagram account
 - Never commit to version control
 

--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { InstagramClient } from '@/platforms/instagram/client'
+import { InstagramCredentialManager } from '@/platforms/instagram/credential-manager'
 import { InstagramError, type InstagramSessionState } from '@/platforms/instagram/types'
 
 const testDir = join(import.meta.dir, `.test-client-${Date.now()}`)
@@ -23,10 +24,13 @@ const SESSION: InstagramSessionState = {
 }
 
 let rsaPublicKeyBase64: string
+const originalConfigDir = process.env['AGENT_MESSENGER_CONFIG_DIR']
 
 beforeAll(() => {
   mkdirSync(testDir, { recursive: true })
   writeFileSync(sessionPath, JSON.stringify(SESSION))
+  // Sandbox default-manager writes (e.g. device.json) so tests never touch the real config dir.
+  process.env['AGENT_MESSENGER_CONFIG_DIR'] = join(testDir, 'config')
 
   const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 1024 })
   const pem = publicKey.export({ type: 'pkcs1', format: 'pem' }) as string
@@ -34,6 +38,8 @@ beforeAll(() => {
 })
 
 afterAll(() => {
+  if (originalConfigDir === undefined) delete process.env['AGENT_MESSENGER_CONFIG_DIR']
+  else process.env['AGENT_MESSENGER_CONFIG_DIR'] = originalConfigDir
   rmSync(testDir, { recursive: true, force: true })
 })
 
@@ -285,6 +291,44 @@ describe('InstagramClient', () => {
 
       expect(err).toBeInstanceOf(InstagramError)
       expect((err as InstagramError).code).toBe('bad_password')
+    })
+  })
+
+  describe('device persistence', () => {
+    function loginResponses(): void {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
+    }
+
+    it('reuses the same persisted device across separate authenticate calls', async () => {
+      const dir = join(testDir, `device-reuse-${Math.random().toString(36).slice(2)}`)
+      const manager = new InstagramCredentialManager(dir)
+
+      loginResponses()
+      await new InstagramClient(manager).authenticate('user', 'secret')
+      const firstHeaders = (fetchCalls[1]?.init?.headers ?? {}) as Record<string, string>
+      const firstAndroidId = firstHeaders['X-IG-Android-ID']
+
+      loginResponses()
+      await new InstagramClient(manager).authenticate('user', 'secret')
+      const secondHeaders = (fetchCalls[3]?.init?.headers ?? {}) as Record<string, string>
+      const secondAndroidId = secondHeaders['X-IG-Android-ID']
+
+      expect(firstAndroidId).toBeTruthy()
+      expect(secondAndroidId).toBe(firstAndroidId)
+    })
+
+    it('persists a device the first time authenticate runs', async () => {
+      const dir = join(testDir, `device-create-${Math.random().toString(36).slice(2)}`)
+      const manager = new InstagramCredentialManager(dir)
+      expect(await manager.loadDevice()).toBeNull()
+
+      loginResponses()
+      await new InstagramClient(manager).authenticate('user', 'secret')
+
+      const saved = await manager.loadDevice()
+      expect(saved).not.toBeNull()
+      expect(saved?.android_device_id).toMatch(/^android-[0-9a-f]{16}$/)
     })
   })
 

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -9,6 +9,7 @@ import {
   extractMessageText,
   getMessageType,
   type InstagramChatSummary,
+  type InstagramDevice,
   type InstagramMessageSummary,
   type InstagramSessionState,
 } from './types'
@@ -60,6 +61,17 @@ function buildUserAgent(deviceString: string): string {
 
 export function generateAndroidDeviceId(): string {
   return `android-${randomBytes(8).toString('hex')}`
+}
+
+export function generateDevice(): InstagramDevice {
+  return {
+    phone_id: randomUUID(),
+    uuid: randomUUID(),
+    android_device_id: generateAndroidDeviceId(),
+    advertising_id: randomUUID(),
+    client_session_id: randomUUID(),
+    device_string: generateDeviceString(),
+  }
 }
 
 // Instagram DM timestamps are in microseconds
@@ -131,16 +143,7 @@ export class InstagramClient {
     challengeRequired?: boolean
     challengePath?: string
   }> {
-    const deviceString = generateDeviceString()
-    const device = {
-      phone_id: randomUUID(),
-      uuid: randomUUID(),
-      android_device_id: generateAndroidDeviceId(),
-      advertising_id: randomUUID(),
-      client_session_id: randomUUID(),
-      device_string: deviceString,
-    }
-
+    const device = await this.resolveDevice()
     this.session = { cookies: '', device }
 
     const encryptionKey = await this.preLoginFlow()
@@ -784,6 +787,16 @@ export class InstagramClient {
     }
 
     await this.saveSession()
+  }
+
+  // Reuse one persisted device per machine so repeat logins present a consistent fingerprint.
+  // Regenerating device ids each attempt looks like a brand-new phone and hurts login trust.
+  private async resolveDevice(): Promise<InstagramDevice> {
+    const existing = await this.credentialManager.loadDevice()
+    if (existing) return existing
+    const device = generateDevice()
+    await this.credentialManager.saveDevice(device)
+    return device
   }
 
   private async saveSession(): Promise<void> {

--- a/src/platforms/instagram/commands/auth.ts
+++ b/src/platforms/instagram/commands/auth.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { Writable } from 'node:stream'
 
@@ -10,7 +9,7 @@ import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { info, warn, error as stderrError, debug } from '@/shared/utils/stderr'
 
-import { InstagramClient, generateAndroidDeviceId, generateDeviceString } from '../client'
+import { InstagramClient, generateDevice } from '../client'
 import { InstagramCredentialManager } from '../credential-manager'
 import { InstagramTokenExtractor } from '../token-extractor'
 import { createAccountId } from '../types'
@@ -421,6 +420,12 @@ async function extractAction(options: { pretty?: boolean; debug?: boolean; brows
 
     const manager = new InstagramCredentialManager()
 
+    let device = await manager.loadDevice()
+    if (!device) {
+      device = generateDevice()
+      await manager.saveDevice(device)
+    }
+
     for (const extracted of results) {
       const session = {
         cookies: [
@@ -433,14 +438,7 @@ async function extractAction(options: { pretty?: boolean; debug?: boolean; brows
         ]
           .filter(Boolean)
           .join('; '),
-        device: {
-          phone_id: randomUUID(),
-          uuid: randomUUID(),
-          android_device_id: generateAndroidDeviceId(),
-          advertising_id: randomUUID(),
-          client_session_id: randomUUID(),
-          device_string: generateDeviceString(),
-        },
+        device,
         user_id: extracted.ds_user_id,
         mid: extracted.mid,
       }

--- a/src/platforms/instagram/credential-manager.test.ts
+++ b/src/platforms/instagram/credential-manager.test.ts
@@ -274,4 +274,34 @@ describe('InstagramCredentialManager', () => {
       expect(paths.session_path).toBe(join(testConfigDir, 'instagram', 'my-account', 'session.json'))
     })
   })
+
+  describe('device persistence', () => {
+    const device = {
+      phone_id: 'phone-1',
+      uuid: 'uuid-1',
+      android_device_id: 'android-abcdef0123456789',
+      advertising_id: 'adid-1',
+      client_session_id: 'csid-1',
+      device_string: '34/14; 480dpi; 1344x2992; Google/google; Pixel 8 Pro; husky; husky; en_US; 719358530',
+    }
+
+    it('returns null when no device is stored', async () => {
+      const manager = setup()
+      expect(await manager.loadDevice()).toBeNull()
+    })
+
+    it('persists and reloads the same device', async () => {
+      const manager = setup()
+      await manager.saveDevice(device)
+      expect(await manager.loadDevice()).toEqual(device)
+    })
+
+    it('shares one device across accounts (machine-level, not per-account)', async () => {
+      const manager = setup()
+      await manager.saveDevice(device)
+      await manager.setAccount(makeAccount({ account_id: 'a' }))
+      await manager.setAccount(makeAccount({ account_id: 'b' }))
+      expect(await manager.loadDevice()).toEqual(device)
+    })
+  })
 })

--- a/src/platforms/instagram/credential-manager.ts
+++ b/src/platforms/instagram/credential-manager.ts
@@ -3,17 +3,39 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { getConfigDir } from '../../shared/utils/config-dir'
-import { createAccountId, type InstagramAccount, type InstagramAccountPaths, type InstagramConfig } from './types'
+import {
+  createAccountId,
+  type InstagramAccount,
+  type InstagramAccountPaths,
+  type InstagramConfig,
+  type InstagramDevice,
+} from './types'
 
 export class InstagramCredentialManager {
   private configDir: string
   private credentialsPath: string
   private instagramRootDir: string
+  private devicePath: string
 
   constructor(configDir?: string) {
     this.configDir = configDir ?? getConfigDir()
     this.credentialsPath = join(this.configDir, 'instagram-credentials.json')
     this.instagramRootDir = join(this.configDir, 'instagram')
+    this.devicePath = join(this.instagramRootDir, 'device.json')
+  }
+
+  async loadDevice(): Promise<InstagramDevice | null> {
+    if (!existsSync(this.devicePath)) return null
+    try {
+      return JSON.parse(await readFile(this.devicePath, 'utf-8')) as InstagramDevice
+    } catch {
+      return null
+    }
+  }
+
+  async saveDevice(device: InstagramDevice): Promise<void> {
+    await mkdir(this.instagramRootDir, { recursive: true })
+    await writeFile(this.devicePath, JSON.stringify(device, null, 2), { mode: 0o600 })
   }
 
   async loadConfig(): Promise<InstagramConfig> {

--- a/src/platforms/instagram/types.ts
+++ b/src/platforms/instagram/types.ts
@@ -60,16 +60,18 @@ export interface InstagramMessageSummary {
   media_url?: string
 }
 
+export interface InstagramDevice {
+  phone_id: string
+  uuid: string
+  android_device_id: string
+  advertising_id: string
+  client_session_id: string
+  device_string: string
+}
+
 export interface InstagramSessionState {
   cookies: string
-  device: {
-    phone_id: string
-    uuid: string
-    android_device_id: string
-    advertising_id: string
-    client_session_id: string
-    device_string: string
-  }
+  device: InstagramDevice
   authorization?: string
   user_id?: string
   mid?: string


### PR DESCRIPTION
## Summary

`authenticate()` generated **fresh random device identifiers** (`phone_id`, `uuid`, `android_device_id`, `advertising_id`) on **every** call. To Instagram, each login attempt looked like a brand-new Android device — a documented contributor to a correct password being rejected as `bad_password`, and to challenges/verification.

This persists **one device profile per machine** and reuses it across all logins and accounts, matching how a real phone with account-switching behaves.

## Why per-machine (not per-account)

A real device has one device identity shared by all the Instagram accounts signed in on it — running a personal + business account on one phone is normal, trusted behavior. So the device profile is stored once per machine (`config-dir/instagram/device.json`) and shared across accounts, rather than fabricating a different "phone" per account.

## Evidence

- instagrapi best-practices: *"If you call `.login()` from scratch on every run, Instagram sees repeated fresh logins. That is much more suspicious than reusing a stable device session."* Fresh `Client()` every run is listed as a `bad_password` contributor.
- Both `subzeroid/instagrapi` (`dump_settings`/`load_settings`) and `dilame/instagram-private-api` (`state.serialize`/`deserialize`, seeded `generateDevice`) persist a stable device.
- Ranked #2 login-trust factor (after IP reputation) in the reference-library issue threads (instagrapi#1498).

## Changes

Two commits:
1. **`feat(instagram): add machine-level device profile storage`** — `InstagramDevice` type + `loadDevice()`/`saveDevice()` on the credential manager (`config-dir/instagram/device.json`, shared across accounts).
2. **`feat(instagram): reuse the persisted device across logins`** — `generateDevice()` factory + `resolveDevice()` (load or create-and-persist once). `authenticate()` and `auth extract` now reuse the shared persisted device instead of regenerating each time.

## Testing

- Credential manager: returns null when absent; persists/reloads; one device shared across accounts.
- Client: two separate `authenticate()` calls send the **same** `X-IG-Android-ID`; first login persists a device.
- Client tests sandbox `AGENT_MESSENGER_CONFIG_DIR` so the default manager never writes to the real config dir.
- `bun lint` ✅ (0 warnings) · `bun typecheck` ✅ · `bun run test` ✅ (3396 pass, 0 fail) · changed files pass `oxfmt --check` ✅
- `format:check` fails only on the pre-existing unrelated `docs/` CSS import issue, same as #272/#273.

## Note

This improves the **odds** of id/pw login succeeding by removing a self-inflicted distrust signal, but is not a guarantee — IP/network reputation (outside code) remains the #1 factor per the research.

Follow-up to #273.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist a stable Instagram device profile per machine and reuse it across logins and accounts to improve login trust. The device is stored at config-dir/instagram/device.json and used in both `authenticate()` and `auth extract`.

- New Features
  - Added `InstagramDevice` and persistence on `InstagramCredentialManager` (`loadDevice`/`saveDevice`).
  - Introduced `generateDevice()` and `resolveDevice()` to load or create-and-persist once.
  - Reuses one device across accounts on the same machine; keeps the same `X-IG-Android-ID` between sessions.

SKILL.md/docs: updated (docs/cli/instagram.mdx, skills/agent-instagram/references/authentication.md).

<sup>Written for commit 405d6f10c878846c5339aa179d1c62f3b48b9dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

