### PR TITLE
feat(teams): enrich realtime messages with channel context and mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,23 @@ import { TeamsClient, TeamsListener } from 'agent-messenger/teams'
 const client = await new TeamsClient().login()
 const listener = new TeamsListener(client)
 
-listener.on('message', (message) => {
+listener.on('message', async (message) => {
   console.log(`New message in ${message.chatId}: ${message.content}`)
+
+  // Channel messages carry team/channel context and parsed @mentions, so you
+  // can reply into the channel or act on who was mentioned.
+  if (message.conversationType === 'channel') {
+    for (const mention of message.mentions) {
+      console.log(`Mentioned: ${mention.displayName} (${mention.mri})`)
+    }
+    await client.sendMessage(message.teamId!, message.channelId!, 'On it 👍')
+  }
 })
 
 await listener.start()
 ```
+
+Each `message` is a `TeamsRealtimeMessage`: `conversationType` is `'chat'` or `'channel'`, `teamId`/`channelId` are set for channel messages, and `mentions` is always present (empty for messages with no `@mentions`).
 
 ### Real-time Events (KakaoTalk)
 

--- a/docs/content/docs/cli/teams.mdx
+++ b/docs/content/docs/cli/teams.mdx
@@ -265,12 +265,26 @@ import { TeamsClient, TeamsListener } from 'agent-messenger/teams'
 const client = await new TeamsClient().login()
 const listener = new TeamsListener(client)
 
-listener.on('message', (message) => {
+listener.on('message', async (message) => {
   console.log(`New message in ${message.chatId}: ${message.content}`)
+
+  // Channel messages carry team/channel context and parsed @mentions.
+  if (message.conversationType === 'channel') {
+    for (const mention of message.mentions) {
+      console.log(`Mentioned: ${mention.displayName} (${mention.mri})`)
+    }
+    await client.sendMessage(message.teamId!, message.channelId!, 'On it 👍')
+  }
 })
 
 await listener.start()
 ```
+
+Each `message` is a `TeamsRealtimeMessage`. Alongside the unchanged
+`chatId`/`content`/`author`, it carries `conversationType` (`'chat'` or
+`'channel'`), `teamId`/`channelId` (set for channel messages, for use with
+`sendMessage`), and `mentions` (always present, empty when there are no
+`@mentions`; each is `{ id, mri?, displayName }`).
 
 The listener reuses your extracted credentials, so the Teams desktop app must be
 logged in. It reconnects automatically and re-authenticates on token expiry.

--- a/docs/content/docs/sdk/teams.mdx
+++ b/docs/content/docs/sdk/teams.mdx
@@ -206,8 +206,38 @@ import type {
   TeamsAccount,
   TeamsConfig,
   TeamsConfigLegacy,
+  TeamsRealtimeMessage,
+  TeamsMention,
+  TeamsListenerEventMap,
+  TeamsTrouterGenericEvent,
 } from 'agent-messenger/teams'
 ```
+
+The real-time listener emits `TeamsRealtimeMessage`:
+
+```typescript
+interface TeamsRealtimeMessage {
+  id: string
+  chatId: string
+  conversationType: 'chat' | 'channel'
+  teamId?: string // set for channel messages
+  channelId?: string // set for channel messages
+  content: string // HTML-stripped text
+  mentions: TeamsMention[] // always present; empty when no @mentions
+  author: { id: string; displayName: string }
+  messageType: string
+  timestamp: string
+}
+
+interface TeamsMention {
+  id: string // positional mention index
+  mri?: string // Skype MRI of the mentioned user/tag
+  displayName: string
+}
+```
+
+These are type-only exports (no Zod schema — the listener constructs the event
+internally rather than parsing untrusted input).
 
 ### Zod Schemas
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -473,12 +473,35 @@ import { TeamsClient, TeamsListener } from 'agent-messenger/teams'
 const client = await new TeamsClient().login()
 const listener = new TeamsListener(client)
 
-listener.on('message', (message) => {
+listener.on('message', async (message) => {
   console.log(`New message in ${message.chatId}: ${message.content}`)
+
+  // Channel messages carry team/channel context and parsed @mentions.
+  if (message.conversationType === 'channel') {
+    for (const mention of message.mentions) {
+      console.log(`Mentioned: ${mention.displayName} (${mention.mri})`)
+    }
+    await client.sendMessage(message.teamId!, message.channelId!, 'On it 👍')
+  }
 })
 
 await listener.start()
 ```
+
+Each `message` is a `TeamsRealtimeMessage`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | `string` | Message id |
+| `chatId` | `string` | Conversation id (unchanged) |
+| `conversationType` | `'chat' \| 'channel'` | `'channel'` for team-channel messages |
+| `teamId` | `string?` | Set for channel messages (use with `sendMessage`) |
+| `channelId` | `string?` | Set for channel messages (use with `sendMessage`) |
+| `content` | `string` | HTML-stripped text (unchanged) |
+| `mentions` | `TeamsMention[]` | Always present; empty when no `@mentions`. Each is `{ id, mri?, displayName }` |
+| `author` | `{ id, displayName }` | Sender (unchanged) |
+| `messageType` | `string` | e.g. `Text`, `RichText/Html` |
+| `timestamp` | `string` | ISO timestamp |
 
 ### Full API Reference
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -589,6 +589,34 @@ export class TeamsClient {
     return Array.from(teamsMap.values())
   }
 
+  // Realtime messages only carry a conversation id; a channel's parent teamId
+  // (== groupId) lives on the conversation, so the listener resolves it through
+  // this channelId -> teamId map.
+  async buildChannelTeamMap(): Promise<Map<string, string>> {
+    interface Conversation {
+      id: string
+      threadProperties?: {
+        groupId?: string
+        productThreadType?: string
+        threadType?: string
+      }
+    }
+    interface ConversationsResponse {
+      conversations: Conversation[]
+    }
+    const data = await this.request<ConversationsResponse>('GET', '/users/ME/conversations')
+
+    const channelToTeam = new Map<string, string>()
+    for (const conv of data.conversations ?? []) {
+      const tp = conv.threadProperties
+      if (!tp?.groupId) continue
+      if (!tp.productThreadType?.includes('Teams') && tp.threadType !== 'space') continue
+      channelToTeam.set(conv.id, tp.groupId)
+    }
+
+    return channelToTeam
+  }
+
   async listChats(): Promise<TeamsChat[]> {
     interface ConversationMessage {
       content?: string

--- a/src/platforms/teams/index.ts
+++ b/src/platforms/teams/index.ts
@@ -20,6 +20,7 @@ export type {
   TeamsCredentials,
   TeamsFile,
   TeamsListenerEventMap,
+  TeamsMention,
   TeamsMessage,
   TeamsRealtimeMessage,
   TeamsReaction,

--- a/src/platforms/teams/listener.test.ts
+++ b/src/platforms/teams/listener.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, mock, it } from 'bun:test'
+
+import { TeamsListener } from '@/platforms/teams/listener'
+import type { TeamsRealtimeMessage } from '@/platforms/teams/types'
+
+type WsHandler = (...args: any[]) => void
+
+let mockWsInstance: MockWs
+
+class MockWs {
+  static OPEN = 1
+  static CLOSED = 3
+  readyState = MockWs.OPEN
+
+  private handlers = new Map<string, WsHandler[]>()
+  sent: string[] = []
+
+  constructor(_url: string, _options?: any) {
+    // oxlint-disable-next-line typescript-eslint/no-this-alias
+    mockWsInstance = this
+  }
+
+  on(event: string, handler: WsHandler) {
+    const list = this.handlers.get(event) ?? []
+    list.push(handler)
+    this.handlers.set(event, list)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = MockWs.CLOSED
+  }
+
+  emit(event: string, ...args: any[]) {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler(...args)
+    }
+  }
+
+  simulateFrame(frame: string) {
+    this.emit('message', Buffer.from(frame))
+  }
+}
+
+mock.module('ws', () => ({ default: MockWs, __esModule: true }))
+
+const actualTrouter = await import('@/platforms/teams/trouter')
+mock.module('@/platforms/teams/trouter', () => ({
+  ...actualTrouter,
+  fetchTrouterInfo: mock(() => Promise.resolve({ socketio: 'wss://fake/', surl: 'https://fake/', connectparams: {} })),
+  fetchTrouterSessionId: mock(() => Promise.resolve('SESSION')),
+  registerEndpoint: mock(() => Promise.resolve()),
+}))
+
+function messageFrame(resource: Record<string, unknown>): string {
+  const body = JSON.stringify({ resourceType: 'NewMessage', resource })
+  return `3:::${JSON.stringify({ id: 1, url: '/v4/f/HASH/messaging', body })}`
+}
+
+function conversationLink(conversationId: string): string {
+  return `https://notifications.skype.net/v1/users/ME/conversations/${conversationId}`
+}
+
+function createMockClient(channelTeamMap: Map<string, string> = new Map()) {
+  return {
+    getToken: mock(() => 'skype-token'),
+    getIdToken: mock(() => Promise.resolve('id-token')),
+    getAccountType: mock(() => 'work'),
+    buildChannelTeamMap: mock(() => Promise.resolve(channelTeamMap)),
+  } as any
+}
+
+async function startAndCapture(
+  client: ReturnType<typeof createMockClient>,
+): Promise<{ listener: TeamsListener; messages: TeamsRealtimeMessage[] }> {
+  const listener = new TeamsListener(client)
+  const messages: TeamsRealtimeMessage[] = []
+  listener.on('message', (message) => messages.push(message))
+  await listener.start()
+  return { listener, messages }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
+describe('TeamsListener.emitMessage', () => {
+  let listener: TeamsListener
+
+  afterEach(() => {
+    listener?.stop()
+  })
+
+  it('classifies a 1:1 chat and carries no team/channel context', async () => {
+    const client = createMockClient()
+    const started = await startAndCapture(client)
+    listener = started.listener
+
+    mockWsInstance.simulateFrame(
+      messageFrame({
+        id: 'm1',
+        messagetype: 'RichText/Html',
+        content: 'hello there',
+        from: 'https://x/contacts/8:orgid:alice',
+        imdisplayname: 'Alice',
+        conversationLink: conversationLink('19:uni01_abc@unq.gbl.spaces'),
+      }),
+    )
+    await flushMicrotasks()
+
+    expect(started.messages).toHaveLength(1)
+    const message = started.messages[0]
+    expect(message.chatId).toBe('19:uni01_abc@unq.gbl.spaces')
+    expect(message.conversationType).toBe('chat')
+    expect(message.teamId).toBeUndefined()
+    expect(message.channelId).toBeUndefined()
+    expect(message.content).toBe('hello there')
+    expect(message.mentions).toEqual([])
+    expect(message.author).toEqual({ id: '8:orgid:alice', displayName: 'Alice' })
+  })
+
+  it('classifies a group chat thread with no groupId as a chat', async () => {
+    const client = createMockClient()
+    const started = await startAndCapture(client)
+    listener = started.listener
+
+    mockWsInstance.simulateFrame(
+      messageFrame({
+        id: 'm2',
+        messagetype: 'RichText/Html',
+        content: 'group hi',
+        from: 'https://x/contacts/8:orgid:bob',
+        imdisplayname: 'Bob',
+        conversationLink: conversationLink('19:group_xyz@thread.tacv2'),
+      }),
+    )
+    await flushMicrotasks()
+
+    expect(started.messages).toHaveLength(1)
+    const message = started.messages[0]
+    expect(message.chatId).toBe('19:group_xyz@thread.tacv2')
+    expect(message.conversationType).toBe('chat')
+    expect(message.teamId).toBeUndefined()
+    expect(message.channelId).toBeUndefined()
+  })
+
+  it('does not refresh the channel map for every group-chat message', async () => {
+    const client = createMockClient()
+    const started = await startAndCapture(client)
+    listener = started.listener
+
+    for (const id of ['g1', 'g2', 'g3']) {
+      mockWsInstance.simulateFrame(
+        messageFrame({
+          id,
+          messagetype: 'RichText/Html',
+          content: 'group hi',
+          from: 'https://x/contacts/8:orgid:bob',
+          imdisplayname: 'Bob',
+          conversationLink: conversationLink('19:group_xyz@thread.tacv2'),
+        }),
+      )
+      await flushMicrotasks()
+    }
+
+    expect(started.messages).toHaveLength(3)
+    // One build at start() + one refresh on the first miss; the negative cache
+    // prevents a fetch on the 2nd and 3rd messages.
+    expect(client.buildChannelTeamMap).toHaveBeenCalledTimes(2)
+  })
+
+  it('classifies a team channel message and resolves teamId plus mentions', async () => {
+    const channelId = '19:channel_abc@thread.tacv2'
+    const client = createMockClient(new Map([[channelId, 'team-group-id']]))
+    const started = await startAndCapture(client)
+    listener = started.listener
+
+    mockWsInstance.simulateFrame(
+      messageFrame({
+        id: 'm3',
+        messagetype: 'RichText/Html',
+        content: '<span itemtype="http://schema.skype.com/Mention" itemscope itemid="0">Alice</span> please review',
+        from: 'https://x/contacts/8:orgid:bob',
+        imdisplayname: 'Bob',
+        conversationLink: conversationLink(channelId),
+        properties: {
+          mentions: [{ itemid: '0', mri: '8:orgid:alice', mentionType: 'person', displayName: 'Alice' }],
+        },
+      }),
+    )
+    await flushMicrotasks()
+
+    expect(started.messages).toHaveLength(1)
+    const message = started.messages[0]
+    expect(message.conversationType).toBe('channel')
+    expect(message.teamId).toBe('team-group-id')
+    expect(message.channelId).toBe(channelId)
+    expect(message.content).toBe('Alice please review')
+    expect(message.mentions).toEqual([{ id: '0', mri: '8:orgid:alice', displayName: 'Alice' }])
+  })
+
+  it('does not re-emit a message with a duplicate id', async () => {
+    const client = createMockClient()
+    const started = await startAndCapture(client)
+    listener = started.listener
+
+    const frame = messageFrame({
+      id: 'dup',
+      messagetype: 'Text',
+      content: 'once',
+      from: 'https://x/contacts/8:orgid:alice',
+      imdisplayname: 'Alice',
+      conversationLink: conversationLink('19:uni01_abc@unq.gbl.spaces'),
+    })
+    mockWsInstance.simulateFrame(frame)
+    await flushMicrotasks()
+    mockWsInstance.simulateFrame(frame)
+    await flushMicrotasks()
+
+    expect(started.messages).toHaveLength(1)
+  })
+
+  it('ignores non-text message types', async () => {
+    const client = createMockClient()
+    const started = await startAndCapture(client)
+    listener = started.listener
+
+    mockWsInstance.simulateFrame(
+      messageFrame({
+        id: 'sys',
+        messagetype: 'ThreadActivity/AddMember',
+        content: '',
+        conversationLink: conversationLink('19:uni01_abc@unq.gbl.spaces'),
+      }),
+    )
+    await flushMicrotasks()
+
+    expect(started.messages).toHaveLength(0)
+  })
+})

--- a/src/platforms/teams/listener.ts
+++ b/src/platforms/teams/listener.ts
@@ -16,6 +16,8 @@ import {
   fetchTrouterInfo,
   fetchTrouterSessionId,
   isMessageLossFrame,
+  isThreadConversation,
+  parseMentions,
   parseRequestFrame,
   registerEndpoint,
   type TrouterInfo,
@@ -40,6 +42,7 @@ interface IncomingResource {
   imdisplayname?: string
   conversationLink?: string
   resourceLink?: string
+  properties?: unknown
 }
 
 export class TeamsListener {
@@ -56,6 +59,9 @@ export class TeamsListener {
   private reregisterTimer: ReturnType<typeof setInterval> | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private seenMessageIds = new Set<string>()
+  private channelTeamMap = new Map<string, string>()
+  private channelMapRefreshing: Promise<void> | null = null
+  private nonChannelThreads = new Set<string>()
 
   constructor(client: TeamsClient) {
     this.client = client
@@ -65,6 +71,7 @@ export class TeamsListener {
     if (this.running) return
     this.running = true
     this.reconnectAttempts = 0
+    await this.refreshChannelMap()
     await this.connect()
   }
 
@@ -214,7 +221,9 @@ export class TeamsListener {
         resource?: IncomingResource
       }
       if (decoded.resourceType === 'NewMessage' && decoded.resource) {
-        this.emitMessage(decoded.resource)
+        void this.emitMessage(decoded.resource).catch((error) => {
+          this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+        })
       }
       this.emitter.emit('teams_event', { resourceType: decoded.resourceType ?? 'unknown', ...decoded })
     } catch (error) {
@@ -222,18 +231,29 @@ export class TeamsListener {
     }
   }
 
-  private emitMessage(resource: IncomingResource): void {
+  private async emitMessage(resource: IncomingResource): Promise<void> {
     if (!resource.messagetype || !TEXT_MESSAGE_TYPES.has(resource.messagetype)) return
 
     const chatId = extractChatId(resource.conversationLink ?? resource.resourceLink)
     if (!chatId || !resource.id) return
+
+    // Dedup before the async classification so duplicate frames don't trigger
+    // redundant channel-map refreshes.
     if (this.seenMessageIds.has(resource.id)) return
     this.rememberMessageId(resource.id)
 
+    const classification = await this.classifyConversation(chatId)
+    if (!this.running) return
+
+    const rawContent = resource.content ?? ''
     const message: TeamsRealtimeMessage = {
       id: resource.id,
       chatId,
-      content: stripHtml(resource.content ?? ''),
+      conversationType: classification.conversationType,
+      teamId: classification.teamId,
+      channelId: classification.channelId,
+      content: stripHtml(rawContent),
+      mentions: parseMentions(resource.properties, rawContent),
       author: {
         id: extractUserId(resource.from) ?? 'unknown',
         displayName: resource.imdisplayname || extractUserId(resource.from) || 'unknown',
@@ -242,6 +262,42 @@ export class TeamsListener {
       timestamp: new Date().toISOString(),
     }
     this.emitter.emit('message', message)
+  }
+
+  private async classifyConversation(
+    chatId: string,
+  ): Promise<Pick<TeamsRealtimeMessage, 'conversationType' | 'teamId' | 'channelId'>> {
+    if (!isThreadConversation(chatId)) return { conversationType: 'chat' }
+
+    let teamId = this.channelTeamMap.get(chatId)
+    // A thread we haven't cached may be a channel created/joined since start;
+    // one best-effort refresh resolves it. Group chats also look like threads
+    // but never carry a groupId, so remember the miss to avoid re-fetching
+    // /users/ME/conversations on every one of their messages.
+    if (!teamId && !this.nonChannelThreads.has(chatId)) {
+      await this.refreshChannelMap()
+      teamId = this.channelTeamMap.get(chatId)
+      if (!teamId) this.nonChannelThreads.add(chatId)
+    }
+    if (!teamId) return { conversationType: 'chat' }
+
+    return { conversationType: 'channel', teamId, channelId: chatId }
+  }
+
+  private async refreshChannelMap(): Promise<void> {
+    if (this.channelMapRefreshing) return this.channelMapRefreshing
+    this.channelMapRefreshing = this.client
+      .buildChannelTeamMap()
+      .then((map) => {
+        this.channelTeamMap = map
+      })
+      .catch((error) => {
+        this.emitter.emit('error', error instanceof Error ? error : new Error(String(error)))
+      })
+      .finally(() => {
+        this.channelMapRefreshing = null
+      })
+    return this.channelMapRefreshing
   }
 
   private rememberMessageId(id: string): void {

--- a/src/platforms/teams/trouter.test.ts
+++ b/src/platforms/teams/trouter.test.ts
@@ -11,6 +11,8 @@ import {
   decodeMessageBody,
   extractChatId,
   isMessageLossFrame,
+  isThreadConversation,
+  parseMentions,
   parseRequestFrame,
   type TrouterInfo,
 } from './trouter'
@@ -111,4 +113,62 @@ it('decodeMessageBody unwraps nested gp (base64) payloads', () => {
   const gp = Buffer.from(inner).toString('base64')
   const decoded = decodeMessageBody({}, JSON.stringify({ gp }))
   expect(decoded).toEqual({ resourceType: 'NewMessage' })
+})
+
+it('isThreadConversation flags @thread ids and rejects 1:1 conversations', () => {
+  expect(isThreadConversation('19:abc@thread.tacv2')).toBe(true)
+  expect(isThreadConversation('19:abc@thread.v2')).toBe(true)
+  expect(isThreadConversation('19:uni01_abc@unq.gbl.spaces')).toBe(false)
+  expect(isThreadConversation('8:orgid:user@oneToOne.skype')).toBe(false)
+})
+
+it('parseMentions prefers the authoritative properties.mentions array', () => {
+  const properties = {
+    mentions: [
+      { itemid: '0', mri: '8:orgid:aaa', mentionType: 'person', displayName: 'Alice' },
+      { itemid: '1', mri: '8:orgid:bbb', mentionType: 'person', displayName: 'Bob' },
+    ],
+  }
+  const content =
+    '<span itemtype="http://schema.skype.com/Mention" itemscope itemid="0">Alice</span> ' +
+    '<span itemtype="http://schema.skype.com/Mention" itemscope itemid="1">Bob</span> hi'
+  expect(parseMentions(properties, content)).toEqual([
+    { id: '0', mri: '8:orgid:aaa', displayName: 'Alice' },
+    { id: '1', mri: '8:orgid:bbb', displayName: 'Bob' },
+  ])
+})
+
+it('parseMentions accepts JSON-stringified properties and mentions', () => {
+  const properties = JSON.stringify({
+    mentions: JSON.stringify([{ itemid: '0', mri: '8:orgid:aaa', displayName: 'Alice' }]),
+  })
+  expect(parseMentions(properties, '')).toEqual([{ id: '0', mri: '8:orgid:aaa', displayName: 'Alice' }])
+})
+
+it('parseMentions keeps tag mentions', () => {
+  const properties = { mentions: [{ itemid: '0', mri: 'tag:eng', mentionType: 'tag', displayName: 'Engineering' }] }
+  expect(parseMentions(properties, '')).toEqual([{ id: '0', mri: 'tag:eng', displayName: 'Engineering' }])
+})
+
+it('parseMentions falls back to content spans when properties are absent', () => {
+  const content =
+    '<readonly class="skipProofing" itemtype="http://schema.skype.com/Mention" contenteditable="false">' +
+    '<span itemtype="http://schema.skype.com/Mention" itemscope itemid="0">Alice</span></readonly> hi'
+  expect(parseMentions(undefined, content)).toEqual([{ id: '0', displayName: 'Alice' }])
+})
+
+it('parseMentions skips property entries missing itemid', () => {
+  const properties = {
+    mentions: [
+      { mri: '8:orgid:aaa', displayName: 'Alice' },
+      { itemid: '1', displayName: 'Bob' },
+    ],
+  }
+  expect(parseMentions(properties, '')).toEqual([{ id: '1', mri: undefined, displayName: 'Bob' }])
+})
+
+it('parseMentions returns an empty array for malformed data', () => {
+  expect(parseMentions('not-json', '')).toEqual([])
+  expect(parseMentions({ mentions: 'not-json' }, '')).toEqual([])
+  expect(parseMentions(null, 'plain text with no mentions')).toEqual([])
 })

--- a/src/platforms/teams/trouter.ts
+++ b/src/platforms/teams/trouter.ts
@@ -226,3 +226,98 @@ export function extractChatId(link: string | undefined): string | null {
   const match = link.match(/conversations\/([^/]+)/)
   return match ? decodeURIComponent(match[1]) : null
 }
+
+// `id` is Teams' positional mention index (the content span's `itemid`); `mri`
+// is the target's Skype MRI, present only via `properties.mentions` metadata.
+export interface TrouterMention {
+  id: string
+  mri?: string
+  displayName: string
+}
+
+// 1:1 chats resolve to a unique roster / one-to-one conversation id; anything on
+// a thread (group chat OR team channel) shares the @thread.* family. The thread
+// family alone cannot tell a group chat from a channel — that needs the
+// conversation's groupId, which the realtime resource does not carry.
+export function isThreadConversation(conversationId: string): boolean {
+  return conversationId.includes('@thread.tacv2') || conversationId.includes('@thread.v2')
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> | undefined {
+  const source = typeof value === 'string' ? safeJsonParse(value) : value
+  if (typeof source !== 'object' || source === null || Array.isArray(source)) return undefined
+  return source as Record<string, unknown>
+}
+
+function parseJsonArray(value: unknown): unknown[] | undefined {
+  const source = typeof value === 'string' ? safeJsonParse(value) : value
+  return Array.isArray(source) ? source : undefined
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+// Mentions arrive two ways: the authoritative `properties.mentions` array (JSON
+// or JSON-string) carries real MRIs, while the message content only has
+// positional `<span itemtype=".../Mention" itemid="N">Name</span>` markup with
+// no MRI. Prefer the metadata; fall back to scraping the content spans so a
+// mention is still surfaced when properties are missing. Never throws — bad
+// data yields an empty list.
+export function parseMentions(properties: unknown, content: string): TrouterMention[] {
+  const fromProperties = parseMentionsFromProperties(properties)
+  if (fromProperties.length > 0) return fromProperties
+  return parseMentionsFromContent(content)
+}
+
+function parseMentionsFromProperties(properties: unknown): TrouterMention[] {
+  const record = parseJsonRecord(properties)
+  if (!record) return []
+  const rawMentions = parseJsonArray(record.mentions)
+  if (!rawMentions) return []
+
+  const mentions: TrouterMention[] = []
+  for (const entry of rawMentions) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const item = entry as Record<string, unknown>
+    const id = item.itemid
+    if (typeof id !== 'string' && typeof id !== 'number') continue
+    mentions.push({
+      id: String(id),
+      mri: typeof item.mri === 'string' ? item.mri : undefined,
+      displayName: typeof item.displayName === 'string' ? item.displayName : '',
+    })
+  }
+  return mentions
+}
+
+const MENTION_SPAN_REGEX = /<span\b[^>]*itemtype=["'][^"']*Mention[^"']*["'][^>]*>(.*?)<\/span>/gi
+
+function parseMentionsFromContent(content: string): TrouterMention[] {
+  const mentions: TrouterMention[] = []
+  for (const match of content.matchAll(MENTION_SPAN_REGEX)) {
+    const attributes = match[0]
+    const itemId = attributes.match(/itemid=["']([^"']*)["']/i)?.[1]
+    if (itemId === undefined) continue
+    mentions.push({
+      id: itemId,
+      displayName: stripTags(match[1]),
+    })
+  }
+  return mentions
+}
+
+function stripTags(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim()
+}

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -252,10 +252,20 @@ export const TeamsConfigLegacySchema = z.object({
   ),
 })
 
+export interface TeamsMention {
+  id: string
+  mri?: string
+  displayName: string
+}
+
 export interface TeamsRealtimeMessage {
   id: string
   chatId: string
+  conversationType: 'chat' | 'channel'
+  teamId?: string
+  channelId?: string
   content: string
+  mentions: TeamsMention[]
   author: {
     id: string
     displayName: string


### PR DESCRIPTION
## Summary

The Teams realtime listener previously emitted `TeamsRealtimeMessage` with only `{ id, chatId, content, author, messageType, timestamp }`. For **channel** messages this dropped the team/channel context and stripped `<at>` mention metadata, so a consumer could neither reply to a channel message (needs `sendMessage(teamId, channelId, …)`) nor detect `@mentions`.

This PR adds **additive** fields to `TeamsRealtimeMessage`, leaving existing consumers untouched.

## What changed

`TeamsRealtimeMessage` gains:

- **`conversationType: 'chat' | 'channel'`** — derived from the conversation id suffix (`@unq.gbl.spaces` / `@oneToOne.skype` ⇒ 1:1; `@thread.tacv2` / `@thread.v2` ⇒ thread), refined to `'channel'` when the conversation resolves to a `groupId`.
- **`teamId?` / `channelId?`** — populated for channel messages. `channelId` is the conversation id; `teamId` is the parent `groupId`.
- **`mentions: TeamsMention[]`** (always present, may be empty) — parsed from the authoritative `properties.mentions` array (carries real MRIs), with a fallback to scraping `<span itemtype="…/Mention" itemid="N">` content spans. Parsing never throws on malformed data.

## Investigation notes (field shapes were verified, not assumed)

The original task assumed the trouter `NewMessage` resource carries `threadProperties.groupId` and that mentions are `<at id="…">` tags. **Both are incorrect** per cross-referenced OSS reverse-engineering projects (EionRobb/purple-teams, m0nkmaster/msteams-mcp, TeamsExportPortable):

- The realtime resource does **not** carry `threadProperties`. It carries a `properties` object (possibly JSON-stringified) with a `mentions` field.
- Mentions are `<span itemtype="http://schema.skype.com/Mention" itemscope itemid="N">Name</span>` where `itemid` is a positional index (not an MRI). The real MRIs live in `properties.mentions` as `{ itemid, mri, mentionType, displayName }`.
- Channel-vs-group-chat is **not** determinable from the payload alone. `teamId` (== `groupId`) must be resolved out-of-band.

Because of this, the listener caches a `channelId → teamId` map via the new `TeamsClient.buildChannelTeamMap()` (`/users/ME/conversations`) at start, and lazily refreshes it once on a thread cache-miss (handles channels created/joined after start). Concurrent refreshes are de-duplicated. Deduplication of message ids runs **before** the async classification so duplicate frames don't trigger redundant refreshes.

## Backward compatibility

- `chatId` / `content` / `author` / `messageType` / `timestamp` are unchanged.
- All new fields are additive; `content` is still emitted HTML-stripped as before.
- **Send/read paths are untouched.**

## Tests

- `trouter.test.ts`: `isThreadConversation` classification + `parseMentions` (properties array, JSON-stringified variants, tag mentions, HTML-span fallback, missing `itemid`, malformed data).
- `listener.test.ts` (new): drives `emitMessage` with real-shaped trouter frames for a **1:1 chat**, a **group chat**, and a **team channel message with an `<at>` mention** — asserting `conversationType`, `teamId`/`channelId` presence, and parsed `mentions`; plus dedup and non-text-type filtering.

## Verification

- `bun typecheck` ✅
- `bun lint` ✅ (0 warnings/errors)
- `bun test` ✅ (3540 pass, 0 fail)
- `bun run format:check` ✅ on all changed files

> Note: `format:check` reports a pre-existing, unrelated error in `docs/src/app/globals.css` (`fumadocs-ui/css/neutral.css` resolution) that also fails on a clean `main` — not touched by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriches Teams realtime messages with channel context and parsed @mentions so apps can reply to channel posts and detect mentions. Adds `conversationType`, `teamId`/`channelId`, and `mentions` to `TeamsRealtimeMessage` without breaking existing consumers.

- **New Features**
  - Added `conversationType: 'chat' | 'channel'`, plus `teamId`/`channelId` for channel messages.
  - Added `mentions: TeamsMention[]`, parsed from `properties.mentions` with a safe content fallback.
  - Built and cached a `channelId → teamId` map via `/users/ME/conversations` with one lazy refresh on cache-miss and early id dedup.
  - Introduced trouter helpers `isThreadConversation` and `parseMentions`; exported `TeamsMention`.

- **Migration**
  - No breaking changes; consumers can start using the new fields now.
  - Docs updated: `README.md`, CLI and SDK docs, and `skills/agent-teams/SKILL.md` include examples of replying to channel messages and reading `mentions`.

<sup>Written for commit d2db82d8c83931d1b6b29c040a781d552e984741. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

