### PR TITLE
feat(teams): add chat message edit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 | Send & list messages       |  ✅   |   ✅    |  ✅   |  ✅   |    ✅     |    ✅     |  ✅   |   —    |    ✅     |    ✅     |         ✅          |
 | Direct messages            |  ✅   |   ✅    |  ✅   |  ✅   |    ✅     |    ✅     |  ✅   |   ✅    |    ✅     |    ✅     |         ✅          |
 | Search messages            |  ✅   |   ✅    |   —   |   —   |    —     |    ✅     |   —   |   —    |    ✅     |    —      |         ✅          |
-| Message edit               |  ✅   |   ✅    |   —   |  ✅   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
+| Message edit               |  ✅   |   ✅    |  ✅¹  |  ✅   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Threads                    |  ✅   |   ✅    |   —   |   —   |    —     |    —     |   —   |   —    |     —     |    —      |         —           |
 | Channels & Users           |  ✅   |   ✅    |  ✅   |  ✅   | partial  |    —     |  ✅   |   ✅    |     —     |    —      |         ✅          |
 | Reactions                  |  ✅   |   ✅    |  ✅   |   —   |    —     |    ✅     |   —   |   —    |     —     |    —      |         —           |
@@ -493,6 +493,8 @@ See the [TUI docs](https://agent-messenger.dev/docs/tui) for keybindings, archit
 | Bot support                |  ✅   |   ✅    |   —   |  ✅   |    ✅     |    ✅     |   —   |   ✅    |     —     |    —      |         ✅          |
 
 > ⚠️ **Teams tokens expire in 60-90 minutes.** Re-run `agent-teams auth extract` to refresh. See [Teams Guide](skills/agent-teams/SKILL.md) for details.
+
+> ¹ **Teams message edit** applies to chats/DMs only. Channel messages are not editable through the internal API this client uses.
 
 > 💬 **iMessage** is supported via the local [imsg](https://github.com/openclaw/imsg) tool (`agent-imessage`), not the table above. It runs **on a Mac** (Apple has no API). v1 covers send & list messages, direct & group chats, chat listing, real-time watch, and standard tapbacks. Typing, edit/unsend, group management, and targeted/custom reactions require imsg's bridge (SIP disabled) and are a later tier. See the [iMessage Guide](skills/agent-imessage/SKILL.md).
 

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -249,9 +249,14 @@ agent-teams chat history <chat-id> --limit 100
 
 # Send a message to a chat
 agent-teams chat send <chat-id> "Hello"
+
+# Edit one of your own chat messages
+agent-teams chat edit <chat-id> <message-id> "Updated text"
 ```
 
 Chat IDs look like `19:guid1_guid2@unq.gbl.spaces` (1:1) or `19:guid@thread.tacv2` (group). Get them from `chat list`. The `48:notes` chat (`type: self`) is your personal "to me" notes thread.
+
+`chat edit` only works on your own messages, and only for chats — Teams channel messages are not editable through this API.
 
 ### Team Commands
 

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -330,6 +330,30 @@ describe('TeamsClient', () => {
     })
   })
 
+  describe('editChatMessage', () => {
+    it('PUTs an HTML-escaped edit to a chat message', async () => {
+      mockResponse({ edittime: 1704067200000 })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const message = await client.editChatMessage('19:1on1@unq.gbl.spaces', 'msg1', 'a <b> & c')
+
+      expect(message.id).toBe('msg1')
+      expect(message.content).toBe('a <b> & c')
+      expect(fetchCalls[0].url).toBe(
+        'https://msgapi.teams.live.com/v1/users/ME/conversations/19%3A1on1%40unq.gbl.spaces/messages/msg1',
+      )
+      expect(fetchCalls[0].options?.method).toBe('PUT')
+      expect(fetchCalls[0].options?.body).toBe(
+        JSON.stringify({
+          content: 'a &lt;b&gt; &amp; c',
+          messagetype: 'RichText/Html',
+          contenttype: 'text',
+          skypeeditedid: 'msg1',
+        }),
+      )
+    })
+  })
+
   describe('getTeam', () => {
     it('returns team info', async () => {
       mockResponse({ id: '111', name: 'Test Team', description: 'A test team' })

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -713,6 +713,34 @@ export class TeamsClient {
     }
   }
 
+  async editChatMessage(chatId: string, messageId: string, content: string): Promise<TeamsMessage> {
+    interface EditResponse {
+      edittime?: string | number
+    }
+    const encodedChatId = encodeURIComponent(chatId)
+    const encodedMessageId = encodeURIComponent(messageId)
+    // Skype messaging backend requires skypeeditedid to duplicate the URL message id.
+    const response = await this.request<EditResponse>(
+      'PUT',
+      `/users/ME/conversations/${encodedChatId}/messages/${encodedMessageId}`,
+      {
+        content: escapeHtml(content),
+        messagetype: 'RichText/Html',
+        contenttype: 'text',
+        skypeeditedid: messageId,
+      },
+    )
+
+    const editTime = response?.edittime
+    return {
+      id: messageId,
+      channel_id: chatId,
+      author: { id: 'ME', displayName: 'Me' },
+      content,
+      timestamp: editTime ? new Date(Number(editTime) || editTime).toISOString() : new Date().toISOString(),
+    }
+  }
+
   async getTeam(teamId: string): Promise<TeamsTeam> {
     return this.request<TeamsTeam>('GET', `/csa/api/v1/teams/${teamId}`, undefined, CSA_API_BASE)
   }

--- a/src/platforms/teams/commands/chat.test.ts
+++ b/src/platforms/teams/commands/chat.test.ts
@@ -2,11 +2,12 @@ import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
-import { historyAction, listAction, sendAction } from './chat'
+import { editAction, historyAction, listAction, sendAction } from './chat'
 
 let clientListChatsSpy: ReturnType<typeof spyOn>
 let clientGetChatMessagesSpy: ReturnType<typeof spyOn>
 let clientSendChatMessageSpy: ReturnType<typeof spyOn>
+let clientEditChatMessageSpy: ReturnType<typeof spyOn>
 let credManagerLoadSpy: ReturnType<typeof spyOn>
 const originalConsoleLog = console.log
 
@@ -34,6 +35,14 @@ beforeEach(() => {
     timestamp: '2025-01-29T10:00:00Z',
   })
 
+  clientEditChatMessageSpy = spyOn(TeamsClient.prototype, 'editChatMessage').mockResolvedValue({
+    id: 'msg_123',
+    channel_id: '19:1on1@unq.gbl.spaces',
+    author: { id: 'ME', displayName: 'Me' },
+    content: 'Edited content',
+    timestamp: '2025-01-29T10:05:00Z',
+  })
+
   credManagerLoadSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue({
     current_account: 'personal',
     accounts: {
@@ -51,6 +60,7 @@ afterEach(() => {
   clientListChatsSpy?.mockRestore()
   clientGetChatMessagesSpy?.mockRestore()
   clientSendChatMessageSpy?.mockRestore()
+  clientEditChatMessageSpy?.mockRestore()
   credManagerLoadSpy?.mockRestore()
   console.log = originalConsoleLog
 })
@@ -97,4 +107,16 @@ it('send: returns sent message', async () => {
   expect(consoleSpy).toHaveBeenCalled()
   const output = consoleSpy.mock.calls[0][0]
   expect(output).toContain('Hello world')
+})
+
+it('edit: edits a chat message and returns updated content', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+
+  await editAction('19:1on1@unq.gbl.spaces', 'msg_123', 'Edited content', { pretty: false })
+
+  expect(clientEditChatMessageSpy).toHaveBeenCalledWith('19:1on1@unq.gbl.spaces', 'msg_123', 'Edited content')
+  expect(consoleSpy).toHaveBeenCalled()
+  const output = consoleSpy.mock.calls[0][0]
+  expect(output).toContain('Edited content')
 })

--- a/src/platforms/teams/commands/chat.ts
+++ b/src/platforms/teams/commands/chat.ts
@@ -100,6 +100,41 @@ export async function sendAction(chatId: string, content: string, options: { pre
   }
 }
 
+export async function editAction(
+  chatId: string,
+  messageId: string,
+  content: string,
+  options: { pretty?: boolean },
+): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const message = await client.editChatMessage(chatId, messageId, content)
+
+    const output = {
+      id: message.id,
+      content: message.content,
+      timestamp: message.timestamp,
+    }
+
+    console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
 export const chatCommand = new Command('chat')
   .description('Chat commands (1:1, group, and self chats)')
   .addCommand(
@@ -128,4 +163,13 @@ export const chatCommand = new Command('chat')
       .argument('<content>', 'Message content')
       .option('--pretty', 'Pretty print JSON output')
       .action(sendAction),
+  )
+  .addCommand(
+    new Command('edit')
+      .description('Edit a message in a chat (your own messages only)')
+      .argument('<chat-id>', 'Chat ID')
+      .argument('<message-id>', 'Message ID')
+      .argument('<content>', 'New message content')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(editAction),
   )


### PR DESCRIPTION
## Summary

Adds message editing to the Teams client, completing the message-edit rollout across all platforms where the underlying API allows it. Editing is scoped to **chats/DMs only** (1:1, group, and self chats) — Teams channel messages are intentionally not supported (see below).

## Changes

### `TeamsClient.editChatMessage(chatId, messageId, content)`
- PUTs to the Skype messaging backend at `/users/ME/conversations/{chatId}/messages/{messageId}` with `messagetype: RichText/Html`.
- Sets `skypeeditedid` to the message id — the backend requires this field to duplicate the id already present in the URL.
- Mirrors the existing `sendChatMessage` method's request shape and response handling.

### `agent-teams chat edit <chat-id> <message-id> <content>`
- New chat-scoped subcommand, added next to `chat send`.
- Same argument shape and output format as `chat send`.

### Docs
- README supported-platforms table: Teams "Message edit" now ✅, with a footnote clarifying it's chat-only.
- `skills/agent-teams/SKILL.md`: documents the `chat edit` command and its chat-only limitation.

## Why chat-only (feasibility)

Teams channel messages go through a different, undocumented internal CSA API. No open-source Teams client implements a channel-message edit against this API, and there's no reliable reference for the correct endpoint/payload shape. Rather than ship a guessed endpoint that could silently corrupt messages or fail unpredictably, channel edit is omitted here and the limitation is documented in both the README and the skill doc.

## Tests

- Client (`client.test.ts`): verifies the `PUT` request is sent to the correct endpoint, with `skypeeditedid` matching the message id and the correct `messagetype`.
- Command (`chat.test.ts`): verifies `editChatMessage` is called with the right arguments and that the edited message is printed.

## Verification

- `bun test` — 3554 pass, 0 fail.
- `bun typecheck` — clean.
- `bun lint` — 0 warnings, 0 errors.
- Changed files pass `oxfmt --check`.
- Note: repo-wide `format:check` fails on a pre-existing, unrelated `docs/` CSS resolution error that also fails on `main`; no `docs/` files are touched in this PR.

## Related

Part of the message-edit rollout:
- #294 — Discord message edit
- #295 — Telegram message edit
- #296 — WhatsApp message edit
- #297 — `update` → `edit` CLI rename

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds chat message edit support for Microsoft Teams chats via the `agent-teams` CLI and client. You can edit your own chat messages; channel messages are not supported.

- **New Features**
  - Client: `TeamsClient.editChatMessage(chatId, messageId, content)` sends a PUT with HTML-escaped content to update messages.
  - CLI: `agent-teams chat edit <chat-id> <message-id> <content>` to edit a chat message. Outputs JSON.
  - Tests: Added unit tests for the client method and CLI command.
  - Docs: Updated `skills/agent-teams/SKILL.md` with the new command and limits; updated README capability matrix with a chats-only footnote.

<sup>Written for commit 3a0001942ab0a4cc1874e4590cb3c8fc98aff680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

