### PR TITLE
feat(kakaotalk): add sendTyping for the animated dots indicator

### DIFF
--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -135,6 +135,34 @@ const result = await client.leaveChat('9876543210')
 
 Leaves a chat room by its chat ID. Works on 1:1, group, open, and PlusChat rooms. Returns `success: true` on a successful leave. The departed chat is immediately evicted from the client's cached chat list — a subsequent `getChats()` call will not include it.
 
+### Typing Indicator
+
+```typescript
+// Fire a single typing pulse — the recipient sees the animated "…" dots
+const result = await client.sendTyping('9876543210')
+// → KakaoTypingResult { success: true, status_code: 0, chat_id: '9876543210' }
+
+// For OpenChat rooms, pass the linkId
+await client.sendTyping('9876543210', { linkId: '77777' })
+```
+
+The KakaoTalk client-side lifetime is ~5s per pulse — to keep the indicator visible while generating a long reply, re-fire faster than that (e.g. every 3s):
+
+```typescript
+const interval = setInterval(() => {
+  client.sendTyping('9876543210').catch(() => {}) // ignore transient errors
+}, 3000)
+
+try {
+  const reply = await generateReply()
+  await client.sendMessage('9876543210', reply)
+} finally {
+  clearInterval(interval)
+}
+```
+
+Errors follow the same shape as `markRead`: transport-level failures (non-zero `statusCode`, including the synthetic `-1` LocoConnection emits on disconnect) throw `KakaoTalkError('send_typing_failed')` so `executeWithReconnect` can retry on a fresh session. Non-numeric `chatId` / `linkId` throw `invalid_chat_id` / `invalid_link_id`.
+
 ### Cleanup
 
 ```typescript
@@ -248,6 +276,7 @@ import type {
   KakaoMember,
   KakaoMessage,
   KakaoSendResult,
+  KakaoTypingResult,
   KakaoAccountCredentials,
   KakaoConfig,
   KakaoDeviceType,
@@ -265,6 +294,7 @@ import {
   KakaoMemberSchema,
   KakaoMessageSchema,
   KakaoSendResultSchema,
+  KakaoTypingResultSchema,
   KakaoAccountCredentialsSchema,
   KakaoConfigSchema,
 } from 'agent-messenger/kakaotalk'

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -16,6 +16,7 @@ const mockSendMessage = mock(() => Promise.resolve({}))
 const mockSendReply = mock(() => Promise.resolve({}))
 const mockMarkRead = mock(() => Promise.resolve({}))
 const mockLeaveChat = mock(() => Promise.resolve({}))
+const mockSendTyping = mock(() => Promise.resolve({}))
 const mockClose = mock(() => {})
 const mockOnClose = mock((_handler: () => void) => {})
 const mockOnPush = mock((_handler: (packet: unknown) => void) => {})
@@ -35,6 +36,7 @@ mock.module('./protocol/session', () => ({
     sendReply = mockSendReply
     markRead = mockMarkRead
     leaveChat = mockLeaveChat
+    sendTyping = mockSendTyping
     close = mockClose
     onClose = mockOnClose
     onPush = mockOnPush
@@ -59,6 +61,7 @@ function resetAllMocks() {
   mockSendReply.mockReset()
   mockMarkRead.mockReset()
   mockLeaveChat.mockReset()
+  mockSendTyping.mockReset()
   mockClose.mockReset()
   mockOnClose.mockReset()
   mockOnPush.mockReset()
@@ -1335,6 +1338,94 @@ describe('KakaoTalkClient', () => {
       } catch (e) {
         expect(e).toBeInstanceOf(KakaoTalkError)
         expect((e as KakaoTalkError).code).toBe('leave_chat_failed')
+      }
+
+      client.close()
+    })
+  })
+
+  describe('sendTyping', () => {
+    it('forwards parsed chatId to session.sendTyping and reports success on statusCode 0', async () => {
+      mockSendTyping.mockResolvedValueOnce({ statusCode: 0, body: {} })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      const result = await client.sendTyping('12345')
+
+      expect(mockSendTyping).toHaveBeenCalledTimes(1)
+      const [chatIdArg, linkIdArg] = mockSendTyping.mock.calls[0] as [{ toString(): string }, unknown]
+      expect(chatIdArg.toString()).toBe('12345')
+      expect(linkIdArg).toBeUndefined()
+      expect(result).toEqual({ success: true, status_code: 0, chat_id: '12345' })
+
+      client.close()
+    })
+
+    it('passes linkId through when provided (open-chat typing)', async () => {
+      mockSendTyping.mockResolvedValueOnce({ statusCode: 0, body: {} })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      await client.sendTyping('12345', { linkId: '77777' })
+
+      const [, linkIdArg] = mockSendTyping.mock.calls[0] as [unknown, { toString(): string }]
+      expect(linkIdArg).toBeDefined()
+      expect(linkIdArg.toString()).toBe('77777')
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(send_typing_failed) on transport-level failure (non-zero statusCode)', async () => {
+      mockSendTyping.mockResolvedValueOnce({ statusCode: -100, body: {} })
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      try {
+        await client.sendTyping('12345')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('send_typing_failed')
+      }
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(send_typing_failed) when the session throws (transport error)', async () => {
+      mockSendTyping.mockRejectedValue(new Error('ACTION failed: statusCode=-1'))
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      try {
+        await client.sendTyping('12345')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('send_typing_failed')
+      }
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(invalid_chat_id) for non-numeric chatId', async () => {
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      try {
+        await client.sendTyping('not-a-number')
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('invalid_chat_id')
+      }
+
+      client.close()
+    })
+
+    it('throws KakaoTalkError(invalid_link_id) for non-numeric linkId', async () => {
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+
+      try {
+        await client.sendTyping('12345', { linkId: 'not-a-number' })
+        throw new Error('expected to throw')
+      } catch (e) {
+        expect(e).toBeInstanceOf(KakaoTalkError)
+        expect((e as KakaoTalkError).code).toBe('invalid_link_id')
       }
 
       client.close()

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -27,6 +27,7 @@ import {
   type KakaoReplyExtra,
   type KakaoReplyTarget,
   type KakaoSendResult,
+  type KakaoTypingResult,
 } from './types'
 
 export type KakaoSessionEvent =
@@ -979,6 +980,30 @@ export class KakaoTalkClient {
         }
       } catch (error) {
         throw wrapError(error, 'send_message_failed')
+      }
+    })
+  }
+
+  async sendTyping(chatId: string, opts?: { linkId?: string }): Promise<KakaoTypingResult> {
+    const parsedChatId = parseChatId(chatId)
+    const parsedLinkId = opts?.linkId !== undefined ? parseLinkId(opts.linkId) : undefined
+
+    return this.executeWithReconnect(async ({ session }) => {
+      try {
+        const response = await session.sendTyping(parsedChatId, parsedLinkId)
+        // Throw on transport-level failure (incl. synthetic { statusCode: -1 }
+        // from LocoConnection.handleClose) so executeWithReconnect retries on
+        // a fresh session — matches the markRead pattern.
+        if (response.statusCode !== 0) {
+          throw new Error(`ACTION failed: statusCode=${response.statusCode}`)
+        }
+        return {
+          success: true,
+          status_code: response.statusCode,
+          chat_id: chatId,
+        }
+      } catch (error) {
+        throw wrapError(error, 'send_typing_failed')
       }
     })
   }

--- a/src/platforms/kakaotalk/index.test.ts
+++ b/src/platforms/kakaotalk/index.test.ts
@@ -17,6 +17,7 @@ import {
   KakaoTalkPushMessageEventSchema,
   KakaoProfileSchema,
   KakaoTalkPushReadEventSchema,
+  KakaoTypingResultSchema,
 } from '@/platforms/kakaotalk/index'
 
 it('KakaoTalkClient is exported from barrel', () => {
@@ -81,4 +82,8 @@ it('classifyKakaoChat is exported from barrel', () => {
 
 it('KakaoLeaveChatResultSchema is exported from barrel', () => {
   expect(typeof KakaoLeaveChatResultSchema.parse).toBe('function')
+})
+
+it('KakaoTypingResultSchema is exported from barrel', () => {
+  expect(typeof KakaoTypingResultSchema.parse).toBe('function')
 })

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -31,6 +31,7 @@ export type {
   KakaoTalkPushMemberEvent,
   KakaoTalkPushMessageEvent,
   KakaoTalkPushReadEvent,
+  KakaoTypingResult,
 } from './types'
 export {
   KAKAO_EMOTICON_KIND_BY_TYPE,
@@ -49,6 +50,7 @@ export {
   KakaoTalkPushMemberEventSchema,
   KakaoTalkPushMessageEventSchema,
   KakaoTalkPushReadEventSchema,
+  KakaoTypingResultSchema,
 } from './types'
 export { attemptLogin, generateDeviceUuid, loginFlow, registerDevice, requestPasscode } from './auth/kakao-login'
 export type { LoginCredentials } from './auth/kakao-login'

--- a/src/platforms/kakaotalk/protocol/session.test.ts
+++ b/src/platforms/kakaotalk/protocol/session.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, mock } from 'bun:test'
+
+import { Long } from 'bson'
+
+import { buildTypingActionBody, sendTypingPacket, TYPING_ACTION_METHOD } from './session'
+import type { LocoPacket } from './types'
+
+type SentPacket = { method: string; body: Record<string, unknown> }
+
+// Fake connection object that captures every sendPacket call. We test
+// sendTypingPacket (the extracted wire-boundary function) directly rather than
+// the LocoSession class method — LocoSession.sendTyping is a two-line delegation
+// to this helper, and testing the class would require mock.module('./session',
+// …) which collides with client.test.ts's LocoSession mock.
+function fakeConnection(returnPacket: LocoPacket = { statusCode: 0, body: {} }): {
+  connection: { sendPacket: (method: string, body: Record<string, unknown>) => Promise<LocoPacket> }
+  sent: SentPacket[]
+  sendPacketMock: ReturnType<typeof mock>
+} {
+  const sent: SentPacket[] = []
+  const sendPacketMock = mock(async (method: string, body: Record<string, unknown>) => {
+    sent.push({ method, body })
+    return returnPacket
+  })
+  return { connection: { sendPacket: sendPacketMock }, sent, sendPacketMock }
+}
+
+describe('typing indicator wire contract', () => {
+  it('TYPING_ACTION_METHOD is the exact string "ACTION" that KakaoTalk expects on the wire', () => {
+    expect(TYPING_ACTION_METHOD).toBe('ACTION')
+  })
+
+  it('emits type=1 and omits linkId entirely for normal chats', () => {
+    const body = buildTypingActionBody(Long.fromString('459750513901477'))
+
+    expect((body.chatId as { toString(): string }).toString()).toBe('459750513901477')
+    expect(body.type).toBe(1)
+    expect('linkId' in body).toBe(false)
+  })
+
+  it('includes linkId when provided (open-chat pulse)', () => {
+    const body = buildTypingActionBody(Long.fromString('123'), Long.fromString('77777'))
+
+    expect(body.type).toBe(1)
+    expect((body.linkId as { toString(): string }).toString()).toBe('77777')
+  })
+
+  it('never sets linkId=null when caller passes undefined (would change server routing)', () => {
+    const body = buildTypingActionBody(Long.fromString('123'), undefined)
+
+    expect(body.linkId).toBeUndefined()
+    expect('linkId' in body).toBe(false)
+  })
+
+  it('body only carries chatId + type for normal chats (no stray fields)', () => {
+    const body = buildTypingActionBody(Long.fromString('123'))
+
+    expect(Object.keys(body).sort()).toEqual(['chatId', 'type'])
+  })
+
+  it('body only carries chatId + type + linkId for open chats (no stray fields)', () => {
+    const body = buildTypingActionBody(Long.fromString('123'), Long.fromString('77777'))
+
+    expect(Object.keys(body).sort()).toEqual(['chatId', 'linkId', 'type'])
+  })
+})
+
+describe('sendTypingPacket → sendPacket wire boundary', () => {
+  it('calls connection.sendPacket("ACTION", body) exactly once for a normal chat, with full-width Long chatId preserved', async () => {
+    const { connection, sent, sendPacketMock } = fakeConnection()
+
+    await sendTypingPacket(connection, Long.fromString('459750513901477'))
+
+    expect(sendPacketMock).toHaveBeenCalledTimes(1)
+    expect(sent).toHaveLength(1)
+    const packet = sent[0]!
+    expect(packet.method).toBe('ACTION')
+    expect((packet.body.chatId as Long).toString()).toBe('459750513901477')
+    expect(packet.body.type).toBe(1)
+    expect('linkId' in packet.body).toBe(false)
+  })
+
+  it('calls sendPacket with full-width Long linkId preserved for an open-chat pulse', async () => {
+    const { connection, sent } = fakeConnection()
+
+    await sendTypingPacket(connection, Long.fromString('459750513901477'), Long.fromString('280368495100000'))
+
+    const packet = sent[0]!
+    expect(packet.method).toBe('ACTION')
+    expect((packet.body.chatId as Long).toString()).toBe('459750513901477')
+    expect((packet.body.linkId as Long).toString()).toBe('280368495100000')
+    expect(packet.body.type).toBe(1)
+  })
+
+  it('propagates the LocoPacket returned by sendPacket verbatim', async () => {
+    const expected = { statusCode: 0, body: { hello: 'world' } }
+    const { connection } = fakeConnection(expected)
+
+    const result = await sendTypingPacket(connection, Long.fromString('123'))
+
+    expect(result).toBe(expected)
+  })
+
+  it('emits the same wire packet the reverse-engineered client builds (spec-lock)', async () => {
+    const { connection, sent } = fakeConnection()
+
+    await sendTypingPacket(connection, Long.fromString('123'), Long.fromString('456'))
+
+    const packet = sent[0]!
+    expect(packet.method).toBe(TYPING_ACTION_METHOD)
+    expect(packet.body).toEqual(buildTypingActionBody(Long.fromString('123'), Long.fromString('456')))
+  })
+})

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -17,6 +17,36 @@ import {
 import { LocoConnection } from './connection'
 import type { BookingResponse, CheckinResponse, LoginListResponse, LocoPacket, SyncState } from './types'
 
+// LOCO opcode string emitted on the wire for typing indicator pulses.
+// Reverse-engineered from KakaoTalk 25.x — see `LocoSession.sendTyping` docs.
+export const TYPING_ACTION_METHOD = 'ACTION'
+
+// Builds the BSON body the official KakaoTalk client emits for the typing
+// indicator subtype of the `ACTION` opcode. Exported so protocol tests can lock
+// the exact field shape.
+export function buildTypingActionBody(chatId: Long, linkId?: Long): Record<string, unknown> {
+  const body: Record<string, unknown> = { chatId, type: 1 }
+  // Must omit the field entirely (not `null`) for normal chats — the official
+  // client only populates linkId for OpenChat rooms, and sending null here
+  // would change server routing.
+  if (linkId !== undefined) body.linkId = linkId
+  return body
+}
+
+// The one-and-only delegation from `LocoSession.sendTyping` to a `sendPacket`
+// implementation. Extracting this makes the wire boundary directly testable
+// with a fake connection object — no `LocoSession` instantiation required,
+// which side-steps the `mock.module('./session', …)` set up by `client.test.ts`.
+// `LocoSession.sendTyping` is a 2-line delegation to this helper, so any test
+// that pins this function's behaviour also pins the class method's contract.
+export async function sendTypingPacket(
+  connection: { sendPacket: (method: string, body: Record<string, unknown>) => Promise<LocoPacket> },
+  chatId: Long,
+  linkId?: Long,
+): Promise<LocoPacket> {
+  return connection.sendPacket(TYPING_ACTION_METHOD, buildTypingActionBody(chatId, linkId))
+}
+
 export class LocoSession {
   private connection: LocoConnection | null = null
   private pingTimer: ReturnType<typeof setInterval> | null = null
@@ -301,6 +331,27 @@ export class LocoSession {
       body.li = linkId
     }
     return this.connection.sendPacket('NOTIREAD', body)
+  }
+
+  /**
+   * Fire a single typing pulse to peers of a chat — this is what triggers the
+   * animated "…" dots the recipient sees while somebody is composing.
+   *
+   * Under the hood this sends the LOCO `ACTION` opcode with `type=1`. The
+   * KakaoTalk client-side lifetime is ~5s per pulse, so callers wanting a
+   * sustained indicator must re-fire faster than that.
+   *
+   * Reverse-engineered from KakaoTalk 25.x: the app's LOCO layer emits an
+   * `ACTION` packet with a BSON body of `{chatId, type, linkId?}` when the
+   * user types in a chat. `type=1` is the value the app uses for the typing
+   * indicator; other `type` values may exist for other in-composition states
+   * (recording audio, attaching media, etc.) but haven't been verified. The
+   * `linkId` field is omitted entirely (not sent as null) for normal chats;
+   * it is only populated for OpenChat rooms.
+   */
+  async sendTyping(chatId: Long, linkId?: Long): Promise<LocoPacket> {
+    if (!this.connection) throw new Error('Not connected')
+    return sendTypingPacket(this.connection, chatId, linkId)
   }
 
   onPush(handler: (packet: LocoPacket) => void): void {

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -213,6 +213,12 @@ export interface KakaoLeaveChatResult {
   chat_id: string
 }
 
+export interface KakaoTypingResult {
+  success: boolean
+  status_code: number
+  chat_id: string
+}
+
 export const KakaoChatSchema = z.object({
   chat_id: z.string(),
   type: z.number(),
@@ -270,6 +276,12 @@ export const KakaoMarkReadResultSchema = z.object({
 })
 
 export const KakaoLeaveChatResultSchema = z.object({
+  success: z.boolean(),
+  status_code: z.number(),
+  chat_id: z.string(),
+})
+
+export const KakaoTypingResultSchema = z.object({
   success: z.boolean(),
   status_code: z.number(),
   chat_id: z.string(),


### PR DESCRIPTION
## Summary

Adds `KakaoTalkClient.sendTyping(chatId, options?)` (and the underlying `LocoSession.sendTyping`) — this is what triggers the animated "…" dots the recipient sees in KakaoTalk while the other side is composing a message.

The KakaoTalk client-side lifetime is ~5s per pulse, so callers wanting a sustained indicator need to re-fire faster than that.

## Motivation

I've been running a KakaoTalk bot on top of this SDK for a while, and the one thing that was very obviously "this is a bot" from the recipient's side was the missing typing indicator — the bot would go silent for 10-20 seconds while generating a reply, then dump the whole message at once. Real people always show the animated dots during composition, so the absence was a dead giveaway.

There didn't seem to be a way to emit that from the SDK, and I couldn't find an existing issue asking for it either, so I dug into how the official app produces it.

## Reverse-engineered from KakaoTalk 25.x

Decompiling the KakaoTalk APK and tracing the call chain that fires when the user types in a chat:

- The LOCO layer at `com.kakao.talk.core.loco.d` exposes a method whose signature is `(long chatId, int type, Long linkId)`.
- Its LocoJob subclass builds the request body as:
  ```
  body.h("chatId", chatId)
  body.h("type",   type)
  if (linkId != null) body.h("linkId", linkId)
  ```
  → `linkId` is **omitted entirely** (not sent as `null`) when absent. Only OpenChat rooms populate it.
- The job's `method` enum is `ACTION`, and `LocoHeader` serializes it via `method.name().getBytes(UTF-8)` into the 11-byte wire method field, so the on-the-wire opcode is exactly the string `"ACTION"`.
- `type=1` is the value the app uses for the typing indicator. Other `type` values may exist for other in-composition states (recording audio, attaching media, etc.) — I haven't verified those, so this PR only exposes typing.

The wrapper follows the same shape as the existing `markRead` (`NOTIREAD`) call for consistency: `chatId` mandatory, `linkId` optional and omitted (not nulled) when absent.

## Changes

### `LocoSession.sendTyping(chatId, linkId?)`
`src/platforms/kakaotalk/protocol/session.ts` — protocol-level call. Sends `sendPacket('ACTION', {chatId, type: 1, linkId?})`.

### `KakaoTalkClient.sendTyping(chatId, opts?)`
`src/platforms/kakaotalk/client.ts` — public SDK wrapper. Mirrors the shape of `markRead` (also a fire-and-forget ack): dedicated result type, `parseChatId` / `parseLinkId` for consistent `KakaoTalkError('invalid_*_id')`, and non-zero `statusCode` **throws** so `executeWithReconnect` retries on a fresh session (this handles the synthetic `{statusCode: -1}` LocoConnection.handleClose emits on disconnect).

### `KakaoTypingResult` / `KakaoTypingResultSchema`
`src/platforms/kakaotalk/types.ts` — new result type with the three fields that actually mean something for a typing pulse (`success`, `status_code`, `chat_id`). I didn't reuse `KakaoSendResult` because its `log_id` / `sent_at` fields don't apply — a typing pulse doesn't produce a message log entry.

### Tests (`client.test.ts`, 6 new)
- Forwards parsed `chatId` to `session.sendTyping` and reports success on `statusCode` 0
- Passes `linkId` through when provided (open-chat case)
- Throws `KakaoTalkError(send_typing_failed)` on transport-level failure (non-zero `statusCode`)
- Wraps session transport errors as `KakaoTalkError(send_typing_failed)`
- Throws `KakaoTalkError(invalid_chat_id)` for non-numeric `chatId`
- Throws `KakaoTalkError(invalid_link_id)` for non-numeric `linkId`

## Verification

- `bun typecheck` ✅
- `bun lint` ✅ (0 warnings, 0 errors)
- `bun test src/platforms/kakaotalk/` ✅ **226/226** (6 new tests, 220 existing unchanged)
- Live end-to-end against a real session: fired 10 pulses at 4s intervals to a chat, all returned `statusCode=0`, the animated dots rendered continuously in the peer's KakaoTalk client for the full duration and cleared naturally when a real message arrived.

## Caveat — server may start dropping these

I observed the KakaoTalk server relaying every `ACTION` I sent during testing, but I can't guarantee that stays true — the server could start rejecting them, or flag the session, if this packet pattern stops looking like something the official app would produce. If that happens, `sendTyping` will throw `KakaoTalkError(send_typing_failed)` (via the same non-zero-statusCode → throw path as `markRead`), so callers can catch and degrade. I did all live testing with a **throwaway KakaoTalk account** and would recommend the same for anyone shipping this in production until it's been running a while.

## Not in this PR

- **CLI verb.** I didn't add `agent-kakaotalk chat typing` — one-shot pulses from a shell aren't a useful UX (the indicator expires in 5s), so this feels SDK-only. Happy to add a CLI verb if you'd prefer.
- **Other ACTION subtypes.** `type=1` (typing) is the only one I've verified. There may be other `type` values for other in-composition states (recording audio, attaching media, etc.), but I haven't reverse-engineered those, so this PR keeps the API scoped to typing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typing indicator support for KakaoTalk via `sendTyping`, triggering the animated dots while composing. Mirrors `markRead` behavior with strict ID validation and retry on transport errors.

- **New Features**
  - Added `KakaoTalkClient.sendTyping(chatId, opts?)` that validates IDs and throws `KakaoTalkError('send_typing_failed')` on non‑zero status so `executeWithReconnect` can retry.
  - Added `LocoSession.sendTyping(chatId, linkId?)`, delegating to `sendTypingPacket` to send `ACTION` with `{ chatId, type: 1, linkId? }` and omitting `linkId` when absent.
  - Introduced `KakaoTypingResult`/`KakaoTypingResultSchema`; exported from the `kakaotalk` barrel along with `TYPING_ACTION_METHOD`, `buildTypingActionBody`, and `sendTypingPacket`. Added protocol tests to lock the wire contract and client tests for success/error/ID validation and barrel exports.
  - Docs updated with usage and re-fire guidance in `docs/sdk/kakaotalk.mdx`; SKILL.md unchanged.

<sup>Written for commit b90dd4a0d19f0cd4ce24147094295f101c05e821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

