### PR TITLE
refactor: standardize message edit CLI verb (update -> edit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 | Send & list messages       |  ✅   |   ✅    |  ✅   |  ✅   |    ✅     |    ✅     |  ✅   |   —    |    ✅     |    ✅     |         ✅          |
 | Direct messages            |  ✅   |   ✅    |  ✅   |  ✅   |    ✅     |    ✅     |  ✅   |   ✅    |    ✅     |    ✅     |         ✅          |
 | Search messages            |  ✅   |   ✅    |   —   |   —   |    —     |    ✅     |   —   |   —    |    ✅     |    —      |         ✅          |
+| Message edit               |  ✅   |   ✅    |   —   |  ✅   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Threads                    |  ✅   |   ✅    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Channels & Users           |  ✅   |   ✅    |  ✅   |  ✅   | partial  |    —     |  ✅   |   ✅    |     —     |    —      |         ✅          |
 | Reactions                  |  ✅   |   ✅    |  ✅   |   —   |    —     |    ✅     |   —   |   —    |     —     |    —      |         —           |

--- a/docs/content/docs/cli/discordbot.mdx
+++ b/docs/content/docs/cli/discordbot.mdx
@@ -173,8 +173,8 @@ agent-discordbot message get <channel> <message-id>
 agent-discordbot message replies <channel> <thread-id>
 agent-discordbot message replies general 9876543210987654321 --limit 50
 
-# Update a message (bot's own messages only)
-agent-discordbot message update <channel> <message-id> <text>
+# Edit a message (bot's own messages only)
+agent-discordbot message edit <channel> <message-id> <text>
 
 # Delete a message (bot's own messages only)
 agent-discordbot message delete <channel> <message-id> --force

--- a/docs/content/docs/cli/slack.mdx
+++ b/docs/content/docs/cli/slack.mdx
@@ -128,8 +128,8 @@ agent-slack message replies general 1234567890.123456 --limit 50
 agent-slack message search <query>
 agent-slack message search "project update" --limit 50
 
-# Update a message
-agent-slack message update <channel> <ts> <new-text>
+# Edit a message
+agent-slack message edit <channel> <ts> <new-text>
 
 # Delete a message
 agent-slack message delete <channel> <ts> --force

--- a/docs/content/docs/cli/slackbot.mdx
+++ b/docs/content/docs/cli/slackbot.mdx
@@ -165,8 +165,8 @@ agent-slackbot message get <channel> <ts>
 agent-slackbot message replies <channel> <thread_ts>
 agent-slackbot message replies C0ACZKTDDC0 1234567890.123456 --limit 50
 
-# Update a message (bot's own messages only)
-agent-slackbot message update <channel> <ts> <new-text>
+# Edit a message (bot's own messages only)
+agent-slackbot message edit <channel> <ts> <new-text>
 
 # Delete a message (bot's own messages only)
 agent-slackbot message delete <channel> <ts> --force

--- a/docs/content/docs/cli/telegrambot.mdx
+++ b/docs/content/docs/cli/telegrambot.mdx
@@ -80,7 +80,7 @@ agent-telegrambot message send <chat> "..." --silent
 agent-telegrambot message send <chat> "..." --thread-id 5
 
 # Edit a message
-agent-telegrambot message update <chat> <message-id> <new-text>
+agent-telegrambot message edit <chat> <message-id> <new-text>
 
 # Delete a message
 agent-telegrambot message delete <chat> <message-id> --force

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -171,7 +171,7 @@ When triggering manually, you can select which platform to test:
 | ------------- | -------------------------------------------------------------- |
 | `auth`        | status                                                         |
 | `workspace`   | list, current                                                  |
-| `message`     | send, list, get, update, delete, thread reply, replies, search |
+| `message`     | send, list, get, edit, delete, thread reply, replies, search |
 | `channel`     | list, list --type, info, history                               |
 | `user`        | list, me, info                                                 |
 | `reaction`    | add, list, remove                                              |
@@ -188,7 +188,7 @@ When triggering manually, you can select which platform to test:
 | Command Group | Tests                                                  |
 | ------------- | ------------------------------------------------------ |
 | `auth`        | status                                                 |
-| `message`     | send, list, get, update, delete, thread reply, replies |
+| `message`     | send, list, get, edit, delete, thread reply, replies |
 | `channel`     | list, info                                             |
 | `user`        | list, info                                             |
 | `reaction`    | add, remove                                            |
@@ -228,7 +228,7 @@ When triggering manually, you can select which platform to test:
 | Command Group | Tests                                            |
 | ------------- | ------------------------------------------------ |
 | `auth`        | status                                           |
-| `message`     | send, list, get, update, delete, thread, replies |
+| `message`     | send, list, get, edit, delete, thread, replies |
 | `channel`     | list, info                                       |
 | `user`        | list, info                                       |
 | `reaction`    | add, remove                                      |

--- a/e2e/discordbot.e2e.test.ts
+++ b/e2e/discordbot.e2e.test.ts
@@ -114,7 +114,7 @@ describe('DiscordBot E2E Tests', () => {
       expect(data?.id).toBe(sent!.id)
     })
 
-    it('message update modifies message', async () => {
+    it('message edit modifies message', async () => {
       const testId = generateTestId()
       const sendResult = await runCLI('discordbot', [
         'message',
@@ -130,7 +130,7 @@ describe('DiscordBot E2E Tests', () => {
 
       const result = await runCLI('discordbot', [
         'message',
-        'update',
+        'edit',
         DISCORDBOT_TEST_CHANNEL_ID,
         sent!.id,
         `Updated ${testId}`,

--- a/e2e/slack.e2e.test.ts
+++ b/e2e/slack.e2e.test.ts
@@ -95,14 +95,14 @@ describe('Slack E2E Tests', () => {
       expect(data?.text).toContain(testId)
     })
 
-    it('message update modifies message', async () => {
+    it('message edit modifies message', async () => {
       const testId = generateTestId()
       const { id: ts } = await createTestMessage('slack', SLACK_TEST_CHANNEL_ID, `Original ${testId}`)
       testMessages.push(ts)
 
       await waitForRateLimit()
 
-      const result = await runCLI('slack', ['message', 'update', SLACK_TEST_CHANNEL_ID, ts, `Updated ${testId}`])
+      const result = await runCLI('slack', ['message', 'edit', SLACK_TEST_CHANNEL_ID, ts, `Updated ${testId}`])
       expect(result.exitCode).toBe(0)
 
       await waitForRateLimit()

--- a/e2e/slackbot.e2e.test.ts
+++ b/e2e/slackbot.e2e.test.ts
@@ -104,7 +104,7 @@ describe('SlackBot E2E Tests', () => {
       expect(data?.ts).toBe(sent!.ts)
     })
 
-    it('message update modifies message', async () => {
+    it('message edit modifies message', async () => {
       const testId = generateTestId()
       const sendResult = await runCLI('slackbot', ['message', 'send', SLACKBOT_TEST_CHANNEL_ID, `Original ${testId}`])
       const sent = parseJSON<{ ts: string }>(sendResult.stdout)
@@ -115,7 +115,7 @@ describe('SlackBot E2E Tests', () => {
 
       const result = await runCLI('slackbot', [
         'message',
-        'update',
+        'edit',
         SLACKBOT_TEST_CHANNEL_ID,
         sent!.ts,
         `Updated ${testId}`,

--- a/e2e/telegrambot.e2e.test.ts
+++ b/e2e/telegrambot.e2e.test.ts
@@ -93,7 +93,7 @@ describe('Telegram Bot E2E Tests', () => {
       if (data?.message?.message_id) trackedMessageIds.push(data.message.message_id)
     })
 
-    it('message update edits previously sent message', async () => {
+    it('message edit edits previously sent message', async () => {
       if (!telegramBotAvailable) return
 
       const testId = generateTestId()
@@ -111,7 +111,7 @@ describe('Telegram Bot E2E Tests', () => {
 
       const updateResult = await runCLI('telegrambot', [
         'message',
-        'update',
+        'edit',
         TELEGRAMBOT_TEST_CHAT_ID,
         String(sent!.message.message_id),
         `Edited ${testId}`,

--- a/skills/agent-discordbot/SKILL.md
+++ b/skills/agent-discordbot/SKILL.md
@@ -220,8 +220,8 @@ agent-discordbot message get <channel-id> <message-id>
 agent-discordbot message replies <channel-id> <message-id>
 agent-discordbot message replies 1234567890123456789 9876543210987654321 --limit 50
 
-# Update a message (bot's own messages only)
-agent-discordbot message update <channel-id> <message-id> <new-content>
+# Edit a message (bot's own messages only)
+agent-discordbot message edit <channel-id> <message-id> <new-content>
 
 # Delete a message (bot's own messages only)
 agent-discordbot message delete <channel-id> <message-id> --force

--- a/skills/agent-discordbot/references/common-patterns.md
+++ b/skills/agent-discordbot/references/common-patterns.md
@@ -107,8 +107,8 @@ sleep 5
 agent-discordbot reaction remove "$CHANNEL" "$MSG_ID" hourglass
 agent-discordbot reaction add "$CHANNEL" "$MSG_ID" white_check_mark
 
-# Update message with result
-agent-discordbot message update "$CHANNEL" "$MSG_ID" "Request processed successfully!"
+# Edit message with result
+agent-discordbot message edit "$CHANNEL" "$MSG_ID" "Request processed successfully!"
 ```
 
 **When to use**: Visual status tracking, acknowledgments, workflow states.

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -217,8 +217,8 @@ agent-slack message replies general 1234567890.123456 --limit 50
 agent-slack message replies general 1234567890.123456 --oldest 1234567890.000000
 agent-slack message replies general 1234567890.123456 --cursor <next_cursor>
 
-# Update a message
-agent-slack message update <channel> <ts> <new-text>
+# Edit a message
+agent-slack message edit <channel> <ts> <new-text>
 
 # Delete a message
 agent-slack message delete <channel> <ts> --force

--- a/skills/agent-slack/references/common-patterns.md
+++ b/skills/agent-slack/references/common-patterns.md
@@ -287,8 +287,8 @@ sleep 5
 agent-slack reaction remove "$CHANNEL" "$MSG_TS" hourglass_flowing_sand
 agent-slack reaction add "$CHANNEL" "$MSG_TS" white_check_mark
 
-# Update message
-agent-slack message update "$CHANNEL" "$MSG_TS" "✅ Deployed v2.1.0 to production successfully!"
+# Edit message
+agent-slack message edit "$CHANNEL" "$MSG_TS" "✅ Deployed v2.1.0 to production successfully!"
 ```
 
 **When to use**: Visual status tracking, workflow states, quick acknowledgments.

--- a/skills/agent-slackbot/SKILL.md
+++ b/skills/agent-slackbot/SKILL.md
@@ -206,8 +206,8 @@ agent-slackbot message get <channel> <ts>
 agent-slackbot message replies <channel> <thread_ts>
 agent-slackbot message replies C0ACZKTDDC0 1234567890.123456 --limit 50
 
-# Update a message (bot's own messages only)
-agent-slackbot message update <channel> <ts> <new-text>
+# Edit a message (bot's own messages only)
+agent-slackbot message edit <channel> <ts> <new-text>
 
 # Delete a message (bot's own messages only)
 agent-slackbot message delete <channel> <ts> --force

--- a/skills/agent-slackbot/references/common-patterns.md
+++ b/skills/agent-slackbot/references/common-patterns.md
@@ -47,8 +47,8 @@ sleep 2
 agent-slackbot message send "$CHANNEL" "Deploying to production..." --thread "$THREAD_TS"
 sleep 2
 
-# Update parent with final status
-agent-slackbot message update "$CHANNEL" "$THREAD_TS" "Deployment complete!"
+# Edit parent with final status
+agent-slackbot message edit "$CHANNEL" "$THREAD_TS" "Deployment complete!"
 
 # Add reaction
 agent-slackbot reaction add "$CHANNEL" "$THREAD_TS" white_check_mark
@@ -110,8 +110,8 @@ sleep 5
 agent-slackbot reaction remove "$CHANNEL" "$MSG_TS" hourglass_flowing_sand
 agent-slackbot reaction add "$CHANNEL" "$MSG_TS" white_check_mark
 
-# Update message with result
-agent-slackbot message update "$CHANNEL" "$MSG_TS" "Request processed successfully!"
+# Edit message with result
+agent-slackbot message edit "$CHANNEL" "$MSG_TS" "Request processed successfully!"
 ```
 
 **When to use**: Visual status tracking, acknowledgments, workflow states.

--- a/skills/agent-telegrambot/SKILL.md
+++ b/skills/agent-telegrambot/SKILL.md
@@ -172,7 +172,7 @@ agent-telegrambot message send @username "Silent message" --silent
 agent-telegrambot message send <chat> "Topic message" --thread-id 5
 
 # Edit a message (bot's own messages only)
-agent-telegrambot message update <chat> <message-id> <new-text>
+agent-telegrambot message edit <chat> <message-id> <new-text>
 
 # Delete a message
 agent-telegrambot message delete <chat> <message-id> --force

--- a/src/platforms/discordbot/commands/message.test.ts
+++ b/src/platforms/discordbot/commands/message.test.ts
@@ -82,7 +82,7 @@ mock.module('../client', () => ({
 }))
 
 import { DiscordBotCredentialManager } from '../credential-manager'
-import { deleteAction, getAction, listAction, repliesAction, sendAction, updateAction } from './message'
+import { deleteAction, editAction, getAction, listAction, repliesAction, sendAction } from './message'
 
 describe('message commands', () => {
   let tempDir: string
@@ -243,9 +243,9 @@ describe('message commands', () => {
     })
   })
 
-  describe('updateAction', () => {
-    it('updates a message', async () => {
-      const result = await updateAction('general', 'msg1', 'updated text', { _credManager: manager })
+  describe('editAction', () => {
+    it('edits a message', async () => {
+      const result = await editAction('general', 'msg1', 'updated text', { _credManager: manager })
 
       expect(result.id).toBe('msg1')
       expect(result.content).toBe('updated text')
@@ -254,7 +254,7 @@ describe('message commands', () => {
     })
 
     it('resolves channel name', async () => {
-      await updateAction('general', 'msg1', 'new', { _credManager: manager })
+      await editAction('general', 'msg1', 'new', { _credManager: manager })
 
       expect(mockResolveChannel).toHaveBeenCalledWith('guild1', 'general')
     })
@@ -262,7 +262,7 @@ describe('message commands', () => {
     it('returns error on failure', async () => {
       mockEditMessage.mockImplementationOnce(() => Promise.reject(new Error('Cannot edit')))
 
-      const result = await updateAction('general', 'msg1', 'new', { _credManager: manager })
+      const result = await editAction('general', 'msg1', 'new', { _credManager: manager })
 
       expect(result.error).toContain('Cannot edit')
     })

--- a/src/platforms/discordbot/commands/message.ts
+++ b/src/platforms/discordbot/commands/message.ts
@@ -95,7 +95,7 @@ export async function getAction(channel: string, messageId: string, options: Bot
   }
 }
 
-export async function updateAction(
+export async function editAction(
   channel: string,
   messageId: string,
   text: string,
@@ -207,8 +207,8 @@ export const messageCommand = new Command('message')
       }),
   )
   .addCommand(
-    new Command('update')
-      .description('Update a message')
+    new Command('edit')
+      .description('Edit a message')
       .argument('<channel>', 'Channel ID or name')
       .argument('<message-id>', 'Message ID')
       .argument('<text>', 'New message text')
@@ -216,7 +216,7 @@ export const messageCommand = new Command('message')
       .option('--server <id>', 'Server ID')
       .option('--pretty', 'Pretty print JSON output')
       .action(async (channel: string, messageId: string, text: string, opts: BotOption) => {
-        cliOutput(await updateAction(channel, messageId, text, opts), opts.pretty)
+        cliOutput(await editAction(channel, messageId, text, opts), opts.pretty)
       }),
   )
   .addCommand(

--- a/src/platforms/slack/commands/message.test.ts
+++ b/src/platforms/slack/commands/message.test.ts
@@ -165,17 +165,17 @@ describe('Message Commands', () => {
     })
   })
 
-  describe('message update', () => {
-    it('updates message text', async () => {
+  describe('message edit', () => {
+    it('edits message text', async () => {
       // Given: A channel, message ts, and new text
       const channel = 'C123'
       const ts = '1234567890.123456'
       const newText = 'Updated message'
 
-      // When: Updating message
+      // When: Editing message
       const result = await mockClient.updateMessage(channel, ts, newText)
 
-      // Then: Should return updated message
+      // Then: Should return edited message
       expect(result.ts).toBe(ts)
       expect(result.text).toBe(newText)
     })

--- a/src/platforms/slack/commands/message.ts
+++ b/src/platforms/slack/commands/message.ts
@@ -114,7 +114,7 @@ async function getAction(channelInput: string, ts: string, options: { pretty?: b
   }
 }
 
-async function updateAction(
+async function editAction(
   channelInput: string,
   ts: string,
   text: string,
@@ -413,13 +413,13 @@ export const messageCommand = new Command('message')
       .action(getAction),
   )
   .addCommand(
-    new Command('update')
-      .description('Update message text')
+    new Command('edit')
+      .description('Edit message text')
       .argument('<channel>', 'Channel ID or name')
       .argument('<ts>', 'Message timestamp')
       .argument('<text>', 'New message text')
       .option('--pretty', 'Pretty print JSON output')
-      .action(updateAction),
+      .action(editAction),
   )
   .addCommand(
     new Command('delete')

--- a/src/platforms/slackbot/commands/message.ts
+++ b/src/platforms/slackbot/commands/message.ts
@@ -59,7 +59,7 @@ async function getAction(channelInput: string, ts: string, options: BotOption): 
   }
 }
 
-async function updateAction(channelInput: string, ts: string, text: string, options: BotOption): Promise<void> {
+async function editAction(channelInput: string, ts: string, text: string, options: BotOption): Promise<void> {
   try {
     const client = await getClient(options)
     const channel = await client.resolveChannel(channelInput)
@@ -158,14 +158,14 @@ export const messageCommand = new Command('message')
       .action(getAction),
   )
   .addCommand(
-    new Command('update')
-      .description('Update a message')
+    new Command('edit')
+      .description('Edit a message')
       .argument('<channel>', 'Channel ID or name')
       .argument('<ts>', 'Message timestamp')
       .argument('<text>', 'New message text')
       .option('--bot <id>', 'Use specific bot')
       .option('--pretty', 'Pretty print JSON output')
-      .action(updateAction),
+      .action(editAction),
   )
   .addCommand(
     new Command('delete')

--- a/src/platforms/telegrambot/commands/message.ts
+++ b/src/platforms/telegrambot/commands/message.ts
@@ -61,7 +61,7 @@ export async function sendAction(
   }
 }
 
-export async function updateAction(
+export async function editAction(
   chat: string,
   messageId: string,
   text: string,
@@ -162,7 +162,7 @@ export const messageCommand = new Command('message')
       ),
   )
   .addCommand(
-    new Command('update')
+    new Command('edit')
       .description("Edit a message (bot's own messages only)")
       .argument('<chat>', 'Chat ID or @username')
       .argument('<message-id>', 'Message ID')
@@ -177,7 +177,7 @@ export const messageCommand = new Command('message')
           text: string,
           opts: BotOption & { parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2' },
         ) => {
-          cliOutput(await updateAction(chat, messageId, text, opts), opts.pretty)
+          cliOutput(await editAction(chat, messageId, text, opts), opts.pretty)
         },
       ),
   )


### PR DESCRIPTION
## Summary

Standardizes the message-edit CLI verb on **`edit`** across all platforms. Previously the surface was split: `slack`, `slackbot`, `discordbot`, and `telegrambot` used `message update`, while `webex`/`webexbot` used `message edit`. This renames the four `update` platforms to `edit` so the whole CLI is consistent (and matches how these apps label the feature in their own UIs, alongside the existing `send`/`delete`/`react` verbs).

> [!WARNING]
> **Breaking change — no backward-compatible alias.** `message update` is removed on Slack, SlackBot, DiscordBot, and TelegramBot. Callers must switch to `message edit`. Scripts using the old subcommand will error.

## What changed

### CLI subcommand rename (`update` → `edit`)
- `agent-slack message update` → `agent-slack message edit`
- `agent-slackbot message update` → `agent-slackbot message edit`
- `agent-discordbot message update` → `agent-discordbot message edit`
- `agent-telegrambot message update` → `agent-telegrambot message edit`

Internally, the `updateAction` handlers were renamed to `editAction`. **Client methods are unchanged** (`updateMessage` on Slack/SlackBot, `editMessage` on DiscordBot, `editMessageText` on TelegramBot) — they mirror each platform's underlying API, and the SDK surface is unaffected.

### Docs & tests
- Updated skill docs (`SKILL.md`, `references/common-patterns.md`), site docs (`docs/content/docs/cli/*.mdx`), and e2e tests to use `edit`.
- Added a **Message edit** row to the README supported-platforms table.

## Why no alias?

Keeping `update` as a hidden alias would perpetuate two names for one action. A clean break gives a single, discoverable verb. (Requested explicitly.)

## Commits

Split per platform + per doc group for reviewability (9 atomic commits).

## Verification

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun test` — 3541 pass, 0 fail.

## Related

Part of the message-edit rollout:
- #294 — Discord (user) message edit
- #295 — Telegram (user) message edit
- #296 — WhatsApp (user) message edit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the `message update` CLI subcommand to `message edit` across Slack, SlackBot, DiscordBot, and TelegramBot for consistency. This is a breaking change with no alias.

- **Refactors**
  - CLI subcommand renamed to `edit`: `agent-slack message edit`, `agent-slackbot message edit`, `agent-discordbot message edit`, `agent-telegrambot message edit`.
  - Handlers renamed `updateAction` → `editAction`; command descriptions updated to “Edit”.
  - Docs/tests updated: `SKILL.md` (all four bots), CLI docs, README (added “Message edit” row), and e2e tests.

- **Migration**
  - Replace all `message update` calls with `message edit`. Example: `agent-slack message update <channel> <ts> <text>` → `agent-slack message edit <channel> <ts> <text>`.

<sup>Written for commit 3f751357806ba373b616db47262567442d4848a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

