### PR TITLE
feat(discord): add native reply support to user client

### DIFF
--- a/src/platforms/discord/client.test.ts
+++ b/src/platforms/discord/client.test.ts
@@ -164,6 +164,38 @@ describe('DiscordClient', () => {
       expect(fetchCalls[0].options?.method).toBe('POST')
       expect(fetchCalls[0].options?.body).toBe(JSON.stringify({ content: 'Hello world' }))
     })
+
+    it('includes message_reference when reply_to is provided', async () => {
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: 'Reply text',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      await client.sendMessage('ch1', 'Reply text', { reply_to: 'parent123' })
+
+      expect(fetchCalls[0].options?.body).toBe(
+        JSON.stringify({ content: 'Reply text', message_reference: { message_id: 'parent123' } }),
+      )
+    })
+
+    it('omits message_reference when reply_to is not provided', async () => {
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: 'Hello world',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      await client.sendMessage('ch1', 'Hello world')
+
+      expect(fetchCalls[0].options?.body).toBe(JSON.stringify({ content: 'Hello world' }))
+    })
   })
 
   describe('getMessages', () => {
@@ -307,6 +339,60 @@ describe('DiscordClient', () => {
       expect(file.filename).toBe('test-upload.txt')
       expect(fetchCalls[0].url).toBe('https://discord.com/api/v10/channels/ch1/messages')
       expect(fetchCalls[0].options?.method).toBe('POST')
+    })
+
+    it('includes payload_json with message_reference when reply_to is provided', async () => {
+      const tempFile = '/tmp/test-upload-reply.txt'
+      await Bun.write(tempFile, 'test content')
+
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: '',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        attachments: [
+          {
+            id: 'att1',
+            filename: 'test-upload-reply.txt',
+            size: 12,
+            url: 'https://cdn.discord.com/attachments/ch1/att1/test-upload-reply.txt',
+          },
+        ],
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      await client.uploadFile('ch1', tempFile, { reply_to: 'parent123' })
+
+      const formData = fetchCalls[0].options?.body as FormData
+      expect(formData.get('payload_json')).toBe(JSON.stringify({ message_reference: { message_id: 'parent123' } }))
+    })
+
+    it('omits payload_json when reply_to is not provided', async () => {
+      const tempFile = '/tmp/test-upload-no-reply.txt'
+      await Bun.write(tempFile, 'test content')
+
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: '',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        attachments: [
+          {
+            id: 'att1',
+            filename: 'test-upload-no-reply.txt',
+            size: 12,
+            url: 'https://cdn.discord.com/attachments/ch1/att1/test-upload-no-reply.txt',
+          },
+        ],
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      await client.uploadFile('ch1', tempFile)
+
+      const formData = fetchCalls[0].options?.body as FormData
+      expect(formData.get('payload_json')).toBeNull()
     })
   })
 

--- a/src/platforms/discord/client.ts
+++ b/src/platforms/discord/client.ts
@@ -226,8 +226,12 @@ export class DiscordClient {
     return this.request<DiscordChannel>('GET', `/channels/${channelId}`)
   }
 
-  async sendMessage(channelId: string, content: string): Promise<DiscordMessage> {
-    return this.request<DiscordMessage>('POST', `/channels/${channelId}/messages`, { content })
+  async sendMessage(channelId: string, content: string, options?: { reply_to?: string }): Promise<DiscordMessage> {
+    const body: Record<string, unknown> = { content }
+    if (options?.reply_to) {
+      body.message_reference = { message_id: options.reply_to }
+    }
+    return this.request<DiscordMessage>('POST', `/channels/${channelId}/messages`, body)
   }
 
   async getMessages(channelId: string, limit: number = 50): Promise<DiscordMessage[]> {
@@ -270,11 +274,14 @@ export class DiscordClient {
     return this.request<DiscordUser>('GET', `/users/${userId}`)
   }
 
-  async uploadFile(channelId: string, filePath: string): Promise<DiscordFile> {
+  async uploadFile(channelId: string, filePath: string, options?: { reply_to?: string }): Promise<DiscordFile> {
     const fileBuffer = await readFile(filePath)
     const filename = filePath.split('/').pop() || 'file'
 
     const formData = new FormData()
+    if (options?.reply_to) {
+      formData.append('payload_json', JSON.stringify({ message_reference: { message_id: options.reply_to } }))
+    }
     formData.append('files[0]', new Blob([fileBuffer]), filename)
 
     interface MessageWithAttachments extends DiscordMessage {


### PR DESCRIPTION
## Summary

Add native reply support to the user-token `DiscordClient`, mirroring the `reply_to` option already available on `DiscordBotClient`. Both `sendMessage` and `uploadFile` now accept an optional `options.reply_to` that sets Discord's `message_reference` so the message renders as a proper reply arrow instead of a plain new message.

## Changes

### `sendMessage(channelId, content, options?)`
- New optional `options.reply_to`.
- When set, the request body includes `message_reference: { message_id: options.reply_to }`.
- Option name (`reply_to`) matches `DiscordBotClient` exactly for API consistency.

### `uploadFile(channelId, filePath, options?)`
- New optional `options.reply_to`.
- When set, a `payload_json` multipart part with `{ message_reference: { message_id } }` is appended, so an attachment-only reply still renders as a native reply.

### Shared behavior
- Both methods still flow through the private `request()` / `requestFormData()` helpers, so Discord super-properties, browser headers, and rate-limit buckets are preserved unchanged.

## Backward compatibility

- `options` is optional on both methods; existing callers passing no options are unaffected.
- When `reply_to` is omitted, no `message_reference` / `payload_json` is sent, matching prior behavior exactly.

## Tests

Mirrors the existing bot-client test style in `client.test.ts`:
- `sendMessage`: body includes `message_reference` when `reply_to` is provided, omits it otherwise.
- `uploadFile`: multipart form contains a `payload_json` part with `{ message_reference: { message_id } }` when `reply_to` is provided, no `payload_json` part otherwise.

## Verification

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun test` — 3499 pass, 0 fail (4 new).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native reply support to the user-token Discord client so `sendMessage` and `uploadFile` can create real reply threads via an optional `reply_to`. No breaking changes.

- **New Features**
  - `sendMessage(channelId, content, { reply_to })` sets `message_reference` to render a native reply.
  - `uploadFile(channelId, filePath, { reply_to })` adds `payload_json` with `message_reference` for attachment-only replies.

- **Migration**
  - No action needed; existing calls work as before.
  - Docs: SKILL.md/docs not updated.

<sup>Written for commit a2777c99f6d77d380b17fecfd338374c4c2069b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

