### PR TITLE
feat(instagram): add one-click email login (auth login-email)

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -3,7 +3,7 @@ import { generateKeyPairSync } from 'node:crypto'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { InstagramClient } from '@/platforms/instagram/client'
+import { InstagramClient, parseOneClickLoginLink } from '@/platforms/instagram/client'
 import { InstagramCredentialManager } from '@/platforms/instagram/credential-manager'
 import { InstagramError, type InstagramSessionState } from '@/platforms/instagram/types'
 
@@ -329,6 +329,81 @@ describe('InstagramClient', () => {
       const saved = await manager.loadDevice()
       expect(saved).not.toBeNull()
       expect(saved?.android_device_id).toMatch(/^android-[0-9a-f]{16}$/)
+    })
+  })
+
+  describe('parseOneClickLoginLink', () => {
+    it('extracts uid and token from a full web_emaillogin URL', () => {
+      const url = 'https://www.instagram.com/_n/web_emaillogin?uid=ENCODED_UID&token=NONCE123&auto_send=0'
+      expect(parseOneClickLoginLink(url)).toEqual({ uid: 'ENCODED_UID', token: 'NONCE123' })
+    })
+
+    it('extracts from a bare query string without a scheme', () => {
+      expect(parseOneClickLoginLink('uid=abc&token=xyz')).toEqual({ uid: 'abc', token: 'xyz' })
+    })
+
+    it('trims surrounding whitespace', () => {
+      expect(parseOneClickLoginLink('  https://x/?uid=a&token=b  ')).toEqual({ uid: 'a', token: 'b' })
+    })
+
+    it('strips a trailing #fragment so token is not corrupted', () => {
+      const url = 'https://www.instagram.com/_n/web_emaillogin?uid=U1&token=T1#tracking-anchor'
+      expect(parseOneClickLoginLink(url)).toEqual({ uid: 'U1', token: 'T1' })
+    })
+
+    it('returns null when uid or token is missing', () => {
+      expect(parseOneClickLoginLink('https://www.instagram.com/?uid=only')).toBeNull()
+      expect(parseOneClickLoginLink('not a link')).toBeNull()
+    })
+  })
+
+  describe('email login flow', () => {
+    it('sends the recovery flow email and reports the contact point', async () => {
+      fetchResponses.push(jsonResponse({ status: 'ok', obfuscated_email: 'j***@example.com' }))
+
+      const client = new InstagramClient()
+      const result = await client.sendRecoveryFlowEmail('user')
+
+      expect(fetchCalls[0]?.url).toContain('/accounts/send_recovery_flow_email/')
+      const body = urlParamsBody(0)
+      expect(body['query']).toBe('user')
+      expect(body['guid']).toBeTruthy()
+      expect(body['device_id']).toBeTruthy()
+      expect(result).toEqual({ sent: true, contactPoint: 'j***@example.com' })
+    })
+
+    it('throws when the recovery email request fails', async () => {
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'No account found' }))
+
+      const client = new InstagramClient()
+      const err = await client.sendRecoveryFlowEmail('nobody').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('recovery_email_failed')
+    })
+
+    it('redeems a one-click login token for a session', async () => {
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '4242' } }))
+
+      const client = new InstagramClient()
+      const result = await client.oneClickLogin('ENCODED_UID', 'NONCE123')
+
+      expect(fetchCalls[0]?.url).toContain('/accounts/one_click_login/')
+      const body = urlParamsBody(0)
+      expect(body['uid']).toBe('ENCODED_UID')
+      expect(body['token']).toBe('NONCE123')
+      expect(body['source']).toBe('one_click_login_email')
+      expect(result.userId).toBe('4242')
+    })
+
+    it('throws when one-click login returns no session', async () => {
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'Invalid token' }, 400))
+
+      const client = new InstagramClient()
+      const err = await client.oneClickLogin('uid', 'bad').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('one_click_login_failed')
     })
   })
 

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -74,6 +74,18 @@ export function generateDevice(): InstagramDevice {
   }
 }
 
+export function parseOneClickLoginLink(input: string): { uid: string; token: string } | null {
+  const trimmed = input.trim()
+  let query = trimmed.includes('?') ? trimmed.slice(trimmed.indexOf('?') + 1) : trimmed
+  const hashIdx = query.indexOf('#')
+  if (hashIdx !== -1) query = query.slice(0, hashIdx)
+  const params = new URLSearchParams(query)
+  const uid = params.get('uid')
+  const token = params.get('token')
+  if (uid && token) return { uid, token }
+  return null
+}
+
 // Instagram DM timestamps are in microseconds
 function microsecondsToISO(us: number): string {
   return new Date(us / 1000).toISOString()
@@ -253,6 +265,59 @@ export class InstagramClient {
 
     await this.finalizeLogin(data)
     return { userId: this.userId ?? '' }
+  }
+
+  async sendRecoveryFlowEmail(query: string): Promise<{ sent: boolean; contactPoint: string }> {
+    const device = await this.ensureDeviceSession()
+
+    const { data } = await this.request('POST', '/accounts/send_recovery_flow_email/', {
+      _csrftoken: this.cookies.get('csrftoken') ?? generateToken(),
+      adid: device.advertising_id,
+      guid: device.uuid,
+      device_id: device.android_device_id,
+      query,
+    })
+
+    if (data['status'] === 'fail') {
+      const message = (data['message'] as string) ?? 'Failed to send login email'
+      throw new InstagramError(message, 'recovery_email_failed')
+    }
+
+    const contactPoint =
+      (data['obfuscated_email'] as string) ?? (data['email'] as string) ?? (data['contact_point'] as string) ?? ''
+    return { sent: true, contactPoint }
+  }
+
+  async oneClickLogin(uid: string, token: string, source = 'one_click_login_email'): Promise<{ userId: string }> {
+    const device = await this.ensureDeviceSession()
+
+    const { status, data } = await this.request('POST', '/accounts/one_click_login/', {
+      uid,
+      token,
+      source,
+      device_id: device.android_device_id,
+      guid: device.uuid,
+      adid: device.advertising_id,
+    })
+
+    if (status !== 200 || (data['status'] != null && data['status'] !== 'ok')) {
+      const message = (data['message'] as string) ?? 'One-click login failed'
+      throw new InstagramError(message, 'one_click_login_failed')
+    }
+
+    if (!data['logged_in_user']) {
+      throw new InstagramError('One-click login did not return a session', 'one_click_login_failed')
+    }
+
+    await this.finalizeLogin(data)
+    return { userId: this.userId ?? '' }
+  }
+
+  private async ensureDeviceSession(): Promise<InstagramDevice> {
+    if (!this.session) {
+      this.session = { cookies: '', device: await this.resolveDevice() }
+    }
+    return this.session.device
   }
 
   private isFacebookLinkedLogin(data: Record<string, unknown>): boolean {

--- a/src/platforms/instagram/commands/auth.test.ts
+++ b/src/platforms/instagram/commands/auth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, it } from 'bun:te
 const originalConsoleLog = console.log
 import type { Command } from 'commander'
 
+import { InstagramClient } from '../client'
 import { InstagramCredentialManager } from '../credential-manager'
 
 const mockGetAccount = mock(() => Promise.resolve(null))
@@ -239,6 +240,127 @@ describe('auth commands', () => {
 
     it('keeps a whitespace-only password (not treated as empty)', () => {
       expect(sanitizePassword('   ')).toBe('   ')
+    })
+  })
+
+  describe('login-email', () => {
+    it('redeems uid/token non-interactively and saves the account', async () => {
+      const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '4242' })
+      const setSessionPathSpy = spyOn(InstagramClient.prototype, 'setSessionPath').mockImplementation(() => {})
+      const ensurePathsSpy = spyOn(InstagramCredentialManager.prototype, 'ensureAccountPaths').mockResolvedValue({
+        account_dir: '/tmp/x',
+        session_path: '/tmp/x/session.json',
+      })
+      const setAccountSpy = spyOn(InstagramCredentialManager.prototype, 'setAccount').mockResolvedValue(undefined)
+
+      await authCommand.parseAsync(
+        ['login-email', '--username', 'alice', '--uid', 'ENCODED_UID', '--token', 'NONCE123', '--pretty'],
+        { from: 'user' },
+      )
+
+      expect(oneClickSpy).toHaveBeenCalledWith('ENCODED_UID', 'NONCE123')
+      expect(setAccountSpy).toHaveBeenCalled()
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string)
+      expect(output.authenticated).toBe(true)
+      expect(output.username).toBe('alice')
+
+      for (const spy of [oneClickSpy, setSessionPathSpy, ensurePathsSpy, setAccountSpy]) spy.mockRestore()
+    })
+
+    it('parses uid/token from a pasted --link', async () => {
+      const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '7' })
+      const setSessionPathSpy = spyOn(InstagramClient.prototype, 'setSessionPath').mockImplementation(() => {})
+      const ensurePathsSpy = spyOn(InstagramCredentialManager.prototype, 'ensureAccountPaths').mockResolvedValue({
+        account_dir: '/tmp/x',
+        session_path: '/tmp/x/session.json',
+      })
+      const setAccountSpy = spyOn(InstagramCredentialManager.prototype, 'setAccount').mockResolvedValue(undefined)
+
+      await authCommand.parseAsync(
+        [
+          'login-email',
+          '--username',
+          'bob',
+          '--link',
+          'https://www.instagram.com/_n/web_emaillogin?uid=U1&token=T1&auto_send=0',
+        ],
+        { from: 'user' },
+      )
+
+      expect(oneClickSpy).toHaveBeenCalledWith('U1', 'T1')
+
+      for (const spy of [oneClickSpy, setSessionPathSpy, ensurePathsSpy, setAccountSpy]) spy.mockRestore()
+    })
+
+    it('errors on an invalid --link instead of sending a new email', async () => {
+      const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '1' })
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+        sent: true,
+        contactPoint: '',
+      })
+
+      await expect(
+        authCommand.parseAsync(['login-email', '--username', 'alice', '--link', 'not-a-link', '--pretty'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(sendEmailSpy).not.toHaveBeenCalled()
+      expect(oneClickSpy).not.toHaveBeenCalled()
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string)
+      expect(output.error).toContain('Invalid login link')
+
+      for (const spy of [oneClickSpy, sendEmailSpy]) spy.mockRestore()
+    })
+
+    it('errors when only --uid is provided without --token', async () => {
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+        sent: true,
+        contactPoint: '',
+      })
+
+      await expect(
+        authCommand.parseAsync(['login-email', '--username', 'alice', '--uid', 'U1', '--pretty'], { from: 'user' }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(sendEmailSpy).not.toHaveBeenCalled()
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string)
+      expect(output.error).toContain('Invalid login link')
+
+      sendEmailSpy.mockRestore()
+    })
+
+    it('treats an explicit empty --link as redeem intent and fails closed', async () => {
+      const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '1' })
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+        sent: true,
+        contactPoint: '',
+      })
+
+      await expect(
+        authCommand.parseAsync(['login-email', '--username', 'alice', '--link', '', '--pretty'], { from: 'user' }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(sendEmailSpy).not.toHaveBeenCalled()
+      expect(oneClickSpy).not.toHaveBeenCalled()
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string)
+      expect(output.error).toContain('Invalid login link')
+
+      for (const spy of [oneClickSpy, sendEmailSpy]) spy.mockRestore()
+    })
+
+    it('requires --username when redeeming non-interactively', async () => {
+      const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '1' })
+
+      await expect(
+        authCommand.parseAsync(['login-email', '--uid', 'U1', '--token', 'T1', '--pretty'], { from: 'user' }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(oneClickSpy).not.toHaveBeenCalled()
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string)
+      expect(output.error).toContain('--username is required')
+
+      oneClickSpy.mockRestore()
     })
   })
 })

--- a/src/platforms/instagram/commands/auth.ts
+++ b/src/platforms/instagram/commands/auth.ts
@@ -9,7 +9,7 @@ import { isInteractive } from '@/shared/utils/interactive'
 import { formatOutput } from '@/shared/utils/output'
 import { info, warn, error as stderrError, debug } from '@/shared/utils/stderr'
 
-import { InstagramClient, generateDevice } from '../client'
+import { InstagramClient, generateDevice, parseOneClickLoginLink } from '../client'
 import { InstagramCredentialManager } from '../credential-manager'
 import { InstagramTokenExtractor } from '../token-extractor'
 import { createAccountId } from '../types'
@@ -197,6 +197,130 @@ async function loginAction(options: LoginOptions): Promise<void> {
   } catch (error) {
     handleError(error as Error)
   }
+}
+
+interface LoginEmailOptions {
+  username?: string
+  link?: string
+  uid?: string
+  token?: string
+  pretty?: boolean
+  debug?: boolean
+}
+
+async function loginEmailAction(options: LoginEmailOptions): Promise<void> {
+  try {
+    const interactive = isInteractive()
+    const manager = new InstagramCredentialManager()
+
+    // Presence (not truthiness) signals redeem intent: an explicit empty --link "" must still
+    // fail closed here rather than falling through to the send-email branch and re-emailing.
+    const redeemAttempted = options.link !== undefined || options.uid !== undefined || options.token !== undefined
+    if (redeemAttempted) {
+      if (!options.username) {
+        console.log(
+          formatOutput({ error: '--username is required when redeeming a login email link.' }, options.pretty),
+        )
+        process.exit(1)
+      }
+      const redeem = resolveOneClickCredentials(options)
+      if (!redeem) {
+        console.log(
+          formatOutput(
+            { error: 'Invalid login link. Provide a valid --link <url>, or both --uid and --token.' },
+            options.pretty,
+          ),
+        )
+        process.exit(1)
+      }
+      await redeemLoginEmail(manager, redeem.uid, redeem.token, options.username, options)
+      return
+    }
+
+    let username = options.username
+    if (!username) {
+      if (!interactive) {
+        console.log(
+          formatOutput(
+            {
+              error:
+                'Username required. Use --username <username> to send the login email, then --link <url> (or --uid and --token) to complete.',
+            },
+            options.pretty,
+          ),
+        )
+        process.exit(1)
+      }
+      username = await promptText('Instagram username')
+      if (!username) {
+        stderrError('Username is required.')
+        process.exit(1)
+      }
+    }
+
+    const client = new InstagramClient(manager)
+    if (options.debug) client.setDebugLog((msg) => debug(`[debug] ${msg}`))
+
+    const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+
+    if (!interactive) {
+      console.log(
+        formatOutput(
+          {
+            email_sent: true,
+            contact_point: contactPoint,
+            message:
+              'Login email sent. Open the "Login as <username>" link and run "agent-instagram auth login-email --username <username> --link <url>" to finish.',
+          },
+          options.pretty,
+        ),
+      )
+      return
+    }
+
+    info(contactPoint ? `\n  Login email sent to: ${contactPoint}` : '\n  Login email sent.')
+    info('  Open the email, copy the "Login as ..." link, and paste it here.')
+    const link = await promptText('Login link')
+    if (!link) {
+      stderrError('Login link is required.')
+      process.exit(1)
+    }
+
+    const parsed = parseOneClickLoginLink(link)
+    if (!parsed) {
+      stderrError('Could not read uid and token from the pasted link.')
+      process.exit(1)
+    }
+
+    await redeemLoginEmail(manager, parsed.uid, parsed.token, username, options, client)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+function resolveOneClickCredentials(options: LoginEmailOptions): { uid: string; token: string } | null {
+  if (options.link) return parseOneClickLoginLink(options.link)
+  if (options.uid && options.token) return { uid: options.uid, token: options.token }
+  return null
+}
+
+async function redeemLoginEmail(
+  manager: InstagramCredentialManager,
+  uid: string,
+  token: string,
+  username: string,
+  options: LoginEmailOptions,
+  existingClient?: InstagramClient,
+): Promise<void> {
+  const client = existingClient ?? new InstagramClient(manager)
+  if (!existingClient && options.debug) client.setDebugLog((msg) => debug(`[debug] ${msg}`))
+
+  const accountId = createAccountId(username)
+  const paths = await manager.ensureAccountPaths(accountId)
+  client.setSessionPath(paths.session_path)
+
+  const result = await client.oneClickLogin(uid, token)
+  await saveAccountAndPrint(manager, accountId, username, result.userId, options.pretty)
 }
 
 async function handleInteractiveChallenge(
@@ -534,6 +658,17 @@ export const authCommand = new Command('auth')
       .option('--pretty', 'Pretty print JSON output')
       .option('--debug', 'Show raw API responses')
       .action(loginAction),
+  )
+  .addCommand(
+    new Command('login-email')
+      .description('Log in via a one-click login email link (no password needed)')
+      .option('--username <username>', 'Instagram username (sends the login email)')
+      .option('--link <url>', 'The "Login as <username>" URL from the email')
+      .option('--uid <uid>', 'uid from the email link (alternative to --link)')
+      .option('--token <token>', 'token from the email link (alternative to --link)')
+      .option('--pretty', 'Pretty print JSON output')
+      .option('--debug', 'Show raw API responses')
+      .action(loginEmailAction),
   )
   .addCommand(
     new Command('extract')


### PR DESCRIPTION
## Summary

Adds a **password-free login path** via Instagram's one-click login email. This can succeed for accounts where `/accounts/login/` rejects a correct password as `bad_password` (device-trust deflection), because it uses a server-issued email nonce instead of the password.

> **Stacked on #277** (device persistence). Base branch is `feat/instagram-device-persistence`; merge that first. The email flow reuses the persisted machine device so the trigger and redeem share one fingerprint.

## How it works (verified, headless — no browser)

1. `POST /accounts/send_recovery_flow_email/` `{ query: username }` → Instagram emails a "Login as <username>" link.
2. The link is `https://www.instagram.com/_n/web_emaillogin?uid=...&token=...` — the `token` is a one-time nonce.
3. `POST /accounts/one_click_login/` `{ uid, token, source, device_id, guid, adid }` → returns `logged_in_user` + session.

Step 3 is the **native Android app's own endpoint** (not the browser `web_emaillogin` page), so the token is redeemable via a headless API call. Verified against the decompiled Instagram app (`SignedOutFragmentActivity` → `accounts/one_click_login/`), `3z/instago`, `mautrix/instagram`, and `dilame/instagram-private-api`.

## Usage

**Interactive:**
```
agent-instagram auth login-email
# prompts for username, sends email, then paste the "Login as ..." link
```

**Non-interactive (AI agents), two phases:**
```
# 1. trigger the email
agent-instagram auth login-email --username alice
# 2. redeem (paste the whole URL, or pass uid/token)
agent-instagram auth login-email --username alice --link "https://www.instagram.com/_n/web_emaillogin?uid=...&token=..."
```

## Changes

Two commits:
1. **`feat(instagram): add one-click email login to the client`** — `sendRecoveryFlowEmail()`, `oneClickLogin()`, and `parseOneClickLoginLink()`. Reuses the persisted device.
2. **`feat(instagram): add "auth login-email" command`** — interactive + non-interactive CLI, parses uid/token from a pasted link.

## Testing

- Client: `parseOneClickLoginLink` (full URL, bare query, whitespace, missing params); `sendRecoveryFlowEmail` success + failure; `oneClickLogin` success + no-session failure.
- Command: non-interactive redeem via `--uid/--token` and via `--link` both call `oneClickLogin` and save the account.
- `bun lint` ✅ (0 warnings) · `bun typecheck` ✅ · `bun run test` ✅ (3406 pass, 0 fail) · changed files pass `oxfmt --check` ✅
- `format:check` fails only on the pre-existing unrelated `docs/` CSS import issue, same as #272/#273.

## Caveats (honest)

- `send_recovery_flow_email` is rate-limited / blocked on datacenter IPs (residential recommended).
- The token is one-time and the user must be able to read the account's email.

Follow-up to #273.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds password-free Instagram login via the one-click email by redeeming the uid/token on the native `accounts/one_click_login` endpoint. Includes a new `auth login-email` command and reuses the persisted device to bypass `bad_password` device-trust checks.

- **New Features**
  - Client: `sendRecoveryFlowEmail`, `oneClickLogin`, and `parseOneClickLoginLink` (trims whitespace, strips fragments); uses the persisted device for both send and redeem.
  - CLI: `auth login-email` supports interactive (send email → paste link) and non-interactive flows: send-only (`--username`) and redeem (`--username` + `--link` or `--uid/--token`); validates inputs and saves the session.
  - Docs: No SKILL.md or docs changes in this PR.

<sup>Written for commit 3020d037bf763c2225c7f5626fabfaf1c172d8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

