### PR TITLE
feat(slack): add QR confirmation code support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "pngjs": "^7.0.0",
         "qrcode": "^1.5.4",
         "thrift": "^0.20.0",
+        "tough-cookie": "^6.0.2",
         "tweetnacl": "^1.0.3",
         "webex-message-handler": "^0.6.10",
         "ws": "^8.19.0",
@@ -716,9 +717,15 @@
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
+    "tldts": ["tldts@7.4.9", "", { "dependencies": { "tldts-core": "^7.4.9" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA=="],
+
+    "tldts-core": ["tldts-core@7.4.9", "", {}, "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
 
     "tsc-alias": ["tsc-alias@1.8.16", "", { "dependencies": { "chokidar": "^3.5.3", "commander": "^9.0.0", "get-tsconfig": "^4.10.0", "globby": "^11.0.4", "mylas": "^2.1.9", "normalize-path": "^3.0.0", "plimit-lit": "^1.2.6" }, "bin": { "tsc-alias": "dist/bin/index.js" } }, "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g=="],
 

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "pngjs": "^7.0.0",
     "qrcode": "^1.5.4",
     "thrift": "^0.20.0",
+    "tough-cookie": "^6.0.2",
     "tweetnacl": "^1.0.3",
     "webex-message-handler": "^0.6.10",
     "ws": "^8.19.0",

--- a/skills/agent-slack/SKILL.md
+++ b/skills/agent-slack/SKILL.md
@@ -607,7 +607,30 @@ await new SlackCredentialManager().setWorkspace({
 })
 ```
 
-`loginWithQr(dataUrl, options)` accepts an optional `{ debug, fetchImpl, maxRedirects }`. It throws `SlackError` with codes `qr_session_failed` (link expired / no session) or `qr_token_failed` (token could not be retrieved). To decode the QR without logging in, use `decodeSlackQr(dataUrl)` which returns `{ url, workspace, teamId, userId }`.
+`loginWithQr(dataUrl, options)` accepts an optional `{ debug, fetchImpl, maxRedirects, requestConfirmationCode }`. It throws `SlackError` with codes `qr_session_failed` (link expired / no session) or `qr_token_failed` (token could not be retrieved). To decode the QR without logging in, use `decodeSlackQr(dataUrl)` which returns `{ url, workspace, teamId, userId }`.
+
+### Handling Slack confirmation codes (workspace 2FA)
+
+Some workspaces make a QR sign-in surface a confirmation-code page (email code, SMS, TOTP, etc.) before issuing the session cookie. Pass `requestConfirmationCode` to complete that step. The callback is only invoked when Slack actually shows a confirmation page — ordinary QR logins that receive the session cookie directly stay prompt-free.
+
+```typescript
+import { loginWithQr, type SlackConfirmationChallenge } from 'agent-messenger/slack'
+
+const session = await loginWithQr(dataUrl, {
+  requestConfirmationCode: async (challenge: SlackConfirmationChallenge) => {
+    // challenge.email is the address Slack sent the code to.
+    // challenge.type is the mechanism ("email", "sms", "totp", ...) or null if unknown.
+    return await promptUserForCode(challenge)
+  },
+})
+```
+
+Contract:
+
+- Return the raw code as a `string`. Whitespace is trimmed before submission.
+- Return an empty string (or all whitespace) to abort — `loginWithQr` throws `qr_session_failed` and no code is posted.
+- The code is submitted to the exact `https://<workspace>.slack.com/login/<qrSecret>` endpoint bound to the QR payload. Redirects to a different workspace host or an unexpected pathname reject the flow before the callback is invoked.
+- The callback and `email`/`type` fields never appear in `debug` output.
 
 ## SDK: Real-Time Events
 

--- a/src/platforms/slack/index.ts
+++ b/src/platforms/slack/index.ts
@@ -3,6 +3,7 @@ export { SlackCredentialManager, CredentialManager } from './credential-manager'
 export { SlackListener } from './listener'
 export { loginWithQr } from './qr-http-login'
 export type { QrLoginOptions, QrSession } from './qr-http-login'
+export type { SlackConfirmationChallenge, SlackConfirmationCodeRequest } from './qr-confirmation'
 export { decodeSlackQr } from './qr-login'
 export type { SlackQrLogin } from './qr-login'
 export type {

--- a/src/platforms/slack/qr-confirmation.ts
+++ b/src/platforms/slack/qr-confirmation.ts
@@ -1,0 +1,80 @@
+import type { SlackQrLogin } from './qr-login'
+
+export interface SlackConfirmationChallenge {
+  readonly email: string
+  readonly type: string | null
+}
+
+export type SlackConfirmationCodeRequest = (challenge: SlackConfirmationChallenge) => Promise<string>
+
+type SigninProps = {
+  readonly magicLogin: string
+  readonly emailAddress: string
+  readonly twoFactorType: string | null
+}
+
+export function parseConfirmationPage(html: string): SigninProps | null {
+  const match = html.match(/id="props_node"[^>]*\bdata-props="([^"]*)"/i)
+  const encoded = match?.[1]
+  if (!encoded) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(decodeHtml(encoded))
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) return null
+
+  const magicLogin = parsed.magicLogin
+  const emailAddress = parsed.emailAddress
+  if (typeof magicLogin !== 'string' || magicLogin === '') return null
+  if (typeof emailAddress !== 'string' || emailAddress === '') return null
+  return {
+    magicLogin,
+    emailAddress,
+    twoFactorType: typeof parsed.twoFactorType === 'string' ? parsed.twoFactorType : null,
+  }
+}
+
+export function buildConfirmationRequest(
+  login: SlackQrLogin,
+  finalUrl: string,
+  props: SigninProps,
+  code: string,
+): { readonly url: string; readonly body: string } | null {
+  const url = new URL(finalUrl)
+  if (url.hostname !== `${login.workspace}.slack.com`) return null
+  if (!url.pathname.includes('/z-app-')) return null
+  const qrSecret = new URL(login.url).pathname.split('/').at(-1)
+  if (!qrSecret || url.pathname.split('/').at(-1) !== qrSecret) return null
+
+  url.search = ''
+  url.searchParams.set('domain', login.workspace)
+  url.searchParams.set('domainLogin', '1')
+  url.searchParams.set('email', props.emailAddress)
+
+  return {
+    url: url.toString(),
+    body: new URLSearchParams({
+      '2fa_magiclogin': props.magicLogin,
+      remember: '0',
+      has_remember: 'false',
+      '2fa_code': code.trim(),
+      '2fa_action': 'submit_primary',
+    }).toString(),
+  }
+}
+
+function decodeHtml(value: string): string {
+  return value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/src/platforms/slack/qr-confirmation.ts
+++ b/src/platforms/slack/qr-confirmation.ts
@@ -43,11 +43,11 @@ export function buildConfirmationRequest(
   props: SigninProps,
   code: string,
 ): { readonly url: string; readonly body: string } | null {
+  const expected = expectedConfirmationPath(login)
+  if (!expected) return null
   const url = new URL(finalUrl)
   if (url.hostname !== `${login.workspace}.slack.com`) return null
-  if (!url.pathname.includes('/z-app-')) return null
-  const qrSecret = new URL(login.url).pathname.split('/').at(-1)
-  if (!qrSecret || url.pathname.split('/').at(-1) !== qrSecret) return null
+  if (url.pathname !== expected) return null
 
   url.search = ''
   url.searchParams.set('domain', login.workspace)
@@ -64,6 +64,12 @@ export function buildConfirmationRequest(
       '2fa_action': 'submit_primary',
     }).toString(),
   }
+}
+
+export function expectedConfirmationPath(login: SlackQrLogin): string | null {
+  const qrSecret = new URL(login.url).pathname.split('/').at(-1)
+  if (!qrSecret || !qrSecret.startsWith('z-app-')) return null
+  return `/login/${qrSecret}`
 }
 
 function decodeHtml(value: string): string {

--- a/src/platforms/slack/qr-cookie-jar.ts
+++ b/src/platforms/slack/qr-cookie-jar.ts
@@ -20,7 +20,7 @@ export class SlackCookieJar {
       },
     })
     for (const setCookie of getSetCookies(response)) {
-      await this.#jar.setCookie(setCookie, url)
+      await this.#jar.setCookie(setCookie, url, { ignoreError: true })
     }
     return response
   }

--- a/src/platforms/slack/qr-cookie-jar.ts
+++ b/src/platforms/slack/qr-cookie-jar.ts
@@ -1,0 +1,66 @@
+import { CookieJar } from 'tough-cookie'
+
+const BROWSER_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
+
+export class SlackCookieJar {
+  readonly #jar = new CookieJar()
+
+  async fetch(doFetch: typeof fetch, url: string, init: RequestInit = {}): Promise<Response> {
+    const cookie = await this.#jar.getCookieString(url)
+    const response = await doFetch(url, {
+      ...init,
+      redirect: 'manual',
+      headers: {
+        'User-Agent': BROWSER_USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        ...init.headers,
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+    })
+    for (const setCookie of getSetCookies(response)) {
+      await this.#jar.setCookie(setCookie, url)
+    }
+    return response
+  }
+}
+
+export function setCookieNames(response: Response): readonly string[] {
+  return getSetCookies(response).flatMap((setCookie) => {
+    const name = setCookie.split('=')[0]?.trim()
+    return name ? [name] : []
+  })
+}
+
+export function sessionCookieFromResponse(
+  response: Response,
+  responseUrl: string,
+  workspace: string,
+  current: string | null,
+): string | null {
+  const hostname = new URL(responseUrl).hostname
+  if (hostname !== `${workspace}.slack.com` && hostname !== 'app.slack.com') return current
+  let sessionCookie = current
+  for (const setCookie of getSetCookies(response)) {
+    if (isDeletedSessionCookie(setCookie)) sessionCookie = null
+    else sessionCookie = parseSessionCookie(setCookie) ?? sessionCookie
+  }
+  return sessionCookie
+}
+
+function getSetCookies(response: Response): readonly string[] {
+  const withGetter = response.headers as Headers & { getSetCookie?: () => string[] }
+  if (typeof withGetter.getSetCookie === 'function') return withGetter.getSetCookie()
+  const single = response.headers.get('set-cookie')
+  return single ? [single] : []
+}
+
+function parseSessionCookie(setCookie: string): string | null {
+  const match = setCookie.match(/(?:^|,\s*)d=(xoxd-[^;]+)/)
+  return match?.[1] ?? null
+}
+
+function isDeletedSessionCookie(setCookie: string): boolean {
+  return /^d=/i.test(setCookie) && /(?:^|;)\s*max-age=0(?:;|$)/i.test(setCookie)
+}

--- a/src/platforms/slack/qr-cookie-jar.ts
+++ b/src/platforms/slack/qr-cookie-jar.ts
@@ -3,6 +3,9 @@ import { CookieJar } from 'tough-cookie'
 const BROWSER_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
 
+const SESSION_COOKIE_NAME = 'd'
+const SESSION_COOKIE_PREFIX = 'xoxd-'
+
 export class SlackCookieJar {
   readonly #jar = new CookieJar()
 
@@ -24,6 +27,16 @@ export class SlackCookieJar {
     }
     return response
   }
+
+  async sessionCookie(url: string): Promise<string | null> {
+    const cookies = await this.#jar.getCookies(url)
+    for (const cookie of cookies) {
+      if (cookie.key === SESSION_COOKIE_NAME && cookie.value.startsWith(SESSION_COOKIE_PREFIX)) {
+        return cookie.value
+      }
+    }
+    return null
+  }
 }
 
 export function setCookieNames(response: Response): readonly string[] {
@@ -33,34 +46,9 @@ export function setCookieNames(response: Response): readonly string[] {
   })
 }
 
-export function sessionCookieFromResponse(
-  response: Response,
-  responseUrl: string,
-  workspace: string,
-  current: string | null,
-): string | null {
-  const hostname = new URL(responseUrl).hostname
-  if (hostname !== `${workspace}.slack.com` && hostname !== 'app.slack.com') return current
-  let sessionCookie = current
-  for (const setCookie of getSetCookies(response)) {
-    if (isDeletedSessionCookie(setCookie)) sessionCookie = null
-    else sessionCookie = parseSessionCookie(setCookie) ?? sessionCookie
-  }
-  return sessionCookie
-}
-
 function getSetCookies(response: Response): readonly string[] {
   const withGetter = response.headers as Headers & { getSetCookie?: () => string[] }
   if (typeof withGetter.getSetCookie === 'function') return withGetter.getSetCookie()
   const single = response.headers.get('set-cookie')
   return single ? [single] : []
-}
-
-function parseSessionCookie(setCookie: string): string | null {
-  const match = setCookie.match(/(?:^|,\s*)d=(xoxd-[^;]+)/)
-  return match?.[1] ?? null
-}
-
-function isDeletedSessionCookie(setCookie: string): boolean {
-  return /^d=/i.test(setCookie) && /(?:^|;)\s*max-age=0(?:;|$)/i.test(setCookie)
 }

--- a/src/platforms/slack/qr-http-login-2fa.test.ts
+++ b/src/platforms/slack/qr-http-login-2fa.test.ts
@@ -251,6 +251,32 @@ describe('loginWithQr confirmation code', () => {
     expect(destinationCookies).not.toContain('deleted=gone')
   })
 
+  it('discards a malformed Set-Cookie header without aborting a valid session cookie', async () => {
+    // Given a redirect that emits an unparseable cookie ahead of the valid d session cookie
+    const dataUrl = await qrDataUrl()
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`, [
+          'bogus=1; Domain=.com; Path=/',
+          `d=${D_COOKIE}; Domain=.slack.com; Path=/`,
+        ])
+      }
+      if (url.includes('/z-app-secret')) return new Response(null, { status: 200 })
+      if (url.includes('/ssb/redirect')) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When login processes the response
+    const session = await loginWithQr(dataUrl, { fetchImpl })
+
+    // Then the malformed cookie is silently discarded and the valid session cookie is captured
+    expect(session.cookie).toBe(D_COOKIE)
+    expect(session.token).toBe(TOKEN)
+  })
+
   it('does not retain a deleted Slack session cookie', async () => {
     // Given a redirect that creates and then deletes the d session cookie
     const dataUrl = await qrDataUrl()

--- a/src/platforms/slack/qr-http-login-2fa.test.ts
+++ b/src/platforms/slack/qr-http-login-2fa.test.ts
@@ -1,0 +1,244 @@
+import QRCode from 'qrcode'
+
+import { loginWithQr } from './qr-http-login'
+
+const WORKSPACE = 'acme'
+const QR_SECRET = 'z-app-1-2-abcdef'
+const MAGIC_LOGIN = 'z-app-1-3-ghijkl'
+const ZAPP_URL = `https://app.slack.com/t/${WORKSPACE}/login/${QR_SECRET}?src=qr_code&user_id=U1&team_id=T1`
+const D_COOKIE = 'xoxd-abc%2Bdef123'
+const TOKEN = `xoxc-1-2-3-${'a'.repeat(64)}`
+
+async function qrDataUrl(): Promise<string> {
+  return QRCode.toDataURL(ZAPP_URL, { margin: 2, width: 256 })
+}
+
+function redirect(location: string, setCookies: readonly string[] = []): Response {
+  const headers = new Headers({ location })
+  for (const cookie of setCookies) headers.append('set-cookie', cookie)
+  return new Response(null, { status: 302, headers })
+}
+
+function confirmationPage(email = 'user@acme.com'): Response {
+  const props = JSON.stringify({
+    action: 'request_primary',
+    emailAddress: email,
+    magicLogin: MAGIC_LOGIN,
+    twoFactorType: 'sms',
+  }).replaceAll('"', '&quot;')
+  return new Response(`<div id="props_node" data-props="${props}"></div>`, { status: 200 })
+}
+
+describe('loginWithQr confirmation code', () => {
+  it('keeps ordinary QR login prompt-free when Slack issues the session cookie directly', async () => {
+    // Given an ordinary QR redirect chain and an optional confirmation callback
+    const dataUrl = await qrDataUrl()
+    let confirmationRequests = 0
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`, [`d=${D_COOKIE}; Domain=.slack.com; Path=/`])
+      }
+      if (url.includes('/z-app-secret')) return new Response(null, { status: 200 })
+      if (url.includes('/ssb/redirect')) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When logging in through the unified QR flow
+    const session = await loginWithQr(dataUrl, {
+      fetchImpl,
+      requestConfirmationCode: async () => {
+        confirmationRequests += 1
+        return '123456'
+      },
+    })
+
+    // Then ordinary QR login succeeds without asking for a confirmation code
+    expect(session.token).toBe(TOKEN)
+    expect(confirmationRequests).toBe(0)
+  })
+
+  it('submits a confirmation code from Slack data-props and returns the session', async () => {
+    // Given a QR chain that reaches Slack's confirmation-code page
+    const dataUrl = await qrDataUrl()
+    const requests: Array<{ url: string; method: string; body: string }> = []
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = init?.method ?? 'GET'
+      const body = typeof init?.body === 'string' ? init.body : ''
+      requests.push({ url, method, body })
+
+      if (method === 'GET' && url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/login/${QR_SECRET}?src=qr_code&user_id=U1&team_id=T1`)
+      }
+      if (method === 'GET' && url.includes(`/login/${QR_SECRET}`)) return confirmationPage()
+      if (method === 'POST' && url.includes(`/login/${QR_SECRET}`)) {
+        return redirect('https://slack.com/checkcookie?redir=x', [`d=${D_COOKIE}; Domain=.slack.com; Path=/`])
+      }
+      if (url.includes('/ssb/redirect')) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`)
+    }) as typeof fetch
+
+    // When the caller supplies the code Slack sent
+    const session = await loginWithQr(dataUrl, {
+      fetchImpl,
+      requestConfirmationCode: async () => '123456',
+    })
+
+    // Then the server-issued magic login and entered code are posted to the exact workspace z-app URL
+    const post = requests.find((request) => request.method === 'POST')
+    expect(post?.url).toBe(
+      `https://${WORKSPACE}.slack.com/login/${QR_SECRET}?domain=${WORKSPACE}&domainLogin=1&email=user%40acme.com`,
+    )
+    expect(post?.body).toContain(`2fa_magiclogin=${MAGIC_LOGIN}`)
+    expect(post?.body).toContain('2fa_code=123456')
+    expect(post?.body).toContain('2fa_action=submit_primary')
+    expect(session).toEqual({ token: TOKEN, cookie: D_COOKIE, workspace: WORKSPACE })
+  })
+
+  it('rejects confirmation pages on another Slack subdomain before requesting the code', async () => {
+    // Given a QR chain redirected to a different Slack workspace host
+    const dataUrl = await qrDataUrl()
+    let confirmationRequests = 0
+    let postRequests = 0
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if ((init?.method ?? 'GET') === 'POST') postRequests += 1
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://other.slack.com/login/${QR_SECRET}`)
+      }
+      if (url.startsWith('https://other.slack.com/')) return confirmationPage()
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When the unified login evaluates the confirmation page
+    const promise = loginWithQr(dataUrl, {
+      fetchImpl,
+      requestConfirmationCode: async () => {
+        confirmationRequests += 1
+        return '123456'
+      },
+    })
+
+    // Then no authentication material is requested or posted to the wrong workspace host
+    await expect(promise).rejects.toThrow(/workspace host|session/)
+    expect(confirmationRequests).toBe(0)
+    expect(postRequests).toBe(0)
+  })
+
+  it('rejects an empty confirmation code without issuing a POST', async () => {
+    // Given a valid confirmation page and a caller that returns only whitespace
+    const dataUrl = await qrDataUrl()
+    let postRequests = 0
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') postRequests += 1
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/login/${QR_SECRET}`)
+      }
+      if (url.includes(`/login/${QR_SECRET}`)) return confirmationPage()
+      throw new Error(`unexpected fetch: ${method} ${url}`)
+    }) as typeof fetch
+
+    // When login receives the empty code
+    const promise = loginWithQr(dataUrl, {
+      fetchImpl,
+      requestConfirmationCode: async () => '   ',
+    })
+
+    // Then login fails before sending authentication material
+    await expect(promise).rejects.toThrow(/session|confirmation/)
+    expect(postRequests).toBe(0)
+  })
+
+  it('keeps debug output free of QR, email, code, and cookie secrets', async () => {
+    // Given a confirmation flow containing secret-bearing URLs and values
+    const dataUrl = await qrDataUrl()
+    const messages: string[] = []
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/login/${QR_SECRET}?email=user%40acme.com`)
+      }
+      if (method === 'GET' && url.includes(`/login/${QR_SECRET}`)) return confirmationPage()
+      if (method === 'POST') {
+        return redirect('https://slack.com/checkcookie', [`d=${D_COOKIE}; Domain=.slack.com; Path=/`])
+      }
+      if (url.includes('/ssb/redirect')) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`)
+    }) as typeof fetch
+
+    // When login emits debug messages
+    await loginWithQr(dataUrl, {
+      fetchImpl,
+      requestConfirmationCode: async () => '123456',
+      debug: (message) => messages.push(message),
+    })
+
+    // Then no authentication material appears in the debug channel
+    const output = messages.join('\n')
+    for (const secret of [QR_SECRET, MAGIC_LOGIN, 'user@acme.com', '123456', D_COOKIE, TOKEN]) {
+      expect(output).not.toContain(secret)
+    }
+  })
+
+  it('respects host, path, and deletion cookie semantics across redirects', async () => {
+    // Given scoped cookies with the same name plus an explicitly deleted cookie
+    const dataUrl = await qrDataUrl()
+    const observedCookies: Record<string, string | null> = {}
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      observedCookies[url] = new Headers(init?.headers).get('cookie')
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/login/${QR_SECRET}`, [
+          'hostOnly=app; Path=/',
+          'shared=root; Domain=.slack.com; Path=/',
+          'shared=login; Domain=.slack.com; Path=/login',
+          'deleted=gone; Domain=.slack.com; Path=/; Max-Age=0',
+        ])
+      }
+      if (url.includes(`/login/${QR_SECRET}`)) return new Response('<title>Link Expired</title>', { status: 200 })
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When redirects move from app.slack.com to the workspace login path
+    await expect(loginWithQr(dataUrl, { fetchImpl })).rejects.toThrow(/expired/)
+
+    // Then only cookies valid for that destination host and path are sent
+    const destinationCookies = observedCookies[`https://${WORKSPACE}.slack.com/login/${QR_SECRET}`]
+    expect(destinationCookies).not.toContain('hostOnly=app')
+    expect(destinationCookies).toContain('shared=root')
+    expect(destinationCookies).toContain('shared=login')
+    expect(destinationCookies).not.toContain('deleted=gone')
+  })
+
+  it('does not retain a deleted Slack session cookie', async () => {
+    // Given a redirect that creates and then deletes the d session cookie
+    const dataUrl = await qrDataUrl()
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/end`, [
+          `d=${D_COOKIE}; Domain=.slack.com; Path=/`,
+          'd=; Domain=.slack.com; Path=/; Max-Age=0',
+        ])
+      }
+      if (url === `https://${WORKSPACE}.slack.com/end`) return new Response(null, { status: 200 })
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When login processes the deleted session cookie
+    const promise = loginWithQr(dataUrl, { fetchImpl })
+
+    // Then the deleted session cannot authenticate the user
+    await expect(promise).rejects.toThrow(/session/)
+  })
+})

--- a/src/platforms/slack/qr-http-login-2fa.test.ts
+++ b/src/platforms/slack/qr-http-login-2fa.test.ts
@@ -130,6 +130,37 @@ describe('loginWithQr confirmation code', () => {
     expect(postRequests).toBe(0)
   })
 
+  it('rejects a same-workspace confirmation URL under an unexpected path prefix', async () => {
+    // Given a same-host redirect at an attacker-chosen path that still contains "/z-app-" and ends with the QR secret
+    const dataUrl = await qrDataUrl()
+    let confirmationRequests = 0
+    let postRequests = 0
+    const attackerPath = `/attacker-chosen/z-app-junk/${QR_SECRET}`
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if ((init?.method ?? 'GET') === 'POST') postRequests += 1
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com${attackerPath}`)
+      }
+      if (url === `https://${WORKSPACE}.slack.com${attackerPath}`) return confirmationPage()
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When the unified login evaluates the confirmation URL
+    const promise = loginWithQr(dataUrl, {
+      fetchImpl,
+      requestConfirmationCode: async () => {
+        confirmationRequests += 1
+        return '123456'
+      },
+    })
+
+    // Then no confirmation code is requested and no material is posted to the wrong path
+    await expect(promise).rejects.toThrow(/session|confirmation|origin/)
+    expect(confirmationRequests).toBe(0)
+    expect(postRequests).toBe(0)
+  })
+
   it('rejects an empty confirmation code without issuing a POST', async () => {
     // Given a valid confirmation page and a caller that returns only whitespace
     const dataUrl = await qrDataUrl()

--- a/src/platforms/slack/qr-http-login-2fa.test.ts
+++ b/src/platforms/slack/qr-http-login-2fa.test.ts
@@ -298,4 +298,103 @@ describe('loginWithQr confirmation code', () => {
     // Then the deleted session cannot authenticate the user
     await expect(promise).rejects.toThrow(/session/)
   })
+
+  it('does not capture a host-only d cookie set from app.slack.com when querying the workspace host', async () => {
+    // Given a d cookie set with no Domain attribute (host-only) on app.slack.com and a working token endpoint
+    const dataUrl = await qrDataUrl()
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/end`, [`d=${D_COOKIE}; Path=/; HttpOnly`])
+      }
+      if (url === `https://${WORKSPACE}.slack.com/end`) return new Response(null, { status: 200 })
+      if (url === `https://${WORKSPACE}.slack.com/ssb/redirect`) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When login queries the jar for the workspace-scoped session cookie
+    const promise = loginWithQr(dataUrl, { fetchImpl })
+
+    // Then the host-only cookie is not treated as a valid workspace session, so auth fails before minting a token
+    await expect(promise).rejects.toThrow(/Could not establish|expired/)
+  })
+
+  it('does not capture a d cookie scoped to a path outside the token URL', async () => {
+    // Given a d cookie scoped to a path the token URL does not fall under and a working token endpoint
+    const dataUrl = await qrDataUrl()
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/end`, [
+          `d=${D_COOKIE}; Domain=.slack.com; Path=/nowhere`,
+        ])
+      }
+      if (url === `https://${WORKSPACE}.slack.com/end`) return new Response(null, { status: 200 })
+      if (url === `https://${WORKSPACE}.slack.com/ssb/redirect`) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When login queries the jar for a cookie sendable to /ssb/redirect
+    const promise = loginWithQr(dataUrl, { fetchImpl })
+
+    // Then the path-restricted cookie is not returned for the token URL, so auth fails before minting a token
+    await expect(promise).rejects.toThrow(/Could not establish|expired/)
+  })
+
+  it('treats a d cookie with a past Expires date as deleted', async () => {
+    // Given a d cookie set and then invalidated via an Expires date in the past, plus a working token endpoint
+    const dataUrl = await qrDataUrl()
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/end`, [
+          `d=${D_COOKIE}; Domain=.slack.com; Path=/`,
+          'd=; Domain=.slack.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+        ])
+      }
+      if (url === `https://${WORKSPACE}.slack.com/end`) return new Response(null, { status: 200 })
+      if (url === `https://${WORKSPACE}.slack.com/ssb/redirect`) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When login processes the expired cookie
+    const promise = loginWithQr(dataUrl, { fetchImpl })
+
+    // Then the expired session is dropped and auth fails before minting a token
+    await expect(promise).rejects.toThrow(/Could not establish|expired/)
+  })
+
+  it('honors a d cookie deletion issued from slack.com root during a later hop', async () => {
+    // Given a workspace-issued d cookie followed by a slack.com-root deletion for the same .slack.com scope
+    const dataUrl = await qrDataUrl()
+    const fetchImpl = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.startsWith('https://app.slack.com/t/')) {
+        return redirect(`https://${WORKSPACE}.slack.com/hop-2`, [`d=${D_COOKIE}; Domain=.slack.com; Path=/`])
+      }
+      if (url === `https://${WORKSPACE}.slack.com/hop-2`) {
+        return redirect('https://slack.com/checkcookie')
+      }
+      if (url === 'https://slack.com/checkcookie') {
+        return redirect(`https://${WORKSPACE}.slack.com/end`, ['d=; Domain=.slack.com; Path=/; Max-Age=0'])
+      }
+      if (url === `https://${WORKSPACE}.slack.com/end`) return new Response(null, { status: 200 })
+      if (url === `https://${WORKSPACE}.slack.com/ssb/redirect`) {
+        return new Response(`<script>var boot_data={"api_token":"${TOKEN}"}</script>`, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    // When login processes the deletion issued from the slack.com root
+    const promise = loginWithQr(dataUrl, { fetchImpl })
+
+    // Then the earlier workspace cookie is not resurrected and auth fails before minting a token
+    await expect(promise).rejects.toThrow(/Could not establish|expired/)
+  })
 })

--- a/src/platforms/slack/qr-http-login.test.ts
+++ b/src/platforms/slack/qr-http-login.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import QRCode from 'qrcode'
 
 import { SlackError } from '@/platforms/slack/client'
-import { isSlackHost, loginWithQr, parseDCookie } from '@/platforms/slack/qr-http-login'
+import { isSlackHost, loginWithQr } from '@/platforms/slack/qr-http-login'
 
 const WORKSPACE = 'acme'
 const ZAPP_URL = `https://app.slack.com/t/${WORKSPACE}/login/z-app-1-2-abcdef?src=qr_code&user_id=U1&team_id=T1`
@@ -24,20 +24,6 @@ const originalFetch = globalThis.fetch
 
 afterEach(() => {
   globalThis.fetch = originalFetch
-})
-
-describe('parseDCookie', () => {
-  it('extracts the d cookie value from a Set-Cookie header', () => {
-    expect(parseDCookie(`d=${D_COOKIE}; Path=/; HttpOnly; Secure`)).toBe(D_COOKIE)
-  })
-
-  it('ignores a non-d cookie', () => {
-    expect(parseDCookie('x=somevalue; Path=/')).toBeNull()
-  })
-
-  it('ignores a d cookie that is not an xoxd value', () => {
-    expect(parseDCookie('d=plainvalue; Path=/')).toBeNull()
-  })
 })
 
 describe('isSlackHost', () => {
@@ -68,7 +54,7 @@ describe('loginWithQr', () => {
         return redirect(`https://${WORKSPACE}.slack.com/app-redir/login/x`)
       }
       if (url.includes('/app-redir/login/')) {
-        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`, `d=${D_COOKIE}; HttpOnly`)
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`, `d=${D_COOKIE}; Domain=.slack.com; Path=/; HttpOnly`)
       }
       if (url.includes('/z-app-secret')) {
         return redirect('https://slack.com/checkcookie?redir=x')
@@ -102,7 +88,7 @@ describe('loginWithQr', () => {
       requests.push({ url, cookie: headers.get('cookie') })
 
       if (url.startsWith('https://app.slack.com/t/')) {
-        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`, `d=${D_COOKIE}; HttpOnly`)
+        return redirect(`https://${WORKSPACE}.slack.com/z-app-secret`, `d=${D_COOKIE}; Domain=.slack.com; Path=/; HttpOnly`)
       }
       if (url.includes('/z-app-secret')) {
         return redirect('https://idp.example.com/saml/login')
@@ -186,7 +172,7 @@ describe('loginWithQr', () => {
     const stepAFetch = (async (input: string | URL) => {
       const url = typeof input === 'string' ? input : input.toString()
       if (url.startsWith('https://app.slack.com/t/')) {
-        return redirect(`https://${WORKSPACE}.slack.com/end`, `d=${D_COOKIE}; HttpOnly`)
+        return redirect(`https://${WORKSPACE}.slack.com/end`, `d=${D_COOKIE}; Domain=.slack.com; Path=/; HttpOnly`)
       }
       return new Response(null, { status: 200 })
     }) as typeof fetch

--- a/src/platforms/slack/qr-http-login.ts
+++ b/src/platforms/slack/qr-http-login.ts
@@ -1,5 +1,7 @@
 import { SlackError } from './client'
 import { refreshTokenFromWeb } from './ensure-auth'
+import { buildConfirmationRequest, parseConfirmationPage, type SlackConfirmationCodeRequest } from './qr-confirmation'
+import { sessionCookieFromResponse, setCookieNames, SlackCookieJar } from './qr-cookie-jar'
 import { decodeSlackQr } from './qr-login'
 
 export interface QrSession {
@@ -12,10 +14,9 @@ export interface QrLoginOptions {
   fetchImpl?: typeof fetch
   maxRedirects?: number
   debug?: (message: string) => void
+  requestConfirmationCode?: SlackConfirmationCodeRequest
 }
 
-const BROWSER_USER_AGENT =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
 const DEFAULT_MAX_REDIRECTS = 10
 
 export async function loginWithQr(dataUrl: string, options: QrLoginOptions = {}): Promise<QrSession> {
@@ -23,7 +24,7 @@ export async function loginWithQr(dataUrl: string, options: QrLoginOptions = {})
   const debug = options.debug
   debug?.(`Decoded QR for workspace ${login.workspace}`)
 
-  const { cookie, denialReason, ssoProvider } = await captureDCookie(login.url, options)
+  const { cookie, denialReason, ssoProvider } = await captureDCookie(login, options)
   if (!cookie) {
     throw new SlackError(
       qrSessionFailureMessage(denialReason, { workspace: login.workspace, ssoProvider }),
@@ -103,16 +104,19 @@ interface CookieCapture {
   ssoProvider: string | null
 }
 
-async function captureDCookie(startUrl: string, options: QrLoginOptions): Promise<CookieCapture> {
+async function captureDCookie(
+  login: ReturnType<typeof decodeSlackQr>,
+  options: QrLoginOptions,
+): Promise<CookieCapture> {
   const doFetch = options.fetchImpl ?? fetch
   const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS
   const debug = options.debug
 
-  let url = startUrl
+  let url = login.url
   let dCookie: string | null = null
   let sessionDenialReason: string | null = null
   let ssoProvider: string | null = null
-  const cookieJar: string[] = []
+  const cookieJar = new SlackCookieJar()
 
   for (let hop = 0; hop < maxRedirects; hop++) {
     // Only ever send captured cookies (including the d session cookie) to Slack
@@ -123,31 +127,57 @@ async function captureDCookie(startUrl: string, options: QrLoginOptions): Promis
       break
     }
 
-    const response = await doFetch(url, {
-      redirect: 'manual',
-      headers: {
-        'User-Agent': BROWSER_USER_AGENT,
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.9',
-        ...(cookieJar.length ? { Cookie: cookieJar.join('; ') } : {}),
-      },
-    })
+    const response = await cookieJar.fetch(doFetch, url)
+    dCookie = sessionCookieFromResponse(response, url, login.workspace, dCookie)
 
-    const cookieNames: string[] = []
-    for (const setCookie of getSetCookies(response)) {
-      const value = parseDCookie(setCookie)
-      if (value) dCookie = value
-      const name = setCookie.split('=')[0]?.trim()
-      if (name) cookieNames.push(name)
-      const pair = setCookie.split(';')[0]?.trim()
-      if (pair) cookieJar.push(pair)
-    }
-
+    const cookieNames = setCookieNames(response)
     debug?.(`hop ${hop}: ${response.status} set-cookie=[${cookieNames.join(',') || 'none'}]`)
 
     const location = response.status >= 300 && response.status < 400 ? response.headers.get('location') : null
     if (!location) {
-      if (!dCookie) sessionDenialReason = await classifySessionDenial(response)
+      if (!dCookie) {
+        const body = await response.text()
+        const props = parseConfirmationPage(body)
+        if (props && options.requestConfirmationCode) {
+          const request = buildConfirmationRequest(login, url, props, '')
+          if (!request) {
+            sessionDenialReason = 'invalid_confirmation_origin'
+            break
+          }
+          const code = await options.requestConfirmationCode({
+            email: props.emailAddress,
+            type: props.twoFactorType,
+          })
+          if (code.trim() === '') {
+            sessionDenialReason = 'confirmation_failed'
+            break
+          }
+          const confirmedRequest = buildConfirmationRequest(login, url, props, code)
+          if (!confirmedRequest) {
+            sessionDenialReason = 'invalid_confirmation_origin'
+            break
+          }
+          const confirmed = await cookieJar.fetch(doFetch, confirmedRequest.url, {
+            method: 'POST',
+            body: confirmedRequest.body,
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          })
+          debug?.(`confirmation submit: ${confirmed.status}`)
+          dCookie = await followConfirmationRedirects(
+            confirmed,
+            confirmedRequest.url,
+            login.workspace,
+            dCookie,
+            cookieJar,
+            doFetch,
+            maxRedirects,
+            debug,
+          )
+          if (!dCookie) sessionDenialReason = 'confirmation_failed'
+        } else {
+          sessionDenialReason = classifySessionDenialBody(body)
+        }
+      }
       break
     }
 
@@ -163,10 +193,48 @@ async function captureDCookie(startUrl: string, options: QrLoginOptions): Promis
       debug?.(`hop ${hop}: redirect target is not a Slack host (${new URL(next).hostname}), stopping`)
       break
     }
+    if (!dCookie && options.requestConfirmationCode && isWorkspaceConfirmationUrl(next, login.workspace) === false) {
+      sessionDenialReason = 'invalid_confirmation_origin'
+      break
+    }
     url = next
   }
 
   return { cookie: dCookie, denialReason: sessionDenialReason, ssoProvider }
+}
+
+function isWorkspaceConfirmationUrl(rawUrl: string, workspace: string): boolean | null {
+  const url = new URL(rawUrl)
+  if (!url.pathname.includes('/z-app-')) return null
+  return url.hostname === `${workspace}.slack.com`
+}
+
+async function followConfirmationRedirects(
+  response: Response,
+  responseUrl: string,
+  workspace: string,
+  sessionCookie: string | null,
+  cookieJar: SlackCookieJar,
+  doFetch: typeof fetch,
+  maxRedirects: number,
+  debug?: (message: string) => void,
+): Promise<string | null> {
+  let currentResponse = response
+  let currentUrl = responseUrl
+  let currentSessionCookie = sessionCookieFromResponse(currentResponse, currentUrl, workspace, sessionCookie)
+  for (let hop = 0; hop < maxRedirects; hop++) {
+    if (currentSessionCookie) return currentSessionCookie
+    const location =
+      currentResponse.status >= 300 && currentResponse.status < 400 ? currentResponse.headers.get('location') : null
+    if (!location) return null
+    const next = new URL(location, currentUrl).toString()
+    if (!isSlackHost(next)) return null
+    currentUrl = next
+    currentResponse = await cookieJar.fetch(doFetch, currentUrl)
+    currentSessionCookie = sessionCookieFromResponse(currentResponse, currentUrl, workspace, currentSessionCookie)
+    debug?.(`confirmation hop ${hop}: ${currentResponse.status}`)
+  }
+  return currentSessionCookie
 }
 
 function ssoProviderFromUrl(rawUrl: string): string | null {
@@ -185,19 +253,12 @@ function ssoProviderFromUrl(rawUrl: string): string | null {
   return null
 }
 
-async function classifySessionDenial(response: Response): Promise<string | null> {
-  try {
-    const body = await response.text()
-    if (/Link Expired/i.test(body) || /trouble signing you in/i.test(body)) {
-      return 'link_expired'
-    }
-    if (/sign in on your other device/i.test(body) || /open Slack/i.test(body) || /confirm/i.test(body)) {
-      return 'awaiting_device_confirmation'
-    }
-    return null
-  } catch {
-    return null
+function classifySessionDenialBody(body: string): string | null {
+  if (/Link Expired/i.test(body) || /trouble signing you in/i.test(body)) return 'link_expired'
+  if (/sign in on your other device/i.test(body) || /open Slack/i.test(body) || /confirm/i.test(body)) {
+    return 'awaiting_device_confirmation'
   }
+  return null
 }
 
 export function isSlackHost(rawUrl: string): boolean {
@@ -213,13 +274,4 @@ export function isSlackHost(rawUrl: string): boolean {
 export function parseDCookie(setCookieHeader: string): string | null {
   const match = setCookieHeader.match(/(?:^|,\s*)d=(xoxd-[^;]+)/)
   return match ? match[1] : null
-}
-
-function getSetCookies(response: Response): string[] {
-  const withGetter = response.headers as Headers & { getSetCookie?: () => string[] }
-  if (typeof withGetter.getSetCookie === 'function') {
-    return withGetter.getSetCookie()
-  }
-  const single = response.headers.get('set-cookie')
-  return single ? [single] : []
 }

--- a/src/platforms/slack/qr-http-login.ts
+++ b/src/platforms/slack/qr-http-login.ts
@@ -1,6 +1,11 @@
 import { SlackError } from './client'
 import { refreshTokenFromWeb } from './ensure-auth'
-import { buildConfirmationRequest, parseConfirmationPage, type SlackConfirmationCodeRequest } from './qr-confirmation'
+import {
+  buildConfirmationRequest,
+  expectedConfirmationPath,
+  parseConfirmationPage,
+  type SlackConfirmationCodeRequest,
+} from './qr-confirmation'
 import { sessionCookieFromResponse, setCookieNames, SlackCookieJar } from './qr-cookie-jar'
 import { decodeSlackQr } from './qr-login'
 
@@ -193,7 +198,7 @@ async function captureDCookie(
       debug?.(`hop ${hop}: redirect target is not a Slack host (${new URL(next).hostname}), stopping`)
       break
     }
-    if (!dCookie && options.requestConfirmationCode && isWorkspaceConfirmationUrl(next, login.workspace) === false) {
+    if (!dCookie && options.requestConfirmationCode && isWorkspaceConfirmationUrl(next, login) === false) {
       sessionDenialReason = 'invalid_confirmation_origin'
       break
     }
@@ -203,10 +208,12 @@ async function captureDCookie(
   return { cookie: dCookie, denialReason: sessionDenialReason, ssoProvider }
 }
 
-function isWorkspaceConfirmationUrl(rawUrl: string, workspace: string): boolean | null {
+function isWorkspaceConfirmationUrl(rawUrl: string, login: ReturnType<typeof decodeSlackQr>): boolean | null {
+  const expected = expectedConfirmationPath(login)
+  if (!expected) return null
   const url = new URL(rawUrl)
-  if (!url.pathname.includes('/z-app-')) return null
-  return url.hostname === `${workspace}.slack.com`
+  if (url.pathname !== expected) return null
+  return url.hostname === `${login.workspace}.slack.com`
 }
 
 async function followConfirmationRedirects(

--- a/src/platforms/slack/qr-http-login.ts
+++ b/src/platforms/slack/qr-http-login.ts
@@ -6,7 +6,7 @@ import {
   parseConfirmationPage,
   type SlackConfirmationCodeRequest,
 } from './qr-confirmation'
-import { sessionCookieFromResponse, setCookieNames, SlackCookieJar } from './qr-cookie-jar'
+import { setCookieNames, SlackCookieJar } from './qr-cookie-jar'
 import { decodeSlackQr } from './qr-login'
 
 export interface QrSession {
@@ -122,6 +122,7 @@ async function captureDCookie(
   let sessionDenialReason: string | null = null
   let ssoProvider: string | null = null
   const cookieJar = new SlackCookieJar()
+  const sessionCookieUrl = tokenUrl(login.workspace)
 
   for (let hop = 0; hop < maxRedirects; hop++) {
     // Only ever send captured cookies (including the d session cookie) to Slack
@@ -133,7 +134,7 @@ async function captureDCookie(
     }
 
     const response = await cookieJar.fetch(doFetch, url)
-    dCookie = sessionCookieFromResponse(response, url, login.workspace, dCookie)
+    dCookie = await cookieJar.sessionCookie(sessionCookieUrl)
 
     const cookieNames = setCookieNames(response)
     debug?.(`hop ${hop}: ${response.status} set-cookie=[${cookieNames.join(',') || 'none'}]`)
@@ -171,8 +172,7 @@ async function captureDCookie(
           dCookie = await followConfirmationRedirects(
             confirmed,
             confirmedRequest.url,
-            login.workspace,
-            dCookie,
+            sessionCookieUrl,
             cookieJar,
             doFetch,
             maxRedirects,
@@ -219,8 +219,7 @@ function isWorkspaceConfirmationUrl(rawUrl: string, login: ReturnType<typeof dec
 async function followConfirmationRedirects(
   response: Response,
   responseUrl: string,
-  workspace: string,
-  sessionCookie: string | null,
+  sessionCookieUrl: string,
   cookieJar: SlackCookieJar,
   doFetch: typeof fetch,
   maxRedirects: number,
@@ -228,7 +227,7 @@ async function followConfirmationRedirects(
 ): Promise<string | null> {
   let currentResponse = response
   let currentUrl = responseUrl
-  let currentSessionCookie = sessionCookieFromResponse(currentResponse, currentUrl, workspace, sessionCookie)
+  let currentSessionCookie = await cookieJar.sessionCookie(sessionCookieUrl)
   for (let hop = 0; hop < maxRedirects; hop++) {
     if (currentSessionCookie) return currentSessionCookie
     const location =
@@ -238,10 +237,14 @@ async function followConfirmationRedirects(
     if (!isSlackHost(next)) return null
     currentUrl = next
     currentResponse = await cookieJar.fetch(doFetch, currentUrl)
-    currentSessionCookie = sessionCookieFromResponse(currentResponse, currentUrl, workspace, currentSessionCookie)
+    currentSessionCookie = await cookieJar.sessionCookie(sessionCookieUrl)
     debug?.(`confirmation hop ${hop}: ${currentResponse.status}`)
   }
   return currentSessionCookie
+}
+
+function tokenUrl(workspace: string): string {
+  return `https://${workspace}.slack.com/ssb/redirect`
 }
 
 function ssoProviderFromUrl(rawUrl: string): string | null {
@@ -276,9 +279,4 @@ export function isSlackHost(rawUrl: string): boolean {
   } catch {
     return false
   }
-}
-
-export function parseDCookie(setCookieHeader: string): string | null {
-  const match = setCookieHeader.match(/(?:^|,\s*)d=(xoxd-[^;]+)/)
-  return match ? match[1] : null
 }


### PR DESCRIPTION
## Summary

Add Slack confirmation-code support to the QR authentication flow.

This enables clients such as TypeClaw to provide a confirmation code when Slack requires additional verification, while preserving the existing prompt-free flow for ordinary QR logins.

Ported from the protocol behavior introduced in TypeClaw PR:
- https://github.com/typeclaw/typeclaw/pull/1235

## Changes

- Add an optional `requestConfirmationCode` callback to `loginWithQr`
- Detect and parse Slack confirmation pages
- Submit confirmation codes to the exact `https://<workspace>.slack.com/login/<qrSecret>` endpoint derived from the QR payload (via a shared `expectedConfirmationPath` helper)
- Preserve the existing non-confirmation QR login flow
- Validate redirect workspace hosts and require the exact `/login/<qrSecret>` pathname before requesting or submitting a code
- Use `tough-cookie` for RFC-compliant cookie handling, and derive the `d` session cookie exclusively from the jar via `SlackCookieJar.sessionCookie(url)` so domain, path, expiry (`Max-Age`, `Expires`), and cross-subdomain deletion are enforced natively — replaces the previous regex-based `sessionCookieFromResponse`
- Isolate per-cookie parse errors with `{ ignoreError: true }` so a single invalid `Set-Cookie` header (malformed value, public-suffix domain, mismatched host, etc.) no longer aborts the auth flow
- Prevent QR secrets, confirmation codes, cookies, and tokens from appearing in debug logs
- Export the public confirmation challenge and callback types
- Add co-located tests for the confirmation flow and security regressions
- Document `requestConfirmationCode` and its challenge/result contract in the Slack SDK skill

## Security

The confirmation exchange is restricted to:

- The workspace hostname encoded in the original QR payload
- The exact `/login/<qrSecret>` pathname derived from the QR payload (previously a loose `pathname.includes('/z-app-')` + last-segment check, which permitted a same-workspace redirect to an attacker-chosen prefix such as `/attacker/z-app-junk/<qrSecret>`)

Redirects to a different Slack workspace, or to an unexpected pathname on the same workspace, are rejected before the confirmation callback is invoked or any credential is posted.

The `d` session cookie is now sourced exclusively from the tough-cookie jar at the token URL (`https://<workspace>.slack.com/ssb/redirect`), so:

- Host-only cookies set on `app.slack.com` are not treated as valid workspace sessions
- Cookies scoped to a path outside the token URL are not captured
- Expired cookies (past `Expires`, non-positive `Max-Age`) are correctly dropped
- `.slack.com`-scoped deletions issued from any Slack subdomain (including `slack.com` root during checkcookie hops) correctly invalidate the session

Sensitive values are excluded from debug logs, including:

- QR secrets and magic-login values
- Email addresses
- Confirmation codes
- Session cookies
- Authentication tokens

## Testing

Tests were written first following the repository's TDD guidelines.

Verified:

- [x] Slack QR authentication tests — 36 passed (up from 20 after review-fix regression coverage)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] Changed-file formatting
- [x] Slack CLI `auth qr --help`

Regression tests added in response to review feedback:

- Same-workspace `/attacker/z-app-junk/<qrSecret>` prefix bypass is rejected before the code is requested
- Malformed `Set-Cookie` (e.g. `Domain=.com` public-suffix violation) does not abort a valid session cookie in the same response
- Host-only `d` cookie set on `app.slack.com` is not captured for the workspace token URL
- `d` cookie with a path outside `/ssb/redirect` is not captured
- `d` cookie deletion via past `Expires` is honored
- `.slack.com`-scoped `d` cookie deletion issued from the `slack.com` root during a later hop is honored

Pre-existing fixtures that emitted host-only `d` cookies (non-representative of production Slack, which sends `Domain=.slack.com; Path=/`) are updated to the production shape so they exercise the jar-backed path faithfully.

The repository-wide test run reached 3,612 passing tests but did not complete within the execution timeout because of four existing Slack `TokenExtractor` timeout failures unrelated to this change.

The repository-wide formatting check is also currently blocked by an existing docs dependency-resolution error for `fumadocs-ui/css/neutral.css`. Formatting checks for all changed files pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Slack QR confirmation-code support to the QR login flow so clients can complete 2FA when Slack asks for a code. Tightens confirmation path validation and uses RFC‑compliant cookie handling to match browser behavior.

- New Features
  - Added optional `requestConfirmationCode` to `loginWithQr` to handle Slack confirmation pages; ordinary QR logins remain prompt-free.
  - Exported `SlackConfirmationChallenge` and `SlackConfirmationCodeRequest`; debug logs redact QR secrets, emails, codes, cookies, and tokens.

- Bug Fixes
  - Enforce exact workspace origin for confirmation: require `https://<workspace>.slack.com/login/<qrSecret>`; reject other hosts or paths before prompting or posting.
  - Read the `d` session cookie from a `tough-cookie` jar to honor host/path/expiry/deletions and ignore bad Set-Cookie headers; regression tests added.

Docs: SKILL.md updated.

<sup>Written for commit 6257cfb0d26fcadd140b93da11a5b680cd3bba4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


