### PR TITLE
feat(teams): silent token refresh for device-code login (Phase 2)

### DIFF
--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -40,7 +40,7 @@ Two co-equal ways to sign in — pick whichever fits:
 
 Credentials are also extracted automatically on first use of any command if none are stored, so `auth extract` can happen silently in the background.
 
-Teams tokens expire in 60-90 minutes (extraction) or a few hours (device-code). Re-run `auth login` or `auth extract` to refresh.
+Teams tokens are short-lived (60-90 minutes for extraction, a few hours for device-code). **Device-code accounts (`auth login`) refresh silently** — the CLI re-mints an expired token from the stored refresh token with no re-login needed. Extraction accounts re-extract automatically as long as you're still signed into the Teams desktop app or a supported browser; if that fails, re-run `auth extract` (or switch to `auth login`).
 
 ### Non-interactive `auth login` (agents / CI)
 
@@ -479,7 +479,7 @@ See the [Teams SDK documentation](https://agent-messenger.dev/docs/sdk/teams) fo
 - No webhook support
 - Plain text messages only (no adaptive cards in v1)
 - User tokens only (no app tokens)
-- **Token expires in 60-90 minutes** - auto-refreshed, but requires Teams desktop app or browser to be logged in
+- **Tokens are short-lived** - device-code (`auth login`) accounts refresh silently from the stored refresh token; extraction accounts auto-refresh but need the Teams desktop app or browser to still be logged in
 
 ## Troubleshooting
 

--- a/src/platforms/teams/credential-manager.ts
+++ b/src/platforms/teams/credential-manager.ts
@@ -136,6 +136,7 @@ export class TeamsCredentialManager {
     teams: Record<string, { team_id: string; team_name: string }>
     currentTeam: string | null
     authMethod?: TeamsAuthMethod
+    makeCurrent?: boolean
   }): Promise<void> {
     let config = await this.loadConfig()
     if (!config) {
@@ -154,7 +155,9 @@ export class TeamsCredentialManager {
       aad_refresh_token: params.aadRefreshToken,
       aad_client_id: params.aadClientId,
     }
-    config.current_account = params.accountType
+    if (params.makeCurrent ?? true) {
+      config.current_account = params.accountType
+    }
     await this.saveConfig(config)
   }
 

--- a/src/platforms/teams/device-login.test.ts
+++ b/src/platforms/teams/device-login.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { TeamsCredentialManager } from './credential-manager'
+import { refreshDeviceCodeAccount } from './device-login'
+
+const testDirs: string[] = []
+const originalFetch = globalThis.fetch
+
+function setup(): TeamsCredentialManager {
+  const dir = join(import.meta.dir, `.test-teams-refresh-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  testDirs.push(dir)
+  return new TeamsCredentialManager(dir)
+}
+
+function mockExchangeAndMint(skypeToken: string, rotatedRefresh: string): void {
+  globalThis.fetch = mock((input: string | URL | Request) => {
+    const url = String(input)
+    if (url.includes('/oauth2/v2.0/token')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ access_token: 'spaces-at', refresh_token: rotatedRefresh }),
+      } as Response)
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ skypeToken: { skypetoken: skypeToken, skypeTokenExpiresIn: 3600 } }),
+    } as Response)
+  }) as typeof fetch
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+afterAll(() => {
+  for (const dir of testDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('refreshDeviceCodeAccount', () => {
+  it('re-mints the skype token, rotates the refresh token, and keeps the account current', async () => {
+    const manager = setup()
+    await manager.setDeviceCodeAccount({
+      accountType: 'personal',
+      token: 'old-skype',
+      tokenExpiresAt: '2000-01-01T00:00:00Z',
+      aadRefreshToken: 'old-refresh',
+      aadClientId: 'client',
+      teams: {},
+      currentTeam: null,
+    })
+
+    mockExchangeAndMint('new-skype', 'new-refresh')
+    const ok = await refreshDeviceCodeAccount('personal', manager)
+
+    expect(ok).toBe(true)
+    const config = await manager.loadConfig()
+    expect(config?.accounts.personal?.token).toBe('new-skype')
+    expect(config?.accounts.personal?.aad_refresh_token).toBe('new-refresh')
+    expect(new Date(config!.accounts.personal!.token_expires_at!).getTime()).toBeGreaterThan(Date.now())
+    expect(config?.current_account).toBe('personal')
+  })
+
+  it('does not change current_account when refreshing a non-current account', async () => {
+    const manager = setup()
+    await manager.setDeviceCodeAccount({
+      accountType: 'personal',
+      token: 'p',
+      tokenExpiresAt: '2000-01-01T00:00:00Z',
+      aadRefreshToken: 'r',
+      aadClientId: 'c',
+      teams: {},
+      currentTeam: null,
+    })
+    await manager.setToken('work-token', 'work', '2100-01-01T00:00:00Z')
+    await manager.setCurrentAccount('work')
+
+    mockExchangeAndMint('new-skype', 'new-refresh')
+    await refreshDeviceCodeAccount('personal', manager)
+
+    const config = await manager.loadConfig()
+    expect(config?.current_account).toBe('work')
+    expect(config?.accounts.personal?.token).toBe('new-skype')
+  })
+
+  it('returns false for a non-device-code account', async () => {
+    const manager = setup()
+    await manager.setToken('extracted-token', 'personal', '2100-01-01T00:00:00Z')
+
+    const ok = await refreshDeviceCodeAccount('personal', manager)
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and leaves the token intact when the exchange fails', async () => {
+    const manager = setup()
+    await manager.setDeviceCodeAccount({
+      accountType: 'personal',
+      token: 'old-skype',
+      tokenExpiresAt: '2000-01-01T00:00:00Z',
+      aadRefreshToken: 'old-refresh',
+      aadClientId: 'client',
+      teams: {},
+      currentTeam: null,
+    })
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve({ ok: false, status: 400, json: () => Promise.resolve({ error: 'invalid_grant' }) } as Response),
+    ) as typeof fetch
+
+    const ok = await refreshDeviceCodeAccount('personal', manager)
+    expect(ok).toBe(false)
+    const config = await manager.loadConfig()
+    expect(config?.accounts.personal?.token).toBe('old-skype')
+  })
+})

--- a/src/platforms/teams/device-login.ts
+++ b/src/platforms/teams/device-login.ts
@@ -125,6 +125,43 @@ async function finalize(
   }
 }
 
+export async function refreshDeviceCodeAccount(
+  accountType: TeamsAccountType,
+  credManager: TeamsCredentialManager = new TeamsCredentialManager(),
+  debug?: (message: string) => void,
+): Promise<boolean> {
+  const config = await credManager.loadConfig()
+  const account = config?.accounts[accountType]
+  if (!account || account.auth_method !== 'device-code' || !account.aad_refresh_token) {
+    return false
+  }
+  const clientId = account.aad_client_id ?? getTeamsAppClientId().clientId
+
+  try {
+    debug?.('Silently refreshing skype token...')
+    const skypeScoped = await exchangeForSkypeScope(account.aad_refresh_token, clientId)
+    const minted = await mintConsumerSkypeToken(skypeScoped.accessToken)
+
+    await credManager.setDeviceCodeAccount({
+      accountType,
+      token: minted.skypeToken,
+      tokenExpiresAt: minted.skypeTokenExpiresAt,
+      aadRefreshToken: skypeScoped.refreshToken,
+      aadClientId: clientId,
+      region: account.region,
+      userName: account.user_name,
+      teams: account.teams,
+      currentTeam: account.current_team,
+      authMethod: 'device-code',
+      makeCurrent: false,
+    })
+    return true
+  } catch (error) {
+    debug?.(`Silent refresh failed: ${(error as Error).message}`)
+    return false
+  }
+}
+
 export class PendingApprovalError extends Error {
   constructor() {
     super('Authorization pending. Approve in the browser, then retry.')

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -2,6 +2,7 @@ import { warn } from '@/shared/utils/stderr'
 
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
+import { refreshDeviceCodeAccount } from './device-login'
 import { TeamsTokenExtractor } from './token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from './types'
 
@@ -11,6 +12,8 @@ export async function ensureTeamsAuth(): Promise<void> {
     const config = await credManager.loadConfig()
 
     if (config && hasValidToken(config)) return
+
+    if (config && (await trySilentRefresh(config, credManager))) return
 
     const extractor = new TeamsTokenExtractor()
     const extracted = await extractor.extract()
@@ -90,6 +93,14 @@ async function resolveAccountType(
     }
   }
   throw lastError ?? new Error('Token validation failed')
+}
+
+async function trySilentRefresh(config: TeamsConfig, credManager: TeamsCredentialManager): Promise<boolean> {
+  const key = TeamsCredentialManager.accountOverride ?? config.current_account
+  if (!key) return false
+  const account = config.accounts[key]
+  if (account?.auth_method !== 'device-code' || !account.aad_refresh_token) return false
+  return refreshDeviceCodeAccount(key as TeamsAccountType, credManager)
 }
 
 function hasValidToken(config: TeamsConfig): boolean {

--- a/src/platforms/teams/index.ts
+++ b/src/platforms/teams/index.ts
@@ -1,6 +1,12 @@
 export { TeamsClient } from './client'
 export { TeamsCredentialManager } from './credential-manager'
-export { completeDeviceCode, loginWithDeviceCode, PendingApprovalError, startDeviceCode } from './device-login'
+export {
+  completeDeviceCode,
+  loginWithDeviceCode,
+  PendingApprovalError,
+  refreshDeviceCodeAccount,
+  startDeviceCode,
+} from './device-login'
 export type { DeviceCodePrompt, DeviceLoginResult } from './device-login'
 export { TeamsListener } from './listener'
 export { TeamsError } from './types'


### PR DESCRIPTION
> **Stacked on #282** — base branch is `feat/teams-device-code-login`. Review/merge #282 first; this diff shows only the Phase 2 changes.

## Summary

Phase 2 of Teams `auth login`: **silent token refresh**. When an account was signed in via `auth login` (device-code) and its skype token has expired (~6h), the CLI now transparently re-mints it from the stored AAD refresh token — no manual re-login. This removes the main pain point of the short skype-token lifetime.

## How

`ensureTeamsAuth` gains a step between "stored token valid?" and the existing cookie-extraction fallback:

```
valid stored token?            → use it
else device-code account with  → refreshDeviceCodeAccount():
  an AAD refresh token?             refresh AAD token (fl.spaces.skype scope)
                                    → mint a new skype token
                                    → persist (rotated refresh + new expiry)
else                           → existing cookie extraction (unchanged)
```

- **Extraction accounts are untouched** — `trySilentRefresh` only runs for `auth_method === 'device-code'` accounts that have a refresh token; everything else falls straight through to the existing behavior.
- Refresh **does not change the active account** (`makeCurrent: false`) and preserves the stored teams/region/user.
- On any failure the old token is left intact and we fall back to extraction.

## Changes

- `device-login.ts` — `refreshDeviceCodeAccount()` (exchange → mint → persist), exported from the SDK.
- `credential-manager.ts` — `setDeviceCodeAccount` gains a `makeCurrent` flag so refresh preserves `current_account`.
- `ensure-auth.ts` — `trySilentRefresh` runs before cookie extraction.

## Testing

- 4 new unit tests: re-mint + refresh-token rotation + stays current; non-current account preserved; non-device-code no-op; failure leaves the token intact.
- Full suite: **3447 pass / 0 fail**. Typecheck, lint, format clean.
- Verified safe against a real (extraction-based) stored account: silent refresh correctly no-ops and `auth status` behaves as before.

## Manual verification (needs a device-code login)

Full end-to-end silent refresh requires an `auth login` session (personal Microsoft account, MFA), which can't be automated here. To verify: `auth login` → force-expire `token_expires_at` in `teams-credentials.json` → run any command → it should re-mint silently without prompting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds silent token refresh for Teams device-code logins. When the stored skype token expires, the CLI re-mints it from the saved AAD refresh token before falling back to cookie extraction, with no prompts or account switching.

- **New Features**
  - `ensureTeamsAuth` now tries silent refresh for device-code accounts before extraction.
  - Added `refreshDeviceCodeAccount` to exchange the stored AAD refresh token for a new skype token and persist it (rotated refresh + new expiry) without changing `current_account`.
  - `TeamsCredentialManager.setDeviceCodeAccount` gains a `makeCurrent` flag to preserve the active account during refresh.
  - Re-exported `refreshDeviceCodeAccount`; added unit tests for refresh, rotation, non-device-code no-op, and failure fallback.
  - Docs: Updated `skills/agent-teams/SKILL.md` to document silent refresh for device-code accounts.

<sup>Written for commit 983f2418754bacd910b6044bffa9585ff177f9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

