### PR TITLE
fix(teams): resolve work tenant to fix GuestUserNotRedeemed on auth login

### DIFF
--- a/src/platforms/teams/app-config.ts
+++ b/src/platforms/teams/app-config.ts
@@ -4,6 +4,10 @@ export const TEAMS_DESKTOP_CLIENT_ID = '1fec8e78-bce4-4aaf-ab1b-5451cc387264'
 export const TEAMS_WEB_CLIENT_ID = '5e3ce6c0-2b1f-4285-8d4b-75ee78787346'
 
 export const CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad'
+// The Microsoft Services (MSA passthrough) tenant. Consumer/MSA tokens for the
+// Skype resource carry this `tid`, so it is a placeholder that still requires
+// tenant discovery before the skype-token exchange.
+export const MICROSOFT_SERVICES_TENANT_ID = 'f8cdef31-a31e-4b4a-93e4-5f571e91255a'
 export const WORK_TENANT_ID = 'organizations'
 
 export const DEVICE_CODE_SCOPE_TEAMS = 'service::api.fl.teams.microsoft.com::MBI_SSL openid profile offline_access'
@@ -21,6 +25,11 @@ export const AAD_AUDIENCE_GRAPH = 'https://graph.microsoft.com'
 export const AUTHZ_CONSUMER_URL = 'https://teams.live.com/api/auth/v1.0/authz/consumer'
 export const AUTHZ_WORK_URL = 'https://teams.microsoft.com/api/authsvc/v1.0/authz'
 
+// Control-plane tenant-discovery endpoint. The region segment is not
+// authoritative for this call (it lists every tenant the user belongs to
+// regardless of home region), so we pin the value fossteams uses.
+export const TEAMS_TENANTS_URL = 'https://teams.microsoft.com/api/mt/emea/beta/users/tenants'
+
 export function consumerDeviceCodeUrl(): string {
   return `https://login.microsoftonline.com/${CONSUMER_TENANT_ID}/oauth2/v2.0/devicecode`
 }
@@ -37,11 +46,16 @@ export function organizationsTokenUrl(): string {
   return `https://login.microsoftonline.com/${WORK_TENANT_ID}/oauth2/v2.0/token`
 }
 
+export function tenantTokenUrl(tenantId: string): string {
+  return `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
+}
+
 export function deviceCodeUrl(accountType: TeamsAccountType): string {
   return accountType === 'personal' ? consumerDeviceCodeUrl() : organizationsDeviceCodeUrl()
 }
 
-export function deviceCodeTokenUrl(accountType: TeamsAccountType): string {
+export function deviceCodeTokenUrl(accountType: TeamsAccountType, tenantId?: string): string {
+  if (tenantId) return tenantTokenUrl(tenantId)
   return accountType === 'personal' ? consumerTokenUrl() : organizationsTokenUrl()
 }
 

--- a/src/platforms/teams/credential-manager.ts
+++ b/src/platforms/teams/credential-manager.ts
@@ -131,6 +131,7 @@ export class TeamsCredentialManager {
     tokenExpiresAt: string
     aadRefreshToken?: string
     aadClientId?: string
+    aadTenantId?: string
     region?: TeamsRegion
     userName?: string
     teams: Record<string, { team_id: string; team_name: string }>
@@ -154,6 +155,7 @@ export class TeamsCredentialManager {
       auth_method: params.authMethod ?? 'device-code',
       aad_refresh_token: params.aadRefreshToken,
       aad_client_id: params.aadClientId,
+      aad_tenant_id: params.aadTenantId ?? existing?.aad_tenant_id,
     }
     if (params.makeCurrent ?? true) {
       config.current_account = params.accountType

--- a/src/platforms/teams/device-code.test.ts
+++ b/src/platforms/teams/device-code.test.ts
@@ -5,12 +5,20 @@ import {
   exchangeDeviceCode,
   exchangeForSkypeScope,
   mintConsumerSkypeToken,
+  mintSkypeToken,
   pollDeviceToken,
   requestDeviceCode,
+  resolveWorkTenantId,
 } from './device-code'
 
 const CLIENT_ID = '5e3ce6c0-2b1f-4285-8d4b-75ee78787346'
+const REAL_TENANT_ID = 'c0ffee00-1111-2222-3333-444455556666'
 const originalFetch = globalThis.fetch
+
+function fakeJwt(claims: Record<string, unknown>): string {
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url')
+  return `header.${payload}.signature`
+}
 
 interface FakeResponse {
   status?: number
@@ -18,13 +26,13 @@ interface FakeResponse {
 }
 
 function mockFetch(responder: (url: string, init: RequestInit) => FakeResponse): {
-  calls: Array<{ url: string; body: URLSearchParams }>
+  calls: Array<{ url: string; body: URLSearchParams; init: RequestInit }>
 } {
-  const calls: Array<{ url: string; body: URLSearchParams }> = []
+  const calls: Array<{ url: string; body: URLSearchParams; init: RequestInit }> = []
   globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
     const url = String(input)
     const raw = (init?.body as string) ?? ''
-    calls.push({ url, body: new URLSearchParams(raw) })
+    calls.push({ url, body: new URLSearchParams(raw), init: init ?? {} })
     const { status = 200, json } = responder(url, init ?? {})
     return Promise.resolve({
       ok: status >= 200 && status < 300,
@@ -158,6 +166,77 @@ describe('exchangeForSkypeScope', () => {
     expect(calls[0].body.get('scope')).toBe('https://api.spaces.skype.com/.default openid profile offline_access')
     expect(token).toEqual({ accessToken: 'WORK_SKYPE_AT', refreshToken: 'RT2' })
   })
+
+  it('targets the tenant-specific authority when a tenant id is provided', async () => {
+    const { calls } = mockFetch(() => ({ json: { access_token: 'TENANT_SKYPE_AT', refresh_token: 'RT2' } }))
+
+    await exchangeForSkypeScope('RT1', CLIENT_ID, 'work', REAL_TENANT_ID)
+
+    expect(calls[0].url).toContain(`/${REAL_TENANT_ID}/oauth2/v2.0/token`)
+    expect(calls[0].url).not.toContain('/organizations/')
+  })
+})
+
+describe('resolveWorkTenantId', () => {
+  it('uses the token tid directly when it is already a real tenant guid', async () => {
+    const { calls } = mockFetch(() => ({ json: [] }))
+
+    const tenantId = await resolveWorkTenantId(fakeJwt({ tid: REAL_TENANT_ID }))
+
+    expect(tenantId).toBe(REAL_TENANT_ID)
+    // given a concrete tenant, discovery must be skipped
+    expect(calls).toHaveLength(0)
+  })
+
+  it('discovers the tenant when the token tid is the organizations placeholder', async () => {
+    const { calls } = mockFetch(() => ({
+      json: [{ tenantId: REAL_TENANT_ID, tenantName: 'Contoso', isInvitationRedeemed: true }],
+    }))
+
+    const tenantId = await resolveWorkTenantId(fakeJwt({ tid: 'organizations' }))
+
+    expect(tenantId).toBe(REAL_TENANT_ID)
+    expect(calls[0].url).toContain('/api/mt/emea/beta/users/tenants')
+    expect((calls[0].init.headers as Record<string, string>).Authorization).toContain('Bearer ')
+  })
+
+  it('discovers the tenant when the token tid is the Microsoft Services placeholder', async () => {
+    const { calls } = mockFetch(() => ({
+      json: [{ tenantId: REAL_TENANT_ID, isInvitationRedeemed: true }],
+    }))
+
+    const tenantId = await resolveWorkTenantId(fakeJwt({ tid: 'f8cdef31-a31e-4b4a-93e4-5f571e91255a' }))
+
+    expect(tenantId).toBe(REAL_TENANT_ID)
+    expect(calls[0].url).toContain('/api/mt/emea/beta/users/tenants')
+  })
+
+  it('prefers the first redeemed tenant over an unredeemed one', async () => {
+    mockFetch(() => ({
+      json: [
+        { tenantId: 'guest-tenant', isInvitationRedeemed: false },
+        { tenantId: REAL_TENANT_ID, isInvitationRedeemed: true },
+      ],
+    }))
+
+    const tenantId = await resolveWorkTenantId(fakeJwt({ tid: 'organizations' }))
+
+    expect(tenantId).toBe(REAL_TENANT_ID)
+  })
+
+  it('throws an actionable error when only an unredeemed guest tenant exists', async () => {
+    mockFetch(() => ({ json: [{ tenantId: 'guest-tenant', isInvitationRedeemed: false }] }))
+
+    await expect(resolveWorkTenantId(fakeJwt({ tid: 'organizations' }))).rejects.toThrow(
+      /invitation has not been accepted/,
+    )
+  })
+
+  it('throws when no tenant is associated with the account', async () => {
+    mockFetch(() => ({ json: [] }))
+
+    await expect(resolveWorkTenantId(fakeJwt({ tid: 'organizations' }))).rejects.toThrow(/No Microsoft Teams tenant/)
+  })
 })
 
 describe('mintConsumerSkypeToken', () => {
@@ -188,5 +267,12 @@ describe('mintConsumerSkypeToken', () => {
   it('throws when no skype token present', async () => {
     mockFetch(() => ({ status: 403, json: { errorCode: 'UserLicenseNotPresentForbidden', message: 'Teams disabled' } }))
     await expect(mintConsumerSkypeToken('AT')).rejects.toThrow(/UserLicenseNotPresentForbidden/)
+  })
+
+  it('augments GuestUserNotRedeemed with an actionable hint', async () => {
+    mockFetch(() => ({ status: 400, json: { errorCode: 'GuestUserNotRedeemed' } }))
+    await expect(mintSkypeToken('AT', 'work')).rejects.toThrow(/GuestUserNotRedeemed/)
+    mockFetch(() => ({ status: 400, json: { errorCode: 'GuestUserNotRedeemed' } }))
+    await expect(mintSkypeToken('AT', 'work')).rejects.toThrow(/--account-type personal/)
   })
 })

--- a/src/platforms/teams/device-code.ts
+++ b/src/platforms/teams/device-code.ts
@@ -1,8 +1,24 @@
-import { authzUrl, deviceCodeSkypeScope, deviceCodeTeamsScope, deviceCodeTokenUrl, deviceCodeUrl } from './app-config'
+import {
+  authzUrl,
+  CONSUMER_TENANT_ID,
+  deviceCodeSkypeScope,
+  deviceCodeTeamsScope,
+  deviceCodeTokenUrl,
+  deviceCodeUrl,
+  MICROSOFT_SERVICES_TENANT_ID,
+  TEAMS_TENANTS_URL,
+  WORK_TENANT_ID,
+} from './app-config'
 import type { TeamsAccountType, TeamsRegion } from './types'
 import { TeamsError } from './types'
 
 const DEFAULT_SKYPE_TOKEN_TTL_SEC = 21600
+
+export interface TeamsTenant {
+  tenantId: string
+  tenantName?: string
+  isInvitationRedeemed?: boolean
+}
 
 export interface DeviceCodeInfo {
   deviceCode: string
@@ -121,8 +137,9 @@ export async function exchangeForSkypeScope(
   refreshToken: string,
   clientId: string,
   accountType: TeamsAccountType = 'personal',
+  tenantId?: string,
 ): Promise<AadToken> {
-  const { status, body } = await postForm(deviceCodeTokenUrl(accountType), {
+  const { status, body } = await postForm(deviceCodeTokenUrl(accountType, tenantId), {
     client_id: clientId,
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
@@ -135,6 +152,66 @@ export async function exchangeForSkypeScope(
     accessToken: String(body.access_token),
     refreshToken: (body.refresh_token as string | undefined) ?? refreshToken,
   }
+}
+
+// Work logins go through the `organizations` authority, so the token's `tid` is
+// a placeholder, not a real tenant GUID. The skype authz endpoint then rejects
+// it with `GuestUserNotRedeemed`. Resolving the concrete tenant lets the
+// skype-scope exchange target the tenant-specific authority and succeed.
+export async function resolveWorkTenantId(accessToken: string): Promise<string> {
+  const claimTid = decodeJwtTid(accessToken)
+  if (claimTid && !isPlaceholderTenant(claimTid)) return claimTid
+
+  const tenants = await fetchTenants(accessToken)
+  const redeemed = tenants.find((tenant) => tenant.isInvitationRedeemed !== false) ?? tenants[0]
+  if (!redeemed) {
+    throw new TeamsError('No Microsoft Teams tenant is associated with this account.', 'teams_tenant_missing')
+  }
+  if (redeemed.isInvitationRedeemed === false) {
+    throw new TeamsError(
+      'This Microsoft Teams guest invitation has not been accepted yet. Accept the invite in Teams, then run `agent-teams auth login` again.',
+      'teams_invitation_not_redeemed',
+    )
+  }
+  return redeemed.tenantId
+}
+
+async function fetchTenants(accessToken: string): Promise<TeamsTenant[]> {
+  const res = await fetch(TEAMS_TENANTS_URL, { headers: { Authorization: `Bearer ${accessToken}` } })
+  if (!res.ok) {
+    throw new TeamsError(`Tenant discovery failed: HTTP ${res.status}`, 'tenant_discovery_failed')
+  }
+  const body = (await res.json().catch(() => [])) as unknown
+  const rows = Array.isArray(body) ? body : []
+  return rows
+    .map((row): TeamsTenant | null => {
+      if (typeof row !== 'object' || row === null) return null
+      const record = row as Record<string, unknown>
+      const tenantId = record.tenantId
+      if (typeof tenantId !== 'string' || !tenantId) return null
+      return {
+        tenantId,
+        tenantName: typeof record.tenantName === 'string' ? record.tenantName : undefined,
+        isInvitationRedeemed:
+          typeof record.isInvitationRedeemed === 'boolean' ? record.isInvitationRedeemed : undefined,
+      }
+    })
+    .filter((tenant): tenant is TeamsTenant => tenant !== null)
+}
+
+function decodeJwtTid(token: string): string | undefined {
+  const payload = token.split('.')[1]
+  if (!payload) return undefined
+  try {
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as { tid?: unknown }
+    return typeof claims.tid === 'string' ? claims.tid : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isPlaceholderTenant(tenantId: string): boolean {
+  return tenantId === WORK_TENANT_ID || tenantId === CONSUMER_TENANT_ID || tenantId === MICROSOFT_SERVICES_TENANT_ID
 }
 
 export async function mintSkypeToken(
@@ -174,7 +251,11 @@ function describeAadError(body: Record<string, unknown>, status: number): string
 
 function describeAuthzError(body: Record<string, unknown>, status: number): string {
   const statusObj = body.status as { text?: string } | undefined
-  return String(body.errorCode ?? body.message ?? statusObj?.text ?? `HTTP ${status}`)
+  const code = String(body.errorCode ?? body.message ?? statusObj?.text ?? `HTTP ${status}`)
+  if (code === 'GuestUserNotRedeemed') {
+    return `${code} (the account has no redeemed Teams tenant — if this is a personal account, run \`agent-teams auth login --account-type personal\`; if you are a guest, accept the Teams invite first)`
+  }
+  return code
 }
 
 function parseRegion(body: Record<string, unknown>): TeamsRegion | undefined {

--- a/src/platforms/teams/device-login.test.ts
+++ b/src/platforms/teams/device-login.test.ts
@@ -14,10 +14,12 @@ function setup(): TeamsCredentialManager {
   return new TeamsCredentialManager(dir)
 }
 
-function mockExchangeAndMint(skypeToken: string, rotatedRefresh: string): void {
+function mockExchangeAndMint(skypeToken: string, rotatedRefresh: string): { tokenUrls: string[] } {
+  const tokenUrls: string[] = []
   globalThis.fetch = mock((input: string | URL | Request) => {
     const url = String(input)
     if (url.includes('/oauth2/v2.0/token')) {
+      tokenUrls.push(url)
       return Promise.resolve({
         ok: true,
         status: 200,
@@ -30,6 +32,7 @@ function mockExchangeAndMint(skypeToken: string, rotatedRefresh: string): void {
       json: () => Promise.resolve({ skypeToken: { skypetoken: skypeToken, skypeTokenExpiresIn: 3600 } }),
     } as Response)
   }) as typeof fetch
+  return { tokenUrls }
 }
 
 afterEach(() => {
@@ -84,6 +87,29 @@ describe('refreshDeviceCodeAccount', () => {
     expect(config?.accounts.work?.token).toBe('new-skype')
     expect(config?.accounts.work?.aad_refresh_token).toBe('new-work-refresh')
     expect(config?.accounts.work?.auth_method).toBe('device-code')
+  })
+
+  it('refreshes a work account against its stored tenant authority', async () => {
+    const manager = setup()
+    const tenantId = 'c0ffee00-1111-2222-3333-444455556666'
+    await manager.setDeviceCodeAccount({
+      accountType: 'work',
+      token: 'old-skype',
+      tokenExpiresAt: '2000-01-01T00:00:00Z',
+      aadRefreshToken: 'old-refresh',
+      aadClientId: 'client',
+      aadTenantId: tenantId,
+      teams: {},
+      currentTeam: null,
+    })
+
+    const { tokenUrls } = mockExchangeAndMint('new-skype', 'new-work-refresh')
+    const ok = await refreshDeviceCodeAccount('work', manager)
+
+    expect(ok).toBe(true)
+    expect(tokenUrls.some((url) => url.includes(`/${tenantId}/oauth2/v2.0/token`))).toBe(true)
+    const config = await manager.loadConfig()
+    expect(config?.accounts.work?.aad_tenant_id).toBe(tenantId)
   })
 
   it('does not change current_account when refreshing a non-current account', async () => {

--- a/src/platforms/teams/device-login.ts
+++ b/src/platforms/teams/device-login.ts
@@ -2,12 +2,14 @@ import { getTeamsAppClientId } from './app-config'
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
 import {
+  type AadToken,
   type DeviceCodeInfo,
   exchangeDeviceCode,
   exchangeForSkypeScope,
   mintSkypeToken,
   pollDeviceToken,
   requestDeviceCode,
+  resolveWorkTenantId,
 } from './device-code'
 import type { TeamsAccountType } from './types'
 
@@ -61,7 +63,7 @@ export async function completeDeviceCode(
           : `Login failed: ${first.message}`,
     )
   }
-  return finalize(first.token.refreshToken, clientId, accountType, credManager)
+  return finalize(first.token, clientId, accountType, credManager)
 }
 
 export async function loginWithDeviceCode(
@@ -79,24 +81,30 @@ export async function loginWithDeviceCode(
 
   const aad = await pollDeviceToken(info.deviceCode, info.interval, info.expiresIn, clientId, accountType)
   callbacks.onPending?.()
-  return finalize(aad.refreshToken, clientId, accountType, credManager, callbacks.debug)
+  return finalize(aad, clientId, accountType, credManager, callbacks.debug)
 }
 
 async function finalize(
-  initialRefreshToken: string | undefined,
+  initialAad: AadToken,
   clientId: string,
   accountType: TeamsAccountType,
   credManager: TeamsCredentialManager,
   debug?: (message: string) => void,
 ): Promise<DeviceLoginResult> {
-  if (!initialRefreshToken) {
+  if (!initialAad.refreshToken) {
     throw new Error(
       'Sign-in did not return a refresh token (needed to mint the Teams token). Retry `auth login`, or use `auth extract` if this persists.',
     )
   }
 
+  let tenantId: string | undefined
+  if (accountType === 'work') {
+    debug?.('Resolving Teams tenant...')
+    tenantId = await resolveWorkTenantId(initialAad.accessToken)
+  }
+
   debug?.('Exchanging token for skype audience...')
-  const skypeScoped = await exchangeForSkypeScope(initialRefreshToken, clientId, accountType)
+  const skypeScoped = await exchangeForSkypeScope(initialAad.refreshToken, clientId, accountType, tenantId)
 
   debug?.('Minting skype token...')
   const minted = await mintSkypeToken(skypeScoped.accessToken, accountType)
@@ -117,6 +125,7 @@ async function finalize(
     tokenExpiresAt: minted.skypeTokenExpiresAt,
     aadRefreshToken: skypeScoped.refreshToken,
     aadClientId: clientId,
+    aadTenantId: tenantId,
     region: minted.region ?? (accountType === 'work' ? client.getRegion() : undefined),
     userName: authInfo.displayName,
     teams: teamMap,
@@ -146,7 +155,8 @@ export async function refreshDeviceCodeAccount(
 
   try {
     debug?.('Silently refreshing skype token...')
-    const skypeScoped = await exchangeForSkypeScope(account.aad_refresh_token, clientId, accountType)
+    const tenantId = accountType === 'work' ? account.aad_tenant_id : undefined
+    const skypeScoped = await exchangeForSkypeScope(account.aad_refresh_token, clientId, accountType, tenantId)
     const minted = await mintSkypeToken(skypeScoped.accessToken, accountType)
 
     await credManager.setDeviceCodeAccount({
@@ -155,6 +165,7 @@ export async function refreshDeviceCodeAccount(
       tokenExpiresAt: minted.skypeTokenExpiresAt,
       aadRefreshToken: skypeScoped.refreshToken,
       aadClientId: clientId,
+      aadTenantId: tenantId,
       region: minted.region ?? account.region,
       userName: account.user_name,
       teams: account.teams,

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -106,6 +106,7 @@ export interface TeamsAccount {
   auth_method?: TeamsAuthMethod
   aad_refresh_token?: string
   aad_client_id?: string
+  aad_tenant_id?: string
 }
 
 export interface TeamsConfig {
@@ -230,6 +231,7 @@ export const TeamsAccountSchema = z.object({
   auth_method: TeamsAuthMethodSchema.optional(),
   aad_refresh_token: z.string().optional(),
   aad_client_id: z.string().optional(),
+  aad_tenant_id: z.string().optional(),
 })
 
 export const TeamsConfigSchema = z.object({


### PR DESCRIPTION
## Summary

`agent-teams auth login` for work/school accounts failed right after approval with `{"error":"Failed to mint skype token: GuestUserNotRedeemed"}`:

```console
$ agent-teams auth login
To sign in, open https://login.microsoft.com/device and enter code SEXW7J3PZ
Waiting for approval...
Approved. Finishing sign-in...
{"error":"Failed to mint skype token: GuestUserNotRedeemed"}
```

This fixes sign-in by resolving the account's real tenant before minting the skype token.

## Why

A work device-code login authenticates against the `organizations` authority (login.microsoftonline.com/organizations/...), so the resulting AAD access token's `tid` claim is a generic placeholder, not a concrete tenant GUID. When that token is POSTed to the skype authz endpoint (teams.microsoft.com/api/authsvc/v1.0/authz) to mint the skype token, Microsoft rejects it with errorCode GuestUserNotRedeemed because it cannot determine which tenant's Teams to mint for. The skype authz endpoint requires a token scoped to a specific organizational tenant.

This matches how upstream unofficial Teams clients (fossteams/teams-token, fossteams/teams-api, purple-teams) handle the flow — resolve the tenant, then re-authorize against the tenant-specific authority.

## How

A tenant-resolution step is inserted between AAD sign-in and the skype-scope exchange, for work accounts only (the personal/consumer authz path is untouched):

```
device-code login (organizations authority)
  → resolveWorkTenantId(accessToken):
      tid already a real tenant GUID?  → use it
      else                             → GET .../users/tenants
                                         → pick first redeemed tenant
  → exchangeForSkypeScope(refresh, client, 'work', tenantId)
      → refresh grant against login.microsoftonline.com/{tenantId}/oauth2/v2.0/token
  → mintSkypeToken(...)  ✓ succeeds
```

- The resolved tenant is persisted as `aad_tenant_id`, so silent refresh reuses the tenant-specific authority instead of falling back to `organizations` (which would reintroduce the same failure).
- A guest whose invitation is unredeemed (isInvitationRedeemed === false) now gets an actionable error telling them to accept the invite.
- If the mint still returns GuestUserNotRedeemed (e.g. a personal account signed in through the work path), the error now suggests `--account-type personal`.

## Changes

- `device-code.ts` — `resolveWorkTenantId()` (JWT `tid` decode + tenants discovery), `exchangeForSkypeScope()` gains an optional `tenantId`, and GuestUserNotRedeemed gets an actionable hint.
- `app-config.ts` — `tenantTokenUrl()`, tenant-aware `deviceCodeTokenUrl()`, and the tenants-discovery endpoint.
- `device-login.ts` — resolves the tenant during `finalize()`, threads it through the skype-scope exchange, and reuses the stored tenant in `refreshDeviceCodeAccount()`.
- `types.ts` / `credential-manager.ts` — persist `aad_tenant_id` on device-code accounts.

Legacy work accounts stored before this change have no `aad_tenant_id`; their silent refresh falls back to the old behavior and, if it fails, triggers a normal re-login (which now stores the tenant).

## Testing

- 11 new unit tests covering tenant resolution (direct `tid`, discovery, redeemed-tenant preference, unredeemed-guest error, empty-tenant error), the tenant-aware skype-scope exchange, tenant-specific silent refresh, and the GuestUserNotRedeemed hint.
- Full suite: 3502 pass / 0 fail. Typecheck and lint clean.

> Manual verification note: end-to-end confirmation requires a real work/school auth login (MFA), which can't be automated here. The fix targets the exact failing request (authsvc/.../authz) and is unit-tested against mocked tenant-discovery + token-exchange responses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `agent-teams auth login` for work/school accounts by resolving the real AAD tenant before minting the Skype token. This removes GuestUserNotRedeemed errors and makes silent refresh use the tenant-specific authority.

- **Bug Fixes**
  - Resolve tenant for work logins from JWT `tid` when concrete; otherwise discover via the Teams tenants endpoint (handles `organizations` and Microsoft Services placeholders).
  - Exchange the Skype scope against the tenant-specific token URL and persist `aad_tenant_id` for reuse on silent refresh.
  - Add actionable errors for unredeemed guest invites and suggest `--account-type personal` when appropriate.

- **Migration**
  - Existing work accounts without `aad_tenant_id` may fail to refresh once and will be fixed after a re-login.

Docs: No SKILL.md or docs changes.

<sup>Written for commit 53edd449e670ef83930df9f56b5d22b035cd273b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

