### PR TITLE
Fix Discord message search while indexing

### DIFF
--- a/src/platforms/discord/client.test.ts
+++ b/src/platforms/discord/client.test.ts
@@ -447,6 +447,127 @@ describe('DiscordClient', () => {
     })
   })
 
+  describe('searchMessages', () => {
+    const searchResult = {
+      id: 'msg1',
+      channel_id: 'ch1',
+      guild_id: 'guild1',
+      author: { id: 'user1', username: 'user1' },
+      content: 'matching message',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      hit: true,
+    }
+
+    it('flattens grouped search results and keeps hits', async () => {
+      mockResponse({
+        doing_deep_historical_index: false,
+        total_results: 1,
+        messages: [[searchResult, { ...searchResult, id: 'context', hit: false }]],
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      const result = await client.searchMessages('guild1', 'matching', { limit: 25 })
+
+      expect(result).toEqual({ results: [searchResult], total: 1 })
+      expect(fetchCalls[0].url).toBe(
+        'https://discord.com/api/v10/guilds/guild1/messages/search?content=matching&limit=25',
+      )
+    })
+
+    it('retries when the search index is not ready', async () => {
+      mockResponse(
+        {
+          message: 'Index not yet available. Try again later',
+          code: 110000,
+          documents_indexed: 0,
+          retry_after: 0,
+        },
+        202,
+      )
+      mockResponse({
+        doing_deep_historical_index: false,
+        total_results: 1,
+        messages: [[searchResult]],
+      })
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      const startTime = Date.now()
+      const result = await client.searchMessages('guild1', 'matching')
+      const elapsed = Date.now() - startTime
+
+      expect(result).toEqual({ results: [searchResult], total: 1 })
+      expect(elapsed).toBeGreaterThanOrEqual(50)
+      expect(fetchCalls).toHaveLength(2)
+    })
+
+    it('throws a clear error when the search index remains unavailable', async () => {
+      for (let attempt = 0; attempt < 4; attempt++) {
+        mockResponse(
+          {
+            message: 'Index not yet available. Try again later',
+            code: 110000,
+            documents_indexed: 0,
+            retry_after: 0.001,
+          },
+          202,
+        )
+      }
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+
+      await expect(client.searchMessages('guild1', 'matching')).rejects.toThrow(
+        'Search index is not ready after retries',
+      )
+      expect(fetchCalls).toHaveLength(4)
+    })
+
+    it('rejects unexpected successful response payloads', async () => {
+      mockResponse(
+        {
+          message: 'Unexpected response',
+          code: 999999,
+          retry_after: 0,
+        },
+        202,
+      )
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+
+      try {
+        await client.searchMessages('guild1', 'matching')
+        throw new Error('Expected searchMessages to throw')
+      } catch (error) {
+        expect(error).toBeInstanceOf(DiscordError)
+        if (!(error instanceof DiscordError)) throw error
+        expect(error.code).toBe('invalid_search_response')
+      }
+      expect(fetchCalls).toHaveLength(1)
+    })
+
+    it('rejects malformed message and retry payloads', async () => {
+      mockResponse({ total_results: 1, messages: null })
+      mockResponse(
+        {
+          message: 'Index not yet available. Try again later',
+          code: 110000,
+          documents_indexed: 0,
+          retry_after: -1,
+        },
+        202,
+      )
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+
+      await expect(client.searchMessages('guild1', 'matching')).rejects.toThrow(
+        'Discord returned an invalid search response',
+      )
+      await expect(client.searchMessages('guild1', 'matching')).rejects.toThrow(
+        'Discord returned an invalid search response',
+      )
+      expect(fetchCalls).toHaveLength(2)
+    })
+  })
+
   describe('rate limiting', () => {
     it('waits when bucket is exhausted before making request', async () => {
       mockResponse({ id: '1', username: 'user1' }, 200, {

--- a/src/platforms/discord/client.ts
+++ b/src/platforms/discord/client.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 
 import { getDiscordHeaders } from './super-properties'
+import { DiscordSearchIndexNotReadyResponseSchema, DiscordSearchResponseSchema } from './types'
 import type {
   DiscordChannel,
   DiscordDMChannel,
@@ -11,7 +12,6 @@ import type {
   DiscordMessage,
   DiscordRelationship,
   DiscordSearchOptions,
-  DiscordSearchResponse,
   DiscordSearchResult,
   DiscordUser,
   DiscordUserNote,
@@ -37,6 +37,7 @@ interface RateLimitBucket {
 const BASE_URL = 'https://discord.com/api/v10'
 const MAX_RETRIES = 3
 const BASE_BACKOFF_MS = 100
+const MAX_SEARCH_INDEX_RETRY_MS = 30_000
 
 export class DiscordClient {
   private token: string | null = null
@@ -393,28 +394,50 @@ export class DiscordClient {
       params.set('offset', options.offset.toString())
     }
 
-    const response = await this.request<DiscordSearchResponse>(
-      'GET',
-      `/guilds/${guildId}/messages/search?${params.toString()}`,
-    )
+    const path = `/guilds/${guildId}/messages/search?${params.toString()}`
 
-    const results = response.messages
-      .flat()
-      .filter((msg) => msg.hit)
-      .map((msg) => ({
-        id: msg.id,
-        channel_id: msg.channel_id,
-        guild_id: msg.guild_id,
-        content: msg.content,
-        author: msg.author,
-        timestamp: msg.timestamp,
-        hit: msg.hit,
-      }))
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const response: unknown = await this.request('GET', path)
+      const searchResponse = DiscordSearchResponseSchema.safeParse(response)
 
-    return {
-      results,
-      total: response.total_results,
+      if (searchResponse.success) {
+        const results = searchResponse.data.messages
+          .flat()
+          .filter((msg) => msg.hit)
+          .map((msg) => ({
+            id: msg.id,
+            channel_id: msg.channel_id,
+            guild_id: msg.guild_id,
+            content: msg.content,
+            author: msg.author,
+            timestamp: msg.timestamp,
+            hit: msg.hit,
+          }))
+
+        return {
+          results,
+          total: searchResponse.data.total_results,
+        }
+      }
+
+      const indexNotReadyResponse = DiscordSearchIndexNotReadyResponseSchema.safeParse(response)
+      if (!indexNotReadyResponse.success) {
+        throw new DiscordError('Discord returned an invalid search response', 'invalid_search_response')
+      }
+
+      if (attempt === MAX_RETRIES) {
+        throw new DiscordError('Search index is not ready after retries', 'search_index_not_ready')
+      }
+
+      const requestedDelayMs = indexNotReadyResponse.data.retry_after * 1000
+      const retryDelayMs = Math.min(
+        requestedDelayMs === 0 ? BASE_BACKOFF_MS : requestedDelayMs,
+        MAX_SEARCH_INDEX_RETRY_MS,
+      )
+      await this.sleep(retryDelayMs)
     }
+
+    throw new DiscordError('Search failed after retries', 'max_retries')
   }
 
   async getUserProfile(userId: string): Promise<DiscordUserProfile> {

--- a/src/platforms/discord/types.ts
+++ b/src/platforms/discord/types.ts
@@ -109,6 +109,15 @@ export interface DiscordSearchResponse {
   messages: DiscordSearchResult[][]
 }
 
+export interface DiscordSearchIndexNotReadyResponse {
+  message: string
+  code: 110000
+  documents_indexed: number
+  retry_after: number
+}
+
+export type DiscordSearchApiResponse = DiscordSearchResponse | DiscordSearchIndexNotReadyResponse
+
 export interface DiscordSearchOptions {
   channelId?: string
   authorId?: string
@@ -265,6 +274,13 @@ export const DiscordSearchResultSchema = z.object({
 export const DiscordSearchResponseSchema = z.object({
   total_results: z.number(),
   messages: z.array(z.array(DiscordSearchResultSchema)),
+})
+
+export const DiscordSearchIndexNotReadyResponseSchema = z.object({
+  message: z.string(),
+  code: z.literal(110000),
+  documents_indexed: z.number(),
+  retry_after: z.number().nonnegative(),
 })
 
 export const DiscordCredentialsSchema = z.object({


### PR DESCRIPTION
## Summary

Discord's guild message search API can return an "index not ready" response instead of normal results while it is still indexing recently sent messages. This indexing payload carries `code: 110000` and has no `messages` field.

`searchMessages` only handled the success shape. It called `.flat()` on the response unconditionally, so the indexing-in-progress payload crashed with a runtime `TypeError` instead of retrying or failing gracefully.

## Root Cause

- The raw API response was cast directly to the success type without validating its shape first.
- The indexing placeholder response has no `messages` field, so calling `.flat()` on it throws.

## Changes

### `types.ts`
- Add a `DiscordSearchIndexNotReadyResponse` interface for the indexing placeholder payload.
- Add a matching `DiscordSearchIndexNotReadyResponseSchema` (zod) to validate it at runtime.
- Add a `DiscordSearchApiResponse` union describing both possible response shapes.

### `client.ts`
- Validate the raw response with the existing search schema before reading any fields from it.
- On the indexing-not-ready shape, retry up to `MAX_RETRIES` times.
- Sleep for the server-provided retry delay between attempts, capped at `MAX_SEARCH_INDEX_RETRY_MS` (30 seconds).
- Reject any response matching neither schema by throwing a `DiscordError` instead of an unhandled type error.
- Throw a `DiscordError` once retries are exhausted and the index is still not ready.

### `client.test.ts`
- Add regression tests for a successful search.
- Add regression tests for the indexing/retry path.
- Add regression tests for retry exhaustion.
- Add regression tests for rejecting a malformed or unrecognized response shape.

## Verification

- [x] `bun test` — 3568 pass, 0 fail.
- [x] `bun typecheck` — clean.
- [x] `bun lint` — 0 warnings, 0 errors.
- [x] `bun run format:check` — clean.
- [x] `bun run build` — clean.
- [x] LSP diagnostics — 0 errors/warnings on changed files.
- [x] Manually reproduced both originally reported search queries against the live Discord API. Both now return valid JSON instead of throwing.