### PR TITLE
feat(teams): add message search via Substrate API

### DIFF
--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -35,8 +35,8 @@ agent-teams channel list <team-id>
 
 Two co-equal ways to sign in — pick whichever fits:
 
-1. **`agent-teams auth login`** (personal Microsoft accounts) — device-code sign-in. Open the printed URL, enter the code, and approve in your browser. No desktop app or browser extraction needed.
-2. **`agent-teams auth extract`** — zero-config extraction from the Teams desktop app, falling back to a Chromium browser. Best when you're already signed into Teams locally.
+1. **`agent-teams auth login`** (work/school **or** personal Microsoft accounts) — device-code sign-in. Open the printed URL, enter the code, and approve in your browser. No desktop app or browser extraction needed. Defaults to a work/school account; use `--account-type personal` for a personal account. Only `auth login` stores the AAD refresh token required by `message search`.
+2. **`agent-teams auth extract`** — zero-config extraction from the Teams desktop app, falling back to a Chromium browser. Best when you're already signed into Teams locally. Yields a Skype token only — sufficient for messaging, but **not** for `message search` (see below).
 
 Credentials are also extracted automatically on first use of any command if none are stored, so `auth extract` can happen silently in the background.
 
@@ -54,7 +54,7 @@ agent-teams auth login
 agent-teams auth login --device-code <device_code>
 ```
 
-`--client-id <id>` overrides the AAD client ID on either call (or set `AGENT_TEAMS_CLIENT_ID`).
+`--client-id <id>` overrides the AAD client ID on either call (or set `AGENT_TEAMS_CLIENT_ID`). `--account-type <work|personal>` selects the account (default `work`); it is preserved across the two-call flow, so pass it to both calls when signing in to a personal account non-interactively.
 
 ### Multi-Team Support
 
@@ -212,7 +212,13 @@ agent-teams message get <team-id> <channel-id> <message-id>
 
 # Delete a message
 agent-teams message delete <team-id> <channel-id> <message-id> --force
+
+# Search messages across Teams (requires `auth login` — see Authentication)
+agent-teams message search <query>
+agent-teams message search "deploy" --limit 10 --from 0
 ```
+
+`message search` requires an `auth login` account: it queries Microsoft's Substrate search API with an AAD token that `auth extract` (cookie-based) cannot provide. Cookie-only accounts get a clear error telling you to run `auth login`. `--limit` is a positive integer (default 20); `--from` is a non-negative offset for pagination (default 0).
 
 ### Channel Commands
 

--- a/skills/agent-teams/references/authentication.md
+++ b/skills/agent-teams/references/authentication.md
@@ -192,6 +192,25 @@ Credentials are stored in:
 - Keep this file secure - it grants access to your Teams account
 - **Tokens auto-expire in 60-90 minutes** - provides some security
 
+## AAD Tokens (required for `message search`)
+
+Most commands use only the Skype token above. **`message search` is different**: it queries Microsoft's Substrate search API, which requires an AAD Bearer token for the `substrate.office.com` audience — a token the Skype cookie cannot produce.
+
+- **Only `auth login` (device-code) can mint it.** That flow stores an `aad_refresh_token` (and `aad_client_id`) alongside the Skype token. `auth extract` (cookie extraction) yields a Skype token only and therefore **cannot** run `message search` — the CLI returns an actionable error telling you to run `auth login`.
+- **Work and personal accounts** are both supported by `auth login`; it defaults to work/school and accepts `--account-type personal`.
+- At search time, the CLI silently exchanges the stored refresh token for a short-lived Substrate access token (per-scope AAD grant), caches it in memory only (never written to disk), and rotates the refresh token. The same mechanism can mint a Graph token for other AAD-gated features.
+
+Credentials for an `auth login` account therefore include additional fields:
+
+```json
+{
+  "account_type": "work",
+  "auth_method": "device-code",
+  "aad_refresh_token": "0.AXoA...redacted...",
+  "aad_client_id": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346"
+}
+```
+
 ## Authentication Status
 
 Check if you're authenticated:

--- a/src/platforms/teams/app-config.ts
+++ b/src/platforms/teams/app-config.ts
@@ -1,10 +1,22 @@
+import type { TeamsAccountType } from './types'
+
 export const TEAMS_DESKTOP_CLIENT_ID = '1fec8e78-bce4-4aaf-ab1b-5451cc387264'
 export const TEAMS_WEB_CLIENT_ID = '5e3ce6c0-2b1f-4285-8d4b-75ee78787346'
 
 export const CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad'
+export const WORK_TENANT_ID = 'organizations'
 
 export const DEVICE_CODE_SCOPE_TEAMS = 'service::api.fl.teams.microsoft.com::MBI_SSL openid profile offline_access'
 export const DEVICE_CODE_SCOPE_SKYPE = 'service::api.fl.spaces.skype.com::MBI_SSL openid profile offline_access'
+export const WORK_DEVICE_CODE_SCOPE_TEAMS = 'https://api.spaces.skype.com/.default openid profile offline_access'
+export const WORK_DEVICE_CODE_SCOPE_SKYPE = 'https://api.spaces.skype.com/.default openid profile offline_access'
+
+export const SUBSTRATE_SEARCH_URL = 'https://substrate.office.com/searchservice/api/v2/query'
+export const TEAMS_WEB_ORIGIN = 'https://teams.microsoft.com'
+export const AAD_SCOPE_SUBSTRATE = 'https://substrate.office.com/.default offline_access'
+export const AAD_SCOPE_GRAPH = 'https://graph.microsoft.com/.default offline_access'
+export const AAD_AUDIENCE_SUBSTRATE = 'https://substrate.office.com'
+export const AAD_AUDIENCE_GRAPH = 'https://graph.microsoft.com'
 
 export const AUTHZ_CONSUMER_URL = 'https://teams.live.com/api/auth/v1.0/authz/consumer'
 export const AUTHZ_WORK_URL = 'https://teams.microsoft.com/api/authsvc/v1.0/authz'
@@ -17,6 +29,34 @@ export function consumerTokenUrl(): string {
   return `https://login.microsoftonline.com/${CONSUMER_TENANT_ID}/oauth2/v2.0/token`
 }
 
+export function organizationsDeviceCodeUrl(): string {
+  return `https://login.microsoftonline.com/${WORK_TENANT_ID}/oauth2/v2.0/devicecode`
+}
+
+export function organizationsTokenUrl(): string {
+  return `https://login.microsoftonline.com/${WORK_TENANT_ID}/oauth2/v2.0/token`
+}
+
+export function deviceCodeUrl(accountType: TeamsAccountType): string {
+  return accountType === 'personal' ? consumerDeviceCodeUrl() : organizationsDeviceCodeUrl()
+}
+
+export function deviceCodeTokenUrl(accountType: TeamsAccountType): string {
+  return accountType === 'personal' ? consumerTokenUrl() : organizationsTokenUrl()
+}
+
+export function deviceCodeTeamsScope(accountType: TeamsAccountType): string {
+  return accountType === 'personal' ? DEVICE_CODE_SCOPE_TEAMS : WORK_DEVICE_CODE_SCOPE_TEAMS
+}
+
+export function deviceCodeSkypeScope(accountType: TeamsAccountType): string {
+  return accountType === 'personal' ? DEVICE_CODE_SCOPE_SKYPE : WORK_DEVICE_CODE_SCOPE_SKYPE
+}
+
+export function authzUrl(accountType: TeamsAccountType): string {
+  return accountType === 'personal' ? AUTHZ_CONSUMER_URL : AUTHZ_WORK_URL
+}
+
 export interface TeamsAppClient {
   clientId: string
   source: 'env' | 'builtin'
@@ -27,10 +67,10 @@ function parseTrimmed(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined
 }
 
-export function getTeamsAppClientId(): TeamsAppClient {
+export function getTeamsAppClientId(accountType: TeamsAccountType = 'personal'): TeamsAppClient {
   const envClientId = parseTrimmed(process.env.AGENT_TEAMS_CLIENT_ID)
   if (envClientId) {
     return { clientId: envClientId, source: 'env' }
   }
-  return { clientId: TEAMS_WEB_CLIENT_ID, source: 'builtin' }
+  return { clientId: accountType === 'work' ? TEAMS_DESKTOP_CLIENT_ID : TEAMS_WEB_CLIENT_ID, source: 'builtin' }
 }

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { unlinkSync } from 'node:fs'
+import { rmSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
 
 import { TeamsClient } from './client'
+import { TeamsCredentialManager } from './credential-manager'
 import { TeamsError } from './types'
 
 const TEMP_FILES_TO_CLEANUP = ['/tmp/test-teams-upload.txt']
+const TEMP_DIRS_TO_CLEANUP: string[] = []
+const SEARCH_TENANT_ID = '11111111-1111-1111-1111-111111111111'
+const SEARCH_USER_ID = '22222222-2222-2222-2222-222222222222'
 
 describe('TeamsClient', () => {
   const originalFetch = globalThis.fetch
@@ -36,7 +41,49 @@ describe('TeamsClient', () => {
         // File may not exist, ignore
       }
     }
+    for (const dir of TEMP_DIRS_TO_CLEANUP.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
+
+  const setupCredentialManager = async (): Promise<TeamsCredentialManager> => {
+    const dir = join(import.meta.dir, `.test-teams-client-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    TEMP_DIRS_TO_CLEANUP.push(dir)
+    const manager = new TeamsCredentialManager(dir)
+    await manager.setDeviceCodeAccount({
+      accountType: 'work',
+      token: 'skype-token',
+      tokenExpiresAt: '2100-01-01T00:00:00Z',
+      aadRefreshToken: 'refresh-token',
+      aadClientId: 'client-id',
+      teams: {},
+      currentTeam: null,
+    })
+    return manager
+  }
+
+  const createSearchJwt = (): string => {
+    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(
+      JSON.stringify({
+        aud: 'https://substrate.office.com',
+        tid: SEARCH_TENANT_ID,
+        oid: SEARCH_USER_ID,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    ).toString('base64url')
+    return `${header}.${payload}.signature`
+  }
+
+  const headerValue = (init: RequestInit | undefined, name: string): string | undefined => {
+    const headers = init?.headers
+    if (headers instanceof Headers) return headers.get(name) ?? undefined
+    if (Array.isArray(headers)) {
+      const pair = headers.find(([key]) => key.toLowerCase() === name.toLowerCase())
+      return pair?.[1]
+    }
+    return headers?.[name]
+  }
 
   const mockResponse = (body: unknown, status = 200, headers: Record<string, string> = {}) => {
     const defaultHeaders: Record<string, string> = {
@@ -436,6 +483,113 @@ describe('TeamsClient', () => {
       expect(fetchCalls[0].url).toBe(
         'https://teams.microsoft.com/api/csa/emea/api/v2/teams/111/channels/ch1/messages/root1/replies?limit=10',
       )
+    })
+  })
+
+  describe('searchMessages', () => {
+    it('posts to Substrate search with bearer token, anchor mailbox, and parses nested results', async () => {
+      const manager = await setupCredentialManager()
+      const searchJwt = createSearchJwt()
+      mockResponse({ access_token: searchJwt, refresh_token: 'rotated-refresh', expires_in: 3600 })
+      mockResponse({
+        EntitySets: [
+          {
+            ResultSets: [
+              {
+                Results: [
+                  {
+                    Id: 'msg-1',
+                    Content: '<p>Deploy complete</p>',
+                    Author: { Id: 'author-1', DisplayName: 'Alice' },
+                    ChannelId: 'channel-1',
+                    ThreadId: 'thread-1',
+                    TeamName: 'Team One',
+                    ChannelName: 'General',
+                    DateTimeSent: '2024-01-01T00:00:00.000Z',
+                    WebUrl: 'https://teams.microsoft.com/l/message/msg-1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+      const client = await new TeamsClient(manager).login({ token: 'skype-token', region: 'emea' })
+      const results = await client.searchMessages('deploy', { limit: 10, from: 5 })
+
+      expect(fetchCalls[1].url).toBe('https://substrate.office.com/searchservice/api/v2/query')
+      expect(fetchCalls[1].options?.method).toBe('POST')
+      expect(headerValue(fetchCalls[1].options, 'Authorization')).toBe(`Bearer ${searchJwt}`)
+      expect(headerValue(fetchCalls[1].options, 'x-anchormailbox')).toBe(`Oid:${SEARCH_USER_ID}@${SEARCH_TENANT_ID}`)
+      const payload = JSON.parse(String(fetchCalls[1].options?.body)) as {
+        entityRequests: Array<{ entityType: string; contentSources: string[]; from: number; size: number }>
+      }
+      expect(payload.entityRequests[0]).toMatchObject({
+        entityType: 'Message',
+        contentSources: ['Teams'],
+        from: 5,
+        size: 10,
+      })
+      expect(results).toEqual([
+        {
+          id: 'msg-1',
+          content: 'Deploy complete',
+          author: { id: 'author-1', displayName: 'Alice' },
+          channel_id: 'channel-1',
+          thread_id: 'thread-1',
+          team_name: 'Team One',
+          channel_name: 'General',
+          timestamp: '2024-01-01T00:00:00.000Z',
+          permalink: 'https://teams.microsoft.com/l/message/msg-1',
+        },
+      ])
+    })
+
+    it('returns an empty array when Substrate has no nested results', async () => {
+      const manager = await setupCredentialManager()
+      mockResponse({ access_token: createSearchJwt(), refresh_token: 'rotated-refresh', expires_in: 3600 })
+      mockResponse({ EntitySets: [] })
+
+      const client = await new TeamsClient(manager).login({ token: 'skype-token', region: 'emea' })
+      const results = await client.searchMessages('zzimprobablequery_xyz')
+
+      expect(results).toEqual([])
+    })
+
+    it('uses the logged-in account refresh token when current account differs', async () => {
+      const manager = await setupCredentialManager()
+      await manager.setDeviceCodeAccount({
+        accountType: 'personal',
+        token: 'personal-skype-token',
+        tokenExpiresAt: '2100-01-01T00:00:00Z',
+        aadRefreshToken: 'personal-refresh-token',
+        aadClientId: 'personal-client-id',
+        teams: {},
+        currentTeam: null,
+      })
+      const searchJwt = createSearchJwt()
+      mockResponse({ access_token: searchJwt, refresh_token: 'work-rotated-refresh', expires_in: 3600 })
+      mockResponse({ EntitySets: [] })
+
+      const client = await new TeamsClient(manager).login({ token: 'skype-token', accountType: 'work', region: 'emea' })
+      await client.searchMessages('deploy')
+
+      const tokenRequestBody = new URLSearchParams(String(fetchCalls[0].options?.body))
+      expect(tokenRequestBody.get('refresh_token')).toBe('refresh-token')
+      expect(tokenRequestBody.get('client_id')).toBe('client-id')
+    })
+
+    it('rejects invalid pagination options', async () => {
+      const manager = await setupCredentialManager()
+      const client = await new TeamsClient(manager).login({ token: 'skype-token', region: 'emea' })
+
+      await expect(client.searchMessages('deploy', { limit: Number.NaN })).rejects.toThrow('positive integer')
+      await expect(client.searchMessages('deploy', { limit: 0 })).rejects.toThrow('positive integer')
+      await expect(client.searchMessages('deploy', { limit: -1 })).rejects.toThrow('positive integer')
+      await expect(client.searchMessages('deploy', { from: -1 })).rejects.toThrow('non-negative integer')
+      await expect(client.searchMessages('deploy', { from: 1.5 })).rejects.toThrow('non-negative integer')
+      expect(fetchCalls).toHaveLength(0)
     })
   })
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -1,7 +1,10 @@
+import { randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { basename } from 'node:path'
 
+import { SUBSTRATE_SEARCH_URL } from './app-config'
 import { TeamsCredentialManager } from './credential-manager'
+import { TeamsTokenProvider } from './token-provider'
 import type {
   TeamsAccountType,
   TeamsChannel,
@@ -10,6 +13,7 @@ import type {
   TeamsFile,
   TeamsMessage,
   TeamsRegion,
+  TeamsSearchResult,
   TeamsTeam,
   TeamsUser,
 } from './types'
@@ -24,6 +28,8 @@ interface RawTeamsMessage extends TeamsMessage {
   rootMessageId?: string
   parentMessageId?: string
 }
+
+type JsonRecord = Record<string, unknown>
 
 const PERSONAL_MSG_API_BASE = 'https://msgapi.teams.live.com/v1'
 const CSA_API_BASE = 'https://teams.microsoft.com/api'
@@ -58,6 +64,109 @@ function stripHtml(content: string | undefined): string | undefined {
     .replace(/&#39;/g, "'")
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringFrom(record: JsonRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
+}
+
+function recordFrom(record: JsonRecord, keys: string[]): JsonRecord | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (isRecord(value)) return value
+  }
+  return undefined
+}
+
+function arrayFrom(record: JsonRecord, keys: string[]): unknown[] {
+  for (const key of keys) {
+    const value = record[key]
+    if (Array.isArray(value)) return value
+  }
+  return []
+}
+
+function propertyValue(record: JsonRecord, names: string[]): string | undefined {
+  const properties = arrayFrom(record, ['Properties', 'properties'])
+  const normalized = names.map((name) => name.toLowerCase())
+  for (const property of properties) {
+    if (!isRecord(property)) continue
+    const name = stringFrom(property, ['Name', 'name', 'Key', 'key'])
+    if (!name || !normalized.includes(name.toLowerCase())) continue
+    const value = property.Value ?? property.value
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
+}
+
+function resultString(record: JsonRecord, keys: string[]): string | undefined {
+  return stringFrom(record, keys) ?? propertyValue(record, keys)
+}
+
+function parseSubstrateResult(value: unknown): TeamsSearchResult | null {
+  if (!isRecord(value)) return null
+  const author = recordFrom(value, ['Author', 'author', 'From', 'from'])
+  const id = resultString(value, ['id', 'Id', 'ReferenceId', 'MessageId'])
+  const channelId = resultString(value, ['channel_id', 'ChannelId', 'ConversationId', 'ThreadId'])
+  if (!id || !channelId) return null
+
+  return {
+    id,
+    content:
+      stripHtml(resultString(value, ['content', 'Content', 'HitHighlightedSummary', 'Summary', 'Preview'])) ?? '',
+    author: {
+      id: author ? (stringFrom(author, ['id', 'Id', 'ObjectId']) ?? '') : (propertyValue(value, ['AuthorId']) ?? ''),
+      displayName: author
+        ? (stringFrom(author, ['displayName', 'DisplayName', 'Name']) ?? 'Unknown')
+        : (propertyValue(value, ['AuthorDisplayName', 'Author']) ?? 'Unknown'),
+    },
+    channel_id: channelId,
+    thread_id: resultString(value, ['thread_id', 'ThreadId']),
+    team_name: resultString(value, ['team_name', 'TeamName']),
+    channel_name: resultString(value, ['channel_name', 'ChannelName']),
+    timestamp: resultString(value, ['timestamp', 'Timestamp', 'DateTimeSent', 'LastModifiedTime']) ?? '',
+    permalink: resultString(value, ['permalink', 'Permalink', 'WebUrl', 'Url']),
+  }
+}
+
+function parseSubstrateResults(data: unknown): TeamsSearchResult[] {
+  if (!isRecord(data)) return []
+  const results: TeamsSearchResult[] = []
+  for (const entitySet of arrayFrom(data, ['EntitySets', 'entitySets'])) {
+    if (!isRecord(entitySet)) continue
+    for (const resultSet of arrayFrom(entitySet, ['ResultSets', 'resultSets'])) {
+      if (!isRecord(resultSet)) continue
+      for (const rawResult of arrayFrom(resultSet, ['Results', 'results'])) {
+        const result = parseSubstrateResult(rawResult)
+        if (result) results.push(result)
+      }
+    }
+  }
+  return results
+}
+
+function validateSearchLimit(value: number | undefined): number {
+  if (value === undefined) return 20
+  if (!Number.isInteger(value) || value < 1) {
+    throw new TeamsError('Search limit must be a positive integer.', 'invalid_pagination')
+  }
+  return value
+}
+
+function validateSearchFrom(value: number | undefined): number {
+  if (value === undefined) return 0
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TeamsError('Search from offset must be a non-negative integer.', 'invalid_pagination')
+  }
+  return value
 }
 
 function escapeHtml(value: string): string {
@@ -105,8 +214,11 @@ export class TeamsClient {
   private isPersonalAccount: boolean = false
   private region: TeamsRegion = DEFAULT_REGION
   private regionDiscovered: boolean = false
+  private tokenProvider?: TeamsTokenProvider
   private buckets: Map<string, RateLimitBucket> = new Map()
   private globalRateLimitUntil: number = 0
+
+  constructor(private credManager: TeamsCredentialManager = new TeamsCredentialManager()) {}
 
   async login(credentials?: {
     token: string
@@ -129,13 +241,15 @@ export class TeamsClient {
         this.region = credentials.region
         this.regionDiscovered = true
       }
+      if (credentials.accountType) {
+        this.getTokenProvider().bindAccount(credentials.accountType)
+      }
       return this
     }
 
     const { ensureTeamsAuth } = await import('./ensure-auth')
     await ensureTeamsAuth()
-    const credManager = new TeamsCredentialManager()
-    const creds = await credManager.getTokenWithExpiry()
+    const creds = await this.credManager.getTokenWithExpiry()
     if (!creds) {
       throw new TeamsError(
         'No Teams credentials found. Make sure Microsoft Teams is logged in via the desktop app or a supported Chromium browser.',
@@ -569,6 +683,53 @@ export class TeamsClient {
       CSA_API_BASE,
     )
     return replies.map((reply) => withThreadMetadata(reply, rootMessageId))
+  }
+
+  async searchMessages(query: string, opts: { limit?: number; from?: number } = {}): Promise<TeamsSearchResult[]> {
+    const size = validateSearchLimit(opts.limit)
+    const from = validateSearchFrom(opts.from)
+    const tokenProvider = this.getTokenProvider()
+    const substrateToken = await tokenProvider.getSubstrateToken()
+    const tenantId = await tokenProvider.getTenantId()
+    const userId = await tokenProvider.getUserId()
+
+    const response = await fetch(SUBSTRATE_SEARCH_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${substrateToken}`,
+        'Content-Type': 'application/json',
+        'x-anchormailbox': `Oid:${userId}@${tenantId}`,
+      },
+      body: JSON.stringify({
+        cvid: randomUUID(),
+        logicalId: randomUUID(),
+        query: { queryString: query },
+        entityRequests: [
+          {
+            entityType: 'Message',
+            contentSources: ['Teams'],
+            from,
+            size,
+            query: { queryString: query },
+          },
+        ],
+      }),
+    })
+
+    const data = (await response.json().catch(() => ({}))) as unknown
+    if (!response.ok) {
+      const message = isRecord(data)
+        ? stringFrom(data, ['message', 'Message', 'error_description', 'error'])
+        : undefined
+      throw new TeamsError(message ?? `HTTP ${response.status}`, `substrate_${response.status}`)
+    }
+
+    return parseSubstrateResults(data)
+  }
+
+  private getTokenProvider(): TeamsTokenProvider {
+    this.tokenProvider ??= new TeamsTokenProvider(this.credManager)
+    return this.tokenProvider
   }
 
   async getMessage(teamId: string, channelId: string, messageId: string): Promise<TeamsMessage> {

--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
+import * as deviceLogin from '../device-login'
 import { TeamsTokenExtractor } from '../token-extractor'
-import { getNoTeamsTokenFoundMessage } from './auth'
+import { getNoTeamsTokenFoundMessage, loginAction } from './auth'
 
 let extractorExtractSpy: ReturnType<typeof spyOn>
 let clientTestAuthSpy: ReturnType<typeof spyOn>
@@ -13,6 +14,7 @@ let credManagerSaveConfigSpy: ReturnType<typeof spyOn>
 let credManagerClearCredentialsSpy: ReturnType<typeof spyOn>
 let credManagerIsTokenExpiredSpy: ReturnType<typeof spyOn>
 let clientGetRegionSpy: ReturnType<typeof spyOn>
+const originalConsoleLog = console.log
 
 beforeEach(() => {
   extractorExtractSpy = spyOn(TeamsTokenExtractor.prototype, 'extract').mockResolvedValue([
@@ -52,6 +54,7 @@ afterEach(() => {
   credManagerClearCredentialsSpy?.mockRestore()
   credManagerIsTokenExpiredSpy?.mockRestore()
   clientGetRegionSpy?.mockRestore()
+  console.log = originalConsoleLog
 })
 
 it('extract: calls TeamsTokenExtractor', async () => {
@@ -97,4 +100,24 @@ it('status: checks token expiry', async () => {
 
 it('no-token message mentions desktop app and browser fallback', () => {
   expect(getNoTeamsTokenFoundMessage()).toContain('desktop app or a supported Chromium browser')
+})
+
+it('login pending hint preserves explicit account type', async () => {
+  const completeSpy = spyOn(deviceLogin, 'completeDeviceCode').mockRejectedValue(new deviceLogin.PendingApprovalError())
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+  const exitSpy = spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`exit:${code}`)
+  })
+
+  await expect(loginAction({ deviceCode: 'device-code', accountType: 'personal', pretty: false })).rejects.toThrow(
+    'exit:1',
+  )
+
+  expect(completeSpy).toHaveBeenCalled()
+  expect(exitSpy.mock.calls[0][0]).toBe(0)
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('agent-teams auth login --device-code <device_code> --account-type personal')
+  completeSpy.mockRestore()
+  consoleSpy.mockRestore()
+  exitSpy.mockRestore()
 })

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -17,22 +17,25 @@ interface LoginOptions {
   debug?: boolean
   deviceCode?: string
   clientId?: string
+  accountType?: string
 }
 
 export async function loginAction(options: LoginOptions): Promise<void> {
   try {
+    const accountType = resolveLoginAccountType(options.accountType)
     if (options.deviceCode) {
-      await finishDeviceCode(options)
+      await finishDeviceCode(options, accountType)
       return
     }
     if (!isInteractive()) {
-      await startNonInteractiveLogin(options.clientId)
+      await startNonInteractiveLogin(options.clientId, accountType)
       return
     }
 
     const debugLog = options.debug ? (msg: string) => debug(`[debug] ${msg}`) : undefined
     const result = await loginWithDeviceCode({
       clientId: options.clientId,
+      accountType,
       onCode: async ({ verificationUri, userCode }) => {
         info(`\nTo sign in, open ${verificationUri} and enter code ${userCode}\n`)
         info('Waiting for approval...')
@@ -45,6 +48,7 @@ export async function loginAction(options: LoginOptions): Promise<void> {
       formatOutput(
         {
           authenticated: true,
+          account_type: result.accountType,
           user: result.userName,
           teams: result.teams.map((t) => `${t.id}/${t.name}`),
           current: result.current,
@@ -57,33 +61,45 @@ export async function loginAction(options: LoginOptions): Promise<void> {
   }
 }
 
-async function startNonInteractiveLogin(clientIdOverride?: string): Promise<void> {
-  const { info: device, clientId } = await startDeviceCode(clientIdOverride)
+function resolveLoginAccountType(value: string | undefined): TeamsAccountType {
+  if (value === undefined) return 'work'
+  if (value === 'work' || value === 'personal') return value
+  throw new Error('Invalid account type. Use "work" or "personal".')
+}
+
+async function startNonInteractiveLogin(
+  clientIdOverride: string | undefined,
+  accountType: TeamsAccountType,
+): Promise<void> {
+  const { info: device, clientId } = await startDeviceCode(clientIdOverride, accountType)
   const clientIdFlag = clientIdOverride ? ` --client-id ${clientIdOverride}` : ''
+  const accountTypeFlag = accountType === 'personal' ? ' --account-type personal' : ''
   console.log(
     formatOutput({
       next_action: 'authorize',
+      account_type: accountType,
       verification_uri: device.verificationUri,
       verification_uri_complete: device.verificationUriComplete,
       user_code: device.userCode,
       device_code: device.deviceCode,
       client_id: clientId,
       expires_at: Date.now() + device.expiresIn * 1000,
-      message: `Show the user \`verification_uri\` and \`user_code\` (or \`verification_uri_complete\`) and ask them to approve in a browser. After they approve, run \`agent-teams auth login --device-code <device_code>${clientIdFlag}\` to finish.`,
+      message: `Show the user \`verification_uri\` and \`user_code\` (or \`verification_uri_complete\`) and ask them to approve in a browser. After they approve, run \`agent-teams auth login --device-code <device_code>${clientIdFlag}${accountTypeFlag}\` to finish.`,
     }),
   )
   process.exit(0)
 }
 
-async function finishDeviceCode(options: LoginOptions): Promise<void> {
+async function finishDeviceCode(options: LoginOptions, accountType: TeamsAccountType): Promise<void> {
   const { getTeamsAppClientId } = await import('../app-config')
-  const clientId = options.clientId ?? getTeamsAppClientId().clientId
+  const clientId = options.clientId ?? getTeamsAppClientId(accountType).clientId
   try {
-    const result = await completeDeviceCode(options.deviceCode!, clientId)
+    const result = await completeDeviceCode(options.deviceCode!, clientId, undefined, accountType)
     console.log(
       formatOutput(
         {
           authenticated: true,
+          account_type: result.accountType,
           user: result.userName,
           teams: result.teams.map((t) => `${t.id}/${t.name}`),
           current: result.current,
@@ -93,13 +109,14 @@ async function finishDeviceCode(options: LoginOptions): Promise<void> {
     )
   } catch (error) {
     if (error instanceof PendingApprovalError) {
+      const clientIdFlag = options.clientId ? ` --client-id ${options.clientId}` : ''
+      const accountTypeFlag = options.accountType ? ` --account-type ${accountType}` : ''
       console.log(
         formatOutput(
           {
             next_action: 'still_pending',
             device_code: options.deviceCode,
-            message:
-              'User has not approved yet. Confirm they completed authorization in the browser, then run `auth login --device-code <device_code>` again.',
+            message: `User has not approved yet. Confirm they completed authorization in the browser, then run \`agent-teams auth login --device-code <device_code>${clientIdFlag}${accountTypeFlag}\` again.`,
           },
           options.pretty,
         ),
@@ -543,11 +560,12 @@ export const authCommand = new Command('auth')
   .description('Authentication commands')
   .addCommand(
     new Command('login')
-      .description('Sign in via device code (no desktop app needed). Personal Microsoft accounts.')
+      .description('Sign in via device code (no desktop app needed). Defaults to work/school accounts.')
       .option('--pretty', 'Pretty print JSON output')
       .option('--debug', 'Show debug output for troubleshooting')
       .option('--device-code <code>', 'Finish a non-interactive login started earlier')
       .option('--client-id <id>', 'Override the AAD client ID')
+      .option('--account-type <type>', 'Account type: work or personal (default: work)')
       .action(loginAction),
   )
   .addCommand(

--- a/src/platforms/teams/commands/message.test.ts
+++ b/src/platforms/teams/commands/message.test.ts
@@ -2,15 +2,17 @@ import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
-import { deleteAction, getAction, listAction, repliesAction, sendAction } from './message'
+import { deleteAction, getAction, listAction, repliesAction, searchAction, sendAction, strictParseInt } from './message'
 
 let clientSendMessageSpy: ReturnType<typeof spyOn>
 let clientGetMessagesSpy: ReturnType<typeof spyOn>
 let clientGetThreadRepliesSpy: ReturnType<typeof spyOn>
 let clientGetMessageSpy: ReturnType<typeof spyOn>
 let clientDeleteMessageSpy: ReturnType<typeof spyOn>
+let clientSearchMessagesSpy: ReturnType<typeof spyOn>
 let credManagerLoadSpy: ReturnType<typeof spyOn>
 const originalConsoleLog = console.log
+const originalConsoleError = console.error
 
 beforeEach(() => {
   clientSendMessageSpy = spyOn(TeamsClient.prototype, 'sendMessage').mockResolvedValue({
@@ -60,6 +62,20 @@ beforeEach(() => {
 
   clientDeleteMessageSpy = spyOn(TeamsClient.prototype, 'deleteMessage').mockResolvedValue(undefined)
 
+  clientSearchMessagesSpy = spyOn(TeamsClient.prototype, 'searchMessages').mockResolvedValue([
+    {
+      id: 'search_123',
+      content: 'Deploy complete',
+      author: { id: 'user_789', displayName: 'Test User' },
+      channel_id: 'ch_456',
+      thread_id: 'thread_123',
+      team_name: 'Test Team',
+      channel_name: 'General',
+      timestamp: '2025-01-29T10:03:00Z',
+      permalink: 'https://teams.microsoft.com/l/message/search_123',
+    },
+  ])
+
   credManagerLoadSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue({
     current_account: 'work',
     accounts: {
@@ -79,8 +95,10 @@ afterEach(() => {
   clientGetThreadRepliesSpy?.mockRestore()
   clientGetMessageSpy?.mockRestore()
   clientDeleteMessageSpy?.mockRestore()
+  clientSearchMessagesSpy?.mockRestore()
   credManagerLoadSpy?.mockRestore()
   console.log = originalConsoleLog
+  console.error = originalConsoleError
 })
 
 it('send: returns message with id', async () => {
@@ -117,6 +135,55 @@ it('replies: returns array of thread replies', async () => {
   const output = consoleSpy.mock.calls[0][0]
   expect(output).toContain('reply_123')
   expect(output).toContain('msg_123')
+})
+
+it('search: returns search results and passes pagination options', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await searchAction('deploy', { limit: 10, from: 5, pretty: false })
+
+  expect(clientSearchMessagesSpy).toHaveBeenCalledWith('deploy', { limit: 10, from: 5 })
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('search_123')
+  expect(output).toContain('Deploy complete')
+})
+
+it.each([
+  ['abc', Number.NaN],
+  ['1.5', Number.NaN],
+  ['1abc', Number.NaN],
+  ['', Number.NaN],
+  ['10', 10],
+  [' 10 ', 10],
+  ['-1', -1],
+])('strictParseInt(%p) -> %p (rejects truncatable strings)', (input, expected) => {
+  const result = strictParseInt(input)
+  if (Number.isNaN(expected)) {
+    expect(Number.isNaN(result)).toBe(true)
+  } else {
+    expect(result).toBe(expected as number)
+  }
+})
+
+it.each([
+  ['--limit abc', { limit: Number.NaN, from: 0 }],
+  ['--limit 0', { limit: 0, from: 0 }],
+  ['--limit -1', { limit: -1, from: 0 }],
+  ['--from -1', { limit: 20, from: -1 }],
+])('search: rejects invalid pagination %s', async (_label, options) => {
+  const consoleErrorSpy = mock((_msg: string) => {})
+  console.error = consoleErrorSpy
+  const exitSpy = spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`exit:${code}`)
+  })
+
+  await expect(searchAction('deploy', { ...options, pretty: false })).rejects.toThrow('exit:1')
+
+  expect(consoleErrorSpy).toHaveBeenCalled()
+  expect(clientSearchMessagesSpy).not.toHaveBeenCalled()
+  exitSpy.mockRestore()
 })
 
 it('get: returns single message', async () => {

--- a/src/platforms/teams/commands/message.ts
+++ b/src/platforms/teams/commands/message.ts
@@ -6,6 +6,7 @@ import { formatOutput } from '@/shared/utils/output'
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import type { TeamsMessage } from '../types'
+import { TeamsAuthCapabilityError } from '../types'
 
 export async function sendAction(
   teamId: string,
@@ -121,6 +122,74 @@ export async function repliesAction(
   }
 }
 
+export async function searchAction(
+  query: string,
+  options: { limit?: number; from?: number; pretty?: boolean },
+): Promise<void> {
+  try {
+    if (!isPositiveInteger(options.limit)) {
+      console.error(formatOutput({ error: '--limit must be a positive integer.' }, options.pretty))
+      process.exit(1)
+    }
+    if (!isNonNegativeInteger(options.from)) {
+      console.error(formatOutput({ error: '--from must be a non-negative integer.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.error(formatOutput({ error: new TeamsAuthCapabilityError().message }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const results = await client.searchMessages(query, { limit: options.limit, from: options.from })
+
+    const output = results.map((result) => ({
+      id: result.id,
+      content: result.content,
+      author: result.author.displayName,
+      author_id: result.author.id,
+      channel_id: result.channel_id,
+      thread_id: result.thread_id,
+      team_name: result.team_name,
+      channel_name: result.channel_name,
+      timestamp: result.timestamp,
+      permalink: result.permalink,
+    }))
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    if (error instanceof TeamsAuthCapabilityError) {
+      console.error(formatOutput({ error: error.message }, options.pretty))
+      process.exit(1)
+    }
+    handleError(error as Error)
+  }
+}
+
+function isPositiveInteger(value: number | undefined): boolean {
+  return value === undefined || (Number.isInteger(value) && value >= 1)
+}
+
+function isNonNegativeInteger(value: number | undefined): boolean {
+  return value === undefined || (Number.isInteger(value) && value >= 0)
+}
+
+// parseInt truncates "1.5"/"1abc" to 1, sneaking malformed input past the integer
+// checks in searchAction, so reject anything that isn't a pure decimal integer up front
+export function strictParseInt(value: string | undefined): number {
+  if (value === undefined) return Number.NaN
+  return /^-?\d+$/.test(value.trim()) ? Number.parseInt(value, 10) : Number.NaN
+}
+
 export async function getAction(
   teamId: string,
   channelId: string,
@@ -233,6 +302,21 @@ export const messageCommand = new Command('message')
       .action((teamId: string, channelId: string, messageId: string, options: any) => {
         return repliesAction(teamId, channelId, messageId, {
           limit: parseInt(options.limit, 10),
+          pretty: options.pretty,
+        })
+      }),
+  )
+  .addCommand(
+    new Command('search')
+      .description('Search Teams messages (requires auth login)')
+      .argument('<query>', 'Search query')
+      .option('--limit <n>', 'Number of results', '20')
+      .option('--from <n>', 'Offset for pagination', '0')
+      .option('--pretty', 'Pretty print JSON output')
+      .action((query: string, options: any) => {
+        return searchAction(query, {
+          limit: strictParseInt(options.limit),
+          from: strictParseInt(options.from),
           pretty: options.pretty,
         })
       }),

--- a/src/platforms/teams/credential-manager.ts
+++ b/src/platforms/teams/credential-manager.ts
@@ -168,6 +168,17 @@ export class TeamsCredentialManager {
     return { refreshToken: account.aad_refresh_token, clientId: account.aad_client_id }
   }
 
+  async updateAadRefreshToken(accountType: TeamsAccountType, refreshToken: string, clientId?: string): Promise<void> {
+    const config = await this.loadConfig()
+    const account = config?.accounts[accountType]
+    if (!config || !account) return
+    account.aad_refresh_token = refreshToken
+    if (clientId !== undefined) {
+      account.aad_client_id = clientId
+    }
+    await this.saveConfig(config)
+  }
+
   async getCurrentTeam(): Promise<{ team_id: string; team_name: string } | null> {
     const config = await this.loadConfig()
     if (!config) return null

--- a/src/platforms/teams/device-code.test.ts
+++ b/src/platforms/teams/device-code.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 
+import { getTeamsAppClientId } from './app-config'
 import {
   exchangeDeviceCode,
   exchangeForSkypeScope,
@@ -38,6 +39,13 @@ afterEach(() => {
   globalThis.fetch = originalFetch
 })
 
+describe('getTeamsAppClientId', () => {
+  it('keeps the consumer client for personal login and uses Teams desktop client for work login', () => {
+    expect(getTeamsAppClientId('personal').clientId).toBe('5e3ce6c0-2b1f-4285-8d4b-75ee78787346')
+    expect(getTeamsAppClientId('work').clientId).toBe('1fec8e78-bce4-4aaf-ab1b-5451cc387264')
+  })
+})
+
 describe('requestDeviceCode', () => {
   it('posts to consumer devicecode endpoint with teams scope and composes verificationUriComplete', async () => {
     const { calls } = mockFetch(() => ({
@@ -58,6 +66,24 @@ describe('requestDeviceCode', () => {
     expect(calls[0].body.get('scope')).toContain('offline_access')
     expect(info.verificationUriComplete).toBe('https://microsoft.com/devicelogin?otc=ABCD-1234')
     expect(info.interval).toBe(5)
+  })
+
+  it('posts work-account device code requests to organizations authority with Teams scope', async () => {
+    const { calls } = mockFetch(() => ({
+      json: {
+        device_code: 'DC',
+        user_code: 'ABCD-1234',
+        verification_uri: 'https://microsoft.com/devicelogin',
+        expires_in: 900,
+        interval: 5,
+      },
+    }))
+
+    await requestDeviceCode(CLIENT_ID, 'work')
+
+    expect(calls[0].url).toContain('/organizations/oauth2/v2.0/devicecode')
+    expect(calls[0].body.get('client_id')).toBe(CLIENT_ID)
+    expect(calls[0].body.get('scope')).toBe('https://api.spaces.skype.com/.default openid profile offline_access')
   })
 
   it('throws on non-200', async () => {
@@ -120,6 +146,17 @@ describe('exchangeForSkypeScope', () => {
     mockFetch(() => ({ json: { access_token: 'SKYPE_AT' } }))
     const token = await exchangeForSkypeScope('RT1', CLIENT_ID)
     expect(token.refreshToken).toBe('RT1')
+  })
+
+  it('refresh-exchanges work accounts against organizations authority with Teams Skype scope', async () => {
+    const { calls } = mockFetch(() => ({ json: { access_token: 'WORK_SKYPE_AT', refresh_token: 'RT2' } }))
+
+    const token = await exchangeForSkypeScope('RT1', CLIENT_ID, 'work')
+
+    expect(calls[0].url).toContain('/organizations/oauth2/v2.0/token')
+    expect(calls[0].body.get('grant_type')).toBe('refresh_token')
+    expect(calls[0].body.get('scope')).toBe('https://api.spaces.skype.com/.default openid profile offline_access')
+    expect(token).toEqual({ accessToken: 'WORK_SKYPE_AT', refreshToken: 'RT2' })
   })
 })
 

--- a/src/platforms/teams/device-code.ts
+++ b/src/platforms/teams/device-code.ts
@@ -1,10 +1,5 @@
-import {
-  AUTHZ_CONSUMER_URL,
-  consumerDeviceCodeUrl,
-  consumerTokenUrl,
-  DEVICE_CODE_SCOPE_SKYPE,
-  DEVICE_CODE_SCOPE_TEAMS,
-} from './app-config'
+import { authzUrl, deviceCodeSkypeScope, deviceCodeTeamsScope, deviceCodeTokenUrl, deviceCodeUrl } from './app-config'
+import type { TeamsAccountType, TeamsRegion } from './types'
 import { TeamsError } from './types'
 
 const DEFAULT_SKYPE_TOKEN_TTL_SEC = 21600
@@ -26,6 +21,7 @@ export interface AadToken {
 export interface MintedSkypeToken {
   skypeToken: string
   skypeTokenExpiresAt: string
+  region?: TeamsRegion
 }
 
 export type DeviceTokenResult =
@@ -49,10 +45,13 @@ async function postForm(
   return { status: res.status, body }
 }
 
-export async function requestDeviceCode(clientId: string): Promise<DeviceCodeInfo> {
-  const { status, body } = await postForm(consumerDeviceCodeUrl(), {
+export async function requestDeviceCode(
+  clientId: string,
+  accountType: TeamsAccountType = 'personal',
+): Promise<DeviceCodeInfo> {
+  const { status, body } = await postForm(deviceCodeUrl(accountType), {
     client_id: clientId,
-    scope: DEVICE_CODE_SCOPE_TEAMS,
+    scope: deviceCodeTeamsScope(accountType),
   })
   if (status !== 200) {
     throw new TeamsError(`Device code request failed: ${describeAadError(body, status)}`, 'device_code_failed')
@@ -69,8 +68,12 @@ export async function requestDeviceCode(clientId: string): Promise<DeviceCodeInf
   }
 }
 
-export async function exchangeDeviceCode(deviceCode: string, clientId: string): Promise<DeviceTokenResult> {
-  const { status, body } = await postForm(consumerTokenUrl(), {
+export async function exchangeDeviceCode(
+  deviceCode: string,
+  clientId: string,
+  accountType: TeamsAccountType = 'personal',
+): Promise<DeviceTokenResult> {
+  const { status, body } = await postForm(deviceCodeTokenUrl(accountType), {
     client_id: clientId,
     grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
     device_code: deviceCode,
@@ -94,12 +97,13 @@ export async function pollDeviceToken(
   interval: number,
   expiresIn: number,
   clientId: string,
+  accountType: TeamsAccountType = 'personal',
 ): Promise<AadToken> {
   const deadline = Date.now() + expiresIn * 1000
   let waitMs = Math.max(interval, 1) * 1000
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, waitMs))
-    const result = await exchangeDeviceCode(deviceCode, clientId)
+    const result = await exchangeDeviceCode(deviceCode, clientId, accountType)
     if (result.status === 'success') return result.token
     if (result.status === 'slow_down') {
       waitMs += 5000
@@ -113,12 +117,16 @@ export async function pollDeviceToken(
   throw new TeamsError('Device code expired before approval.', 'device_code_expired')
 }
 
-export async function exchangeForSkypeScope(refreshToken: string, clientId: string): Promise<AadToken> {
-  const { status, body } = await postForm(consumerTokenUrl(), {
+export async function exchangeForSkypeScope(
+  refreshToken: string,
+  clientId: string,
+  accountType: TeamsAccountType = 'personal',
+): Promise<AadToken> {
+  const { status, body } = await postForm(deviceCodeTokenUrl(accountType), {
     client_id: clientId,
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
-    scope: DEVICE_CODE_SCOPE_SKYPE,
+    scope: deviceCodeSkypeScope(accountType),
   })
   if (status !== 200) {
     throw new TeamsError(`Token exchange failed: ${describeAadError(body, status)}`, 'token_exchange_failed')
@@ -129,8 +137,11 @@ export async function exchangeForSkypeScope(refreshToken: string, clientId: stri
   }
 }
 
-export async function mintConsumerSkypeToken(spacesAccessToken: string): Promise<MintedSkypeToken> {
-  const res = await fetch(AUTHZ_CONSUMER_URL, {
+export async function mintSkypeToken(
+  spacesAccessToken: string,
+  accountType: TeamsAccountType = 'personal',
+): Promise<MintedSkypeToken> {
+  const res = await fetch(authzUrl(accountType), {
     method: 'POST',
     headers: { Authorization: `Bearer ${spacesAccessToken}`, Accept: 'application/json; ver=1.0' },
   })
@@ -148,7 +159,12 @@ export async function mintConsumerSkypeToken(spacesAccessToken: string): Promise
   return {
     skypeToken,
     skypeTokenExpiresAt: new Date(Date.now() + ttlSec * 1000).toISOString(),
+    region: parseRegion(body),
   }
+}
+
+export async function mintConsumerSkypeToken(spacesAccessToken: string): Promise<MintedSkypeToken> {
+  return mintSkypeToken(spacesAccessToken, 'personal')
 }
 
 function describeAadError(body: Record<string, unknown>, status: number): string {
@@ -159,4 +175,11 @@ function describeAadError(body: Record<string, unknown>, status: number): string
 function describeAuthzError(body: Record<string, unknown>, status: number): string {
   const statusObj = body.status as { text?: string } | undefined
   return String(body.errorCode ?? body.message ?? statusObj?.text ?? `HTTP ${status}`)
+}
+
+function parseRegion(body: Record<string, unknown>): TeamsRegion | undefined {
+  const regionGtms = body.regionGtms as { region?: string; middleTier?: string; mt?: string } | undefined
+  const raw = regionGtms?.region ?? regionGtms?.middleTier ?? regionGtms?.mt
+  if (raw === 'amer' || raw === 'emea' || raw === 'apac') return raw
+  return undefined
 }

--- a/src/platforms/teams/device-login.test.ts
+++ b/src/platforms/teams/device-login.test.ts
@@ -64,6 +64,28 @@ describe('refreshDeviceCodeAccount', () => {
     expect(config?.current_account).toBe('personal')
   })
 
+  it('refreshes work device-code accounts and persists the rotated refresh token', async () => {
+    const manager = setup()
+    await manager.setDeviceCodeAccount({
+      accountType: 'work',
+      token: 'old-skype',
+      tokenExpiresAt: '2000-01-01T00:00:00Z',
+      aadRefreshToken: 'old-refresh',
+      aadClientId: 'client',
+      teams: {},
+      currentTeam: null,
+    })
+
+    mockExchangeAndMint('new-skype', 'new-work-refresh')
+    const ok = await refreshDeviceCodeAccount('work', manager)
+
+    expect(ok).toBe(true)
+    const config = await manager.loadConfig()
+    expect(config?.accounts.work?.token).toBe('new-skype')
+    expect(config?.accounts.work?.aad_refresh_token).toBe('new-work-refresh')
+    expect(config?.accounts.work?.auth_method).toBe('device-code')
+  })
+
   it('does not change current_account when refreshing a non-current account', async () => {
     const manager = setup()
     await manager.setDeviceCodeAccount({

--- a/src/platforms/teams/device-login.ts
+++ b/src/platforms/teams/device-login.ts
@@ -5,7 +5,7 @@ import {
   type DeviceCodeInfo,
   exchangeDeviceCode,
   exchangeForSkypeScope,
-  mintConsumerSkypeToken,
+  mintSkypeToken,
   pollDeviceToken,
   requestDeviceCode,
 } from './device-code'
@@ -30,11 +30,15 @@ interface LoginCallbacks {
   onPending?: () => void
   debug?: (message: string) => void
   clientId?: string
+  accountType?: TeamsAccountType
 }
 
-export async function startDeviceCode(clientIdOverride?: string): Promise<{ info: DeviceCodeInfo; clientId: string }> {
-  const clientId = clientIdOverride ?? getTeamsAppClientId().clientId
-  const info = await requestDeviceCode(clientId)
+export async function startDeviceCode(
+  clientIdOverride?: string,
+  accountType: TeamsAccountType = 'personal',
+): Promise<{ info: DeviceCodeInfo; clientId: string }> {
+  const clientId = clientIdOverride ?? getTeamsAppClientId(accountType).clientId
+  const info = await requestDeviceCode(clientId, accountType)
   return { info, clientId }
 }
 
@@ -42,8 +46,9 @@ export async function completeDeviceCode(
   deviceCode: string,
   clientId: string,
   credManager: TeamsCredentialManager = new TeamsCredentialManager(),
+  accountType: TeamsAccountType = 'personal',
 ): Promise<DeviceLoginResult> {
-  const first = await exchangeDeviceCode(deviceCode, clientId)
+  const first = await exchangeDeviceCode(deviceCode, clientId, accountType)
   if (first.status === 'pending' || first.status === 'slow_down') {
     throw new PendingApprovalError()
   }
@@ -56,14 +61,15 @@ export async function completeDeviceCode(
           : `Login failed: ${first.message}`,
     )
   }
-  return finalize(first.token.refreshToken, clientId, credManager)
+  return finalize(first.token.refreshToken, clientId, accountType, credManager)
 }
 
 export async function loginWithDeviceCode(
   callbacks: LoginCallbacks,
   credManager: TeamsCredentialManager = new TeamsCredentialManager(),
 ): Promise<DeviceLoginResult> {
-  const { info, clientId } = await startDeviceCode(callbacks.clientId)
+  const accountType = callbacks.accountType ?? 'personal'
+  const { info, clientId } = await startDeviceCode(callbacks.clientId, accountType)
   await callbacks.onCode({
     verificationUri: info.verificationUri,
     verificationUriComplete: info.verificationUriComplete,
@@ -71,14 +77,15 @@ export async function loginWithDeviceCode(
     expiresAt: Date.now() + info.expiresIn * 1000,
   })
 
-  const aad = await pollDeviceToken(info.deviceCode, info.interval, info.expiresIn, clientId)
+  const aad = await pollDeviceToken(info.deviceCode, info.interval, info.expiresIn, clientId, accountType)
   callbacks.onPending?.()
-  return finalize(aad.refreshToken, clientId, credManager, callbacks.debug)
+  return finalize(aad.refreshToken, clientId, accountType, credManager, callbacks.debug)
 }
 
 async function finalize(
   initialRefreshToken: string | undefined,
   clientId: string,
+  accountType: TeamsAccountType,
   credManager: TeamsCredentialManager,
   debug?: (message: string) => void,
 ): Promise<DeviceLoginResult> {
@@ -89,12 +96,11 @@ async function finalize(
   }
 
   debug?.('Exchanging token for skype audience...')
-  const skypeScoped = await exchangeForSkypeScope(initialRefreshToken, clientId)
+  const skypeScoped = await exchangeForSkypeScope(initialRefreshToken, clientId, accountType)
 
   debug?.('Minting skype token...')
-  const minted = await mintConsumerSkypeToken(skypeScoped.accessToken)
+  const minted = await mintSkypeToken(skypeScoped.accessToken, accountType)
 
-  const accountType: TeamsAccountType = 'personal'
   const client = await new TeamsClient().login({ token: minted.skypeToken, accountType })
   const authInfo = await client.testAuth()
   const teams = await client.listTeams()
@@ -111,6 +117,7 @@ async function finalize(
     tokenExpiresAt: minted.skypeTokenExpiresAt,
     aadRefreshToken: skypeScoped.refreshToken,
     aadClientId: clientId,
+    region: minted.region ?? (accountType === 'work' ? client.getRegion() : undefined),
     userName: authInfo.displayName,
     teams: teamMap,
     currentTeam,
@@ -135,12 +142,12 @@ export async function refreshDeviceCodeAccount(
   if (!account || account.auth_method !== 'device-code' || !account.aad_refresh_token) {
     return false
   }
-  const clientId = account.aad_client_id ?? getTeamsAppClientId().clientId
+  const clientId = account.aad_client_id ?? getTeamsAppClientId(accountType).clientId
 
   try {
     debug?.('Silently refreshing skype token...')
-    const skypeScoped = await exchangeForSkypeScope(account.aad_refresh_token, clientId)
-    const minted = await mintConsumerSkypeToken(skypeScoped.accessToken)
+    const skypeScoped = await exchangeForSkypeScope(account.aad_refresh_token, clientId, accountType)
+    const minted = await mintSkypeToken(skypeScoped.accessToken, accountType)
 
     await credManager.setDeviceCodeAccount({
       accountType,
@@ -148,7 +155,7 @@ export async function refreshDeviceCodeAccount(
       tokenExpiresAt: minted.skypeTokenExpiresAt,
       aadRefreshToken: skypeScoped.refreshToken,
       aadClientId: clientId,
-      region: account.region,
+      region: minted.region ?? account.region,
       userName: account.user_name,
       teams: account.teams,
       currentTeam: account.current_team,

--- a/src/platforms/teams/index.test.ts
+++ b/src/platforms/teams/index.test.ts
@@ -13,7 +13,9 @@ import {
   TeamsFileSchema,
   TeamsMessageSchema,
   TeamsReactionSchema,
+  TeamsSearchResultSchema,
   TeamsTeamSchema,
+  TeamsTokenProvider,
   TeamsUserSchema,
 } from '@/platforms/teams/index'
 
@@ -29,6 +31,10 @@ it('TeamsCredentialManager is exported from barrel', () => {
   expect(typeof TeamsCredentialManager).toBe('function')
 })
 
+it('TeamsTokenProvider is exported from barrel', () => {
+  expect(typeof TeamsTokenProvider).toBe('function')
+})
+
 it('TeamsTeamSchema is exported from barrel', () => {
   expect(typeof TeamsTeamSchema.parse).toBe('function')
 })
@@ -39,6 +45,10 @@ it('TeamsChannelSchema is exported from barrel', () => {
 
 it('TeamsMessageSchema is exported from barrel', () => {
   expect(typeof TeamsMessageSchema.parse).toBe('function')
+})
+
+it('TeamsSearchResultSchema is exported from barrel', () => {
+  expect(typeof TeamsSearchResultSchema.parse).toBe('function')
 })
 
 it('TeamsUserSchema is exported from barrel', () => {

--- a/src/platforms/teams/index.ts
+++ b/src/platforms/teams/index.ts
@@ -1,5 +1,6 @@
 export { TeamsClient } from './client'
 export { TeamsCredentialManager } from './credential-manager'
+export { TeamsTokenProvider } from './token-provider'
 export {
   completeDeviceCode,
   loginWithDeviceCode,
@@ -9,7 +10,7 @@ export {
 } from './device-login'
 export type { DeviceCodePrompt, DeviceLoginResult } from './device-login'
 export { TeamsListener } from './listener'
-export { TeamsError } from './types'
+export { TeamsAuthCapabilityError, TeamsError } from './types'
 export type {
   TeamsAccount,
   TeamsAccountType,
@@ -22,6 +23,7 @@ export type {
   TeamsMessage,
   TeamsRealtimeMessage,
   TeamsReaction,
+  TeamsSearchResult,
   TeamsTeam,
   TeamsTrouterGenericEvent,
   TeamsUser,
@@ -36,6 +38,7 @@ export {
   TeamsFileSchema,
   TeamsMessageSchema,
   TeamsReactionSchema,
+  TeamsSearchResultSchema,
   TeamsTeamSchema,
   TeamsUserSchema,
 } from './types'

--- a/src/platforms/teams/token-provider.test.ts
+++ b/src/platforms/teams/token-provider.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { TeamsCredentialManager } from './credential-manager'
+import { TeamsTokenProvider } from './token-provider'
+import { TeamsAuthCapabilityError } from './types'
+
+const TENANT_ID = '11111111-1111-1111-1111-111111111111'
+const USER_ID = '22222222-2222-2222-2222-222222222222'
+const CLIENT_ID = '1fec8e78-bce4-4aaf-ab1b-5451cc387264'
+const SUBSTRATE_AUD = 'https://substrate.office.com'
+const GRAPH_AUD = 'https://graph.microsoft.com'
+const originalFetch = globalThis.fetch
+const testDirs: string[] = []
+
+interface FetchCall {
+  url: string
+  init: RequestInit
+  body: URLSearchParams
+}
+
+interface TokenResponseConfig {
+  aud: string
+  refreshToken: string
+  expiresIn?: number
+  marker?: string
+}
+
+function setup(): TeamsCredentialManager {
+  const dir = join(import.meta.dir, `.test-teams-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  testDirs.push(dir)
+  return new TeamsCredentialManager(dir)
+}
+
+async function seedDeviceAccount(manager: TeamsCredentialManager, refreshToken = 'old-refresh'): Promise<void> {
+  await manager.setDeviceCodeAccount({
+    accountType: 'work',
+    token: 'skype-token',
+    tokenExpiresAt: '2100-01-01T00:00:00Z',
+    aadRefreshToken: refreshToken,
+    aadClientId: CLIENT_ID,
+    teams: {},
+    currentTeam: null,
+  })
+}
+
+async function seedPersonalDeviceAccount(
+  manager: TeamsCredentialManager,
+  refreshToken = 'personal-refresh',
+): Promise<void> {
+  await manager.setDeviceCodeAccount({
+    accountType: 'personal',
+    token: 'personal-skype-token',
+    tokenExpiresAt: '2100-01-01T00:00:00Z',
+    aadRefreshToken: refreshToken,
+    aadClientId: CLIENT_ID,
+    teams: {},
+    currentTeam: null,
+  })
+}
+
+function createJwt(aud: string, marker = 'token'): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
+  const payload = Buffer.from(
+    JSON.stringify({ aud, tid: TENANT_ID, oid: USER_ID, exp: Math.floor(Date.now() / 1000) + 3600, jti: marker }),
+  ).toString('base64url')
+  return `${header}.${payload}.signature`
+}
+
+function bodyParams(body: BodyInit | null | undefined): URLSearchParams {
+  if (body instanceof URLSearchParams) return body
+  if (typeof body === 'string') return new URLSearchParams(body)
+  return new URLSearchParams()
+}
+
+function headerValue(init: RequestInit, name: string): string | undefined {
+  const headers = init.headers
+  if (headers instanceof Headers) return headers.get(name) ?? undefined
+  if (Array.isArray(headers)) {
+    const pair = headers.find(([key]) => key.toLowerCase() === name.toLowerCase())
+    return pair?.[1]
+  }
+  return headers?.[name]
+}
+
+function mockTokenResponses(responses: TokenResponseConfig[]): { calls: FetchCall[] } {
+  const calls: FetchCall[] = []
+  const queue = [...responses]
+  globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+    const requestInit = init ?? {}
+    calls.push({ url: String(input), init: requestInit, body: bodyParams(requestInit.body) })
+    const next = queue.shift()
+    if (!next) {
+      return Promise.resolve(new Response(JSON.stringify({ error: 'no_mock_response' }), { status: 500 }))
+    }
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          access_token: createJwt(next.aud, next.marker),
+          refresh_token: next.refreshToken,
+          expires_in: next.expiresIn ?? 3600,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+  }) as typeof fetch
+  return { calls }
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+afterAll(() => {
+  for (const dir of testDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('TeamsTokenProvider', () => {
+  it('refresh-exchanges substrate tokens with Origin and persists rotated refresh tokens', async () => {
+    const manager = setup()
+    await seedDeviceAccount(manager)
+    const { calls } = mockTokenResponses([{ aud: SUBSTRATE_AUD, refreshToken: 'rotated-refresh' }])
+
+    const provider = new TeamsTokenProvider(manager)
+    const token = await provider.getSubstrateToken()
+
+    expect(token).toContain('.signature')
+    expect(calls[0].url).toContain('/organizations/oauth2/v2.0/token')
+    expect(calls[0].body.get('grant_type')).toBe('refresh_token')
+    expect(calls[0].body.get('client_id')).toBe(CLIENT_ID)
+    expect(calls[0].body.get('refresh_token')).toBe('old-refresh')
+    expect(calls[0].body.get('scope')).toBe('https://substrate.office.com/.default offline_access')
+    expect(headerValue(calls[0].init, 'Origin')).toBe('https://teams.microsoft.com')
+
+    const config = await manager.loadConfig()
+    expect(config?.accounts.work?.aad_refresh_token).toBe('rotated-refresh')
+  })
+
+  it('throws when the acquired token audience does not match the requested audience', async () => {
+    const manager = setup()
+    await seedDeviceAccount(manager)
+    mockTokenResponses([{ aud: GRAPH_AUD, refreshToken: 'rotated-refresh' }])
+
+    const provider = new TeamsTokenProvider(manager)
+    await expect(provider.getSubstrateToken()).rejects.toThrow(/audience/i)
+  })
+
+  it('throws TeamsAuthCapabilityError for cookie-only credentials', async () => {
+    const manager = setup()
+    await manager.setToken('skype-token', 'work', '2100-01-01T00:00:00Z')
+
+    const provider = new TeamsTokenProvider(manager)
+    await expect(provider.getSubstrateToken()).rejects.toThrow(TeamsAuthCapabilityError)
+    await expect(provider.getSubstrateToken()).rejects.toThrow(/auth login/)
+  })
+
+  it('uses the in-memory cache until the five-minute refresh buffer', async () => {
+    const manager = setup()
+    await seedDeviceAccount(manager)
+    const { calls } = mockTokenResponses([{ aud: SUBSTRATE_AUD, refreshToken: 'rotated-refresh', marker: 'cached' }])
+
+    const provider = new TeamsTokenProvider(manager)
+    const first = await provider.getSubstrateToken()
+    const second = await provider.getSubstrateToken()
+
+    expect(second).toBe(first)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('refreshes cached tokens inside the five-minute buffer', async () => {
+    const manager = setup()
+    await seedDeviceAccount(manager)
+    const { calls } = mockTokenResponses([
+      { aud: SUBSTRATE_AUD, refreshToken: 'near-expiry-refresh', expiresIn: 299, marker: 'near-expiry' },
+      { aud: SUBSTRATE_AUD, refreshToken: 'fresh-refresh', expiresIn: 3600, marker: 'fresh' },
+    ])
+
+    const provider = new TeamsTokenProvider(manager)
+    const first = await provider.getSubstrateToken()
+    const second = await provider.getSubstrateToken()
+
+    expect(second).not.toBe(first)
+    expect(calls).toHaveLength(2)
+    const config = await manager.loadConfig()
+    expect(config?.accounts.work?.aad_refresh_token).toBe('fresh-refresh')
+  })
+
+  it('does not reuse bearer tokens across bound accounts', async () => {
+    const manager = setup()
+    await seedDeviceAccount(manager, 'work-refresh')
+    await seedPersonalDeviceAccount(manager, 'personal-refresh')
+    const { calls } = mockTokenResponses([
+      { aud: SUBSTRATE_AUD, refreshToken: 'work-rotated-refresh', marker: 'work-token' },
+      { aud: SUBSTRATE_AUD, refreshToken: 'personal-rotated-refresh', marker: 'personal-token' },
+    ])
+
+    const provider = new TeamsTokenProvider(manager)
+    const workToken = await provider.bindAccount('work').getSubstrateToken()
+    const personalToken = await provider.bindAccount('personal').getSubstrateToken()
+
+    expect(personalToken).not.toBe(workToken)
+    expect(calls).toHaveLength(2)
+    expect(calls[0].body.get('refresh_token')).toBe('work-refresh')
+    expect(calls[1].body.get('refresh_token')).toBe('personal-refresh')
+  })
+
+  it('restores tenant/user identity on a cached bearer hit after switching accounts back', async () => {
+    const manager = setup()
+    await seedDeviceAccount(manager, 'work-refresh')
+    await seedPersonalDeviceAccount(manager, 'personal-refresh')
+    mockTokenResponses([
+      { aud: SUBSTRATE_AUD, refreshToken: 'work-rotated', marker: 'work-token' },
+      { aud: SUBSTRATE_AUD, refreshToken: 'personal-rotated', marker: 'personal-token' },
+    ])
+
+    const provider = new TeamsTokenProvider(manager)
+    // work mints + caches (identity set), personal switch resets identity,
+    // then work again is served from cache and must re-restore identity
+    await provider.bindAccount('work').getSubstrateToken()
+    await provider.bindAccount('personal').getSubstrateToken()
+    await provider.bindAccount('work').getSubstrateToken()
+
+    expect(await provider.getTenantId()).toBe(TENANT_ID)
+    expect(await provider.getUserId()).toBe(USER_ID)
+  })
+})

--- a/src/platforms/teams/token-provider.ts
+++ b/src/platforms/teams/token-provider.ts
@@ -1,0 +1,284 @@
+import {
+  AAD_AUDIENCE_GRAPH,
+  AAD_AUDIENCE_SUBSTRATE,
+  AAD_SCOPE_GRAPH,
+  AAD_SCOPE_SUBSTRATE,
+  consumerTokenUrl,
+  getTeamsAppClientId,
+  organizationsTokenUrl,
+  TEAMS_WEB_ORIGIN,
+} from './app-config'
+import { TeamsCredentialManager } from './credential-manager'
+import type { TeamsAccount, TeamsAccountType } from './types'
+import { TeamsAuthCapabilityError, TeamsError } from './types'
+
+export type TokenAudience = 'skype' | 'substrate' | 'graph'
+
+type BearerAudience = Exclude<TokenAudience, 'skype'>
+
+interface CachedToken {
+  accessToken: string
+  expiresAt: number
+  aud: string
+  tenantId?: string
+  userId?: string
+}
+
+type CacheKey = TokenAudience | `${TeamsAccountType}:${BearerAudience}`
+
+interface CurrentAccountContext {
+  accountType: TeamsAccountType
+  account: TeamsAccount
+}
+
+interface BearerAudienceConfig {
+  scope: string
+  aud: string
+}
+
+interface JwtClaims {
+  aud?: string
+  tid?: string
+  oid?: string
+  exp?: number
+  [key: string]: unknown
+}
+
+const REFRESH_BUFFER_MS = 5 * 60 * 1000
+const DEFAULT_ACCESS_TOKEN_TTL_SEC = 3600
+
+const BEARER_AUDIENCES: Record<BearerAudience, BearerAudienceConfig> = {
+  substrate: { scope: AAD_SCOPE_SUBSTRATE, aud: AAD_AUDIENCE_SUBSTRATE },
+  graph: { scope: AAD_SCOPE_GRAPH, aud: AAD_AUDIENCE_GRAPH },
+}
+
+export class TeamsTokenProvider {
+  private cache: Map<CacheKey, CachedToken> = new Map()
+  private tenantId?: string
+  private userId?: string
+  private boundAccountType?: TeamsAccountType
+  private lastAccountType?: TeamsAccountType
+
+  constructor(private credManager: TeamsCredentialManager = new TeamsCredentialManager()) {}
+
+  bindAccount(accountType: TeamsAccountType): this {
+    this.boundAccountType = accountType
+    return this
+  }
+
+  async getSkypeToken(): Promise<string> {
+    const cached = this.getCached('skype')
+    if (cached) return cached.accessToken
+
+    const cred = await this.credManager.getTokenWithExpiry()
+    if (!cred?.token) {
+      throw new TeamsError(
+        'No Teams credentials found. Run `agent-teams auth login` or `agent-teams auth extract`.',
+        'no_credentials',
+      )
+    }
+
+    const expiresAt = cred.tokenExpiresAt ? new Date(cred.tokenExpiresAt).getTime() : Number.POSITIVE_INFINITY
+    if (expiresAt <= Date.now()) {
+      throw new TeamsError('Token has expired. Run "auth login" or "auth extract" to refresh.', 'token_expired')
+    }
+
+    this.cache.set('skype', { accessToken: cred.token, expiresAt, aud: 'skype' })
+    return cred.token
+  }
+
+  async getSubstrateToken(): Promise<string> {
+    return this.getBearerToken('substrate')
+  }
+
+  async getGraphToken(): Promise<string> {
+    return this.getBearerToken('graph')
+  }
+
+  async getTenantId(): Promise<string> {
+    await this.ensureIdentity()
+    if (!this.tenantId) {
+      throw new TeamsError(
+        'Microsoft token did not include a tenant id needed for Teams search.',
+        'aad_identity_missing',
+      )
+    }
+    return this.tenantId
+  }
+
+  async getUserId(): Promise<string> {
+    await this.ensureIdentity()
+    if (!this.userId) {
+      throw new TeamsError('Microsoft token did not include a user id needed for Teams search.', 'aad_identity_missing')
+    }
+    return this.userId
+  }
+
+  private getCached(key: CacheKey): CachedToken | undefined {
+    const cached = this.cache.get(key)
+    if (!cached) return undefined
+    return cached.expiresAt - Date.now() > REFRESH_BUFFER_MS ? cached : undefined
+  }
+
+  private async getBearerToken(audience: BearerAudience): Promise<string> {
+    const current = await this.getCurrentAccount()
+    this.resetIdentityIfAccountChanged(current.accountType)
+    const cacheKey: CacheKey = `${current.accountType}:${audience}`
+    const cached = this.getCached(cacheKey)
+    if (cached) {
+      // a cache hit after an account switch reset our identity, so restore the
+      // tenant/user claims captured when this token was minted
+      this.tenantId = cached.tenantId ?? this.tenantId
+      this.userId = cached.userId ?? this.userId
+      return cached.accessToken
+    }
+
+    if (!current.account.aad_refresh_token) {
+      throw new TeamsAuthCapabilityError()
+    }
+
+    const clientId = current.account.aad_client_id ?? getTeamsAppClientId(current.accountType).clientId
+    const config = BEARER_AUDIENCES[audience]
+    const token = await this.refreshBearerToken({
+      accountType: current.accountType,
+      clientId,
+      refreshToken: current.account.aad_refresh_token,
+      audience,
+      config,
+    })
+
+    this.cache.set(cacheKey, token)
+    return token.accessToken
+  }
+
+  private async refreshBearerToken(params: {
+    accountType: TeamsAccountType
+    clientId: string
+    refreshToken: string
+    audience: BearerAudience
+    config: BearerAudienceConfig
+  }): Promise<CachedToken> {
+    const response = await fetch(tokenUrlForAccount(params.accountType), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Origin: TEAMS_WEB_ORIGIN,
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: params.clientId,
+        refresh_token: params.refreshToken,
+        scope: params.config.scope,
+      }),
+    })
+
+    const body = (await response.json().catch(() => ({}))) as Record<string, unknown>
+    if (!response.ok) {
+      throw new TeamsError(
+        `Microsoft token refresh failed: ${describeAadError(body, response.status)}`,
+        'aad_refresh_failed',
+      )
+    }
+
+    const accessToken = stringField(body, 'access_token')
+    if (!accessToken) {
+      throw new TeamsError('Microsoft token refresh response did not include an access token.', 'aad_access_missing')
+    }
+
+    const claims = decodeJwt(accessToken)
+    if (claims.aud !== params.config.aud) {
+      throw new TeamsError(
+        `Microsoft token audience mismatch: expected ${params.config.aud}, got ${claims.aud ?? 'missing'}.`,
+        'aad_audience_mismatch',
+      )
+    }
+
+    this.tenantId = claims.tid ?? this.tenantId
+    this.userId = claims.oid ?? this.userId
+
+    const rotatedRefreshToken = stringField(body, 'refresh_token')
+    if (rotatedRefreshToken) {
+      await this.credManager.updateAadRefreshToken(params.accountType, rotatedRefreshToken, params.clientId)
+    }
+
+    const expiresIn = numberField(body, 'expires_in') ?? DEFAULT_ACCESS_TOKEN_TTL_SEC
+    return {
+      accessToken,
+      expiresAt: Date.now() + expiresIn * 1000,
+      aud: params.config.aud,
+      tenantId: claims.tid,
+      userId: claims.oid,
+    }
+  }
+
+  private async getCurrentAccount(): Promise<CurrentAccountContext> {
+    const config = await this.credManager.loadConfig()
+    if (!config) {
+      throw new TeamsError(
+        'No Teams credentials found. Run `agent-teams auth login` or `agent-teams auth extract`.',
+        'no_credentials',
+      )
+    }
+    const accountKey = this.boundAccountType ?? TeamsCredentialManager.accountOverride ?? config.current_account
+    if (accountKey !== 'work' && accountKey !== 'personal') {
+      throw new TeamsError(
+        'No active Teams account selected. Run `agent-teams auth switch-account`.',
+        'no_current_account',
+      )
+    }
+    const account = config.accounts[accountKey]
+    if (!account) {
+      throw new TeamsError(
+        'No active Teams account selected. Run `agent-teams auth switch-account`.',
+        'no_current_account',
+      )
+    }
+    return { accountType: accountKey, account }
+  }
+
+  private resetIdentityIfAccountChanged(accountType: TeamsAccountType): void {
+    if (this.lastAccountType === accountType) return
+    this.tenantId = undefined
+    this.userId = undefined
+    this.lastAccountType = accountType
+  }
+
+  private async ensureIdentity(): Promise<void> {
+    if (this.tenantId && this.userId) return
+    await this.getSubstrateToken()
+  }
+}
+
+function tokenUrlForAccount(accountType: TeamsAccountType): string {
+  return accountType === 'personal' ? consumerTokenUrl() : organizationsTokenUrl()
+}
+
+function decodeJwt(token: string): JwtClaims {
+  const payload = token.split('.')[1]
+  if (!payload) {
+    throw new TeamsError('Microsoft token response was not a JWT.', 'aad_token_invalid')
+  }
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<string, unknown>
+  return {
+    ...decoded,
+    aud: typeof decoded.aud === 'string' ? decoded.aud : undefined,
+    tid: typeof decoded.tid === 'string' ? decoded.tid : undefined,
+    oid: typeof decoded.oid === 'string' ? decoded.oid : undefined,
+    exp: typeof decoded.exp === 'number' ? decoded.exp : undefined,
+  }
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key]
+  return typeof value === 'number' ? value : undefined
+}
+
+function describeAadError(body: Record<string, unknown>, status: number): string {
+  const desc = body.error_description ?? body.error
+  return typeof desc === 'string' ? desc.split('\n')[0] : `HTTP ${status}`
+}

--- a/src/platforms/teams/types.test.ts
+++ b/src/platforms/teams/types.test.ts
@@ -8,6 +8,7 @@ import {
   TeamsFileSchema,
   TeamsMessageSchema,
   TeamsReactionSchema,
+  TeamsSearchResultSchema,
   TeamsTeamSchema,
   TeamsUserSchema,
 } from './types'
@@ -85,6 +86,22 @@ it('TeamsMessageSchema rejects missing required fields', () => {
     content: 'Hello world',
   })
   expect(result.success).toBe(false)
+})
+
+it('TeamsSearchResultSchema validates search result shape', () => {
+  const result = TeamsSearchResultSchema.safeParse({
+    id: 'msg-123',
+    content: 'Deploy complete',
+    author: { id: 'user-123', displayName: 'Alice' },
+    channel_id: 'channel-123',
+    thread_id: 'thread-123',
+    team_name: 'Team One',
+    channel_name: 'General',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    permalink: 'https://teams.microsoft.com/l/message/msg-123',
+  })
+
+  expect(result.success).toBe(true)
 })
 
 // TeamsUserSchema tests

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -31,6 +31,21 @@ export interface TeamsMessage {
   is_thread_reply?: boolean
 }
 
+export interface TeamsSearchResult {
+  id: string
+  content: string
+  author: {
+    id: string
+    displayName: string
+  }
+  channel_id: string
+  thread_id?: string
+  team_name?: string
+  channel_name?: string
+  timestamp: string
+  permalink?: string
+}
+
 export interface TeamsUser {
   id: string
   displayName: string
@@ -136,6 +151,21 @@ export const TeamsMessageSchema = z.object({
   root_message_id: z.string().optional(),
   parent_message_id: z.string().optional(),
   is_thread_reply: z.boolean().optional(),
+})
+
+export const TeamsSearchResultSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  author: z.object({
+    id: z.string(),
+    displayName: z.string(),
+  }),
+  channel_id: z.string(),
+  thread_id: z.string().optional(),
+  team_name: z.string().optional(),
+  channel_name: z.string().optional(),
+  timestamp: z.string(),
+  permalink: z.string().optional(),
 })
 
 export const TeamsUserSchema = z.object({
@@ -248,5 +278,14 @@ export class TeamsError extends Error {
     super(message)
     this.name = 'TeamsError'
     this.code = code
+  }
+}
+
+export class TeamsAuthCapabilityError extends Error {
+  constructor() {
+    super(
+      'Requires `agent-teams auth login` — cookie-based auth (`auth extract`) can only provide a Skype token, not the Microsoft token needed for search.',
+    )
+    this.name = 'TeamsAuthCapabilityError'
   }
 }


### PR DESCRIPTION
> **Stacked on #285** — base branch is `feat/teams-threads`. Review/merge #285 first; this diff shows only this PR's changes.

## Summary

PR 2 of 3 in the Teams feature initiative (thread replies → **message search** → file downloads). Adds `agent-teams message search <query>` plus the AAD auth infrastructure it requires — a different token flow than the skype token every other Teams request uses.

## Why the auth work

Message search calls the **Substrate Search API**, which requires an AAD Bearer token for the `substrate.office.com` audience. That token can only be minted from an AAD refresh token, and refresh tokens are only stored by `auth login` (device-code) — `auth extract` (cookie extraction) only ever yields a skype token. So this PR extends `auth login` and adds a token provider before it can add search itself.

## How

```
auth login (device-code)          → now also supports work/school accounts
  → stores aad_refresh_token
TeamsTokenProvider                → per-scope AAD refresh grant
  (Origin: https://teams.microsoft.com, aud verification, refresh-token
  rotation, 5-min-buffer in-memory cache)
  → mints Substrate / Graph Bearer tokens on demand
TeamsClient.searchMessages()      → Substrate Search API, provider-minted token
```

Cookie-only (`auth extract`) accounts have no refresh token, so `TeamsTokenProvider` raises `TeamsAuthCapabilityError` — `message search` prints an actionable message and exits 1 instead of crashing.

## Changes

- `device-code.ts` / `device-login.ts` — device-code login supports organizational accounts, storing `aad_refresh_token` and `aad_client_id`. Personal-account path is unchanged.
- `app-config.ts` / `credential-manager.ts` — Substrate/Graph scopes and audiences, the organizations token endpoint, and persistence for the rotated refresh token.
- `token-provider.ts` — `TeamsTokenProvider`: lazy per-audience token minting/caching, refresh-token rotation, `TeamsAuthCapabilityError`.
- `client.ts` / `commands/message.ts` — `TeamsClient.searchMessages()` and `agent-teams message search <query>` (`--limit`, `--from`, `--pretty`).
- `index.ts` — exports `TeamsSearchResult` (+ schema), `TeamsTokenProvider`, `TeamsAuthCapabilityError`.

Access tokens are cached in-memory only; only the rotated refresh token is persisted to disk.

## Testing

- 254 Teams tests pass (15 new). Typecheck and lint clean.

## Follow-ups (not in this PR)

- `auth extract` users can't use `message search` until they run `auth login` — worth documenting in the SKILL.md as a known limitation.
- PR 3 (file downloads) reuses `TeamsTokenProvider` for its Graph token needs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Teams message search via the Substrate API using AAD tokens, plus work/school device‑code login and a new `TeamsTokenProvider` for per‑audience tokens. SKILL.md and `skills/agent-teams/references/authentication.md` were updated to cover account types, AAD tokens, and search.

- **New Features**
  - CLI: `agent-teams message search <query>` with `--limit` and `--from`; strict integer parsing; cookie‑only accounts show a `TeamsAuthCapabilityError` with guidance.
  - SDK: `TeamsClient.searchMessages()` posts to Substrate with `x-anchormailbox` and parses nested results; exports `TeamsSearchResult` (+ schema), `TeamsTokenProvider`, and `TeamsAuthCapabilityError`.
  - Auth: `auth login` supports work/school (default) and personal via `--account-type`; non‑interactive flow and pending hints preserve `--account-type`; stores `aad_refresh_token` (rotated).
  - Tokens: `TeamsTokenProvider` mints/caches Substrate/Graph tokens with SPA `Origin`, audience verification, refresh‑token rotation (persisted), and a 5‑minute refresh buffer.

- **Migration**
  - To use search, run `agent-teams auth login` (`auth extract` can’t mint the required AAD token).
  - For non‑interactive login, pass `--account-type` consistently (default `work`); access tokens are in‑memory only.

<sup>Written for commit 014b6986ce0916222eac2058ae933715f028d519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

