### PR TITLE
feat(telegram): add message edit support

### DIFF
--- a/skills/agent-telegram/SKILL.md
+++ b/skills/agent-telegram/SKILL.md
@@ -117,6 +117,9 @@ agent-telegram chat get @durov
 # List recent messages
 agent-telegram message list @durov --limit 10
 
+# Edit one of your own messages (within 48h)
+agent-telegram message edit @durov <message-id> "Updated text"
+
 # Logout
 agent-telegram auth logout
 ```

--- a/src/platforms/telegram/client.test.ts
+++ b/src/platforms/telegram/client.test.ts
@@ -235,3 +235,63 @@ describe('sendMessage confirmation', () => {
     expect(result.id).toBe(serverId)
   })
 })
+
+describe('editMessage', () => {
+  it('returns the edited message from the editMessageText response', async () => {
+    const events: any[] = []
+    let editRequest: any = null
+
+    const createClientId = mock(() => 1)
+    const send = mock((_clientId: number, request: any) => {
+      if (request['@type'] === 'getAuthorizationState') {
+        events.push({
+          '@type': 'updateAuthorizationState',
+          authorization_state: { '@type': 'authorizationStateReady' },
+          '@extra': request['@extra'],
+        })
+      }
+
+      if (request['@type'] === 'getChat') {
+        events.push({ '@type': 'chat', id: 42, title: 'test', unread_count: 0, '@extra': request['@extra'] })
+      }
+
+      if (request['@type'] === 'editMessageText') {
+        editRequest = request
+        events.push({
+          '@type': 'message',
+          id: 555,
+          chat_id: 42,
+          date: 1_710_000_002,
+          is_outgoing: true,
+          sender_id: { '@type': 'messageSenderUser', user_id: 1 },
+          content: {
+            '@type': 'messageText',
+            text: { '@type': 'formattedText', text: 'edited text', entities: [] },
+          },
+          '@extra': request['@extra'],
+        })
+      }
+    })
+
+    const receive = mock(() => events.shift() ?? null)
+    const client = new (TelegramTdlibClient as unknown as new (
+      account: TelegramAccount,
+      paths: TelegramAccountPaths,
+      tdjson: any,
+    ) => TelegramTdlibClient)(mockAccount, mockPaths, {
+      createClientId,
+      send,
+      receive,
+      libraryPath: '/mock/lib',
+    })
+
+    const result = await client.editMessage('42', 555, 'edited text')
+
+    expect(result.id).toBe(555)
+    expect(result.text).toBe('edited text')
+    expect(editRequest.chat_id).toBe(42)
+    expect(editRequest.message_id).toBe(555)
+    expect(editRequest.input_message_content['@type']).toBe('inputMessageText')
+    expect(editRequest.input_message_content.text.text).toBe('edited text')
+  })
+})

--- a/src/platforms/telegram/client.ts
+++ b/src/platforms/telegram/client.ts
@@ -312,6 +312,30 @@ export class TelegramTdlibClient {
     return simplifyMessage(message, chat.id)
   }
 
+  async editMessage(reference: string, messageId: number, text: string): Promise<TelegramMessageSummary> {
+    await this.ensureReady()
+    const chat = await this.resolveChat(reference)
+
+    const message = (await this.call({
+      '@type': 'editMessageText',
+      chat_id: chat.id,
+      message_id: messageId,
+      reply_markup: null,
+      input_message_content: {
+        '@type': 'inputMessageText',
+        text: {
+          '@type': 'formattedText',
+          text,
+          entities: [],
+        },
+        link_preview_options: null,
+        clear_draft: false,
+      },
+    })) as TdMessage
+
+    return simplifyMessage(message, chat.id)
+  }
+
   private async ensureReady(): Promise<void> {
     const state = await this.connect()
     if (state?.['@type'] !== 'authorizationStateReady') {

--- a/src/platforms/telegram/commands/message.test.ts
+++ b/src/platforms/telegram/commands/message.test.ts
@@ -9,9 +9,12 @@ const mockListMessages = mock(() =>
 
 const mockSendMessage = mock(() => Promise.resolve({ id: 3, text: 'Sent message', sender_id: 'user-1', date: 3000 }))
 
+const mockEditMessage = mock(() => Promise.resolve({ id: 3, text: 'Edited message', sender_id: 'user-1', date: 3000 }))
+
 const mockClient = {
   listMessages: mockListMessages,
   sendMessage: mockSendMessage,
+  editMessage: mockEditMessage,
 }
 
 mock.module('./shared', () => ({
@@ -35,6 +38,10 @@ describe('message commands', () => {
     mockSendMessage.mockReset()
     mockSendMessage.mockImplementation(() =>
       Promise.resolve({ id: 3, text: 'Sent message', sender_id: 'user-1', date: 3000 }),
+    )
+    mockEditMessage.mockReset()
+    mockEditMessage.mockImplementation(() =>
+      Promise.resolve({ id: 3, text: 'Edited message', sender_id: 'user-1', date: 3000 }),
     )
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
     processExitSpy = spyOn(process, 'exit').mockImplementation((() => {}) as (code?: number) => never)
@@ -84,6 +91,37 @@ describe('message commands', () => {
       const parsed = JSON.parse(output)
       expect(parsed).toBeObject()
       expect(parsed.id).toBe(3)
+    })
+  })
+
+  describe('edit subcommand', () => {
+    it('calls editMessage with chat reference, numeric message id, and text', async () => {
+      await messageCommand.parseAsync(['edit', 'chat-123', '3', 'Edited message'], { from: 'user' })
+
+      expect(mockEditMessage).toHaveBeenCalledWith('chat-123', 3, 'Edited message')
+    })
+
+    it('outputs the edited message as JSON', async () => {
+      await messageCommand.parseAsync(['edit', 'chat-123', '3', 'Edited message'], { from: 'user' })
+
+      expect(consoleSpy).toHaveBeenCalled()
+      const output = consoleSpy.mock.calls[0][0] as string
+      const parsed = JSON.parse(output)
+      expect(parsed.text).toBe('Edited message')
+    })
+
+    it('rejects non-decimal, unsafe, or non-positive message ids', async () => {
+      const invalidIds = ['not-a-number', '1e3', '0x10', '0', '9007199254740993']
+
+      for (const invalidId of invalidIds) {
+        mockEditMessage.mockClear()
+        processExitSpy.mockClear()
+
+        await messageCommand.parseAsync(['edit', 'chat-123', invalidId, 'text'], { from: 'user' })
+
+        expect(mockEditMessage).not.toHaveBeenCalled()
+        expect(processExitSpy).toHaveBeenCalledWith(1)
+      }
     })
   })
 })

--- a/src/platforms/telegram/commands/message.ts
+++ b/src/platforms/telegram/commands/message.ts
@@ -30,6 +30,35 @@ async function sendAction(
   }
 }
 
+async function editAction(
+  reference: string,
+  messageId: string,
+  text: string,
+  options: { account?: string; pretty?: boolean },
+): Promise<void> {
+  try {
+    const trimmedMessageId = messageId.trim()
+    const parsedMessageId = Number.parseInt(trimmedMessageId, 10)
+    if (!/^\d+$/.test(trimmedMessageId) || !Number.isSafeInteger(parsedMessageId) || parsedMessageId <= 0) {
+      console.log(
+        formatOutput(
+          { error: 'Invalid message ID. Provide the numeric message ID from "message list".' },
+          options.pretty,
+        ),
+      )
+      process.exit(1)
+      return
+    }
+
+    const message = await withTelegramClient(options, async (client) =>
+      client.editMessage(reference, parsedMessageId, text),
+    )
+    console.log(formatOutput(message, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export const messageCommand = new Command('message')
   .description('Telegram message commands')
   .addCommand(
@@ -49,4 +78,14 @@ export const messageCommand = new Command('message')
       .option('--account <id>', 'Use a specific Telegram account')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
+  )
+  .addCommand(
+    new Command('edit')
+      .description('Edit a text message (your own messages only, within 48h)')
+      .argument('<chat>', 'Chat ID, @username, or title')
+      .argument('<message-id>', 'Message ID')
+      .argument('<text>', 'New message text')
+      .option('--account <id>', 'Use a specific Telegram account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(editAction),
   )


### PR DESCRIPTION
## Summary

Adds message editing to the user-token Telegram client. Telegram's TDLib exposes `editMessageText`, which lets a **user account** edit its own already-sent text messages (within Telegram's 48-hour window). A new `message edit` CLI subcommand surfaces this.

## Changes

### `TelegramTdlibClient.editMessage(reference, messageId, text)`
- Calls the TDLib function `editMessageText` with `chat_id`, `message_id`, `reply_markup: null` (bots only), and an `inputMessageText` content — mirroring the existing `sendMessage` content structure.
- Per TDLib, `editMessageText` returns the updated `Message` synchronously (after the server completes the edit), so we simplify and return it directly — no async-confirmation wait needed.

### `message edit` CLI subcommand
```bash
agent-telegram message edit <chat> <message-id> "New text"
```
- Resolves the chat the same way as `list`/`send` (ID, `@username`, or title).
- Validates that `<message-id>` is a positive integer before calling the client.

## Notes / constraints

- Only **your own** messages can be edited, and only within Telegram's ~48h edit window (enforced server-side; TDLib reports `messageProperties.can_be_edited`).
- `reply_markup` is intentionally `null` — inline keyboards are bots-only.

## Tests

- **Client** (`client.test.ts`): drives the mocked tdjson transport, asserts an `editMessageText` request is sent with the correct `chat_id`/`message_id`/`inputMessageText`, and that the returned edited message is surfaced.
- **Command** (`commands/message.test.ts`): verifies `editMessage` is called with a numeric message id, that the edited message is printed, and that a non-numeric id is rejected with exit code 1.

## Verification

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun test` — 3545 pass, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds message editing to the Telegram user client and CLI. Users can edit their own text messages within Telegram’s 48-hour window, and the client returns the updated message immediately.

- **New Features**
  - Client: `TelegramTdlibClient.editMessage(reference, messageId, text)` uses TDLib `editMessageText` and returns the edited message.
  - CLI: `agent-telegram message edit <chat> <message-id> "New text"`; resolves chat by ID, `@username`, or title, and requires a positive, base-10, safe numeric message ID.
  - Behavior: Only your messages; within 48h; no `reply_markup` (bots-only).
  - Docs: Updated `skills/agent-telegram/SKILL.md` with the edit command.

<sup>Written for commit 2004d77461249dec1616b813d1cc1c40de4acc4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

