### PR TITLE
Document Discord unread mentions in the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,17 @@ const msg = await discord.sendMessage(channelId, 'Deploying…')
 await discord.editMessage(channelId, msg.id, 'Deployed ✅')
 ```
 
+### Unread Mentions (Discord)
+
+`getUnreadMentions` returns only the mentions behind Discord's unread-mention badge by correlating your recent mention history (Discord's 7-day window) with per-channel read state. `count` is the enumerated unread mentions, `badgeCount` is Discord's account-wide badge total, and `complete` is `true` when the scan exhausted all available mention history and `false` when it stopped early due to the limit or a non-advancing cursor.
+
+```typescript
+import { DiscordClient } from 'agent-messenger/discord'
+
+const discord = await new DiscordClient().login()
+const { mentions, count, badgeCount, complete } = await discord.getUnreadMentions()
+```
+
 ### QR Code Login (Slack)
 
 Sign in with a QR code from Slack's "Sign in on mobile" screen — no desktop app or browser automation, just HTTP. `dataUrl` is the QR image as a `data:image/png;base64,...` string.

--- a/docs/content/docs/sdk/discord.mdx
+++ b/docs/content/docs/sdk/discord.mdx
@@ -144,7 +144,18 @@ const dm = await client.createDM(userId)
 const mentions = await client.getMentions()
 const filtered = await client.getMentions({ limit: 10, guildId: serverId })
 // → DiscordMention[]
+
+// Get only unread mentions — the messages behind Discord's unread-mention badge
+const unread = await client.getUnreadMentions()
+const scoped = await client.getUnreadMentions({ guildId: serverId, limit: 200 })
+// → DiscordUnreadMentionsResult { mentions, count, badgeCount, complete, windowDays }
+
+// Snapshot per-channel read state directly (one-shot gateway connect)
+const readState = await client.fetchReadState()
+// → DiscordReadState[] { channelId, lastMessageId, mentionCount }
 ```
+
+`getUnreadMentions` correlates recent mention history (Discord's 7-day window) with per-channel read state, returning only mentions newer than each channel's read marker. `count` is the number of enumerated unread mentions; `badgeCount` is Discord's own account-wide unread-mention badge total (not narrowed by `guildId`, since read states carry no guild association); `complete` is `true` when the scan exhausted all available mention history (Discord's 7-day window) and `false` when it stopped early at `limit` or a non-advancing cursor.
 
 ### User Notes
 
@@ -345,6 +356,9 @@ import type {
   DiscordReaction,
   DiscordFile,
   DiscordMention,
+  DiscordReadState,
+  DiscordUnreadMention,
+  DiscordUnreadMentionsResult,
   DiscordUserNote,
   DiscordSearchResult,
   DiscordSearchResponse,
@@ -475,6 +489,30 @@ for (const mention of mentions) {
     ? `${existing.note}\n[${new Date().toISOString()}] Mentioned me: "${mention.content.slice(0, 80)}"`
     : `[${new Date().toISOString()}] Mentioned me: "${mention.content.slice(0, 80)}"`
   await client.setUserNote(mention.author.id, noteText)
+}
+```
+
+### Unread Mentions Digest
+
+Fetch only unread mentions, reply to each, and mark them read.
+
+```typescript
+import { DiscordClient } from 'agent-messenger/discord'
+
+const client = await new DiscordClient().login({ token })
+
+const { mentions, count, badgeCount, complete } = await client.getUnreadMentions()
+
+console.log(`${count} unread mentions fetched (badge shows ${badgeCount})`)
+if (!complete) {
+  console.log('The scan hit the limit — some unread mentions may not have been fetched')
+}
+
+for (const mention of mentions) {
+  await client.sendMessage(mention.channel_id, `On it <@${mention.author.id}>!`)
+
+  // Mark the message read so it drops off the unread badge
+  await client.ackMessage(mention.channel_id, mention.id)
 }
 ```
 

--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -515,6 +515,12 @@ const { results } = await client.searchMessages(serverId, 'deployment', {
   limit: 5,
 })
 
+// List unread mentions (correlates mention history with per-channel read state)
+const { mentions, count, badgeCount, complete } = await client.getUnreadMentions()
+// count = enumerated unread mentions; badgeCount = account-wide badge total;
+// complete = true when all available mentions (7-day window) were scanned,
+// false when the scan stopped early at the limit or a non-advancing cursor
+
 // Create a thread
 const thread = await client.createThread(channelId, 'Discussion Topic')
 await client.sendMessage(thread.id, 'First message in thread')


### PR DESCRIPTION
Follow-up to #308.

## What

PR #308 added `DiscordClient.getUnreadMentions()` / `fetchReadState()` and the `DiscordReadState`, `DiscordUnreadMention`, `DiscordUnreadMentionsResult` types, and exported them from `agent-messenger/discord`. The API was reachable from the SDK but not documented. This PR documents it across all three SDK doc surfaces.

## Changes (docs only)

- **`docs/content/docs/sdk/discord.mdx`** (canonical SDK reference)
  - Mentions section: added `getUnreadMentions()` and `fetchReadState()` with return-shape annotations and a note on `count` vs `badgeCount` vs `complete` semantics.
  - Types import block: added `DiscordReadState`, `DiscordUnreadMention`, `DiscordUnreadMentionsResult`.
  - Added an "Unread Mentions Digest" example (fetch unread → reply → `ackMessage`).
- **`skills/agent-discord/SKILL.md`** — added a `getUnreadMentions()` snippet to the SDK Example section.
- **`README.md`** — added an "Unread Mentions (Discord)" SDK subsection, matching the existing "Editing Messages" pattern.

No code changes — the SDK surface was already exposed in #308.

## Notes

- `badgeCount` is documented as Discord's account-wide badge total (not narrowed by `guildId`, since READY read states carry no guild association), consistent with the type doc and CLI docs.
- `bun typecheck`, `bun lint`, and `bun run test` (3610 tests) pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SDK docs for Discord unread mentions: `getUnreadMentions()` and `fetchReadState()`, with examples and types. No platform source changes; updated SDK docs, `README`, and `skills/agent-discord/SKILL.md`.

- **Docs**
  - `docs/content/docs/sdk/discord.mdx`: added both APIs with return shapes; explained `count`, `badgeCount`, `complete`, and `windowDays`; imported `DiscordReadState`, `DiscordUnreadMention`, `DiscordUnreadMentionsResult`; added an “Unread Mentions Digest” example.
  - `README.md`: added an “Unread Mentions (Discord)” section with a usage snippet.
  - `skills/agent-discord/SKILL.md`: added a `getUnreadMentions()` snippet and notes.

<sup>Written for commit defd66707cfbb9dc4c9e6084c0dd5525cc477ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

