### PR TITLE
Revert "fix(teams): show prefilled login link in interactive auth"

### DIFF
--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
-import * as interactive from '@/shared/utils/interactive'
-import * as stderr from '@/shared/utils/stderr'
-
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import * as deviceLogin from '../device-login'
@@ -123,30 +120,4 @@ it('login pending hint preserves explicit account type', async () => {
   completeSpy.mockRestore()
   consoleSpy.mockRestore()
   exitSpy.mockRestore()
-})
-
-it('interactive login shows the prefilled verification link alongside the code', async () => {
-  const interactiveSpy = spyOn(interactive, 'isInteractive').mockReturnValue(true)
-  const infoSpy = spyOn(stderr, 'info').mockImplementation(() => {})
-  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
-  const loginSpy = spyOn(deviceLogin, 'loginWithDeviceCode').mockImplementation(async ({ onCode }) => {
-    await onCode({
-      verificationUri: 'https://login.microsoft.com/device',
-      verificationUriComplete: 'https://login.microsoft.com/device?otc=ABCD1234',
-      userCode: 'ABCD1234',
-      expiresAt: Date.now() + 900_000,
-    })
-    return { accountType: 'work', userName: 'Test User', teams: [], current: null }
-  })
-
-  await loginAction({ pretty: false })
-
-  const messages = infoSpy.mock.calls.map((call) => call[0]).join('\n')
-  expect(messages).toContain('https://login.microsoft.com/device?otc=ABCD1234')
-  expect(messages).toContain('ABCD1234')
-
-  interactiveSpy.mockRestore()
-  infoSpy.mockRestore()
-  consoleSpy.mockRestore()
-  loginSpy.mockRestore()
 })

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -36,9 +36,8 @@ export async function loginAction(options: LoginOptions): Promise<void> {
     const result = await loginWithDeviceCode({
       clientId: options.clientId,
       accountType,
-      onCode: async ({ verificationUri, verificationUriComplete, userCode }) => {
-        info(`\nTo sign in, open ${verificationUri} and enter code ${userCode}`)
-        info(`Or open this direct link (code prefilled): ${verificationUriComplete}\n`)
+      onCode: async ({ verificationUri, userCode }) => {
+        info(`\nTo sign in, open ${verificationUri} and enter code ${userCode}\n`)
         info('Waiting for approval...')
       },
       onPending: () => info('Approved. Finishing sign-in...'),


### PR DESCRIPTION
Reverts #288.

## Summary

#288 surfaced a "direct link (code prefilled)" in the interactive `agent-teams auth login` prompt. That link doesn't actually prefill the code — reverting it.

## Why

The prefilled link is fabricated in `device-code.ts` as `${verification_uri}?otc=${user_code}`. Microsoft's device code flow does **not** support this:

- Microsoft's `/oauth2/v2.0/devicecode` endpoint does **not** return `verification_uri_complete`. The [official docs](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code) state: *"The `verification_uri_complete` response field is not included or supported at this time."* MSAL's own `ServerDeviceCodeResponse` type omits it too.
- `verification_uri` is always `https://microsoft.com/devicelogin`, a page that does not accept the code as a query parameter.
- Appending `?otc=<user_code>` is [explicitly unsupported](https://learn.microsoft.com/en-us/answers/questions/2150552/query-string-for-user-code-in-verification-uri-for): *"embedding the user_code directly into the verification_uri (e.g., as a query string) is not supported. The user must manually enter the code."*

So the advertised link lands on `microsoft.com/devicelogin` with an **empty** input field. #288 only made this broken link visible to interactive users, so reverting removes the misleading output. The prompt returns to showing the verification URL and the code to type manually — which is what MSAL and the official docs prescribe.

## Changes

- `commands/auth.ts` — interactive `onCode` no longer prints the "Or open this direct link (code prefilled)" line; back to the URL + code instruction only.
- `commands/auth.test.ts` — removed the test asserting the prefilled link (and its now-unused imports).

## Testing

- Teams auth tests pass. Typecheck and lint clean.

## Follow-up (not in this PR)

The underlying `verificationUriComplete` fabrication still exists in `device-code.ts` and is still emitted as `verification_uri_complete` in the non-interactive JSON output. A separate PR can strip that field entirely so agents don't surface the same non-working link.
