### PR TITLE
feat(whatsapp): add message edit support

### DIFF
--- a/skills/agent-whatsapp/SKILL.md
+++ b/skills/agent-whatsapp/SKILL.md
@@ -251,6 +251,10 @@ agent-whatsapp message send +1234567890 "Hello!"
 agent-whatsapp message send 123456789-123345@g.us "Hello team!"
 agent-whatsapp message send +1234567890 "Hello!" --account <id>
 
+# Edit one of your own messages (within ~15 minutes)
+agent-whatsapp message edit <chat> <message-id> <text>
+agent-whatsapp message edit +1234567890 ABC123DEF456 "Updated text"
+
 # React to a message
 agent-whatsapp message react <chat> <message-id> <emoji>
 agent-whatsapp message react +1234567890 ABC123DEF456 "👍"

--- a/skills/agent-whatsapp/SKILL.md
+++ b/skills/agent-whatsapp/SKILL.md
@@ -346,6 +346,26 @@ agent-whatsapp message list +1234567890 --limit 1
 agent-whatsapp message react +1234567890 <message-id> "👍"
 ```
 
+### Edit one of your own messages
+
+```bash
+# Get the message ID of a message you sent
+agent-whatsapp message list +1234567890 --limit 5
+
+# Edit it (only your own messages, within ~15 minutes)
+agent-whatsapp message edit +1234567890 <message-id> "Updated text"
+```
+
+The SDK exposes the same capability via `WhatsAppClient.editMessage`:
+
+```typescript
+import { WhatsAppClient } from 'agent-messenger/whatsapp'
+
+const client = await new WhatsAppClient().login()
+const sent = await client.sendMessage('+1234567890', 'Deploying…')
+await client.editMessage('+1234567890', sent.id, 'Deployed ✅')
+```
+
 ## Error Handling
 
 All commands return consistent error format:

--- a/src/platforms/whatsapp/client.test.ts
+++ b/src/platforms/whatsapp/client.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { WAMessage } from '@whiskeysockets/baileys'
+
+import { summarizeMessage } from '@/platforms/whatsapp/client'
+
+describe('summarizeMessage', () => {
+  it('summarizes a plain text message', () => {
+    const msg = {
+      key: { id: 'msg-1', remoteJid: '12025551234@s.whatsapp.net', fromMe: true },
+      messageTimestamp: 1_700_000_000,
+      message: { conversation: 'Hello' },
+    } as unknown as WAMessage
+
+    const summary = summarizeMessage(msg)
+
+    expect(summary.id).toBe('msg-1')
+    expect(summary.type).toBe('text')
+    expect(summary.text).toBe('Hello')
+  })
+
+  it('unwraps a Baileys edit protocolMessage to the edited content', () => {
+    const msg = {
+      key: { id: 'msg-2', remoteJid: '12025551234@s.whatsapp.net', fromMe: true },
+      messageTimestamp: 1_700_000_100,
+      message: {
+        protocolMessage: {
+          type: 14,
+          editedMessage: { conversation: 'Edited text' },
+        },
+      },
+    } as unknown as WAMessage
+
+    const summary = summarizeMessage(msg)
+
+    expect(summary.id).toBe('msg-2')
+    expect(summary.type).toBe('text')
+    expect(summary.text).toBe('Edited text')
+  })
+
+  it('unwraps an edit that uses extendedTextMessage', () => {
+    const msg = {
+      key: { id: 'msg-3', remoteJid: '12025551234@s.whatsapp.net', fromMe: true },
+      messageTimestamp: 1_700_000_200,
+      message: {
+        protocolMessage: {
+          type: 14,
+          editedMessage: { extendedTextMessage: { text: 'Edited via extended' } },
+        },
+      },
+    } as unknown as WAMessage
+
+    const summary = summarizeMessage(msg)
+
+    expect(summary.type).toBe('text')
+    expect(summary.text).toBe('Edited via extended')
+  })
+})

--- a/src/platforms/whatsapp/client.ts
+++ b/src/platforms/whatsapp/client.ts
@@ -48,10 +48,14 @@ function resolveJid(input: string): string {
   return `${digits}@s.whatsapp.net`
 }
 
-function summarizeMessage(msg: WAMessage): WhatsAppMessageSummary {
+export function summarizeMessage(msg: WAMessage): WhatsAppMessageSummary {
   const jid = msg.key.remoteJid ?? ''
   const isGroup = jid.endsWith('@g.us')
   const from = msg.key.fromMe ? '' : isGroup ? (msg.key.participant ?? msg.participant ?? jid) : jid
+
+  // Baileys wraps an edit as a protocolMessage whose editedMessage holds the new
+  // content; unwrap it so the summary reflects the edited text and type.
+  const content = msg.message?.protocolMessage?.editedMessage ?? msg.message
 
   return {
     id: msg.key.id ?? '',
@@ -60,8 +64,8 @@ function summarizeMessage(msg: WAMessage): WhatsAppMessageSummary {
     from_name: msg.pushName ?? undefined,
     timestamp: new Date(toTimestampMs(msg.messageTimestamp)).toISOString(),
     is_outgoing: Boolean(msg.key.fromMe),
-    type: getMessageType(msg.message),
-    text: extractMessageText(msg.message),
+    type: getMessageType(content),
+    text: extractMessageText(content),
   }
 }
 
@@ -658,6 +662,22 @@ export class WhatsAppClient {
     await this.sock.sendMessage(resolvedJid, {
       react: { text: emoji, key: { remoteJid: resolvedJid, fromMe, id: messageId } },
     })
+  }
+
+  async editMessage(jid: string, messageId: string, text: string): Promise<WhatsAppMessageSummary> {
+    if (!this.sock) throw new WhatsAppError('Not connected', 'not_connected')
+
+    const resolvedJid = resolveJid(jid)
+    const result = await this.sock.sendMessage(resolvedJid, {
+      text,
+      edit: { remoteJid: resolvedJid, fromMe: true, id: messageId },
+    })
+
+    if (!result) {
+      throw new WhatsAppError('Failed to edit message', 'edit_failed')
+    }
+
+    return summarizeMessage(result)
   }
 
   async close(): Promise<void> {

--- a/src/platforms/whatsapp/commands/message.test.ts
+++ b/src/platforms/whatsapp/commands/message.test.ts
@@ -42,6 +42,16 @@ const mockSendMessage = mock(() =>
   }),
 )
 
+const mockEditMessage = mock(() =>
+  Promise.resolve({
+    id: 'msg-2',
+    text: 'Edited text',
+    from: 'me@s.whatsapp.net',
+    timestamp: 3000,
+    fromMe: true,
+  }),
+)
+
 const mockSendReaction = mock(() => Promise.resolve())
 const mockConnect = mock(() => Promise.resolve())
 const mockClose = mock(() => Promise.resolve())
@@ -55,6 +65,7 @@ mock.module('../client', () => ({
     close = mockClose
     getMessages = mockGetMessages
     sendMessage = mockSendMessage
+    editMessage = mockEditMessage
     sendReaction = mockSendReaction
   },
 }))
@@ -71,6 +82,7 @@ describe('message commands', () => {
     mockEnsureAccountPaths.mockReset()
     mockGetMessages.mockReset()
     mockSendMessage.mockReset()
+    mockEditMessage.mockReset()
     mockSendReaction.mockReset()
     mockConnect.mockReset()
     mockClose.mockReset()
@@ -104,6 +116,15 @@ describe('message commands', () => {
         text: 'Hi there',
         from: 'me@s.whatsapp.net',
         timestamp: 2000,
+        fromMe: true,
+      }),
+    )
+    mockEditMessage.mockImplementation(() =>
+      Promise.resolve({
+        id: 'msg-2',
+        text: 'Edited text',
+        from: 'me@s.whatsapp.net',
+        timestamp: 3000,
         fromMe: true,
       }),
     )
@@ -176,6 +197,28 @@ describe('message commands', () => {
       await messageCommand.parseAsync(['send', '12025551234@s.whatsapp.net', 'Hi', '--account', 'my-account'], {
         from: 'user',
       })
+
+      expect(processExitSpy).toHaveBeenCalledWith(0)
+      expect(mockGetAccount).toHaveBeenCalledWith('my-account')
+    })
+  })
+
+  describe('edit', () => {
+    it('edits a message in a chat', async () => {
+      await messageCommand.parseAsync(['edit', '12025551234@s.whatsapp.net', 'msg-2', 'Edited text'], { from: 'user' })
+
+      expect(processExitSpy).toHaveBeenCalledWith(0)
+      expect(mockEditMessage).toHaveBeenCalledWith('12025551234@s.whatsapp.net', 'msg-2', 'Edited text')
+      const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(output.id).toBe('msg-2')
+      expect(output.text).toBe('Edited text')
+    })
+
+    it('passes account option to credential manager', async () => {
+      await messageCommand.parseAsync(
+        ['edit', '12025551234@s.whatsapp.net', 'msg-2', 'Edited text', '--account', 'my-account'],
+        { from: 'user' },
+      )
 
       expect(processExitSpy).toHaveBeenCalledWith(0)
       expect(mockGetAccount).toHaveBeenCalledWith('my-account')

--- a/src/platforms/whatsapp/commands/message.ts
+++ b/src/platforms/whatsapp/commands/message.ts
@@ -29,6 +29,21 @@ async function sendAction(chat: string, text: string, options: { account?: strin
   }
 }
 
+async function editAction(
+  chat: string,
+  messageId: string,
+  text: string,
+  options: { account?: string; pretty?: boolean },
+): Promise<void> {
+  try {
+    const message = await withWhatsAppClient(options, (client) => client.editMessage(chat, messageId, text))
+    console.log(formatOutput(message, options.pretty))
+    process.exit(0)
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 async function reactAction(
   chat: string,
   messageId: string,
@@ -63,6 +78,16 @@ export const messageCommand = new Command('message')
       .option('--account <id>', 'Use a specific WhatsApp account')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
+  )
+  .addCommand(
+    new Command('edit')
+      .description('Edit one of your own messages (within ~15 minutes)')
+      .argument('<chat>', 'Chat JID or phone number')
+      .argument('<message-id>', 'Message ID to edit')
+      .argument('<text>', 'New message text')
+      .option('--account <id>', 'Use a specific WhatsApp account')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(editAction),
   )
   .addCommand(
     new Command('react')


### PR DESCRIPTION
## Summary

Adds message editing to the user-token WhatsApp client (Baileys). WhatsApp's multi-device protocol supports editing your own recently-sent messages, exposed by Baileys via the `edit` option on `sendMessage`. A new `message edit` CLI subcommand surfaces this.

## Changes

### `WhatsAppClient.editMessage(jid, messageId, text)`
- Calls `sock.sendMessage(jid, { text, edit: key })` where `key` is `{ remoteJid, fromMe: true, id: messageId }` — mirroring how `sendReaction` builds its message key.
- `fromMe` is hardcoded `true`: WhatsApp only lets you edit **your own** messages.
- Resolves the chat JID the same way as `send`/`react` (phone number or JID), and returns the summarized edited message.

### `message edit` CLI subcommand
```bash
agent-whatsapp message edit <chat> <message-id> "New text"
```
- Same argument shape as `react` (`<chat> <message-id> ...`).

## Notes / constraints

- Only **your own** messages, and only within WhatsApp's edit window (~15 minutes, enforced server-side).
- Text messages only.

## Tests

- **Command** (`commands/message.test.ts`): verifies `editMessage` is called with the chat, message id, and new text; that the edited message is printed; and that `--account` routing works. Follows the existing mocked-client style used by `send`/`react` (WhatsApp has no client-level unit tests because the Baileys socket isn't mockable at that layer — consistent with the current suite).

## Verification

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun test` — 3543 pass, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds message editing to the user-token WhatsApp client via `@whiskeysockets/baileys` and a `message edit` CLI command. Summaries now unwrap edited messages so callers see the new text and type.

- **New Features**
  - Client: `editMessage(jid, messageId, text)` uses `sock.sendMessage` with `{ text, edit: { remoteJid, fromMe: true, id } }` and returns a message summary.
  - Summary: `summarizeMessage` now unwraps `protocolMessage.editedMessage` so the edited text/type are returned.
  - CLI: `agent-whatsapp message edit <chat> <message-id> <text>` with `--account` and `--pretty`; `skills/agent-whatsapp/SKILL.md` updated with CLI and SDK examples.
  - Constraints: Only your own messages, within ~15 minutes, text only; added unit tests for `summarizeMessage` and the CLI command.

<sup>Written for commit ca211f4ee44095ae2788162ce5595336eabcf21d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

