### PR TITLE
fix(teams): show prefilled login link in interactive auth

### DIFF
--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
+import * as interactive from '@/shared/utils/interactive'
+import * as stderr from '@/shared/utils/stderr'
+
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import * as deviceLogin from '../device-login'
@@ -120,4 +123,30 @@ it('login pending hint preserves explicit account type', async () => {
   completeSpy.mockRestore()
   consoleSpy.mockRestore()
   exitSpy.mockRestore()
+})
+
+it('interactive login shows the prefilled verification link alongside the code', async () => {
+  const interactiveSpy = spyOn(interactive, 'isInteractive').mockReturnValue(true)
+  const infoSpy = spyOn(stderr, 'info').mockImplementation(() => {})
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+  const loginSpy = spyOn(deviceLogin, 'loginWithDeviceCode').mockImplementation(async ({ onCode }) => {
+    await onCode({
+      verificationUri: 'https://login.microsoft.com/device',
+      verificationUriComplete: 'https://login.microsoft.com/device?otc=ABCD1234',
+      userCode: 'ABCD1234',
+      expiresAt: Date.now() + 900_000,
+    })
+    return { accountType: 'work', userName: 'Test User', teams: [], current: null }
+  })
+
+  await loginAction({ pretty: false })
+
+  const messages = infoSpy.mock.calls.map((call) => call[0]).join('\n')
+  expect(messages).toContain('https://login.microsoft.com/device?otc=ABCD1234')
+  expect(messages).toContain('ABCD1234')
+
+  interactiveSpy.mockRestore()
+  infoSpy.mockRestore()
+  consoleSpy.mockRestore()
+  loginSpy.mockRestore()
 })

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -36,8 +36,9 @@ export async function loginAction(options: LoginOptions): Promise<void> {
     const result = await loginWithDeviceCode({
       clientId: options.clientId,
       accountType,
-      onCode: async ({ verificationUri, userCode }) => {
-        info(`\nTo sign in, open ${verificationUri} and enter code ${userCode}\n`)
+      onCode: async ({ verificationUri, verificationUriComplete, userCode }) => {
+        info(`\nTo sign in, open ${verificationUri} and enter code ${userCode}`)
+        info(`Or open this direct link (code prefilled): ${verificationUriComplete}\n`)
         info('Waiting for approval...')
       },
       onPending: () => info('Approved. Finishing sign-in...'),


### PR DESCRIPTION
## Summary

While live-verifying the just-merged Teams auth login features (#282/#284/#286), the interactive prompt only printed the verification URL and code.
This forced the user to type the code by hand.
This surfaces the one-click prefilled link the non-interactive JSON output already returns, so the user can just open it instead.

## Preview

Interactive `agent-teams auth login` (TTY) output:

**Before**

```console
$ agent-teams auth login --account-type personal

To sign in, open https://www.microsoft.com/link and enter code YCUG2XC3

Waiting for approval...
```

**After**

```console
$ agent-teams auth login --account-type personal

To sign in, open https://www.microsoft.com/link and enter code YCUG2XC3
Or open this direct link (code prefilled): https://www.microsoft.com/link?otc=YCUG2XC3

Waiting for approval...
```

The non-interactive (piped / agent) JSON path is unchanged — it already returns `verification_uri_complete`.

## Changes

- The interactive `onCode` callback now also prints a second line with the direct prefilled link, alongside the existing URL and code line.
- The prefilled link was already passed into the callback by the device-login flow.
- It just wasn't being displayed.
- No changes to the non-interactive JSON path.
- It already includes the prefilled link field.

## Testing

- New test asserting the interactive login path emits both the prefilled link and the code.
- 279 Teams tests pass. Typecheck and lint clean.
