### PR TITLE
feat(teams): add "file download" command

### DIFF
--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -306,7 +306,14 @@ agent-teams file list <team-id> <channel-id>
 
 # Get file info
 agent-teams file info <team-id> <channel-id> <file-id>
+
+# Download a file (to a path or directory; defaults to the current dir)
+agent-teams file download <team-id> <channel-id> <file-id>
+agent-teams file download <team-id> <channel-id> <file-id> ./report.pdf
+agent-teams file download <team-id> <channel-id> <file-id> ./downloads/ --pretty
 ```
+
+`file download` output: `{ "id", "name", "size", "content_type", "path" }` where `path` is where the file was written. Inline/image attachments download with the extracted Skype token and work for any signed-in account; SharePoint/OneDrive documents download via Microsoft Graph and require an `auth login` account (cookie-only `auth extract` accounts get a clear error telling you to run `auth login`).
 
 ### Snapshot Command
 

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -10,6 +10,7 @@ const TEMP_FILES_TO_CLEANUP = ['/tmp/test-teams-upload.txt']
 const TEMP_DIRS_TO_CLEANUP: string[] = []
 const SEARCH_TENANT_ID = '11111111-1111-1111-1111-111111111111'
 const SEARCH_USER_ID = '22222222-2222-2222-2222-222222222222'
+const GRAPH_AUDIENCE = 'https://graph.microsoft.com'
 
 describe('TeamsClient', () => {
   const originalFetch = globalThis.fetch
@@ -75,6 +76,19 @@ describe('TeamsClient', () => {
     return `${header}.${payload}.signature`
   }
 
+  const createGraphJwt = (): string => {
+    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(
+      JSON.stringify({
+        aud: GRAPH_AUDIENCE,
+        tid: SEARCH_TENANT_ID,
+        oid: SEARCH_USER_ID,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    ).toString('base64url')
+    return `${header}.${payload}.signature`
+  }
+
   const headerValue = (init: RequestInit | undefined, name: string): string | undefined => {
     const headers = init?.headers
     if (headers instanceof Headers) return headers.get(name) ?? undefined
@@ -98,6 +112,10 @@ describe('TeamsClient', () => {
         headers: defaultHeaders,
       }),
     )
+  }
+
+  const mockBinaryResponse = (body: string, status = 200) => {
+    fetchResponses.push(new Response(body, { status }))
   }
 
   describe('login', () => {
@@ -719,6 +737,90 @@ describe('TeamsClient', () => {
       expect(files).toHaveLength(2)
       expect(files[0].name).toBe('doc.pdf')
       expect(fetchCalls[0].url).toBe('https://teams.microsoft.com/api/csa/emea/api/v2/teams/111/channels/ch1/files')
+    })
+  })
+
+  describe('downloadFile', () => {
+    it('downloads SharePoint files through Graph shares with base64url share id', async () => {
+      const manager = await setupCredentialManager()
+      const shareUrl = 'https://contoso.sharepoint.com/sites/team/Shared%20Documents/report.docx'
+      mockResponse([
+        { id: 'file1', name: 'report.docx', size: 11, url: shareUrl, contentType: 'application/vnd.ms-word' },
+      ])
+      mockResponse({ access_token: createGraphJwt(), refresh_token: 'rotated-refresh', expires_in: 3600 })
+      mockBinaryResponse('graph-bytes')
+
+      const client = await new TeamsClient(manager).login({ token: 'skype-token', region: 'emea' })
+      const result = await client.downloadFile('111', 'ch1', 'file1')
+
+      const shareId = `u!${Buffer.from(shareUrl).toString('base64url').replace(/=+$/, '')}`
+      expect(fetchCalls[2].url).toBe(`https://graph.microsoft.com/v1.0/shares/${shareId}/driveItem/content`)
+      expect(headerValue(fetchCalls[2].options, 'Authorization')).toBe(`Bearer ${createGraphJwt()}`)
+      expect(Buffer.from(result.buffer).toString()).toBe('graph-bytes')
+      expect(result.file.id).toBe('file1')
+    })
+
+    it('downloads inline object URLs with the Skype token', async () => {
+      mockResponse([
+        {
+          id: 'file2',
+          name: 'image.png',
+          size: 10,
+          url: 'https://teams.microsoft.com/files/image.png',
+          object_url: 'https://us-api.asm.skype.com/v1/objects/0-weu-d1/image.png',
+          contentType: 'image/png',
+        },
+      ])
+      mockBinaryResponse('image-bytes')
+
+      const client = await new TeamsClient().login({ token: 'skype-token', region: 'emea' })
+      const result = await client.downloadFile('111', 'ch1', 'file2')
+
+      expect(fetchCalls[1].url).toBe('https://us-api.asm.skype.com/v1/objects/0-weu-d1/image.png')
+      expect(headerValue(fetchCalls[1].options, 'Authorization')).toBe('Bearer skype-token')
+      expect(headerValue(fetchCalls[1].options, 'X-Skypetoken')).toBe('skype-token')
+      expect(Buffer.from(result.buffer).toString()).toBe('image-bytes')
+    })
+
+    it('throws TeamsAuthCapabilityError for SharePoint files with cookie-only credentials', async () => {
+      const dir = join(
+        import.meta.dir,
+        `.test-teams-client-cookie-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      )
+      TEMP_DIRS_TO_CLEANUP.push(dir)
+      const manager = new TeamsCredentialManager(dir)
+      await manager.setToken('skype-token', 'work', '2100-01-01T00:00:00Z')
+      mockResponse([
+        {
+          id: 'file3',
+          name: 'deck.pptx',
+          size: 10,
+          url: 'https://contoso.sharepoint.com/sites/team/Shared%20Documents/deck.pptx',
+        },
+      ])
+
+      const client = await new TeamsClient(manager).login({ token: 'skype-token', region: 'emea' })
+
+      await expect(client.downloadFile('111', 'ch1', 'file3')).rejects.toThrow('Requires `agent-teams auth login`')
+      expect(fetchCalls).toHaveLength(1)
+    })
+
+    it('refuses to send the Skype token to an untrusted host', async () => {
+      mockResponse([
+        {
+          id: 'file4',
+          name: 'evil.bin',
+          size: 10,
+          url: 'https://evil.example.com/steal',
+          object_url: 'https://evil.example.com/steal',
+        },
+      ])
+
+      const client = await new TeamsClient().login({ token: 'skype-token', region: 'emea' })
+
+      await expect(client.downloadFile('111', 'ch1', 'file4')).rejects.toThrow('untrusted host')
+      // only the listFiles call happened — no credentialed download fetch to the untrusted host
+      expect(fetchCalls).toHaveLength(1)
     })
   })
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -37,6 +37,7 @@ const MAX_RETRIES = 3
 const BASE_BACKOFF_MS = 100
 const DEFAULT_REGION: TeamsRegion = 'amer'
 const REGIONS: TeamsRegion[] = ['amer', 'emea', 'apac']
+const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0'
 
 // Personal (Teams for Life) skypetokens carry a consumer `skypeid` (e.g.
 // "live:..." or "8:live:..."); work/school tokens carry an org identity. Used
@@ -167,6 +168,66 @@ function validateSearchFrom(value: number | undefined): number {
     throw new TeamsError('Search from offset must be a non-negative integer.', 'invalid_pagination')
   }
   return value
+}
+
+function isSharePointOrOneDriveUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    const normalizedHost = hostname.toLowerCase()
+    return (
+      normalizedHost.includes('sharepoint.com') ||
+      normalizedHost.includes('-my.sharepoint') ||
+      normalizedHost === '1drv.ms' ||
+      normalizedHost.endsWith('.1drv.ms') ||
+      normalizedHost === 'onedrive.live.com' ||
+      normalizedHost.endsWith('.onedrive.live.com')
+    )
+  } catch {
+    return false
+  }
+}
+
+// Only these hosts receive the Skype token on a raw download fetch. Teams file
+// metadata can carry arbitrary URLs, so we never attach credentials to a host
+// outside this allowlist — that would leak the token to a third party.
+function isTrustedSkypeDownloadHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+    return (
+      host === 'teams.microsoft.com' ||
+      host.endsWith('.teams.microsoft.com') ||
+      host.endsWith('.asm.skype.com') ||
+      host.endsWith('.asyncgw.teams.microsoft.com') ||
+      host === 'substrate.office.com' ||
+      host.endsWith('.substrate.office.com')
+    )
+  } catch {
+    return false
+  }
+}
+
+function getFileDownloadSource(file: TeamsFile): { route: 'graph' | 'skype'; url: string } {
+  const shareUrl = [file.sharepoint_url, file.url, file.object_url].find((candidate): candidate is string =>
+    Boolean(candidate && isSharePointOrOneDriveUrl(candidate)),
+  )
+  if (shareUrl) return { route: 'graph', url: shareUrl }
+
+  const directUrl = file.object_url ?? file.url
+  if (!directUrl) {
+    throw new TeamsError(`File has no downloadable URL: ${file.id}`, 'file_url_missing')
+  }
+  if (!isTrustedSkypeDownloadHost(directUrl)) {
+    throw new TeamsError(`Refusing to download ${file.id} from an untrusted host: ${directUrl}`, 'file_url_untrusted')
+  }
+  return { route: 'skype', url: directUrl }
+}
+
+async function readDownloadResponse(response: Response, codePrefix: string): Promise<Buffer> {
+  if (!response.ok) {
+    throw new TeamsError(`File download failed with HTTP ${response.status}`, `${codePrefix}_${response.status}`)
+  }
+
+  return Buffer.from(await response.arrayBuffer())
 }
 
 function escapeHtml(value: string): string {
@@ -797,5 +858,39 @@ export class TeamsClient {
       undefined,
       CSA_API_BASE,
     )
+  }
+
+  async downloadFile(teamId: string, channelId: string, fileId: string): Promise<{ buffer: Buffer; file: TeamsFile }> {
+    const files = await this.listFiles(teamId, channelId)
+    const file = files.find((candidate) => candidate.id === fileId)
+    if (!file) {
+      throw new TeamsError(`File not found: ${fileId}`, 'file_not_found')
+    }
+
+    const source = getFileDownloadSource(file)
+    if (source.route === 'graph') {
+      const graphToken = await new TeamsTokenProvider(this.credManager).getGraphToken()
+      const shareId = `u!${Buffer.from(source.url).toString('base64url').replace(/=+$/, '')}`
+      const response = await fetch(`${GRAPH_API_BASE}/shares/${shareId}/driveItem/content`, {
+        headers: {
+          Authorization: `Bearer ${graphToken}`,
+        },
+        redirect: 'follow',
+      })
+      return { buffer: await readDownloadResponse(response, 'graph_download'), file }
+    }
+
+    if (this.isTokenExpired()) {
+      throw new TeamsError('Token has expired. Run "auth login" or "auth extract" to refresh.', 'token_expired')
+    }
+    const skypeToken = this.getToken()
+    const response = await fetch(source.url, {
+      headers: {
+        Authorization: `Bearer ${skypeToken}`,
+        'X-Skypetoken': skypeToken,
+      },
+      redirect: 'follow',
+    })
+    return { buffer: await readDownloadResponse(response, 'skype_download'), file }
   }
 }

--- a/src/platforms/teams/commands/file.test.ts
+++ b/src/platforms/teams/commands/file.test.ts
@@ -1,13 +1,22 @@
 import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
-import { infoAction, listAction, uploadAction } from './file'
+import { TeamsAuthCapabilityError } from '../types'
+import { downloadAction, infoAction, listAction, uploadAction } from './file'
 
 let clientUploadFileSpy: ReturnType<typeof spyOn>
 let clientListFilesSpy: ReturnType<typeof spyOn>
+let clientDownloadFileSpy: ReturnType<typeof spyOn>
 let credManagerLoadConfigSpy: ReturnType<typeof spyOn>
+let processExitSpy: ReturnType<typeof spyOn>
+const tempDirs: string[] = []
 const originalConsoleLog = console.log
+const originalConsoleError = console.error
+const originalCwd = process.cwd()
 
 beforeEach(() => {
   clientUploadFileSpy = spyOn(TeamsClient.prototype, 'uploadFile').mockResolvedValue({
@@ -35,6 +44,17 @@ beforeEach(() => {
     },
   ])
 
+  clientDownloadFileSpy = spyOn(TeamsClient.prototype, 'downloadFile').mockResolvedValue({
+    buffer: Buffer.from('downloaded-content'),
+    file: {
+      id: 'file_123',
+      name: 'folder\\test.pdf',
+      size: 18,
+      url: 'https://teams.microsoft.com/files/123/test.pdf',
+      contentType: 'application/pdf',
+    },
+  })
+
   credManagerLoadConfigSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue({
     current_account: 'work',
     accounts: {
@@ -46,13 +66,24 @@ beforeEach(() => {
       },
     },
   })
+
+  processExitSpy = spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined): never => {
+    throw new Error(`process.exit:${code ?? 0}`)
+  })
 })
 
 afterEach(() => {
   clientUploadFileSpy?.mockRestore()
   clientListFilesSpy?.mockRestore()
+  clientDownloadFileSpy?.mockRestore()
   credManagerLoadConfigSpy?.mockRestore()
+  processExitSpy?.mockRestore()
   console.log = originalConsoleLog
+  console.error = originalConsoleError
+  process.chdir(originalCwd)
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 it('upload: sends multipart request and returns file info', async () => {
@@ -89,4 +120,64 @@ it('info: returns single file details', async () => {
   const output = consoleSpy.mock.calls[0][0]
   expect(output).toContain('file_123')
   expect(output).toContain('test.pdf')
+})
+
+it('download: writes to a directory using a safe basename', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+  const dir = mkdtempSync(join(tmpdir(), 'teams-download-dir-'))
+  tempDirs.push(dir)
+
+  await downloadAction('team_123', 'ch_456', 'file_123', dir, { pretty: false })
+
+  const downloadedPath = join(dir, 'test.pdf')
+  expect(readFileSync(downloadedPath, 'utf8')).toBe('downloaded-content')
+  expect(clientDownloadFileSpy).toHaveBeenCalledWith('team_123', 'ch_456', 'file_123')
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain(downloadedPath)
+})
+
+it('download: writes to an explicit output file path', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+  const dir = mkdtempSync(join(tmpdir(), 'teams-download-file-'))
+  tempDirs.push(dir)
+  const outputPath = join(dir, 'renamed.pdf')
+
+  await downloadAction('team_123', 'ch_456', 'file_123', outputPath, { pretty: false })
+
+  expect(readFileSync(outputPath, 'utf8')).toBe('downloaded-content')
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain(outputPath)
+})
+
+it('download: writes to cwd when output path is omitted', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+  const dir = mkdtempSync(join(tmpdir(), 'teams-download-cwd-'))
+  tempDirs.push(dir)
+  process.chdir(dir)
+
+  await downloadAction('team_123', 'ch_456', 'file_123', undefined, { pretty: false })
+
+  const downloadedPath = join(dir, 'test.pdf')
+  expect(readFileSync(downloadedPath, 'utf8')).toBe('downloaded-content')
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain(downloadedPath)
+})
+
+it('download: exits on capability error without writing a partial file', async () => {
+  const consoleErrorSpy = mock((_msg: string) => {})
+  console.error = consoleErrorSpy
+  const dir = mkdtempSync(join(tmpdir(), 'teams-download-capability-'))
+  tempDirs.push(dir)
+  const outputPath = join(dir, 'sharepoint.docx')
+  clientDownloadFileSpy.mockRejectedValue(new TeamsAuthCapabilityError())
+
+  await expect(downloadAction('team_123', 'ch_456', 'file_123', outputPath, { pretty: false })).rejects.toThrow(
+    'process.exit:1',
+  )
+
+  expect(existsSync(outputPath)).toBe(false)
+  expect(consoleErrorSpy.mock.calls[0][0]).toContain('Requires `agent-teams auth login`')
 })

--- a/src/platforms/teams/commands/file.ts
+++ b/src/platforms/teams/commands/file.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'node:path'
+import { statSync, writeFileSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
 
 import { Command } from 'commander'
 
@@ -8,6 +9,7 @@ import { formatOutput } from '@/shared/utils/output'
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import type { TeamsFile } from '../types'
+import { TeamsAuthCapabilityError } from '../types'
 
 export async function uploadAction(
   teamId: string,
@@ -122,6 +124,69 @@ export async function infoAction(
   }
 }
 
+export async function downloadAction(
+  teamId: string,
+  channelId: string,
+  fileId: string,
+  outputPath: string | undefined,
+  options: { pretty?: boolean },
+): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const { buffer, file } = await client.downloadFile(teamId, channelId, fileId)
+
+    const safeName = basename(file.name.replace(/\\/g, '/'))
+    let destPath = outputPath ? resolve(outputPath) : resolve(safeName)
+    let isDirectory = false
+    try {
+      isDirectory = statSync(destPath).isDirectory()
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code !== 'ENOENT') {
+        throw error
+      }
+    }
+
+    if (isDirectory) {
+      destPath = join(destPath, safeName)
+    }
+
+    writeFileSync(destPath, buffer)
+
+    console.log(
+      formatOutput(
+        {
+          id: file.id,
+          name: file.name,
+          size: file.size,
+          content_type: file.contentType || null,
+          path: destPath,
+        },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    if (error instanceof TeamsAuthCapabilityError) {
+      console.error(error.message)
+      process.exit(1)
+    }
+    handleError(error as Error)
+  }
+}
+
 export const fileCommand = new Command('file')
   .description('File commands')
   .addCommand(
@@ -149,4 +214,14 @@ export const fileCommand = new Command('file')
       .argument('<file-id>', 'File ID')
       .option('--pretty', 'Pretty print JSON output')
       .action(infoAction),
+  )
+  .addCommand(
+    new Command('download')
+      .description('Download file from channel')
+      .argument('<team-id>', 'Team ID')
+      .argument('<channel-id>', 'Channel ID')
+      .argument('<file-id>', 'File ID')
+      .argument('[output-path]', 'Output file or directory path')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(downloadAction),
   )

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -74,6 +74,8 @@ export interface TeamsFile {
   size: number
   url: string
   contentType?: string
+  sharepoint_url?: string
+  object_url?: string
 }
 
 export interface TeamsCredentials {
@@ -196,6 +198,8 @@ export const TeamsFileSchema = z.object({
   size: z.number(),
   url: z.string(),
   contentType: z.string().optional(),
+  sharepoint_url: z.string().optional(),
+  object_url: z.string().optional(),
 })
 
 export const TeamsCredentialsSchema = z.object({
@@ -284,7 +288,7 @@ export class TeamsError extends Error {
 export class TeamsAuthCapabilityError extends Error {
   constructor() {
     super(
-      'Requires `agent-teams auth login` — cookie-based auth (`auth extract`) can only provide a Skype token, not the Microsoft token needed for search.',
+      'Requires `agent-teams auth login` — cookie-based auth (`auth extract`) can only provide a Skype token, not the Microsoft token needed for search or SharePoint/OneDrive file downloads.',
     )
     this.name = 'TeamsAuthCapabilityError'
   }


### PR DESCRIPTION
> **Stacked on #286** — base branch is `feat/teams-search`, which is itself stacked on #285 (`feat/teams-threads`). Merge order: #285 → #286 → this PR. Review/merge both first; this diff shows only this PR's 2 commits.

## Summary

PR 3 of 3 in the Teams feature initiative (thread replies → message search → file downloads). Adds `agent-teams file download`, letting agents pull channel attachments to disk instead of only listing metadata.

## Why

Teams channel files come from two different backends depending on how they were shared, and each needs a different token:

- **Inline / ASM object URLs** (pasted images) are served from the same Teams messaging infra as everything else, so the existing **Skype token** downloads them directly — this works for every account, including cookie-only (`auth extract`).
- **SharePoint / OneDrive documents** (the common case for files shared into a channel) live behind the Graph shares API and need a Graph Bearer token, which only `auth login` accounts can mint via the `TeamsTokenProvider` from #286.

Rather than forcing everyone through `auth login`, `downloadFile()` picks the route per file and only fails cookie-only users for the SharePoint case, with a clear message telling them what to do instead of a raw error.

## How

- `TeamsClient.downloadFile(teamId, channelId, fileId)` looks up the file, classifies its source URL (SharePoint/OneDrive host vs. inline/ASM), and returns `{ buffer, file }`:
  - Graph route: `GET graph.microsoft.com/v1.0/shares/u!{base64url}/driveItem/content` with a provider-minted Graph token.
  - Skype route: direct `fetch` of the object URL with the existing Skype token.
- `TeamsFile` gains optional `sharepoint_url` / `object_url` source hints used for routing.
- `agent-teams file download <team> <channel> <file-id> [output-path]` — directory-aware output path (writes into a directory using the file's basename), sanitizes the basename, and defaults to the CWD when no path is given, mirroring the Slack `file download` UX.
- Cookie-only accounts hitting a SharePoint file get `TeamsAuthCapabilityError` (exit 1, stderr) instead of a crash or a corrupt file — no partial file is written on failure. Inline images still work for them without `auth login`.
- No new auth acquisition path — reuses the `TeamsTokenProvider` from #286.

## Changes

- `client.ts` — `downloadFile()`, source-URL classification, Graph shares download, Skype-token download.
- `types.ts` — `TeamsFile.sharepoint_url` / `object_url`.
- `commands/file.ts` — `file download` command and `downloadAction`.

## Testing

- 261 Teams tests pass (7 new). Typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `agent-teams file download` to save channel attachments to disk. Routes downloads via Graph shares or the Skype token based on the file source and refuses untrusted hosts.

- **New Features**
  - Added `TeamsClient.downloadFile()` with automatic routing: Graph shares for SharePoint/OneDrive; Skype token for inline/ASM. Enforces a strict host allowlist for Skype downloads.
  - New CLI: `agent-teams file download <team-id> <channel-id> <file-id> [output-path]` — directory-aware, uses a safe basename, defaults to CWD; prints JSON with `id`, `name`, `size`, `content_type`, `path`.
  - `TeamsFile` now includes `sharepoint_url` and `object_url` hints for routing.
  - SharePoint/OneDrive downloads require `auth login`; cookie-only accounts get `TeamsAuthCapabilityError`. No partial file is written on failure.

SKILL.md/docs: Updated with `file download` usage and output fields.

<sup>Written for commit 10f04f482dcdab853e922143e3c98220eba417e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

