### PR TITLE
fix(instagram): stop login from hanging on stalled connections

### DIFF
--- a/src/platforms/instagram/client.test.ts
+++ b/src/platforms/instagram/client.test.ts
@@ -486,6 +486,22 @@ describe('InstagramClient', () => {
       expect(headers['Content-Type']).toContain('application/x-www-form-urlencoded')
     })
 
+    it('sends the current Android fingerprint headers so IG does not silently drop the login', async () => {
+      fetchResponses.push(encryptionKeyResponse())
+      fetchResponses.push(jsonResponse({ status: 'ok', logged_in_user: { pk: '99' } }))
+
+      const client = new InstagramClient()
+      await client.authenticate('user', 'pass')
+
+      const headers = fetchCalls[0]?.init?.headers as Record<string, string>
+
+      expect(headers['X-FB-HTTP-Engine']).toBe('Tigon/MNS/TCP')
+      expect(headers['IG-INTENDED-USER-ID']).toBe('0')
+      expect(headers['X-IG-App-Locale']).toBe('en_US')
+      expect(headers['X-Pigeon-Session-Id']).toMatch(/^UFS-/)
+      expect(headers['Priority']).toBe('u=3')
+    })
+
     it('includes device headers when session is set', async () => {
       fetchResponses.push(jsonResponse({ status: 'ok', inbox: { threads: [] } }))
 
@@ -637,6 +653,43 @@ describe('InstagramClient', () => {
       const chats = await client.listChats()
 
       expect(chats).toEqual([])
+    })
+
+    it('passes an abort signal so a stalled connection cannot hang forever', async () => {
+      fetchResponses.push(jsonResponse({ status: 'ok', inbox: { threads: [] } }))
+
+      const client = await loadedClient()
+      await client.listChats()
+
+      expect(fetchCalls[0]?.init?.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    it('surfaces request_stalled when the request times out', async () => {
+      ;(globalThis as Record<string, unknown>).fetch = (): Promise<Response> =>
+        Promise.reject(new DOMException('The operation timed out.', 'TimeoutError'))
+
+      const client = await loadedClient()
+
+      const err = await client.listChats().catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('request_stalled')
+      expect((err as InstagramError).message).toContain('auth extract')
+    })
+
+    it('surfaces request_stalled when the body stalls after headers arrive', async () => {
+      const stalledBody = {
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.reject(new DOMException('The operation was aborted.', 'AbortError')),
+      } as unknown as Response
+      ;(globalThis as Record<string, unknown>).fetch = (): Promise<Response> => Promise.resolve(stalledBody)
+
+      const client = await loadedClient()
+
+      const err = await client.listChats().catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(InstagramError)
+      expect((err as InstagramError).code).toBe('request_stalled')
+      expect((err as InstagramError).message).toContain('auth extract')
     })
   })
 

--- a/src/platforms/instagram/client.ts
+++ b/src/platforms/instagram/client.ts
@@ -21,6 +21,11 @@ const IG_VERSION_CODE = '719358530'
 // Bloks client versioning id; required header for Bloks endpoints (2FA / CAA flows).
 const IG_BLOKS_VERSION_ID = '5f56efad68e1edec7801f630b5c122704ec5378adbee6609a448f105f34a9c73'
 const IG_CAPABILITIES = '3brTv10='
+const IG_LOCALE = 'en_US'
+// Instagram silently holds the socket open (no response) for flagged IPs / fingerprints instead
+// of returning an error, so an unbounded fetch hangs forever. Cap every request and surface a
+// clear, actionable error instead of a frozen process.
+const IG_REQUEST_TIMEOUT_MS = 30_000
 const ANDROID_VERSION = '14'
 const ANDROID_RELEASE = '34'
 const DEVICE_DPI = '480dpi'
@@ -53,6 +58,52 @@ function createJazoest(input: string): string {
 
 function generateToken(): string {
   return randomBytes(16).toString('hex')
+}
+
+function isTimeoutAbort(error: unknown): boolean {
+  // AbortSignal.timeout aborts the connect AND the body stream, surfacing as TimeoutError on the
+  // fetch and AbortError when a stalled body read is aborted mid-stream; both mean "IG stalled".
+  return error instanceof DOMException && (error.name === 'TimeoutError' || error.name === 'AbortError')
+}
+
+function stalledError(path: string): InstagramError {
+  return new InstagramError(
+    `Instagram did not respond within ${IG_REQUEST_TIMEOUT_MS / 1000}s (${path}). The connection stalled, ` +
+      'which usually means the IP is flagged (VPN/datacenter/proxy or prior automated attempts) or the ' +
+      'device fingerprint was rejected. Try "agent-instagram auth extract" from a browser logged into ' +
+      'instagram.com instead of password login.',
+    'request_stalled',
+  )
+}
+
+interface TimedRequest {
+  response: Response
+  readText: () => Promise<string>
+}
+
+// One AbortSignal.timeout covers the whole request lifecycle: connect, headers, AND the body read.
+// Reading the body through readText() keeps a post-header stall mapped to request_stalled instead
+// of leaking out as a generic parse failure.
+async function fetchWithTimeout(url: string, init: RequestInit, path: string): Promise<TimedRequest> {
+  const signal = AbortSignal.timeout(IG_REQUEST_TIMEOUT_MS)
+  let response: Response
+  try {
+    response = await fetch(url, { ...init, signal })
+  } catch (error) {
+    if (isTimeoutAbort(error)) throw stalledError(path)
+    throw error
+  }
+
+  const readText = async (): Promise<string> => {
+    try {
+      return await response.text()
+    } catch (error) {
+      if (isTimeoutAbort(error)) throw stalledError(path)
+      throw error
+    }
+  }
+
+  return { response, readText }
 }
 
 function buildUserAgent(deviceString: string): string {
@@ -711,17 +762,21 @@ export class InstagramClient {
     const url = `${IG_BASE_URL}/qe/sync/`
     const headers = this.buildHeaders()
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: new URLSearchParams(
-        signBody({
-          id: this.session!.device.uuid,
-          experiments:
-            'ig_android_fci,ig_android_device_detection_info_upload,ig_android_device_verification_fb_signup',
-        }),
-      ).toString(),
-    })
+    const { response } = await fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        headers,
+        body: new URLSearchParams(
+          signBody({
+            id: this.session!.device.uuid,
+            experiments:
+              'ig_android_fci,ig_android_device_detection_info_upload,ig_android_device_verification_fb_signup',
+          }),
+        ).toString(),
+      },
+      '/qe/sync/',
+    )
     this.extractResponseCookies(response.headers)
 
     const wwwClaim = response.headers.get('x-ig-set-www-claim')
@@ -799,7 +854,7 @@ export class InstagramClient {
       requestInit.body = new URLSearchParams(payload).toString()
     }
 
-    const response = await fetch(url, requestInit)
+    const { response, readText } = await fetchWithTimeout(url, requestInit, path)
     this.extractResponseCookies(response.headers)
 
     const authHeader = response.headers.get('ig-set-authorization')
@@ -812,10 +867,11 @@ export class InstagramClient {
       this.session.www_claim = wwwClaim
     }
 
+    const rawBody = await readText()
+
     if (response.status === 429) {
-      const body = await response.text().catch(() => '')
-      this.debugLog?.(`429 from ${path} body=${body}`)
-      const igMessage = this.extractJsonMessage(body)
+      this.debugLog?.(`429 from ${path} body=${rawBody}`)
+      const igMessage = this.extractJsonMessage(rawBody)
       throw new InstagramError(
         igMessage
           ? `Rate limited by Instagram: ${igMessage} Wait before trying again.`
@@ -826,7 +882,7 @@ export class InstagramClient {
 
     let data: Record<string, unknown>
     try {
-      data = (await response.json()) as Record<string, unknown>
+      data = JSON.parse(rawBody) as Record<string, unknown>
     } catch {
       throw new InstagramError(`Failed to parse response from ${path}`, response.status)
     }
@@ -845,14 +901,29 @@ export class InstagramClient {
 
   private buildHeaders(): Record<string, string> {
     const deviceString = this.session?.device.device_string ?? generateDeviceString()
+    // Instagram's edge silently drops connections whose fingerprint headers don't match a real
+    // Android client. This is a partial alignment toward the current app profile
+    // (per subzeroid/instagrapi) covering the highest-signal headers, not a full fingerprint match
+    // (e.g. X-Tigon-Is-Retry, X-Zero-*, X-IG-Nav-Chain, X-IG-SALT-IDS are intentionally omitted).
     const headers: Record<string, string> = {
       'User-Agent': buildUserAgent(deviceString),
+      'X-IG-App-Locale': IG_LOCALE,
+      'X-IG-Device-Locale': IG_LOCALE,
+      'X-IG-Mapped-Locale': IG_LOCALE,
+      'X-Pigeon-Session-Id': `UFS-${randomUUID()}-0`,
+      'X-Pigeon-Rawclienttime': (Date.now() / 1000).toFixed(3),
+      'X-IG-Bandwidth-Speed-KBPS': '-1.000',
+      'X-IG-Bandwidth-TotalBytes-B': '0',
+      'X-IG-Bandwidth-TotalTime-MS': '0',
+      'X-IG-App-Startup-Country': 'US',
       'X-IG-App-ID': IG_APP_ID,
       'X-IG-Capabilities': IG_CAPABILITIES,
       'X-IG-Connection-Type': 'WIFI',
       'X-IG-Timezone-Offset': String(new Date().getTimezoneOffset() * -60),
       'X-Bloks-Version-Id': IG_BLOKS_VERSION_ID,
-      'X-FB-HTTP-Engine': 'Liger',
+      'X-FB-HTTP-Engine': 'Tigon/MNS/TCP',
+      Priority: 'u=3',
+      'IG-INTENDED-USER-ID': this.userId ?? '0',
       'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
       Accept: '*/*',
       'Accept-Language': 'en-US,en;q=0.9',


### PR DESCRIPTION
## Problem

`agent-instagram auth login` could **hang forever** with no error. With `--debug` it froze right after:

```
[debug] encryption key_id=64 pub_key_length=604 ...
[debug] encrypting password with key_id=64
```

### Root cause

The hang is **not** in password encryption (that step is fully synchronous Node `crypto` and returns instantly). It's the `POST /accounts/login/` request that never returns:

1. Every `fetch()` in the Instagram client (`request()` and `preLoginFlow()`) had **no timeout / `AbortSignal`**. Instagram is known to *silently hold the socket open with no response* — rather than returning a 4xx/challenge — for flagged IPs (VPN/datacenter/proxy or prior automated attempts) and rejected device fingerprints. With no timeout, the process freezes indefinitely.
2. The login `buildHeaders()` set used the stale `X-FB-HTTP-Engine: Liger` and was missing several fingerprint headers the current Instagram Android client sends. A stale/incomplete fingerprint is a known trigger for the silent connection drop.

Cross-checked the protocol against `subzeroid/instagrapi` (current reference): the crypto, `enc_password` wire format, RSA PKCS1 padding, `jazoest`, and `SIGNATURE.` body signing were already correct — the gap was the missing timeout and header drift.

## Changes

- **Timeout (fixes the hang):** a single `AbortSignal.timeout` (30s) now covers the **full request lifecycle** — connect, headers, *and* the body read. The body is consumed via a `readText()` helper so a post-header stall (`AbortError`) maps to the same actionable `request_stalled` `InstagramError` as a connect `TimeoutError`, instead of leaking out as a generic parse failure. The error points the user to `auth extract`.
- **Header alignment (partial, reduces silent drops):** a deliberate *partial* alignment toward the current Android profile covering the highest-signal headers — `X-FB-HTTP-Engine` → `Tigon/MNS/TCP`, plus `X-IG-App-Locale`/`Device-Locale`/`Mapped-Locale`, `X-Pigeon-Session-Id`, `X-Pigeon-Rawclienttime`, `X-IG-Bandwidth-*`, `X-IG-App-Startup-Country`, `Priority: u=3`, and `IG-INTENDED-USER-ID`. This is **not** a full fingerprint match: transport/anti-bot headers whose correct values are randomized/opaque from outside the app (`X-Tigon-Is-Retry`, `X-Zero-*`, `X-IG-Nav-Chain`, `X-IG-SALT-IDS`, etc.) are intentionally omitted to avoid drift risk, and the code comment documents this.

## Tests

Added tests (`client.test.ts`):
- request passes an `AbortSignal` to `fetch`
- a connect timeout surfaces `request_stalled` pointing at `auth extract`
- a **body stall after headers arrive** surfaces `request_stalled` (per review)
- `buildHeaders` emits the current Android fingerprint headers

`bun typecheck`, `bun lint`, and `bun test` (3433 pass / 0 fail) all green.

## Note

No `auth login` was run against Instagram during development (to avoid deepening any account flag / ban risk). Behavior is covered via mocked `fetch`.