### PR TITLE
fix(teams): detect personal vs work accounts for device login

### DIFF
--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -35,7 +35,7 @@ agent-teams channel list <team-id>
 
 Two co-equal ways to sign in — pick whichever fits:
 
-1. **`agent-teams auth login`** (work/school **or** personal Microsoft accounts) — device-code sign-in. Open the printed URL, enter the code, and approve in your browser. No desktop app or browser extraction needed. Defaults to a work/school account; use `--account-type personal` for a personal account. Only `auth login` stores the AAD refresh token required by `message search`.
+1. **`agent-teams auth login`** (work/school **or** personal Microsoft accounts) — device-code sign-in. Open the printed URL, enter the code, and approve in your browser. No desktop app or browser extraction needed. It prompts for your Microsoft email (or pass `--email <email>`) and auto-detects work vs personal, then starts the matching flow; pass `--account-type work|personal` to force it and skip detection. Only `auth login` stores the AAD refresh token required by `message search`.
 2. **`agent-teams auth extract`** — zero-config extraction from the Teams desktop app, falling back to a Chromium browser. Best when you're already signed into Teams locally. Yields a Skype token only — sufficient for messaging, but **not** for `message search` (see below).
 
 Credentials are also extracted automatically on first use of any command if none are stored, so `auth extract` can happen silently in the background.
@@ -47,8 +47,10 @@ Teams tokens are short-lived (60-90 minutes for extraction, a few hours for devi
 When there's no TTY, `auth login` splits into two calls:
 
 ```bash
-# 1. Start — returns verification_uri, user_code, and device_code as JSON
-agent-teams auth login
+# 1. Start — returns verification_uri, user_code, and device_code as JSON.
+#    Pass --email to auto-detect the account type (no prompt without a TTY),
+#    or --account-type work|personal to force it.
+agent-teams auth login --email <email>
 
 # 2. After the user approves in a browser, finish with the device_code
 agent-teams auth login --device-code <device_code>

--- a/skills/agent-teams/references/authentication.md
+++ b/skills/agent-teams/references/authentication.md
@@ -197,7 +197,7 @@ Credentials are stored in:
 Most commands use only the Skype token above. **`message search` is different**: it queries Microsoft's Substrate search API, which requires an AAD Bearer token for the `substrate.office.com` audience — a token the Skype cookie cannot produce.
 
 - **Only `auth login` (device-code) can mint it.** That flow stores an `aad_refresh_token` (and `aad_client_id`) alongside the Skype token. `auth extract` (cookie extraction) yields a Skype token only and therefore **cannot** run `message search` — the CLI returns an actionable error telling you to run `auth login`.
-- **Work and personal accounts** are both supported by `auth login`; it defaults to work/school and accepts `--account-type personal`.
+- **Work and personal accounts** are both supported by `auth login`. It detects the account type from your Microsoft email (prompted interactively, or via `--email <email>`) and starts the matching flow; `--account-type work|personal` forces it and skips detection. If a personal account still reaches the work flow, the CLI stops with an actionable hint to rerun with `--account-type personal`.
 - At search time, the CLI silently exchanges the stored refresh token for a short-lived Substrate access token (per-scope AAD grant), caches it in memory only (never written to disk), and rotates the refresh token. The same mechanism can mint a Graph token for other AAD-gated features.
 
 Credentials for an `auth login` account therefore include additional fields:

--- a/src/platforms/teams/app-config.ts
+++ b/src/platforms/teams/app-config.ts
@@ -30,6 +30,8 @@ export const AUTHZ_WORK_URL = 'https://teams.microsoft.com/api/authsvc/v1.0/auth
 // regardless of home region), so we pin the value fossteams uses.
 export const TEAMS_TENANTS_URL = 'https://teams.microsoft.com/api/mt/emea/beta/users/tenants'
 
+export const GET_CREDENTIAL_TYPE_URL = 'https://login.microsoftonline.com/common/GetCredentialType'
+
 export function consumerDeviceCodeUrl(): string {
   return `https://login.microsoftonline.com/${CONSUMER_TENANT_ID}/oauth2/v2.0/devicecode`
 }

--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
+import * as interactive from '@/shared/utils/interactive'
+
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import * as deviceLogin from '../device-login'
+import * as realmDiscovery from '../realm-discovery'
 import { TeamsTokenExtractor } from '../token-extractor'
 import { getNoTeamsTokenFoundMessage, loginAction } from './auth'
 
@@ -120,4 +123,70 @@ it('login pending hint preserves explicit account type', async () => {
   completeSpy.mockRestore()
   consoleSpy.mockRestore()
   exitSpy.mockRestore()
+})
+
+it('routes to the personal flow when the email probe reports a personal account', async () => {
+  const interactiveSpy = spyOn(interactive, 'isInteractive').mockReturnValue(true)
+  const probeSpy = spyOn(realmDiscovery, 'probeAccountType').mockResolvedValue('personal')
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+  const loginSpy = spyOn(deviceLogin, 'loginWithDeviceCode').mockResolvedValue({
+    accountType: 'personal',
+    userName: 'Personal User',
+    teams: [],
+    current: null,
+  })
+
+  await loginAction({ email: 'user@outlook.com', pretty: false })
+
+  expect(probeSpy).toHaveBeenCalledWith('user@outlook.com')
+  expect(loginSpy.mock.calls[0][0].accountType).toBe('personal')
+
+  interactiveSpy.mockRestore()
+  probeSpy.mockRestore()
+  consoleSpy.mockRestore()
+  loginSpy.mockRestore()
+})
+
+it('skips the email probe when an account type is forced explicitly', async () => {
+  const interactiveSpy = spyOn(interactive, 'isInteractive').mockReturnValue(true)
+  const probeSpy = spyOn(realmDiscovery, 'probeAccountType').mockResolvedValue('personal')
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+  const loginSpy = spyOn(deviceLogin, 'loginWithDeviceCode').mockResolvedValue({
+    accountType: 'work',
+    userName: 'Work User',
+    teams: [],
+    current: null,
+  })
+
+  await loginAction({ email: 'user@outlook.com', accountType: 'work', pretty: false })
+
+  expect(probeSpy).not.toHaveBeenCalled()
+  expect(loginSpy.mock.calls[0][0].accountType).toBe('work')
+
+  interactiveSpy.mockRestore()
+  probeSpy.mockRestore()
+  consoleSpy.mockRestore()
+  loginSpy.mockRestore()
+})
+
+it('falls back to the default flow when the email probe is inconclusive', async () => {
+  const interactiveSpy = spyOn(interactive, 'isInteractive').mockReturnValue(true)
+  const probeSpy = spyOn(realmDiscovery, 'probeAccountType').mockResolvedValue(undefined)
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+  const loginSpy = spyOn(deviceLogin, 'loginWithDeviceCode').mockResolvedValue({
+    accountType: 'work',
+    userName: 'Work User',
+    teams: [],
+    current: null,
+  })
+
+  await loginAction({ email: 'user@unknown.test', pretty: false })
+
+  expect(probeSpy).toHaveBeenCalledWith('user@unknown.test')
+  expect(loginSpy.mock.calls[0][0].accountType).toBe('work')
+
+  interactiveSpy.mockRestore()
+  probeSpy.mockRestore()
+  consoleSpy.mockRestore()
+  loginSpy.mockRestore()
 })

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -38,7 +38,7 @@ export async function loginAction(options: LoginOptions): Promise<void> {
       accountType,
       onCode: async ({ verificationUri, userCode }) => {
         info(`\nTo sign in, open ${verificationUri} and enter code ${userCode}\n`)
-        info('Waiting for approval...')
+        info(`Waiting for approval of code ${userCode}...`)
       },
       onPending: () => info('Approved. Finishing sign-in...'),
       debug: debugLog,

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -9,6 +9,7 @@ import { debug, info } from '@/shared/utils/stderr'
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import { completeDeviceCode, loginWithDeviceCode, PendingApprovalError, startDeviceCode } from '../device-login'
+import { probeAccountType } from '../realm-discovery'
 import { TeamsTokenExtractor } from '../token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from '../types'
 
@@ -18,21 +19,26 @@ interface LoginOptions {
   deviceCode?: string
   clientId?: string
   accountType?: string
+  email?: string
 }
 
 export async function loginAction(options: LoginOptions): Promise<void> {
   try {
-    const accountType = resolveLoginAccountType(options.accountType)
+    const explicitAccountType = resolveLoginAccountType(options.accountType)
     if (options.deviceCode) {
-      await finishDeviceCode(options, accountType)
+      await finishDeviceCode(options, explicitAccountType)
       return
     }
     if (!isInteractive()) {
+      const accountType = options.email
+        ? await resolveAccountTypeFromEmail(options, explicitAccountType)
+        : explicitAccountType
       await startNonInteractiveLogin(options.clientId, accountType)
       return
     }
 
     const debugLog = options.debug ? (msg: string) => debug(`[debug] ${msg}`) : undefined
+    const accountType = await resolveAccountTypeFromEmail(options, explicitAccountType)
     const result = await loginWithDeviceCode({
       clientId: options.clientId,
       accountType,
@@ -65,6 +71,37 @@ function resolveLoginAccountType(value: string | undefined): TeamsAccountType {
   if (value === undefined) return 'work'
   if (value === 'work' || value === 'personal') return value
   throw new Error('Invalid account type. Use "work" or "personal".')
+}
+
+// When the user did not force --account-type, look the account up by email so a
+// personal account is routed to the personal flow up front instead of failing
+// after approval. Any misstep falls back to the caller's default account type.
+async function resolveAccountTypeFromEmail(
+  options: LoginOptions,
+  fallback: TeamsAccountType,
+): Promise<TeamsAccountType> {
+  if (options.accountType !== undefined) return fallback
+
+  const email = options.email ?? (isInteractive() ? await promptEmail() : undefined)
+  if (!email) return fallback
+
+  const probed = await probeAccountType(email)
+  if (!probed) return fallback
+  if (probed === 'personal') {
+    info('Detected a personal Microsoft account. Using personal sign-in.')
+  }
+  return probed
+}
+
+async function promptEmail(): Promise<string | undefined> {
+  const { createInterface } = await import('node:readline/promises')
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true })
+  try {
+    const answer = await rl.question('Microsoft email (press Enter to skip): ')
+    return answer.trim() || undefined
+  } finally {
+    rl.close()
+  }
 }
 
 async function startNonInteractiveLogin(
@@ -560,12 +597,13 @@ export const authCommand = new Command('auth')
   .description('Authentication commands')
   .addCommand(
     new Command('login')
-      .description('Sign in via device code (no desktop app needed). Defaults to work/school accounts.')
+      .description('Sign in via device code (no desktop app needed). Detects the account type from your email.')
       .option('--pretty', 'Pretty print JSON output')
       .option('--debug', 'Show debug output for troubleshooting')
       .option('--device-code <code>', 'Finish a non-interactive login started earlier')
       .option('--client-id <id>', 'Override the AAD client ID')
-      .option('--account-type <type>', 'Account type: work or personal (default: work)')
+      .option('--account-type <type>', 'Force account type: work or personal (skips email detection)')
+      .option('--email <email>', 'Microsoft email, used to auto-detect work vs personal')
       .action(loginAction),
   )
   .addCommand(

--- a/src/platforms/teams/device-code.test.ts
+++ b/src/platforms/teams/device-code.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, mock } from 'bun:test'
 
 import { getTeamsAppClientId } from './app-config'
 import {
+  decodeJwtTid,
   exchangeDeviceCode,
   exchangeForSkypeScope,
+  isConsumerTenant,
   mintConsumerSkypeToken,
   mintSkypeToken,
   pollDeviceToken,
@@ -232,10 +234,41 @@ describe('resolveWorkTenantId', () => {
     )
   })
 
-  it('throws when no tenant is associated with the account', async () => {
+  it('throws when no tenant is associated with the account and points to the personal flow', async () => {
     mockFetch(() => ({ json: [] }))
 
-    await expect(resolveWorkTenantId(fakeJwt({ tid: 'organizations' }))).rejects.toThrow(/No Microsoft Teams tenant/)
+    await expect(resolveWorkTenantId(fakeJwt({ tid: 'organizations' }))).rejects.toThrow(/--account-type personal/)
+  })
+})
+
+describe('decodeJwtTid', () => {
+  it('returns the tid claim from a JWT access token', () => {
+    expect(decodeJwtTid(fakeJwt({ tid: '9188040d-6c67-4c5b-b112-36a304b66dad' }))).toBe(
+      '9188040d-6c67-4c5b-b112-36a304b66dad',
+    )
+  })
+
+  it('returns undefined for a malformed token', () => {
+    expect(decodeJwtTid('not-a-jwt')).toBeUndefined()
+  })
+
+  it('returns undefined when the tid claim is absent', () => {
+    expect(decodeJwtTid(fakeJwt({ sub: 'user' }))).toBeUndefined()
+  })
+})
+
+describe('isConsumerTenant', () => {
+  it('recognizes the consumer tenant as personal', () => {
+    expect(isConsumerTenant('9188040d-6c67-4c5b-b112-36a304b66dad')).toBe(true)
+  })
+
+  it('does not treat the Microsoft Services placeholder as personal (work tokens carry it too)', () => {
+    expect(isConsumerTenant('f8cdef31-a31e-4b4a-93e4-5f571e91255a')).toBe(false)
+  })
+
+  it('does not treat the organizations placeholder or a real tenant as personal', () => {
+    expect(isConsumerTenant('organizations')).toBe(false)
+    expect(isConsumerTenant(REAL_TENANT_ID)).toBe(false)
   })
 })
 

--- a/src/platforms/teams/device-code.ts
+++ b/src/platforms/teams/device-code.ts
@@ -165,7 +165,10 @@ export async function resolveWorkTenantId(accessToken: string): Promise<string> 
   const tenants = await fetchTenants(accessToken)
   const redeemed = tenants.find((tenant) => tenant.isInvitationRedeemed !== false) ?? tenants[0]
   if (!redeemed) {
-    throw new TeamsError('No Microsoft Teams tenant is associated with this account.', 'teams_tenant_missing')
+    throw new TeamsError(
+      'No Microsoft Teams tenant is associated with this account. If this is a personal Microsoft account, run `agent-teams auth login --account-type personal`.',
+      'teams_tenant_missing',
+    )
   }
   if (redeemed.isInvitationRedeemed === false) {
     throw new TeamsError(
@@ -199,7 +202,7 @@ async function fetchTenants(accessToken: string): Promise<TeamsTenant[]> {
     .filter((tenant): tenant is TeamsTenant => tenant !== null)
 }
 
-function decodeJwtTid(token: string): string | undefined {
+export function decodeJwtTid(token: string): string | undefined {
   const payload = token.split('.')[1]
   if (!payload) return undefined
   try {
@@ -208,6 +211,14 @@ function decodeJwtTid(token: string): string | undefined {
   } catch {
     return undefined
   }
+}
+
+// The consumer tenant unambiguously marks a personal account: it has no org
+// tenant, so a work login carrying it can never resolve a Teams tenant. The
+// Microsoft Services placeholder is intentionally excluded — it also appears on
+// legitimate work tokens, which resolveWorkTenantId() resolves via discovery.
+export function isConsumerTenant(tenantId: string): boolean {
+  return tenantId === CONSUMER_TENANT_ID
 }
 
 function isPlaceholderTenant(tenantId: string): boolean {

--- a/src/platforms/teams/device-login.test.ts
+++ b/src/platforms/teams/device-login.test.ts
@@ -1,9 +1,31 @@
-import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test'
+import { afterAll, afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { rmSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
-import { refreshDeviceCodeAccount } from './device-login'
+import * as deviceCode from './device-code'
+import type { DeviceCodeInfo } from './device-code'
+import { loginWithDeviceCode, refreshDeviceCodeAccount } from './device-login'
+
+const CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad'
+const MICROSOFT_SERVICES_TENANT_ID = 'f8cdef31-a31e-4b4a-93e4-5f571e91255a'
+const REAL_TENANT_ID = 'c0ffee00-1111-2222-3333-444455556666'
+
+function fakeJwt(claims: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.signature`
+}
+
+function fakeDeviceCodeInfo(): DeviceCodeInfo {
+  return {
+    deviceCode: 'device-code',
+    userCode: 'USER-CODE',
+    verificationUri: 'https://microsoft.com/devicelogin',
+    verificationUriComplete: 'https://microsoft.com/devicelogin?otc=USER-CODE',
+    expiresIn: 900,
+    interval: 1,
+  }
+}
 
 const testDirs: string[] = []
 const originalFetch = globalThis.fetch
@@ -162,5 +184,105 @@ describe('refreshDeviceCodeAccount', () => {
     expect(ok).toBe(false)
     const config = await manager.loadConfig()
     expect(config?.accounts.personal?.token).toBe('old-skype')
+  })
+})
+
+describe('loginWithDeviceCode personal-account detection', () => {
+  const spies: Array<ReturnType<typeof spyOn>> = []
+
+  function spy<T extends object, K extends keyof T>(obj: T, key: K): ReturnType<typeof spyOn> {
+    const s = spyOn(obj, key as never)
+    spies.push(s)
+    return s
+  }
+
+  afterEach(() => {
+    for (const s of spies.splice(0)) s.mockRestore()
+  })
+
+  function stubFinalizeChain(): void {
+    spy(deviceCode, 'exchangeForSkypeScope').mockResolvedValue({ accessToken: 'spaces-at', refreshToken: 'rt' })
+    spy(deviceCode, 'mintSkypeToken').mockResolvedValue({
+      skypeToken: 'skype',
+      skypeTokenExpiresAt: '2100-01-01T00:00:00Z',
+    })
+    spy(TeamsClient.prototype, 'login').mockResolvedValue(new TeamsClient())
+    spy(TeamsClient.prototype, 'testAuth').mockResolvedValue({
+      id: 'u',
+      displayName: 'Work User',
+      email: 'w@example.com',
+    })
+    spy(TeamsClient.prototype, 'listTeams').mockResolvedValue([])
+    spy(TeamsClient.prototype, 'getRegion').mockReturnValue('emea')
+    spy(TeamsCredentialManager.prototype, 'setDeviceCodeAccount').mockResolvedValue(undefined)
+  }
+
+  it('stops with an actionable hint when a work login resolves to a consumer account', async () => {
+    const requestSpy = spy(deviceCode, 'requestDeviceCode').mockResolvedValue(fakeDeviceCodeInfo())
+    spy(deviceCode, 'pollDeviceToken').mockResolvedValue({
+      accessToken: fakeJwt({ tid: CONSUMER_TENANT_ID }),
+      refreshToken: 'work-rt',
+    })
+    const tenantSpy = spy(deviceCode, 'resolveWorkTenantId')
+    const exchangeSpy = spy(deviceCode, 'exchangeForSkypeScope')
+
+    // given: a work login whose token carries a consumer tenant
+    // then: it throws --account-type personal guidance without minting a token
+    await expect(loginWithDeviceCode({ accountType: 'work', onCode: () => {} })).rejects.toThrow(
+      /--account-type personal/,
+    )
+    expect(requestSpy).toHaveBeenCalledTimes(1)
+    expect(tenantSpy).not.toHaveBeenCalled()
+    expect(exchangeSpy).not.toHaveBeenCalled()
+  })
+
+  it('finishes a work login normally when it resolves to a real organizational tenant', async () => {
+    const requestSpy = spy(deviceCode, 'requestDeviceCode').mockResolvedValue(fakeDeviceCodeInfo())
+    spy(deviceCode, 'pollDeviceToken').mockResolvedValue({
+      accessToken: fakeJwt({ tid: REAL_TENANT_ID }),
+      refreshToken: 'work-rt',
+    })
+    const tenantSpy = spy(deviceCode, 'resolveWorkTenantId').mockResolvedValue(REAL_TENANT_ID)
+    stubFinalizeChain()
+
+    const result = await loginWithDeviceCode({ accountType: 'work', onCode: () => {} })
+
+    expect(requestSpy).toHaveBeenCalledTimes(1)
+    expect(tenantSpy).toHaveBeenCalledTimes(1)
+    expect(result.accountType).toBe('work')
+  })
+
+  it('runs tenant discovery for a work login carrying the Microsoft Services placeholder', async () => {
+    // given: a work token whose tid is the MSA-passthrough placeholder, which
+    // legitimate work accounts also carry and which discovery can still resolve
+    spy(deviceCode, 'requestDeviceCode').mockResolvedValue(fakeDeviceCodeInfo())
+    spy(deviceCode, 'pollDeviceToken').mockResolvedValue({
+      accessToken: fakeJwt({ tid: MICROSOFT_SERVICES_TENANT_ID }),
+      refreshToken: 'work-rt',
+    })
+    const tenantSpy = spy(deviceCode, 'resolveWorkTenantId').mockResolvedValue(REAL_TENANT_ID)
+    stubFinalizeChain()
+
+    // then: it is not rejected early — discovery runs and the login completes
+    const result = await loginWithDeviceCode({ accountType: 'work', onCode: () => {} })
+
+    expect(tenantSpy).toHaveBeenCalledTimes(1)
+    expect(result.accountType).toBe('work')
+  })
+
+  it('finishes a personal login without tenant discovery', async () => {
+    const requestSpy = spy(deviceCode, 'requestDeviceCode').mockResolvedValue(fakeDeviceCodeInfo())
+    spy(deviceCode, 'pollDeviceToken').mockResolvedValue({
+      accessToken: fakeJwt({ tid: CONSUMER_TENANT_ID }),
+      refreshToken: 'personal-rt',
+    })
+    const tenantSpy = spy(deviceCode, 'resolveWorkTenantId')
+    stubFinalizeChain()
+
+    const result = await loginWithDeviceCode({ accountType: 'personal', onCode: () => {} })
+
+    expect(requestSpy.mock.calls[0][1]).toBe('personal')
+    expect(tenantSpy).not.toHaveBeenCalled()
+    expect(result.accountType).toBe('personal')
   })
 })

--- a/src/platforms/teams/device-login.ts
+++ b/src/platforms/teams/device-login.ts
@@ -4,14 +4,19 @@ import { TeamsCredentialManager } from './credential-manager'
 import {
   type AadToken,
   type DeviceCodeInfo,
+  decodeJwtTid,
   exchangeDeviceCode,
   exchangeForSkypeScope,
+  isConsumerTenant,
   mintSkypeToken,
   pollDeviceToken,
   requestDeviceCode,
   resolveWorkTenantId,
 } from './device-code'
-import type { TeamsAccountType } from './types'
+import { type TeamsAccountType, TeamsError } from './types'
+
+const PERSONAL_ACCOUNT_HINT =
+  'This looks like a personal Microsoft account. Run `agent-teams auth login --account-type personal` to sign in.'
 
 export interface DeviceCodePrompt {
   verificationUri: string
@@ -80,8 +85,21 @@ export async function loginWithDeviceCode(
   })
 
   const aad = await pollDeviceToken(info.deviceCode, info.interval, info.expiresIn, clientId, accountType)
+
+  // A work login can resolve to a personal (MSA) account, whose token carries a
+  // consumer tenant. Such accounts have no org tenant and can't be finished on
+  // the work flow, so stop with an actionable hint rather than fail obscurely.
+  if (accountType === 'work' && isPersonalAccount(aad)) {
+    throw new TeamsError(PERSONAL_ACCOUNT_HINT, 'teams_personal_account_on_work_login')
+  }
+
   callbacks.onPending?.()
   return finalize(aad, clientId, accountType, credManager, callbacks.debug)
+}
+
+function isPersonalAccount(aad: AadToken): boolean {
+  const tid = decodeJwtTid(aad.accessToken)
+  return tid !== undefined && isConsumerTenant(tid)
 }
 
 async function finalize(

--- a/src/platforms/teams/realm-discovery.test.ts
+++ b/src/platforms/teams/realm-discovery.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import { probeAccountType } from './realm-discovery'
+
+const originalFetch = globalThis.fetch
+
+function mockFetch(response: { status?: number; json?: unknown; reject?: boolean }): {
+  calls: Array<{ url: string; init: RequestInit }>
+} {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    if (response.reject) return Promise.reject(new Error('network down'))
+    const status = response.status ?? 200
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(response.json),
+    } as Response)
+  }) as typeof fetch
+  return { calls }
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('probeAccountType', () => {
+  it('posts the email to GetCredentialType as JSON', async () => {
+    const { calls } = mockFetch({ json: { EstsProperties: { DomainType: 3 } } })
+
+    await probeAccountType('user@contoso.com')
+
+    expect(calls[0].url).toBe('https://login.microsoftonline.com/common/GetCredentialType')
+    expect(calls[0].init.method).toBe('POST')
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({ Username: 'user@contoso.com' })
+  })
+
+  it('maps a consumer DomainType to personal', async () => {
+    mockFetch({ json: { EstsProperties: { DomainType: 2 } } })
+    expect(await probeAccountType('user@outlook.com')).toBe('personal')
+  })
+
+  it('treats a known consumer domain as personal even without DomainType', async () => {
+    mockFetch({ json: { EstsProperties: { IsConsumerDomain: true } } })
+    expect(await probeAccountType('user@hotmail.com')).toBe('personal')
+  })
+
+  it('maps a managed DomainType to work', async () => {
+    mockFetch({ json: { EstsProperties: { DomainType: 3 } } })
+    expect(await probeAccountType('user@contoso.com')).toBe('work')
+  })
+
+  it('maps a federated DomainType to work', async () => {
+    mockFetch({ json: { EstsProperties: { DomainType: 4 } } })
+    expect(await probeAccountType('user@fabrikam.com')).toBe('work')
+  })
+
+  it('returns undefined when the domain type is missing', async () => {
+    mockFetch({ json: { EstsProperties: {} } })
+    expect(await probeAccountType('user@unknown.test')).toBeUndefined()
+  })
+
+  it('returns undefined on a non-ok response', async () => {
+    mockFetch({ status: 429, json: {} })
+    expect(await probeAccountType('user@contoso.com')).toBeUndefined()
+  })
+
+  it('returns undefined when the request throws', async () => {
+    mockFetch({ reject: true })
+    expect(await probeAccountType('user@contoso.com')).toBeUndefined()
+  })
+})

--- a/src/platforms/teams/realm-discovery.ts
+++ b/src/platforms/teams/realm-discovery.ts
@@ -1,0 +1,42 @@
+import { GET_CREDENTIAL_TYPE_URL } from './app-config'
+import type { TeamsAccountType } from './types'
+
+// GetCredentialType (the endpoint Microsoft's own login page calls) reports
+// EstsProperties.DomainType, which distinguishes a personal account from a
+// work account before any device code is issued.
+const DOMAIN_TYPE_CONSUMER = 2
+
+interface CredentialTypeResponse {
+  IfExistsResult?: number
+  EstsProperties?: {
+    DomainType?: number
+    IsConsumerDomain?: boolean
+  }
+}
+
+// Returns the account type for an email, or undefined when it can't be
+// determined (network error, throttling, unknown domain) so the caller can
+// fall back to its default flow rather than block sign-in.
+export async function probeAccountType(email: string): Promise<TeamsAccountType | undefined> {
+  let body: CredentialTypeResponse
+  try {
+    const res = await fetch(GET_CREDENTIAL_TYPE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ Username: email }),
+    })
+    if (!res.ok) return undefined
+    body = (await res.json()) as CredentialTypeResponse
+  } catch {
+    return undefined
+  }
+
+  const ests = body.EstsProperties
+  if (ests?.DomainType === DOMAIN_TYPE_CONSUMER || ests?.IsConsumerDomain === true) {
+    return 'personal'
+  }
+  if (typeof ests?.DomainType === 'number') {
+    return 'work'
+  }
+  return undefined
+}


### PR DESCRIPTION
## Problem

Running `agent-teams auth login` with a **personal** Microsoft account (a `@gmail.com`/`@outlook.com`-style MSA) completed the device-code approval but then failed at "Finishing sign-in":

```
{"error":"No Microsoft Teams tenant is associated with this account."}
```

Follow-up to #289.

## Root cause

`auth login` defaulted to the work (`organizations`) authority. A personal account **can** authenticate there, so approval succeeds — but `resolveWorkTenantId()` then queries the tenant-discovery endpoint, which returns empty for personal accounts (they have no organizational tenant), and the error is thrown.

## Fix — detect the account type *before* login, with a safety net after

**1. Pre-login detection (primary).** `auth login` now prompts for a Microsoft email (or accepts `--email`) and calls Microsoft's `GetCredentialType` endpoint — the same unauthenticated call the real login page makes — to classify the account as work or personal (`EstsProperties.DomainType`: `2` = consumer/personal, `3`/`4` = managed/federated work). It then starts the **matching** device-code flow. A personal account is routed correctly up front, with no wrong-flow rejection and no second approval.

The probe is best-effort — a forced `--account-type`, a skipped email, or an inconclusive/failed lookup all fall back to the previous default flow.

**2. Post-approval guard (safety net).** If a personal account still reaches the work flow (e.g. email skipped), decoding the token's `tid` reveals a consumer/MSA tenant, and login stops with an actionable message instead of the obscure tenant error:

> This looks like a personal Microsoft account. Run `agent-teams auth login --account-type personal` to sign in.

### Why not auto-restart the personal flow after approval?

An earlier iteration tried that; it produced a confusing double-approval that looked like a hang (a device-code approval is bound to its one-time code, so switching flows needs a *second* code the user must enter — right after the browser said "signed in successfully"). Detecting from the email up front avoids the wrong flow entirely; the post-approval path only needs to guide, not restart.

Also: the tenant-missing error and the "Waiting for approval" line (now includes the user code) were made more actionable/debuggable.

## New surface

- `--email <email>` — Microsoft email used to auto-detect work vs personal (optional; prompted interactively when omitted).
- `--account-type <type>` — still available to force work/personal and skip detection.

## User impact

| Before | After |
| --- | --- |
| Personal account → obscure tenant failure after approval | Email probe routes it to the personal flow before any code is shown |
| No way to detect account type up front | `GetCredentialType` pre-flight (with graceful fallback) |
| If it still reached the work flow → cryptic error | Clear `--account-type personal` guidance |

## Testing

- `probeAccountType`: consumer/managed/federated mapping, known-consumer-domain shortcut, and graceful `undefined` on missing domain type / non-ok / network error.
- `loginAction`: routes to personal when the probe says personal, skips the probe when `--account-type` is forced, and falls back to the default when the probe is inconclusive.
- `decodeJwtTid` / `isConsumerTenant` unit tests; post-approval guard tests (work-on-consumer throws the hint; real org tenant finishes; personal finishes without tenant discovery); updated tenant-missing test.
- `bun typecheck`, `bun lint`, and `bun test` (3526 pass, 0 fail) all green. Changed files pass `oxfmt --check`; the repo-wide `format:check` failure comes from the separate `docs/` workspace (`fumadocs-ui` not installed) and predates this branch.