### PR TITLE
feat(discord): add message edit support

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -193,6 +193,10 @@ agent-discord message list 1234567890123456789 --limit 50
 agent-discord message get <channel-id> <message-id>
 agent-discord message get 1234567890123456789 9876543210987654321
 
+# Edit a message
+agent-discord message edit <channel-id> <message-id> <content>
+agent-discord message edit 1234567890123456789 9876543210987654321 "Updated text"
+
 # Delete a message
 agent-discord message delete <channel-id> <message-id> --force
 

--- a/src/platforms/discord/client.test.ts
+++ b/src/platforms/discord/client.test.ts
@@ -246,6 +246,28 @@ describe('DiscordClient', () => {
     })
   })
 
+  describe('editMessage', () => {
+    it('edits message with PATCH', async () => {
+      mockResponse({
+        id: 'msg1',
+        channel_id: 'ch1',
+        author: { id: '123', username: 'bot' },
+        content: 'Updated content',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        edited_timestamp: '2024-01-01T00:05:00.000Z',
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      const message = await client.editMessage('ch1', 'msg1', 'Updated content')
+
+      expect(message.content).toBe('Updated content')
+      expect(message.edited_timestamp).toBe('2024-01-01T00:05:00.000Z')
+      expect(fetchCalls[0].url).toBe('https://discord.com/api/v10/channels/ch1/messages/msg1')
+      expect(fetchCalls[0].options?.method).toBe('PATCH')
+      expect(fetchCalls[0].options?.body).toBe(JSON.stringify({ content: 'Updated content' }))
+    })
+  })
+
   describe('deleteMessage', () => {
     it('deletes message', async () => {
       mockResponse(null, 204)

--- a/src/platforms/discord/client.ts
+++ b/src/platforms/discord/client.ts
@@ -242,6 +242,10 @@ export class DiscordClient {
     return this.request<DiscordMessage>('GET', `/channels/${channelId}/messages/${messageId}`)
   }
 
+  async editMessage(channelId: string, messageId: string, content: string): Promise<DiscordMessage> {
+    return this.request<DiscordMessage>('PATCH', `/channels/${channelId}/messages/${messageId}`, { content })
+  }
+
   async deleteMessage(channelId: string, messageId: string): Promise<void> {
     return this.request<void>('DELETE', `/channels/${channelId}/messages/${messageId}`)
   }

--- a/src/platforms/discord/commands/message.test.ts
+++ b/src/platforms/discord/commands/message.test.ts
@@ -2,11 +2,12 @@ import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
 
 import { DiscordClient } from '../client'
 import { DiscordCredentialManager } from '../credential-manager'
-import { ackAction, deleteAction, getAction, listAction, searchAction, sendAction } from './message'
+import { ackAction, deleteAction, editAction, getAction, listAction, searchAction, sendAction } from './message'
 
 let clientSendMessageSpy: ReturnType<typeof spyOn>
 let clientGetMessagesSpy: ReturnType<typeof spyOn>
 let clientGetMessageSpy: ReturnType<typeof spyOn>
+let clientEditMessageSpy: ReturnType<typeof spyOn>
 let clientDeleteMessageSpy: ReturnType<typeof spyOn>
 let clientAckMessageSpy: ReturnType<typeof spyOn>
 let clientSearchMessagesSpy: ReturnType<typeof spyOn>
@@ -45,6 +46,15 @@ beforeEach(() => {
     author: { id: 'user_789', username: 'testuser' },
     content: 'Hello world',
     timestamp: '2025-01-29T10:00:00Z',
+  })
+
+  clientEditMessageSpy = spyOn(DiscordClient.prototype, 'editMessage').mockResolvedValue({
+    id: 'msg_123',
+    channel_id: 'ch_456',
+    author: { id: 'user_789', username: 'testuser' },
+    content: 'Updated content',
+    timestamp: '2025-01-29T10:00:00Z',
+    edited_timestamp: '2025-01-29T10:05:00Z',
   })
 
   clientDeleteMessageSpy = spyOn(DiscordClient.prototype, 'deleteMessage').mockResolvedValue(undefined)
@@ -87,6 +97,7 @@ afterEach(() => {
   clientSendMessageSpy?.mockRestore()
   clientGetMessagesSpy?.mockRestore()
   clientGetMessageSpy?.mockRestore()
+  clientEditMessageSpy?.mockRestore()
   clientDeleteMessageSpy?.mockRestore()
   clientAckMessageSpy?.mockRestore()
   clientSearchMessagesSpy?.mockRestore()
@@ -125,6 +136,20 @@ it('get: returns single message', async () => {
   expect(consoleSpy).toHaveBeenCalled()
   const output = consoleSpy.mock.calls[0][0]
   expect(output).toContain('msg_123')
+})
+
+it('edit: returns updated message', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await editAction('ch_456', 'msg_123', 'Updated content', { pretty: false })
+
+  expect(clientEditMessageSpy).toHaveBeenCalledWith('ch_456', 'msg_123', 'Updated content')
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('msg_123')
+  expect(output).toContain('Updated content')
+  expect(output).toContain('edited_timestamp')
 })
 
 it('delete: returns success', async () => {

--- a/src/platforms/discord/commands/message.ts
+++ b/src/platforms/discord/commands/message.ts
@@ -121,6 +121,38 @@ export async function deleteAction(
   }
 }
 
+export async function editAction(
+  channelId: string,
+  messageId: string,
+  content: string,
+  options: { pretty?: boolean },
+): Promise<void> {
+  try {
+    const credManager = new DiscordCredentialManager()
+    const config = await credManager.load()
+
+    if (!config.token) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new DiscordClient().login({ token: config.token })
+    const message = await client.editMessage(channelId, messageId, content)
+
+    const output = {
+      id: message.id,
+      content: message.content,
+      author: message.author.username,
+      timestamp: message.timestamp,
+      edited_timestamp: message.edited_timestamp,
+    }
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export async function ackAction(channelId: string, messageId: string, options: { pretty?: boolean }): Promise<void> {
   try {
     const credManager = new DiscordCredentialManager()
@@ -243,6 +275,15 @@ export const messageCommand = new Command('message')
       .option('--force', 'Skip confirmation')
       .option('--pretty', 'Pretty print JSON output')
       .action(deleteAction),
+  )
+  .addCommand(
+    new Command('edit')
+      .description('Edit a message')
+      .argument('<channel-id>', 'Channel ID')
+      .argument('<message-id>', 'Message ID')
+      .argument('<content>', 'New message content')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(editAction),
   )
   .addCommand(
     new Command('ack')


### PR DESCRIPTION
## Summary

Adds message editing to the user-token `DiscordClient`, matching the `editMessage` capability already available on `DiscordBotClient`. A new `message edit` CLI subcommand lets you update a message's text in place.

Discord's REST API supports editing your own messages via `PATCH /channels/{channel_id}/messages/{message_id}`, so this works with a user token — no bot required.

## Changes

### `DiscordClient.editMessage(channelId, messageId, content)`
- New client method issuing `PATCH /channels/{id}/messages/{id}` with body `{ content }`.
- Flows through the existing private `request()` helper, so super-properties, headers, and rate-limit buckets are preserved unchanged.
- Returns the updated `DiscordMessage` (which already carries `edited_timestamp`).

### `message edit` CLI subcommand
```bash
agent-discord message edit <channel-id> <message-id> <content>
```
- Follows the same structure/output shape as the existing `send`/`delete` subcommands.
- Output includes `edited_timestamp` so callers can confirm the edit landed.

## Naming

Uses `edit` (not `update`) — this matches how Discord labels the feature in its own UI and fits the existing verb family (`send`, `delete`, `react`). A follow-up PR standardizes the existing `update` platforms onto `edit` for consistency.

## Tests

- **Client** (`client.test.ts`): verifies `PATCH` method, exact endpoint, and `{ content }` body; asserts `edited_timestamp` round-trips.
- **Command** (`commands/message.test.ts`): verifies `editMessage` is called with the right args and that output contains the updated content and `edited_timestamp`.

## Verification

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun test` — 3543 pass, 0 fail.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds message editing to the user-token `DiscordClient` and a `message edit` CLI command so you can update your own Discord messages in place. Matches existing `send`/`delete` flows and returns the updated message with `edited_timestamp`.

- **New Features**
  - `DiscordClient.editMessage(channelId, messageId, content)` uses PATCH `/channels/{channel_id}/messages/{message_id}` and returns `DiscordMessage`.
  - CLI: `agent-discord message edit <channel-id> <message-id> <content>` prints id, content, author, timestamp, and `edited_timestamp`.
  - Docs: Updated `skills/agent-discord/SKILL.md` with `message edit` examples.

<sup>Written for commit 7074e331b0e1057202b06346bde2a4ce9b3268fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

