### PR TITLE
feat(instagram): auto-fall back to email login on bad_password

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -293,6 +293,51 @@ describe('InstagramClient', () => {
       expect(err).toBeInstanceOf(InstagramError)
       expect((err as InstagramError).code).toBe('bad_password')
     })
+
+    it('surfaces oneClickEmailAvailable when Instagram offers send_one_click_login_email', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(
+        jsonResponse(
+          {
+            status: 'fail',
+            error_type: 'bad_password',
+            message: 'We can send you an email to help you get back into your account.',
+            buttons: [
+              { title: 'Send email', action: 'send_one_click_login_email' },
+              { title: 'Try again', action: 'dismiss' },
+            ],
+          },
+          400,
+        ),
+      )
+
+      const client = new InstagramClient()
+      const result = await client.authenticate('user', 'secret')
+
+      expect(result.oneClickEmailAvailable).toBe(true)
+      expect(result.userId).toBe('')
+    })
+
+    it('login(credentials) throws instead of returning an unauthenticated client on one-click email', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(
+        jsonResponse(
+          {
+            status: 'fail',
+            error_type: 'bad_password',
+            buttons: [{ title: 'Send email', action: 'send_one_click_login_email' }],
+          },
+          400,
+        ),
+      )
+
+      const client = new InstagramClient()
+      const err = await client.login({ username: 'user', password: 'secret' }).catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('one_click_email_available')
+      expect(client.getUserId()).toBeNull()
+    })
   })
 
   describe('device persistence', () => {

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -109,7 +109,28 @@ export class InstagramClient {
 
   async login(credentials?: { username: string; password: string }, accountId?: string): Promise<this> {
     if (credentials) {
-      await this.authenticate(credentials.username, credentials.password)
+      const result = await this.authenticate(credentials.username, credentials.password)
+      if (!result.userId) {
+        if (result.requiresTwoFactor) {
+          throw new InstagramError(
+            'Two-factor authentication required. Use the CLI (auth login/verify) to complete 2FA.',
+            'two_factor_required',
+          )
+        }
+        if (result.challengeRequired) {
+          throw new InstagramError(
+            'Instagram requires a security challenge. Use the CLI (auth login/challenge) to resolve it.',
+            'challenge_required',
+          )
+        }
+        if (result.oneClickEmailAvailable) {
+          throw new InstagramError(
+            'Password login was rejected; this account can log in by email. Use the CLI "auth login-email" to complete it.',
+            'one_click_email_available',
+          )
+        }
+        throw new InstagramError('Login did not complete.', 'login_incomplete')
+      }
       return this
     }
 
@@ -154,6 +175,7 @@ export class InstagramClient {
     twoFactorInfo?: Record<string, unknown>
     challengeRequired?: boolean
     challengePath?: string
+    oneClickEmailAvailable?: boolean
   }> {
     const device = await this.resolveDevice()
     this.session = { cookies: '', device }
@@ -219,6 +241,11 @@ export class InstagramClient {
           'Setting a password may enable "auth login", though Instagram can still reject automated logins from a new device.',
         'facebook_linked',
       )
+    }
+
+    if (this.hasLoginButton(data, 'send_one_click_login_email')) {
+      this.session.cookies = this.serializeCookies()
+      return { userId: '', oneClickEmailAvailable: true }
     }
 
     if (status !== 200 || data['status'] !== 'ok') {
@@ -321,9 +348,13 @@ export class InstagramClient {
   }
 
   private isFacebookLinkedLogin(data: Record<string, unknown>): boolean {
+    return this.hasLoginButton(data, 'login_with_facebook')
+  }
+
+  private hasLoginButton(data: Record<string, unknown>, action: string): boolean {
     const buttons = data['buttons']
     if (!Array.isArray(buttons)) return false
-    return buttons.some((button) => (button as Record<string, unknown>)?.['action'] === 'login_with_facebook')
+    return buttons.some((button) => (button as Record<string, unknown>)?.['action'] === action)
   }
 
   private isBloksTwoFactorFallback(status: number, data: Record<string, unknown>): boolean {

--- a/src/platforms/instagram/commands/auth.test.ts
+++ b/src/platforms/instagram/commands/auth.test.ts
@@ -363,4 +363,33 @@ describe('auth commands', () => {
       oneClickSpy.mockRestore()
     })
   })
+
+  describe('login email fallback', () => {
+    it('non-interactively sends the login email when password login offers it', async () => {
+      const authSpy = spyOn(InstagramClient.prototype, 'authenticate').mockResolvedValue({
+        userId: '',
+        oneClickEmailAvailable: true,
+      })
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+        sent: true,
+        contactPoint: 'j***@example.com',
+      })
+      const ensurePathsSpy = spyOn(InstagramCredentialManager.prototype, 'ensureAccountPaths').mockResolvedValue({
+        account_dir: '/tmp/x',
+        session_path: '/tmp/x/session.json',
+      })
+
+      await authCommand.parseAsync(['login', '--username', 'alice', '--password', 'wrong', '--pretty'], {
+        from: 'user',
+      })
+
+      expect(sendEmailSpy).toHaveBeenCalledWith('alice')
+      const output = JSON.parse(consoleLogSpy.mock.calls[0]![0] as string)
+      expect(output.one_click_email_available).toBe(true)
+      expect(output.email_sent).toBe(true)
+      expect(output.contact_point).toBe('j***@example.com')
+
+      for (const spy of [authSpy, sendEmailSpy, ensurePathsSpy]) spy.mockRestore()
+    })
+  })
 })

--- a/src/platforms/instagram/commands/auth.ts
+++ b/src/platforms/instagram/commands/auth.ts
@@ -193,6 +193,27 @@ async function loginAction(options: LoginOptions): Promise<void> {
       return
     }
 
+    if (result.oneClickEmailAvailable) {
+      if (interactive) {
+        await runEmailLogin(manager, username, options, client)
+      } else {
+        const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+        console.log(
+          formatOutput(
+            {
+              one_click_email_available: true,
+              email_sent: true,
+              contact_point: contactPoint,
+              message:
+                'Password login was rejected, but this account can log in by email. A login email was sent. Open the "Login as <username>" link and run "agent-instagram auth login-email --username <username> --link <url>" to finish.',
+            },
+            options.pretty,
+          ),
+        )
+      }
+      return
+    }
+
     await saveAccountAndPrint(manager, accountId, username, result.userId, options.pretty)
   } catch (error) {
     handleError(error as Error)
@@ -261,9 +282,8 @@ async function loginEmailAction(options: LoginEmailOptions): Promise<void> {
     const client = new InstagramClient(manager)
     if (options.debug) client.setDebugLog((msg) => debug(`[debug] ${msg}`))
 
-    const { contactPoint } = await client.sendRecoveryFlowEmail(username)
-
     if (!interactive) {
+      const { contactPoint } = await client.sendRecoveryFlowEmail(username)
       console.log(
         formatOutput(
           {
@@ -278,24 +298,35 @@ async function loginEmailAction(options: LoginEmailOptions): Promise<void> {
       return
     }
 
-    info(contactPoint ? `\n  Login email sent to: ${contactPoint}` : '\n  Login email sent.')
-    info('  Open the email, copy the "Login as ..." link, and paste it here.')
-    const link = await promptText('Login link')
-    if (!link) {
-      stderrError('Login link is required.')
-      process.exit(1)
-    }
-
-    const parsed = parseOneClickLoginLink(link)
-    if (!parsed) {
-      stderrError('Could not read uid and token from the pasted link.')
-      process.exit(1)
-    }
-
-    await redeemLoginEmail(manager, parsed.uid, parsed.token, username, options, client)
+    await runEmailLogin(manager, username, options, client)
   } catch (error) {
     handleError(error as Error)
   }
+}
+
+async function runEmailLogin(
+  manager: InstagramCredentialManager,
+  username: string,
+  options: LoginEmailOptions,
+  client: InstagramClient,
+): Promise<void> {
+  const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+
+  info(contactPoint ? `\n  Login email sent to: ${contactPoint}` : '\n  Login email sent.')
+  info('  Open the email, copy the "Login as ..." link, and paste it here.')
+  const link = await promptText('Login link')
+  if (!link) {
+    stderrError('Login link is required.')
+    process.exit(1)
+  }
+
+  const parsed = parseOneClickLoginLink(link)
+  if (!parsed) {
+    stderrError('Could not read uid and token from the pasted link.')
+    process.exit(1)
+  }
+
+  await redeemLoginEmail(manager, parsed.uid, parsed.token, username, options, client)
 }
 
 function resolveOneClickCredentials(options: LoginEmailOptions): { uid: string; token: string } | null {

--- a/src/tui/adapters/instagram-adapter.ts
+++ b/src/tui/adapters/instagram-adapter.ts
@@ -107,7 +107,20 @@ export class InstagramAdapter implements PlatformAdapter {
       if (!code) throw new Error('Verification code is required')
       const challengeResult = await client.challengeSubmitCode(result.challengePath, code)
       userId = challengeResult.userId || userId
+    } else if (result.oneClickEmailAvailable) {
+      const { parseOneClickLoginLink } = await import('@/platforms/instagram/client')
+      io.print('Password login was rejected; this account can log in by email. Sending a login email...')
+      const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+      io.print(contactPoint ? `Login email sent to ${contactPoint}.` : 'Login email sent.')
+      const link = await io.prompt('Paste the "Login as ..." link from the email')
+      if (!link) throw new Error('Login link is required')
+      const parsed = parseOneClickLoginLink(link)
+      if (!parsed) throw new Error('Could not read uid and token from the pasted link')
+      const emailResult = await client.oneClickLogin(parsed.uid, parsed.token)
+      userId = emailResult.userId || userId
     }
+
+    if (!userId) throw new Error('Login did not complete')
 
     const now = new Date().toISOString()
     await this.credManager.setAccount({


### PR DESCRIPTION
## Summary

When `agent-instagram auth login` hits a `bad_password` that Instagram offers to resolve via a one-click login email (the `send_one_click_login_email` button — common for accounts Instagram distrusts the login context for, even with a correct password), the CLI now **offers the email login flow automatically** instead of just printing the raw error. This wires the `auth login-email` capability (#278) directly into the normal login path.

## Behavior

- **Interactive TTY**: automatically calls `send_recovery_flow_email`, prompts *"paste the Login as <username> link"*, redeems it via `one_click_login`, and completes the login — all in one command.
- **Non-interactive** (scripts/CI): sends the email and returns a structured hint so no email is silently triggered inside a redeem-only pipeline:
  ```json
  {
    "one_click_email_available": true,
    "email_sent": true,
    "contact_point": "j***@example.com",
    "message": "... run \"agent-instagram auth login-email --username <username> --link <url>\" to finish."
  }
  ```

The only manual step is pasting the link — the CLI cannot read the user's email inbox, so full end-to-end automation isn't possible without inbox integration (out of scope).

## Why

For accounts where password login is rejected as `bad_password` despite a correct password (device/IP trust), the emailed one-click login is a working, password-free path. This removes the need for the user to notice the failure and manually switch to `auth login-email`.

## Changes

Two commits:
1. **`feat(instagram): detect one-click email login availability on bad_password`** — `authenticate()` surfaces `oneClickEmailAvailable` (instead of throwing) when the response carries the `send_one_click_login_email` button. Extracts a shared `hasLoginButton()` helper (reused by the Facebook-linked check).
2. **`feat(instagram): auto-fall back to email login on bad_password`** — `loginAction` branches on `oneClickEmailAvailable`; extracts the send-email-and-redeem flow into a shared `runEmailLogin()` used by both `auth login` (fallback) and `auth login-email`.

## Testing

- Client: `authenticate()` returns `oneClickEmailAvailable: true` for a `send_one_click_login_email` response.
- Command: non-interactive `auth login` with a rejected password sends the email and returns `one_click_email_available` + `email_sent` + `contact_point`.
- `bun lint` ✅ (0 warnings) · `bun typecheck` ✅ · `bun run test` ✅ (3413 pass, 0 fail) · changed files pass `oxfmt --check` ✅
- `format:check` fails only on the pre-existing unrelated `docs/` CSS import issue, same as #272/#273.

Follow-up to #278.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-fallback to email login when Instagram returns `bad_password`. Interactive flows complete via the pasted “Login as <username>” link; non-interactive runs send-only and prints a structured hint.

- **New Features**
  - Detects `send_one_click_login_email`; `authenticate()` returns `oneClickEmailAvailable`. `client.login()` now throws `one_click_email_available` (and `two_factor_required`/`challenge_required`) when login didn’t complete.
  - `auth login`:
    - Interactive: sends email, prompts for link, redeems, finishes login.
    - Non-interactive: sends email and prints JSON with `one_click_email_available`, `email_sent`, `contact_point`, and a next-step message.
  - TUI (`InstagramAdapter`): handles email fallback with a prompt and one-click redemption.

- **Refactors**
  - Added `hasLoginButton()` and `runEmailLogin()` shared by `auth login` and `auth login-email`.
  - Tests added for one-click detection and non-interactive output.
  - SKILL.md/docs: Not updated.

<sup>Written for commit 8e2cae0e5b902956c7459f84f73c88f20f63e36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

