### PR TITLE
fix(instagram): trigger login email via the correct one_click_login endpoint

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -404,28 +404,42 @@ describe('InstagramClient', () => {
   })
 
   describe('email login flow', () => {
-    it('sends the recovery flow email and reports the contact point', async () => {
+    it('looks up the user id then triggers one_click_login with auto_send', async () => {
+      fetchResponses.push(jsonResponse({ status: 'ok', user_id: '4242' }))
       fetchResponses.push(jsonResponse({ status: 'ok', obfuscated_email: 'j***@example.com' }))
 
       const client = new InstagramClient()
-      const result = await client.sendRecoveryFlowEmail('user')
+      const result = await client.sendOneClickLoginEmail('user')
 
-      expect(fetchCalls[0]?.url).toContain('/accounts/send_recovery_flow_email/')
-      const body = urlParamsBody(0)
-      expect(body['query']).toBe('user')
-      expect(body['guid']).toBeTruthy()
-      expect(body['device_id']).toBeTruthy()
+      expect(fetchCalls[0]?.url).toContain('/users/lookup/')
+      expect(fetchCalls[1]?.url).toContain('/accounts/one_click_login/')
+      const body = urlParamsBody(1)
+      expect(body['uid']).toBe('4242')
+      expect(body['source']).toBe('one_click_login_email')
+      expect(body['auto_send']).toBe('true')
+      expect(body['token']).toBeUndefined()
       expect(result).toEqual({ sent: true, contactPoint: 'j***@example.com' })
     })
 
-    it('throws when the recovery email request fails', async () => {
-      fetchResponses.push(jsonResponse({ status: 'fail', message: 'No account found' }))
+    it('throws when the username cannot be resolved to a user id', async () => {
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'User not found' }))
 
       const client = new InstagramClient()
-      const err = await client.sendRecoveryFlowEmail('nobody').catch((e: unknown) => e)
+      const err = await client.sendOneClickLoginEmail('nobody').catch((e: unknown) => e)
 
       expect(err).toBeInstanceOf(InstagramError)
-      expect((err as InstagramError).code).toBe('recovery_email_failed')
+      expect((err as InstagramError).code).toBe('user_lookup_failed')
+    })
+
+    it('throws when the one_click_login auto_send request fails', async () => {
+      fetchResponses.push(jsonResponse({ status: 'ok', user_id: '4242' }))
+      fetchResponses.push(jsonResponse({ status: 'fail', message: 'Please wait a few minutes' }))
+
+      const client = new InstagramClient()
+      const err = await client.sendOneClickLoginEmail('user').catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('one_click_email_failed')
     })
 
     it('redeems a one-click login token for a session', async () => {

--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -607,6 +607,21 @@ describe('InstagramClient', () => {
       expect((err as InstagramError).code).toBe('rate_limited')
     })
 
+    it('surfaces Instagram message from a 429 JSON body', async () => {
+      fetchResponses.push(
+        new Response(JSON.stringify({ message: 'Please wait a few minutes before you try again.', status: 'fail' }), {
+          status: 429,
+        }),
+      )
+
+      const client = await loadedClient()
+
+      const err = await client.listChats().catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('rate_limited')
+      expect((err as InstagramError).message).toContain('Please wait a few minutes')
+    })
+
     it('throws on JSON parse error', async () => {
       fetchResponses.push(new Response('not json', { status: 200 }))
 

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -294,25 +294,55 @@ export class InstagramClient {
     return { userId: this.userId ?? '' }
   }
 
-  async sendRecoveryFlowEmail(query: string): Promise<{ sent: boolean; contactPoint: string }> {
+  // The login dialog's "send_one_click_login_email" button triggers /accounts/one_click_login/
+  // with auto_send=true (NOT /accounts/send_recovery_flow_email/, which is the generic password
+  // reset). It needs the account's numeric user id, resolved via a pre-login /users/lookup/.
+  async sendOneClickLoginEmail(username: string): Promise<{ sent: boolean; contactPoint: string }> {
     const device = await this.ensureDeviceSession()
+    const uid = await this.lookupUserId(username)
 
-    const { data } = await this.request('POST', '/accounts/send_recovery_flow_email/', {
-      _csrftoken: this.cookies.get('csrftoken') ?? generateToken(),
-      adid: device.advertising_id,
+    const { status, data } = await this.request('POST', '/accounts/one_click_login/', {
+      uid,
+      source: 'one_click_login_email',
+      auto_send: 'true',
       guid: device.uuid,
       device_id: device.android_device_id,
-      query,
+      adid: device.advertising_id,
     })
 
-    if (data['status'] === 'fail') {
+    if (status !== 200 || data['status'] === 'fail') {
       const message = (data['message'] as string) ?? 'Failed to send login email'
-      throw new InstagramError(message, 'recovery_email_failed')
+      throw new InstagramError(message, 'one_click_email_failed')
     }
 
     const contactPoint =
       (data['obfuscated_email'] as string) ?? (data['email'] as string) ?? (data['contact_point'] as string) ?? ''
     return { sent: true, contactPoint }
+  }
+
+  private async lookupUserId(username: string): Promise<string> {
+    const device = await this.ensureDeviceSession()
+
+    const { data } = await this.request(
+      'POST',
+      '/users/lookup/',
+      {
+        q: username,
+        directly_sign_in: 'true',
+        _csrftoken: this.cookies.get('csrftoken') ?? generateToken(),
+        guid: device.uuid,
+        device_id: device.android_device_id,
+        country_codes: JSON.stringify([{ country_code: this.countryCode, source: ['default'] }]),
+      },
+      { signed: true },
+    )
+
+    const userId = (data['user_id'] ?? data['uid'] ?? data['pk']) as string | number | undefined
+    if (userId == null || String(userId).length === 0) {
+      const message = (data['message'] as string) ?? `Could not find an Instagram account for "${username}".`
+      throw new InstagramError(message, 'user_lookup_failed')
+    }
+    return String(userId)
   }
 
   async oneClickLogin(uid: string, token: string, source = 'one_click_login_email'): Promise<{ userId: string }> {

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -301,6 +301,7 @@ export class InstagramClient {
     const device = await this.ensureDeviceSession()
     const uid = await this.lookupUserId(username)
 
+    this.debugLog?.(`one_click_login auto_send for uid=${uid}`)
     const { status, data } = await this.request('POST', '/accounts/one_click_login/', {
       uid,
       source: 'one_click_login_email',
@@ -309,6 +310,7 @@ export class InstagramClient {
       device_id: device.android_device_id,
       adid: device.advertising_id,
     })
+    this.debugLog?.(`one_click_login response status=${status} body=${JSON.stringify(data)}`)
 
     if (status !== 200 || data['status'] === 'fail') {
       const message = (data['message'] as string) ?? 'Failed to send login email'
@@ -323,7 +325,8 @@ export class InstagramClient {
   private async lookupUserId(username: string): Promise<string> {
     const device = await this.ensureDeviceSession()
 
-    const { data } = await this.request(
+    this.debugLog?.(`users/lookup for ${username}`)
+    const { status, data } = await this.request(
       'POST',
       '/users/lookup/',
       {
@@ -336,6 +339,7 @@ export class InstagramClient {
       },
       { signed: true },
     )
+    this.debugLog?.(`users/lookup response status=${status} body=${JSON.stringify(data)}`)
 
     const userId = (data['user_id'] ?? data['uid'] ?? data['pk']) as string | number | undefined
     if (userId == null || String(userId).length === 0) {
@@ -809,7 +813,15 @@ export class InstagramClient {
     }
 
     if (response.status === 429) {
-      throw new InstagramError('Rate limited by Instagram. Try again later.', 'rate_limited')
+      const body = await response.text().catch(() => '')
+      this.debugLog?.(`429 from ${path} body=${body}`)
+      const igMessage = this.extractJsonMessage(body)
+      throw new InstagramError(
+        igMessage
+          ? `Rate limited by Instagram: ${igMessage} Wait before trying again.`
+          : 'Rate limited by Instagram. Try again later.',
+        'rate_limited',
+      )
     }
 
     let data: Record<string, unknown>
@@ -820,6 +832,15 @@ export class InstagramClient {
     }
 
     return { status: response.status, data }
+  }
+
+  private extractJsonMessage(body: string): string {
+    try {
+      const parsed = JSON.parse(body) as Record<string, unknown>
+      return (parsed['message'] as string) ?? ''
+    } catch {
+      return ''
+    }
   }
 
   private buildHeaders(): Record<string, string> {

--- a/src/platforms/instagram/commands/auth.test.ts
+++ b/src/platforms/instagram/commands/auth.test.ts
@@ -294,7 +294,7 @@ describe('auth commands', () => {
 
     it('errors on an invalid --link instead of sending a new email', async () => {
       const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '1' })
-      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendOneClickLoginEmail').mockResolvedValue({
         sent: true,
         contactPoint: '',
       })
@@ -314,7 +314,7 @@ describe('auth commands', () => {
     })
 
     it('errors when only --uid is provided without --token', async () => {
-      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendOneClickLoginEmail').mockResolvedValue({
         sent: true,
         contactPoint: '',
       })
@@ -332,7 +332,7 @@ describe('auth commands', () => {
 
     it('treats an explicit empty --link as redeem intent and fails closed', async () => {
       const oneClickSpy = spyOn(InstagramClient.prototype, 'oneClickLogin').mockResolvedValue({ userId: '1' })
-      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendOneClickLoginEmail').mockResolvedValue({
         sent: true,
         contactPoint: '',
       })
@@ -370,7 +370,7 @@ describe('auth commands', () => {
         userId: '',
         oneClickEmailAvailable: true,
       })
-      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendRecoveryFlowEmail').mockResolvedValue({
+      const sendEmailSpy = spyOn(InstagramClient.prototype, 'sendOneClickLoginEmail').mockResolvedValue({
         sent: true,
         contactPoint: 'j***@example.com',
       })

--- a/src/platforms/instagram/commands/auth.ts
+++ b/src/platforms/instagram/commands/auth.ts
@@ -197,7 +197,7 @@ async function loginAction(options: LoginOptions): Promise<void> {
       if (interactive) {
         await runEmailLogin(manager, username, options, client)
       } else {
-        const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+        const { contactPoint } = await client.sendOneClickLoginEmail(username)
         console.log(
           formatOutput(
             {
@@ -283,7 +283,7 @@ async function loginEmailAction(options: LoginEmailOptions): Promise<void> {
     if (options.debug) client.setDebugLog((msg) => debug(`[debug] ${msg}`))
 
     if (!interactive) {
-      const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+      const { contactPoint } = await client.sendOneClickLoginEmail(username)
       console.log(
         formatOutput(
           {
@@ -310,7 +310,7 @@ async function runEmailLogin(
   options: LoginEmailOptions,
   client: InstagramClient,
 ): Promise<void> {
-  const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+  const { contactPoint } = await client.sendOneClickLoginEmail(username)
 
   info(contactPoint ? `\n  Login email sent to: ${contactPoint}` : '\n  Login email sent.')
   info('  Open the email, copy the "Login as ..." link, and paste it here.')

--- a/src/tui/adapters/instagram-adapter.ts
+++ b/src/tui/adapters/instagram-adapter.ts
@@ -110,7 +110,7 @@ export class InstagramAdapter implements PlatformAdapter {
     } else if (result.oneClickEmailAvailable) {
       const { parseOneClickLoginLink } = await import('@/platforms/instagram/client')
       io.print('Password login was rejected; this account can log in by email. Sending a login email...')
-      const { contactPoint } = await client.sendRecoveryFlowEmail(username)
+      const { contactPoint } = await client.sendOneClickLoginEmail(username)
       io.print(contactPoint ? `Login email sent to ${contactPoint}.` : 'Login email sent.')
       const link = await io.prompt('Paste the "Login as ..." link from the email')
       if (!link) throw new Error('Login link is required')


### PR DESCRIPTION
## Summary

The one-click login email (added in #278/#279) **never actually arrived** because we called the wrong endpoint. This fixes the endpoint so the email is genuinely sent.

## Root cause

The login dialog's `send_one_click_login_email` button maps to:

```
POST /api/v1/accounts/one_click_login/   { uid, source: "one_click_login_email", auto_send: "true", ... }
```

**not** `POST /api/v1/accounts/send_recovery_flow_email/` (which is the generic *"Forgot password?"* reset — a different flow). Verified against `3z/instago` (which mirrors the decompiled Instagram app: `OneClickLogin(uid, "one_click_login_email", true)`), cross-checked with `dilame/instagram-private-api`, `mautrix/instagram`, and `subzeroid/instagrapi`.

Because we hit the wrong endpoint, **no email was sent** and Instagram returned a misleading `"Please wait a few minutes before you try again."` (its generic soft-block message), which looked like rate-limiting but was really the wrong-flow rejection.

## Changes

Two commits:
1. **`fix(instagram): trigger the login email via the correct one_click_login endpoint`**
   - Replace `sendRecoveryFlowEmail()` with `sendOneClickLoginEmail(username)`.
   - Resolve the account's **numeric** user id via a pre-login `POST /users/lookup/` (signed body: `q`, `directly_sign_in`, `guid`, `device_id`, `country_codes`, `_csrftoken`), since `one_click_login` needs the numeric uid, not the username (the `bad_password` response only carries the username).
   - `POST /accounts/one_click_login/` with `{ uid, source: 'one_click_login_email', auto_send: 'true', guid, device_id, adid }` as **raw form fields** (matching instago and our existing redeem path — no signing, no `logged_in_user` required for the trigger).
   - `oneClickLogin(uid, token)` (redeem the emailed link) is unchanged.
2. **`fix(instagram): point login-email callers at sendOneClickLoginEmail`**
   - Repoint the `auth login` fallback, the `auth login-email` command, and the TUI adapter to the new method.

## Testing

- Client: `sendOneClickLoginEmail` does lookup → `one_click_login` with `auto_send=true` and no token; throws `user_lookup_failed` when the username can't be resolved; throws `one_click_email_failed` when the trigger fails. `oneClickLogin` redeem unchanged.
- Command spies updated to the new method name.
- `bun lint` ✅ (0 warnings) · `bun typecheck` ✅ · `bun run test` ✅ (3415 pass, 0 fail) · changed files pass `oxfmt --check` ✅
- `format:check` fails only on the pre-existing unrelated `docs/` CSS import issue, same as #272/#273.

## Caveats

- The account/IP may still carry a soft-block from the prior wrong-endpoint attempts; endpoint-specific limits are often separate, so retry once after this lands rather than hammering.
- Datacenter IPs are more likely to be throttled on this endpoint; a residential network is more reliable.

Follow-up to #279.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Instagram one‑click login by using the correct `POST /accounts/one_click_login/` flow with a uid lookup first. Also improves 429 errors and adds debug logs so email login issues are easier to diagnose.

- **Bug Fixes**
  - Trigger email via `POST /accounts/one_click_login/` with `auto_send=true`.
  - Resolve numeric uid via `POST /users/lookup/` before sending.
  - Replace `sendRecoveryFlowEmail()` with `sendOneClickLoginEmail(username)`; update CLI/TUI to use it.
  - New errors: `user_lookup_failed`, `one_click_email_failed`; redeem (`oneClickLogin`) unchanged.

- **Improvements**
  - 429 errors now include Instagram’s message (e.g., “Please wait a few minutes”) and log both lookup and one‑click requests with `--debug`.
  - Docs: No changes to SKILL.md or docs.

<sup>Written for commit 2e28c65257b0183068e55c0781d1682b7110ccd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

