### PR TITLE
Fix Discord message lookup for user tokens

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -199,10 +199,10 @@ When triggering manually, you can select which platform to test:
 | ------------- | ------------------------------------------ |
 | `auth`        | status                                     |
 | `server`      | list, current, info                        |
-| `message`     | send, list, get\*, delete, ack, search     |
+| `message`     | send, list, get, delete, ack, search       |
 | `channel`     | list, info, history                        |
 | `user`        | list\*, me, info                           |
-| `reaction`    | add\*, list\*, remove\*                    |
+| `reaction`    | add, list, remove                           |
 | `file`        | upload, list, info                         |
 | `snapshot`    | default\*, --channels-only, --users-only\* |
 

--- a/e2e/discord.e2e.test.ts
+++ b/e2e/discord.e2e.test.ts
@@ -83,7 +83,7 @@ describe('Discord E2E Tests', () => {
       expect(Array.isArray(data)).toBe(true)
     })
 
-    it.skip('message get retrieves specific message (requires bot token)', async () => {
+    it('message get retrieves specific message', async () => {
       const testId = generateTestId()
       const { id } = await createTestMessage('discord', DISCORD_TEST_CHANNEL_ID, `Get test ${testId}`)
       testMessages.push(id)
@@ -194,7 +194,7 @@ describe('Discord E2E Tests', () => {
   })
 
   describe('reaction', () => {
-    it.skip('reaction add/list/remove lifecycle (requires bot token)', async () => {
+    it('reaction add/list/remove lifecycle', async () => {
       const testId = generateTestId()
       const { id } = await createTestMessage('discord', DISCORD_TEST_CHANNEL_ID, `Reaction test ${testId}`)
       testMessages.push(id)
@@ -210,12 +210,26 @@ describe('Discord E2E Tests', () => {
       // List reactions
       const listResult = await runCLI('discord', ['reaction', 'list', DISCORD_TEST_CHANNEL_ID, id])
       expect(listResult.exitCode).toBe(0)
+      const listed = parseJSON<{ reactions: Array<{ emoji: { name: string | null }; count: number }> }>(
+        listResult.stdout,
+      )
+      const addedReaction = listed?.reactions.find((reaction) => reaction.emoji.name === '👍')
+      expect(addedReaction?.count).toBeGreaterThan(0)
 
       await waitForRateLimit()
 
       // Remove reaction
       const removeResult = await runCLI('discord', ['reaction', 'remove', DISCORD_TEST_CHANNEL_ID, id, '👍'])
       expect(removeResult.exitCode).toBe(0)
+
+      await waitForRateLimit()
+
+      const afterRemoveResult = await runCLI('discord', ['reaction', 'list', DISCORD_TEST_CHANNEL_ID, id])
+      expect(afterRemoveResult.exitCode).toBe(0)
+      const afterRemove = parseJSON<{ reactions: Array<{ emoji: { name: string | null }; count: number }> }>(
+        afterRemoveResult.stdout,
+      )
+      expect(afterRemove?.reactions.find((reaction) => reaction.emoji.name === '👍')).toBeUndefined()
     }, 15000) // Longer timeout for multiple operations
   })
 

--- a/src/platforms/discord/client.test.ts
+++ b/src/platforms/discord/client.test.ts
@@ -226,23 +226,50 @@ describe('DiscordClient', () => {
 
       expect(fetchCalls[0].url).toBe('https://discord.com/api/v10/channels/ch1/messages?limit=50')
     })
+
+    it('gets messages around a specific message', async () => {
+      mockResponse([])
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      await client.getMessages('ch1', 1, { around: 'msg/1' })
+
+      expect(fetchCalls[0].url).toBe('https://discord.com/api/v10/channels/ch1/messages?around=msg%2F1&limit=1')
+    })
   })
 
   describe('getMessage', () => {
     it('returns single message', async () => {
-      mockResponse({
-        id: 'msg1',
-        channel_id: 'ch1',
-        author: { id: '123', username: 'user1' },
-        content: 'Message 1',
-        timestamp: '2024-01-01T00:00:00.000Z',
-      })
+      mockResponse([
+        {
+          id: 'msg1',
+          channel_id: 'ch1',
+          author: { id: '123', username: 'user1' },
+          content: 'Message 1',
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      ])
 
       const client = await new DiscordClient().login({ token: 'test-token' })
       const message = await client.getMessage('ch1', 'msg1')
 
       expect(message.id).toBe('msg1')
-      expect(fetchCalls[0].url).toBe('https://discord.com/api/v10/channels/ch1/messages/msg1')
+      expect(fetchCalls[0].url).toBe('https://discord.com/api/v10/channels/ch1/messages?around=msg1&limit=1')
+    })
+
+    it('throws when the requested message is not returned', async () => {
+      mockResponse([
+        {
+          id: 'neighbor',
+          channel_id: 'ch1',
+          author: { id: '123', username: 'user1' },
+          content: 'Nearby message',
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      ])
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+
+      await expect(client.getMessage('ch1', 'missing')).rejects.toEqual(new DiscordError('Message not found', '10008'))
     })
   })
 
@@ -672,6 +699,25 @@ describe('DiscordClient', () => {
       await client.getMessages('123456789')
       await client.getMessages('987654321')
 
+      expect(fetchCalls.length).toBe(2)
+    })
+
+    it('normalizes query strings for the same channel route', async () => {
+      mockResponse([], 200, {
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': String(Date.now() / 1000 + 0.1),
+        'X-RateLimit-Bucket': 'messages-bucket',
+      })
+      mockResponse([])
+
+      const client = await new DiscordClient().login({ token: 'test-token' })
+      await client.getMessages('123456789', 1, { around: 'message-1' })
+
+      const startTime = Date.now()
+      await client.getMessages('123456789', 1, { around: 'message-2' })
+      const elapsed = Date.now() - startTime
+
+      expect(elapsed).toBeGreaterThanOrEqual(50)
       expect(fetchCalls.length).toBe(2)
     })
   })

--- a/src/platforms/discord/client.ts
+++ b/src/platforms/discord/client.ts
@@ -75,7 +75,9 @@ export class DiscordClient {
   }
 
   private getBucketKey(method: string, path: string): string {
-    const normalized = path
+    const queryIndex = path.indexOf('?')
+    const route = queryIndex === -1 ? path : path.slice(0, queryIndex)
+    const normalized = route
       .replace(/\/channels\/\d+/, '/channels/{channel_id}')
       .replace(/\/guilds\/\d+/, '/guilds/{guild_id}')
       .replace(/\/users\/\d+/, '/users/{user_id}')
@@ -235,12 +237,22 @@ export class DiscordClient {
     return this.request<DiscordMessage>('POST', `/channels/${channelId}/messages`, body)
   }
 
-  async getMessages(channelId: string, limit: number = 50): Promise<DiscordMessage[]> {
-    return this.request<DiscordMessage[]>('GET', `/channels/${channelId}/messages?limit=${limit}`)
+  async getMessages(channelId: string, limit: number = 50, options?: { around?: string }): Promise<DiscordMessage[]> {
+    const params = new URLSearchParams()
+    if (options?.around) {
+      params.set('around', options.around)
+    }
+    params.set('limit', limit.toString())
+    return this.request<DiscordMessage[]>('GET', `/channels/${channelId}/messages?${params}`)
   }
 
   async getMessage(channelId: string, messageId: string): Promise<DiscordMessage> {
-    return this.request<DiscordMessage>('GET', `/channels/${channelId}/messages/${messageId}`)
+    const messages = await this.getMessages(channelId, 1, { around: messageId })
+    const message = messages[0]
+    if (!message || message.id !== messageId) {
+      throw new DiscordError('Message not found', '10008')
+    }
+    return message
   }
 
   async editMessage(channelId: string, messageId: string, content: string): Promise<DiscordMessage> {

--- a/src/platforms/discord/commands/reaction.test.ts
+++ b/src/platforms/discord/commands/reaction.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
         count: 1,
       },
     ],
-  } as any)
+  })
 
   // Spy on DiscordCredentialManager.prototype methods
   credManagerLoadSpy = spyOn(DiscordCredentialManager.prototype, 'load').mockResolvedValue({

--- a/src/platforms/discord/commands/reaction.ts
+++ b/src/platforms/discord/commands/reaction.ts
@@ -101,7 +101,7 @@ export async function listAction(channelId: string, messageId: string, options: 
       process.exit(1)
     }
 
-    const reactions = (message as any).reactions || []
+    const reactions = message.reactions ?? []
 
     console.log(
       formatOutput(

--- a/src/platforms/discord/types.test.ts
+++ b/src/platforms/discord/types.test.ts
@@ -150,6 +150,17 @@ it('DiscordReactionSchema validates reaction with custom emoji', () => {
   expect(result.success).toBe(true)
 })
 
+it('DiscordReactionSchema validates nullable emoji fields', () => {
+  const result = DiscordReactionSchema.safeParse({
+    emoji: {
+      id: null,
+      name: null,
+    },
+    count: 1,
+  })
+  expect(result.success).toBe(true)
+})
+
 it('DiscordReactionSchema rejects missing required fields', () => {
   const result = DiscordReactionSchema.safeParse({
     emoji: {

--- a/src/platforms/discord/types.ts
+++ b/src/platforms/discord/types.ts
@@ -38,6 +38,7 @@ export interface DiscordMessage {
   timestamp: string
   edited_timestamp?: string
   thread_id?: string
+  reactions?: DiscordReaction[]
 }
 
 export interface DiscordUser {
@@ -58,8 +59,8 @@ export interface DiscordDMChannel {
 
 export interface DiscordReaction {
   emoji: {
-    id?: string
-    name: string
+    id?: string | null
+    name: string | null
   }
   count: number
 }
@@ -190,6 +191,14 @@ export const DiscordChannelSchema = z.object({
   position: z.number().optional(),
 })
 
+export const DiscordReactionSchema = z.object({
+  emoji: z.object({
+    id: z.string().nullish(),
+    name: z.string().nullable(),
+  }),
+  count: z.number(),
+})
+
 export const DiscordMessageSchema = z.object({
   id: z.string(),
   channel_id: z.string(),
@@ -201,6 +210,7 @@ export const DiscordMessageSchema = z.object({
   timestamp: z.string(),
   edited_timestamp: z.string().optional(),
   thread_id: z.string().optional(),
+  reactions: z.array(DiscordReactionSchema).optional(),
 })
 
 export const DiscordUserSchema = z.object({
@@ -217,14 +227,6 @@ export const DiscordDMChannelSchema = z.object({
   last_message_id: z.string().optional(),
   recipients: z.array(DiscordUserSchema),
   name: z.string().optional(),
-})
-
-export const DiscordReactionSchema = z.object({
-  emoji: z.object({
-    id: z.string().optional(),
-    name: z.string(),
-  }),
-  count: z.number(),
 })
 
 export const DiscordFileSchema = z.object({


### PR DESCRIPTION
## Summary

User-token `message get` and `reaction list` on Discord both routed through `GET /channels/{channel}/messages/{id}`, which is a bot-only endpoint — it 403s for user (non-bot) tokens. This PR reworks message lookup to go through the list endpoint instead, which both token types can use, and types the embedded reaction summaries that lookup now surfaces.

Closes #305.

## Changes

### `client.ts`
- `getMessages()` gains an optional `{ around }` param and now builds its querystring with `URLSearchParams`, so callers can request messages centered on a given ID.
- `getMessage()` no longer hits the single-message endpoint. It calls `getMessages(channelId, 1, { around: messageId })` and requires the returned message's `id` to exactly match the requested one, throwing `DiscordError('Message not found', '10008')` (mirroring Discord's own unknown-message error code) if it doesn't — this keeps prior "not found" semantics even though the underlying endpoint is now a windowed list rather than a direct lookup.

### `types.ts`
- Add `reactions?: DiscordReaction[]` to `DiscordMessage` and `DiscordMessageSchema`, and move `DiscordReactionSchema` above `DiscordMessageSchema` so the schema can reference it. Reaction summaries embedded in message payloads are now typed instead of relying on an `any` cast downstream.

### `commands/reaction.ts`
- Replace the `(message as any).reactions` cast with the now-typed `message.reactions ?? []`.

### `client.test.ts`
- Add a regression test asserting `getMessages()` builds the `around` + `limit` querystring correctly.
- Update `getMessage()` tests to mock the list-shaped response, and add a case asserting it throws `DiscordError('Message not found', '10008')` when the returned window doesn't contain the requested ID.

### E2E (`e2e/discord.e2e.test.ts`, `e2e/README.md`)
- Un-skip "message get retrieves specific message" and "reaction add/list/remove lifecycle" — both were previously marked `requires bot token` and skipped; they are now enabled to validate the user-token-compatible route in CI/live-credential environments.
- Update the e2e coverage table to drop the bot-token asterisks on `message get` and `reaction add/list/remove`.

## Verification

- [x] `bun test` — 3,587 pass, 0 fail.
- [x] `bun run build` — clean.
- [x] `bun typecheck` — clean.
- [x] `bun lint` — 0 warnings, 0 errors.
- [x] `bun run format:check` — clean.
- [ ] Live Discord E2E — not run locally (no dedicated E2E credentials available in this environment). The relevant E2E cases (`message get`, `reaction add/list/remove`) are now enabled and should run in CI/against real credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Discord user-token message lookup by using the list endpoint with `around` and `limit=1`. Adds typed reaction summaries and normalizes rate-limit buckets so different `around` queries share the same route.

- **Bug Fixes**
  - `getMessages(channelId, limit, { around })` builds the query via URLSearchParams and supports centered lookups.
  - `getMessage()` uses the list endpoint and throws `DiscordError('Message not found', '10008')` when the exact ID isn’t in the window.
  - Rate-limit bucket key now ignores query strings, grouping message-list requests by route even when `around` differs.
  - Typed `reactions` on `DiscordMessage` and `DiscordMessageSchema`; `reaction list` now reads `message.reactions ?? []`.
  - E2E: un-skipped `message get` and `reaction add/list/remove`; added verification after removal.
  - Docs: updated `e2e/README`; no SKILL.md changes.

<sup>Written for commit 56d41e488c42b51f7e3435b1cbb76dfff5c06654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

