### PR TITLE
docs: document editMessage in the SDK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,18 @@ const client = await new SlackClient().login({ token: 'xoxc-...', cookie: 'xoxd-
 const messages = await client.getMessages('C01234567')
 ```
 
+### Editing Messages
+
+Clients that support message editing expose an `editMessage` method (matching each platform's API, Slack/SlackBot use `updateMessage` and TelegramBot uses `editMessageText`). You can only edit your own messages, subject to each platform's edit window.
+
+```typescript
+import { DiscordClient } from 'agent-messenger/discord'
+
+const discord = await new DiscordClient().login()
+const msg = await discord.sendMessage(channelId, 'Deploying…')
+await discord.editMessage(channelId, msg.id, 'Deployed ✅')
+```
+
 ### QR Code Login (Slack)
 
 Sign in with a QR code from Slack's "Sign in on mobile" screen — no desktop app or browser automation, just HTTP. `dataUrl` is the QR image as a `data:image/png;base64,...` string.


### PR DESCRIPTION
## Summary

Documents the `editMessage` SDK method in the README's SDK section. The method is already exposed on the exported client classes (public methods, reachable via `import { DiscordClient } from 'agent-messenger/discord'`) — this just adds a discoverable usage example.

## Changes

- New **Editing Messages** subsection under SDK, with a Discord example (`editMessage`) and a note that Slack/SlackBot use `updateMessage` to match their API, and that edits are limited to your own messages within each platform's edit window.

## Scope note

Only Discord is shown here because its `editMessage` is already on `main` (via #294). The WhatsApp SDK snippet is added in #296 (still open), co-located with the code that introduces `WhatsAppClient.editMessage`, so the docs never reference a method that isn't yet on the target branch.

## Verification

- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- `bun run format:check` — clean.
- `bun test` — 3543 pass, 0 fail.

## Related

- #294 (merged) — Discord message edit
- #295 — Telegram message edit
- #296 — WhatsApp message edit (includes its own SDK doc snippet)
- #297 — `update` → `edit` CLI rename

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Editing Messages” subsection to the SDK docs with a Discord `editMessage` example, noting Slack/SlackBot use `updateMessage` and TelegramBot uses `editMessageText`, and that you can only edit your own messages within each platform’s edit window. README only; no platform code changes (SKILL.md unchanged).

<sup>Written for commit 2ec641d9e15adfd9813937e6fe8c39777b2faf98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

