### PR TITLE
feat(teams): add channel thread/reply support

### DIFF
--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -325,6 +325,29 @@ describe('TeamsClient', () => {
       expect(fetchCalls[0].options?.method).toBe('POST')
       expect(fetchCalls[0].options?.body).toBe(JSON.stringify({ content: 'Hello world' }))
     })
+
+    it('sends a reply to a channel thread', async () => {
+      mockResponse({
+        id: 'reply1',
+        channel_id: 'ch1',
+        author: { id: '123', displayName: 'Test User' },
+        content: 'Thread reply',
+        timestamp: '2024-01-01T00:01:00.000Z',
+      })
+
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
+      const message = await client.sendMessage('111', 'ch1', 'Thread reply', 'root1')
+
+      expect(fetchCalls[0].url).toBe(
+        'https://teams.microsoft.com/api/csa/emea/api/v2/teams/111/channels/ch1/messages/root1/replies',
+      )
+      expect(fetchCalls[0].options?.method).toBe('POST')
+      expect(fetchCalls[0].options?.body).toBe(JSON.stringify({ content: 'Thread reply', parentMessageId: 'root1' }))
+      // the reply the API echoes back omits thread ids, so the client normalizes them from the root
+      expect(message.root_message_id).toBe('root1')
+      expect(message.parent_message_id).toBe('root1')
+      expect(message.is_thread_reply).toBe(true)
+    })
   })
 
   describe('getMessages', () => {
@@ -357,6 +380,61 @@ describe('TeamsClient', () => {
 
       expect(fetchCalls[0].url).toBe(
         'https://teams.microsoft.com/api/csa/emea/api/v2/teams/111/channels/ch1/messages?limit=50',
+      )
+    })
+
+    it('preserves thread fields for replies without inventing them for top-level messages', async () => {
+      mockResponse([
+        {
+          id: 'reply1',
+          channel_id: 'ch1',
+          author: { id: '123', displayName: 'User 1' },
+          content: 'Reply',
+          timestamp: '2024-01-01T00:01:00.000Z',
+          rootMessageId: 'root1',
+          parentMessageId: 'root1',
+        },
+        {
+          id: 'root1',
+          channel_id: 'ch1',
+          author: { id: '123', displayName: 'User 1' },
+          content: 'Top level',
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      ])
+
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
+      const messages = await client.getMessages('111', 'ch1')
+
+      expect(messages[0].root_message_id).toBe('root1')
+      expect(messages[0].parent_message_id).toBe('root1')
+      expect(messages[0].is_thread_reply).toBe(true)
+      expect(messages[1].root_message_id).toBeUndefined()
+      expect(messages[1].is_thread_reply).toBeFalsy()
+    })
+  })
+
+  describe('getThreadReplies', () => {
+    it('returns replies for a channel thread with root metadata', async () => {
+      mockResponse([
+        {
+          id: 'reply1',
+          channel_id: 'ch1',
+          author: { id: '123', displayName: 'User 1' },
+          content: 'Reply 1',
+          timestamp: '2024-01-01T00:01:00.000Z',
+        },
+      ])
+
+      const client = await new TeamsClient().login({ token: 'test-token', region: 'emea' })
+      const replies = await client.getThreadReplies('111', 'ch1', 'root1', 10)
+
+      expect(replies).toHaveLength(1)
+      expect(replies[0].root_message_id).toBe('root1')
+      expect(replies[0].parent_message_id).toBe('root1')
+      expect(replies[0].is_thread_reply).toBe(true)
+      expect(fetchCalls[0].url).toBe(
+        'https://teams.microsoft.com/api/csa/emea/api/v2/teams/111/channels/ch1/messages/root1/replies?limit=10',
       )
     })
   })

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -20,6 +20,11 @@ interface RateLimitBucket {
   resetAt: number
 }
 
+interface RawTeamsMessage extends TeamsMessage {
+  rootMessageId?: string
+  parentMessageId?: string
+}
+
 const PERSONAL_MSG_API_BASE = 'https://msgapi.teams.live.com/v1'
 const CSA_API_BASE = 'https://teams.microsoft.com/api'
 const MAX_RETRIES = 3
@@ -62,6 +67,23 @@ function escapeHtml(value: string): string {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;')
+}
+
+function withThreadMetadata(message: RawTeamsMessage, rootMessageId?: string): TeamsMessage {
+  const { rootMessageId: messageRootMessageId, parentMessageId, ...teamsMessage } = message
+  const rawRootMessageId = rootMessageId ?? messageRootMessageId
+  const isThreadReply = Boolean(
+    rootMessageId ||
+    (messageRootMessageId !== undefined && messageRootMessageId !== message.id) ||
+    (parentMessageId !== undefined && parentMessageId !== message.id),
+  )
+
+  return {
+    ...teamsMessage,
+    root_message_id: isThreadReply ? rawRootMessageId : undefined,
+    parent_message_id: isThreadReply ? (parentMessageId ?? rawRootMessageId) : undefined,
+    is_thread_reply: isThreadReply ? true : undefined,
+  }
 }
 
 // groupId => Teams/channel thread (handled by listTeams). "48:notes"/
@@ -505,7 +527,17 @@ export class TeamsClient {
     )
   }
 
-  async sendMessage(teamId: string, channelId: string, content: string): Promise<TeamsMessage> {
+  async sendMessage(teamId: string, channelId: string, content: string, rootMessageId?: string): Promise<TeamsMessage> {
+    if (rootMessageId) {
+      const response = await this.request<RawTeamsMessage>(
+        'POST',
+        `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages/${rootMessageId}/replies`,
+        { content, parentMessageId: rootMessageId },
+        CSA_API_BASE,
+      )
+      return withThreadMetadata(response, rootMessageId)
+    }
+
     return this.request<TeamsMessage>(
       'POST',
       `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages`,
@@ -515,12 +547,28 @@ export class TeamsClient {
   }
 
   async getMessages(teamId: string, channelId: string, limit: number = 50): Promise<TeamsMessage[]> {
-    return this.request<TeamsMessage[]>(
+    const messages = await this.request<RawTeamsMessage[]>(
       'GET',
       `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages?limit=${limit}`,
       undefined,
       CSA_API_BASE,
     )
+    return messages.map((message) => withThreadMetadata(message))
+  }
+
+  async getThreadReplies(
+    teamId: string,
+    channelId: string,
+    rootMessageId: string,
+    limit: number = 50,
+  ): Promise<TeamsMessage[]> {
+    const replies = await this.request<RawTeamsMessage[]>(
+      'GET',
+      `/csa/${this.region}/api/v2/teams/${teamId}/channels/${channelId}/messages/${rootMessageId}/replies?limit=${limit}`,
+      undefined,
+      CSA_API_BASE,
+    )
+    return replies.map((reply) => withThreadMetadata(reply, rootMessageId))
   }
 
   async getMessage(teamId: string, channelId: string, messageId: string): Promise<TeamsMessage> {

--- a/src/platforms/teams/commands/message.test.ts
+++ b/src/platforms/teams/commands/message.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
-import { deleteAction, getAction, listAction, sendAction } from './message'
+import { deleteAction, getAction, listAction, repliesAction, sendAction } from './message'
 
 let clientSendMessageSpy: ReturnType<typeof spyOn>
 let clientGetMessagesSpy: ReturnType<typeof spyOn>
+let clientGetThreadRepliesSpy: ReturnType<typeof spyOn>
 let clientGetMessageSpy: ReturnType<typeof spyOn>
 let clientDeleteMessageSpy: ReturnType<typeof spyOn>
 let credManagerLoadSpy: ReturnType<typeof spyOn>
@@ -37,6 +38,18 @@ beforeEach(() => {
     },
   ])
 
+  clientGetThreadRepliesSpy = spyOn(TeamsClient.prototype, 'getThreadReplies').mockResolvedValue([
+    {
+      id: 'reply_123',
+      channel_id: 'ch_456',
+      author: { id: 'user_789', displayName: 'Test User' },
+      content: 'Thread reply',
+      timestamp: '2025-01-29T10:02:00Z',
+      root_message_id: 'msg_123',
+      is_thread_reply: true,
+    },
+  ])
+
   clientGetMessageSpy = spyOn(TeamsClient.prototype, 'getMessage').mockResolvedValue({
     id: 'msg_123',
     channel_id: 'ch_456',
@@ -63,6 +76,7 @@ beforeEach(() => {
 afterEach(() => {
   clientSendMessageSpy?.mockRestore()
   clientGetMessagesSpy?.mockRestore()
+  clientGetThreadRepliesSpy?.mockRestore()
   clientGetMessageSpy?.mockRestore()
   clientDeleteMessageSpy?.mockRestore()
   credManagerLoadSpy?.mockRestore()
@@ -90,6 +104,19 @@ it('list: returns array of messages', async () => {
   const output = consoleSpy.mock.calls[0][0]
   expect(output).toContain('msg_123')
   expect(output).toContain('msg_124')
+})
+
+it('replies: returns array of thread replies', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await repliesAction('team_123', 'ch_456', 'msg_123', { limit: 10, pretty: false })
+
+  expect(clientGetThreadRepliesSpy).toHaveBeenCalledWith('team_123', 'ch_456', 'msg_123', 10)
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('reply_123')
+  expect(output).toContain('msg_123')
 })
 
 it('get: returns single message', async () => {

--- a/src/platforms/teams/commands/message.ts
+++ b/src/platforms/teams/commands/message.ts
@@ -11,7 +11,7 @@ export async function sendAction(
   teamId: string,
   channelId: string,
   content: string,
-  options: { pretty?: boolean },
+  options: { pretty?: boolean; thread?: string },
 ): Promise<void> {
   try {
     const credManager = new TeamsCredentialManager()
@@ -28,13 +28,15 @@ export async function sendAction(
       accountType: cred.accountType,
       region: cred.region,
     })
-    const message = await client.sendMessage(teamId, channelId, content)
+    const message = await client.sendMessage(teamId, channelId, content, options.thread)
 
     const output = {
       id: message.id,
       content: message.content,
       author: message.author.displayName,
       timestamp: message.timestamp,
+      root_message_id: message.root_message_id,
+      parent_message_id: message.parent_message_id,
     }
 
     console.log(formatOutput(output, options.pretty))
@@ -71,6 +73,46 @@ export async function listAction(
       content: msg.content,
       author: msg.author.displayName,
       timestamp: msg.timestamp,
+      root_message_id: msg.root_message_id,
+      is_thread_reply: msg.is_thread_reply,
+    }))
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export async function repliesAction(
+  teamId: string,
+  channelId: string,
+  messageId: string,
+  options: { limit?: number; pretty?: boolean },
+): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const limit = options.limit || 50
+    const replies = await client.getThreadReplies(teamId, channelId, messageId, limit)
+
+    const output = replies.map((msg: TeamsMessage) => ({
+      id: msg.id,
+      content: msg.content,
+      author: msg.author.displayName,
+      timestamp: msg.timestamp,
+      root_message_id: msg.root_message_id,
     }))
 
     console.log(formatOutput(output, options.pretty))
@@ -158,10 +200,11 @@ export const messageCommand = new Command('message')
   .description('Message commands')
   .addCommand(
     new Command('send')
-      .description('Send message to channel')
+      .description('Send message to channel (--thread <message-id> replies to a thread)')
       .argument('<team-id>', 'Team ID')
       .argument('<channel-id>', 'Channel ID')
       .argument('<content>', 'Message content')
+      .option('--thread <message-id>', 'Reply to a thread root message')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
   )
@@ -174,6 +217,21 @@ export const messageCommand = new Command('message')
       .option('--pretty', 'Pretty print JSON output')
       .action((teamId: string, channelId: string, options: any) => {
         return listAction(teamId, channelId, {
+          limit: parseInt(options.limit, 10),
+          pretty: options.pretty,
+        })
+      }),
+  )
+  .addCommand(
+    new Command('replies')
+      .description('List replies for a message thread')
+      .argument('<team-id>', 'Team ID')
+      .argument('<channel-id>', 'Channel ID')
+      .argument('<message-id>', 'Message ID')
+      .option('--limit <n>', 'Number of replies to retrieve', '50')
+      .option('--pretty', 'Pretty print JSON output')
+      .action((teamId: string, channelId: string, messageId: string, options: any) => {
+        return repliesAction(teamId, channelId, messageId, {
           limit: parseInt(options.limit, 10),
           pretty: options.pretty,
         })

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -26,6 +26,9 @@ export interface TeamsMessage {
   }
   content: string
   timestamp: string
+  root_message_id?: string
+  parent_message_id?: string
+  is_thread_reply?: boolean
 }
 
 export interface TeamsUser {
@@ -130,6 +133,9 @@ export const TeamsMessageSchema = z.object({
   }),
   content: z.string(),
   timestamp: z.string(),
+  root_message_id: z.string().optional(),
+  parent_message_id: z.string().optional(),
+  is_thread_reply: z.boolean().optional(),
 })
 
 export const TeamsUserSchema = z.object({


### PR DESCRIPTION
## Summary

First of a 3-PR Teams feature batch (thread replies → message search → file downloads). Adds **channel thread/reply support** to `agent-teams` using the existing skype token — no new auth flow.

## How

- `TeamsClient.getThreadReplies(teamId, channelId, rootMessageId, limit)` reads replies via the `/messages/{id}/replies` sub-resource, mirroring the existing `/reactions` endpoint pattern.
- `TeamsClient.sendMessage(...)` gains an optional `rootMessageId` param that posts into a thread (`parentMessageId` in the request body) instead of the channel root.
- `TeamsMessage` (+ its Zod schema) gains optional `root_message_id`, `parent_message_id`, `is_thread_reply`, derived from `rootMessageId` on the raw response. Top-level posts leave these fields `undefined`, so existing consumers are unaffected.

## Changes

- `client.ts` / `types.ts` — thread-aware `getThreadReplies`, `sendMessage`, and message metadata.
- `commands/message.ts` — new `agent-teams message replies <team> <channel> <message-id>` command, and a `--thread <message-id>` flag on `message send`.

## Testing

- New tests in `client.test.ts` and `commands/message.test.ts`.
- Full suite green (239 Teams tests pass). Typecheck and lint clean.

## Follow-ups (not in this PR)

- Message search.
- File downloads.

Both build on the thread metadata introduced here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Teams channel thread and reply support in `agent-teams`. You can list thread replies and post replies, with thread metadata surfaced and no breaking changes.

- **New Features**
  - Client: `getThreadReplies(teamId, channelId, rootMessageId, limit)` reads `/messages/{id}/replies`; `sendMessage(..., rootMessageId?)` posts a reply and normalizes thread metadata if the API omits it.
  - Messages: adds optional `root_message_id`, `parent_message_id`, `is_thread_reply`; `getMessages(...)`/`getThreadReplies(...)` set these for replies, top-level messages leave them undefined.
  - CLI: `message replies <team> <channel> <message-id>` lists replies; `message send --thread <message-id>` posts a reply; outputs include thread IDs where relevant.

- **Migration**
  - No new auth and no breaking changes. SKILL.md/docs: not updated.

<sup>Written for commit 3ebba5226049e877c6adda2eb5c687e269b3c694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

