### PR TITLE
fix(channeltalk): extract cookies from the rebranded Channel Works app

### DIFF
--- a/docs/content/docs/cli/channeltalk.mdx
+++ b/docs/content/docs/cli/channeltalk.mdx
@@ -238,16 +238,16 @@ Use **agent-channeltalk** when you want zero-config access acting as yourself. U
 
 ### Channel Talk desktop app not found
 
-The CLI looks for the Channel Talk desktop app's cookie database in:
+The CLI looks for the desktop app's cookie database in the locations below. The app was rebranded from Channel Talk to Channel Works, so both names are probed, `Channel Works` first.
 
 **macOS:**
 
-1. `~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/Channel Talk/Cookies` (Mac App Store)
-2. `~/Library/Application Support/Channel Talk/Cookies` (Electron version)
+1. `~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/{Channel Works,Channel Talk}/Cookies` (Mac App Store)
+2. `~/Library/Application Support/{Channel Works,Channel Talk}/Cookies` (Electron version)
 
 **Windows:**
 
-1. `%APPDATA%\Channel Talk\Network\Cookies`
+1. `%APPDATA%\{Channel Works,Channel Talk}\Network\Cookies`
 
 If none exist, either install the Channel Talk desktop app and log in, or log in via a Chromium browser (Chrome, Edge, Arc, Brave, etc.) — the CLI will fall back to browser extraction automatically.
 

--- a/skills/agent-channeltalk/SKILL.md
+++ b/skills/agent-channeltalk/SKILL.md
@@ -438,14 +438,14 @@ npx -y agent-messenger channeltalk snapshot --pretty
 
 ### Channel Talk desktop app not found
 
-The CLI looks for the Channel Talk desktop app's cookie database in these locations:
+The CLI looks for the desktop app's cookie database in these locations. The app was rebranded from Channel Talk to Channel Works, so both names are probed, `Channel Works` first.
 
 **macOS:**
-1. `~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/Channel Talk/Cookies` (Mac App Store version)
-2. `~/Library/Application Support/Channel Talk/Cookies` (direct download / Electron version)
+1. `~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/{Channel Works,Channel Talk}/Cookies` (Mac App Store version)
+2. `~/Library/Application Support/{Channel Works,Channel Talk}/Cookies` (direct download / Electron version)
 
 **Windows:**
-1. `%APPDATA%\Channel Talk\Network\Cookies`
+1. `%APPDATA%\{Channel Works,Channel Talk}\Network\Cookies`
 
 If none exist, log in to Channel Talk in a supported Chromium browser (Chrome, Edge, Arc, Brave) or install the desktop app and log in.
 

--- a/skills/agent-channeltalk/references/authentication.md
+++ b/skills/agent-channeltalk/references/authentication.md
@@ -29,7 +29,7 @@ Use `--browser-profile <path>` for agent-browser profiles, custom Chrome user da
 1. Locates the Channel Talk desktop app's SQLite cookie database
 2. Scans Chromium browser profiles for Channel Talk cookies when the desktop app isn't found, or when custom `--browser-profile` paths are provided
 3. Copies the database to a temp file (avoids locking the original)
-4. Reads `x-account` and `ch-session-1` cookies for `*.channel.io`
+4. Reads `x-account` and `ch-session-1` cookies for `*.channel.io` and `*.channel.works`
 5. Decrypts encrypted cookies if needed (macOS Keychain, Linux peanuts, Windows DPAPI)
 6. Validates cookies against the Channel Talk API
 7. Discovers ALL workspaces you belong to
@@ -48,15 +48,19 @@ When extracting from the desktop app, no Keychain prompt is needed (cookies are 
 
 ### Platform-Specific Paths
 
+The desktop app was rebranded from Channel Talk to Channel Works. Both directory names are probed, `Channel Works` first, so upgraded and legacy installs both work.
+
 **macOS (Mac App Store / sandboxed):**
 
 ```
+~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/Channel Works/Cookies
 ~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/Channel Talk/Cookies
 ```
 
 **macOS (Electron / direct download):**
 
 ```
+~/Library/Application Support/Channel Works/Cookies
 ~/Library/Application Support/Channel Talk/Cookies
 ```
 
@@ -253,10 +257,10 @@ No credentials are configured and auto-extraction failed:
 
 The CLI first checks for the desktop app, then falls back to Chromium browsers.
 
-Desktop app paths:
-1. **macOS (Mac App Store)**: `~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/Channel Talk/Cookies`
-2. **macOS (Electron)**: `~/Library/Application Support/Channel Talk/Cookies`
-3. **Windows**: `%APPDATA%/Channel Talk/Network/Cookies`
+Desktop app paths (`Channel Works` is the current name, `Channel Talk` the legacy one; both are probed):
+1. **macOS (Mac App Store)**: `~/Library/Containers/com.zoyi.channel.desk.osx/Data/Library/Application Support/{Channel Works,Channel Talk}/Cookies`
+2. **macOS (Electron)**: `~/Library/Application Support/{Channel Works,Channel Talk}/Cookies`
+3. **Windows**: `%APPDATA%/{Channel Works,Channel Talk}/Network/Cookies`
 
 If neither the desktop app nor browser cookies are found:
 

--- a/src/platforms/channeltalk/token-extractor.test.ts
+++ b/src/platforms/channeltalk/token-extractor.test.ts
@@ -18,9 +18,59 @@ describe('ChannelTokenExtractor', () => {
   })
 
   describe('getAppDataDir', () => {
+    const originalAppData = process.env.APPDATA
+
+    afterEach(() => {
+      if (originalAppData === undefined) delete process.env.APPDATA
+      else process.env.APPDATA = originalAppData
+    })
+
     it('returns null for unsupported platform', () => {
       const extractor = new ChannelTokenExtractor('freebsd' as NodeJS.Platform)
       expect(extractor.getAppDataDir()).toBeNull()
+    })
+
+    it('resolves the rebranded Channel Works directory', () => {
+      // given
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-appdata-'))
+      tempDirs.push(tempDir)
+      mkdirSync(join(tempDir, 'Channel Works'), { recursive: true })
+      process.env.APPDATA = tempDir
+
+      // when
+      const extractor = new ChannelTokenExtractor('win32')
+
+      // then
+      expect(extractor.getAppDataDir()).toBe(join(tempDir, 'Channel Works'))
+    })
+
+    it('falls back to the legacy Channel Talk directory', () => {
+      // given
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-appdata-'))
+      tempDirs.push(tempDir)
+      mkdirSync(join(tempDir, 'Channel Talk'), { recursive: true })
+      process.env.APPDATA = tempDir
+
+      // when
+      const extractor = new ChannelTokenExtractor('win32')
+
+      // then
+      expect(extractor.getAppDataDir()).toBe(join(tempDir, 'Channel Talk'))
+    })
+
+    it('prefers Channel Works when an upgraded install keeps both directories', () => {
+      // given
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-appdata-'))
+      tempDirs.push(tempDir)
+      mkdirSync(join(tempDir, 'Channel Talk'), { recursive: true })
+      mkdirSync(join(tempDir, 'Channel Works'), { recursive: true })
+      process.env.APPDATA = tempDir
+
+      // when
+      const extractor = new ChannelTokenExtractor('win32')
+
+      // then
+      expect(extractor.getAppDataDir()).toBe(join(tempDir, 'Channel Works'))
     })
   })
 
@@ -171,6 +221,39 @@ describe('ChannelTokenExtractor', () => {
           sessionCookie: 'session-jwt',
         },
       ])
+    })
+
+    it('extracts cookies stored on the rebranded channel.works domain', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
+      tempDirs.push(tempDir)
+      const dbPath = join(tempDir, 'Cookies')
+      await createCookieDatabase(dbPath, [
+        { name: 'x-account', value: 'account-jwt', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+        { name: 'ch-session-1', value: 'session-jwt', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+      ])
+
+      class TestExtractor extends ChannelTokenExtractor {
+        constructor(private dbPath: string) {
+          super('darwin')
+        }
+
+        override getCookiesPath(): string | null {
+          return this.dbPath
+        }
+      }
+
+      const extractor = new TestExtractor(dbPath)
+      // Browser profiles are stubbed out so a real logged-in browser on the host cannot leak in.
+      const browserSpy = spyOn(extractor as any, 'extractAllFromBrowserPaths').mockResolvedValue([])
+
+      expect(await extractor.extract()).toEqual([
+        {
+          accountCookie: 'account-jwt',
+          sessionCookie: 'session-jwt',
+        },
+      ])
+
+      browserSpy.mockRestore()
     })
 
     it('returns token with undefined sessionCookie when only x-account is present', async () => {

--- a/src/platforms/channeltalk/token-extractor.test.ts
+++ b/src/platforms/channeltalk/token-extractor.test.ts
@@ -223,6 +223,87 @@ describe('ChannelTokenExtractor', () => {
       ])
     })
 
+    it('ignores look-alike hosts that merely contain a channel domain', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
+      tempDirs.push(tempDir)
+      const dbPath = join(tempDir, 'Cookies')
+      // These hosts all contain a channel domain as a substring but are not the domain nor a
+      // subdomain of it, so nobody who controls one may speak for Channel. They are inserted
+      // first so a substring match would let them shadow the real cookies below.
+      await createCookieDatabase(dbPath, [
+        {
+          name: 'x-account',
+          value: 'imposter-account',
+          encrypted_value: Buffer.alloc(0),
+          host_key: '.channel.works.example.com',
+        },
+        {
+          name: 'ch-session-1',
+          value: 'imposter-session',
+          encrypted_value: Buffer.alloc(0),
+          host_key: '.channel.works.example.com',
+        },
+        { name: 'x-account', value: 'imposter-io', encrypted_value: Buffer.alloc(0), host_key: '.channel.io.evil.net' },
+        { name: 'x-account', value: 'real-account', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+        { name: 'ch-session-1', value: 'real-session', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+      ])
+
+      class TestExtractor extends ChannelTokenExtractor {
+        constructor(private dbPath: string) {
+          super('darwin')
+        }
+
+        override getCookiesPath(): string | null {
+          return this.dbPath
+        }
+      }
+
+      const extractor = new TestExtractor(dbPath)
+      const browserSpy = spyOn(extractor as any, 'extractAllFromBrowserPaths').mockResolvedValue([])
+
+      expect(await extractor.extract()).toEqual([
+        {
+          accountCookie: 'real-account',
+          sessionCookie: 'real-session',
+        },
+      ])
+
+      browserSpy.mockRestore()
+    })
+
+    it('extracts cookies from a subdomain of a channel domain', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
+      tempDirs.push(tempDir)
+      const dbPath = join(tempDir, 'Cookies')
+      // The boundary check must not be so strict that it drops legitimate subdomains.
+      await createCookieDatabase(dbPath, [
+        { name: 'x-account', value: 'account-jwt', encrypted_value: Buffer.alloc(0), host_key: '.desk.channel.works' },
+        { name: 'ch-session-1', value: 'session-jwt', encrypted_value: Buffer.alloc(0), host_key: 'channel.works' },
+      ])
+
+      class TestExtractor extends ChannelTokenExtractor {
+        constructor(private dbPath: string) {
+          super('darwin')
+        }
+
+        override getCookiesPath(): string | null {
+          return this.dbPath
+        }
+      }
+
+      const extractor = new TestExtractor(dbPath)
+      const browserSpy = spyOn(extractor as any, 'extractAllFromBrowserPaths').mockResolvedValue([])
+
+      expect(await extractor.extract()).toEqual([
+        {
+          accountCookie: 'account-jwt',
+          sessionCookie: 'session-jwt',
+        },
+      ])
+
+      browserSpy.mockRestore()
+    })
+
     it('prefers channel.works cookies over stale legacy channel.io cookies', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
       tempDirs.push(tempDir)

--- a/src/platforms/channeltalk/token-extractor.test.ts
+++ b/src/platforms/channeltalk/token-extractor.test.ts
@@ -223,6 +223,77 @@ describe('ChannelTokenExtractor', () => {
       ])
     })
 
+    it('prefers channel.works cookies over stale legacy channel.io cookies', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
+      tempDirs.push(tempDir)
+      const dbPath = join(tempDir, 'Cookies')
+      // Legacy rows are inserted first so they win a naive find() that ignores the domain.
+      await createCookieDatabase(dbPath, [
+        { name: 'x-account', value: 'stale-account', encrypted_value: Buffer.alloc(0), host_key: '.channel.io' },
+        { name: 'ch-session-1', value: 'stale-session', encrypted_value: Buffer.alloc(0), host_key: '.channel.io' },
+        { name: 'x-account', value: 'live-account', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+        { name: 'ch-session-1', value: 'live-session', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+      ])
+
+      class TestExtractor extends ChannelTokenExtractor {
+        constructor(private dbPath: string) {
+          super('darwin')
+        }
+
+        override getCookiesPath(): string | null {
+          return this.dbPath
+        }
+      }
+
+      const extractor = new TestExtractor(dbPath)
+      const browserSpy = spyOn(extractor as any, 'extractAllFromBrowserPaths').mockResolvedValue([])
+
+      expect(await extractor.extract()).toEqual([
+        {
+          accountCookie: 'live-account',
+          sessionCookie: 'live-session',
+        },
+      ])
+
+      browserSpy.mockRestore()
+    })
+
+    it('never pairs an x-account with a session cookie from the other domain', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
+      tempDirs.push(tempDir)
+      const dbPath = join(tempDir, 'Cookies')
+      // channel.works holds an identity but no session; the only session belongs to channel.io.
+      // The live identity must be returned session-less rather than borrowing the legacy session,
+      // which belongs to a different domain and would not authenticate it.
+      await createCookieDatabase(dbPath, [
+        { name: 'x-account', value: 'works-account', encrypted_value: Buffer.alloc(0), host_key: '.channel.works' },
+        { name: 'x-account', value: 'io-account', encrypted_value: Buffer.alloc(0), host_key: '.channel.io' },
+        { name: 'ch-session-1', value: 'io-session', encrypted_value: Buffer.alloc(0), host_key: '.channel.io' },
+      ])
+
+      class TestExtractor extends ChannelTokenExtractor {
+        constructor(private dbPath: string) {
+          super('darwin')
+        }
+
+        override getCookiesPath(): string | null {
+          return this.dbPath
+        }
+      }
+
+      const extractor = new TestExtractor(dbPath)
+      const browserSpy = spyOn(extractor as any, 'extractAllFromBrowserPaths').mockResolvedValue([])
+
+      expect(await extractor.extract()).toEqual([
+        {
+          accountCookie: 'works-account',
+          sessionCookie: undefined,
+        },
+      ])
+
+      browserSpy.mockRestore()
+    })
+
     it('extracts cookies stored on the rebranded channel.works domain', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'channel-cookie-db-'))
       tempDirs.push(tempDir)

--- a/src/platforms/channeltalk/token-extractor.ts
+++ b/src/platforms/channeltalk/token-extractor.ts
@@ -23,8 +23,23 @@ type CookieRow = { name: string; value: string; encrypted_value: Uint8Array | Bu
 const COOKIE_QUERY = `
   SELECT name, value, encrypted_value FROM cookies
   WHERE name IN ('x-account', 'ch-session-1', 'ch-session')
-  AND host_key LIKE '%.channel.io%'
+  AND (host_key LIKE '%.channel.io%' OR host_key LIKE '%.channel.works%')
 `
+
+// Channel Talk was rebranded to Channel Works: the desktop app now stores its cookies under a
+// "Channel Works" directory. Both names are probed, newest first, so upgraded and legacy
+// installs (which keep the old directory around) both resolve.
+const APP_DIR_NAMES = ['Channel Works', 'Channel Talk']
+
+function findExistingAppDir(bases: string[]): string | null {
+  for (const base of bases) {
+    for (const name of APP_DIR_NAMES) {
+      const appDir = join(base, name)
+      if (existsSync(appDir)) return appDir
+    }
+  }
+  return null
+}
 
 export class ChannelTokenExtractor {
   private platform: NodeJS.Platform
@@ -42,7 +57,7 @@ export class ChannelTokenExtractor {
   getAppDataDir(): string | null {
     switch (this.platform) {
       case 'darwin': {
-        const sandboxedPath = join(
+        const sandboxedBase = join(
           homedir(),
           'Library',
           'Containers',
@@ -50,18 +65,13 @@ export class ChannelTokenExtractor {
           'Data',
           'Library',
           'Application Support',
-          'Channel Talk',
         )
-        if (existsSync(sandboxedPath)) {
-          return sandboxedPath
-        }
-        const directPath = join(homedir(), 'Library', 'Application Support', 'Channel Talk')
-        return existsSync(directPath) ? directPath : null
+        const directBase = join(homedir(), 'Library', 'Application Support')
+        return findExistingAppDir([sandboxedBase, directBase])
       }
       case 'win32': {
         const appdata = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming')
-        const appDir = join(appdata, 'Channel Talk')
-        return existsSync(appDir) ? appDir : null
+        return findExistingAppDir([appdata])
       }
       default:
         return null

--- a/src/platforms/channeltalk/token-extractor.ts
+++ b/src/platforms/channeltalk/token-extractor.ts
@@ -20,12 +20,6 @@ import type { ExtractedChannelToken } from './types'
 
 type CookieRow = { name: string; value: string; encrypted_value: Uint8Array | Buffer; host_key: string }
 
-const COOKIE_QUERY = `
-  SELECT name, value, encrypted_value, host_key FROM cookies
-  WHERE name IN ('x-account', 'ch-session-1', 'ch-session')
-  AND (host_key LIKE '%.channel.io%' OR host_key LIKE '%.channel.works%')
-`
-
 // Channel Talk was rebranded to Channel Works: the desktop app now stores its cookies under a
 // "Channel Works" directory. Both names are probed, newest first, so upgraded and legacy
 // installs (which keep the old directory around) both resolve.
@@ -34,6 +28,31 @@ const APP_DIR_NAMES = ['Channel Works', 'Channel Talk']
 // Cookies for the rebranded channel.works domain and the legacy channel.io domain can coexist in
 // one profile, most likely on a browser that was signed in before and after the rebrand.
 const COOKIE_DOMAINS = ['channel.works', 'channel.io']
+
+/**
+ * Match a cookie's host key against a domain on an exact label boundary: the domain itself, or a
+ * subdomain of it.
+ *
+ * Substring matching is not good enough here. `host_key LIKE '%.channel.works%'` also admits an
+ * unrelated host such as `.channel.works.example.com`, so a cookie planted by anyone who controls
+ * a name of that shape could shadow the real one and be sent to the Channel API as our identity.
+ */
+function hostMatchesDomain(hostKey: string, domain: string): boolean {
+  const host = hostKey.startsWith('.') ? hostKey.slice(1) : hostKey
+  return host === domain || host.endsWith(`.${domain}`)
+}
+
+// Mirrors hostMatchesDomain in SQL so the database does the same boundary-aware narrowing. The
+// domains are hardcoded constants, never caller input, so interpolating them is safe.
+const COOKIE_HOST_FILTER = COOKIE_DOMAINS.map((domain) => `host_key = '${domain}' OR host_key LIKE '%.${domain}'`).join(
+  ' OR ',
+)
+
+const COOKIE_QUERY = `
+  SELECT name, value, encrypted_value, host_key FROM cookies
+  WHERE name IN ('x-account', 'ch-session-1', 'ch-session')
+  AND (${COOKIE_HOST_FILTER})
+`
 
 function findExistingAppDir(bases: string[]): string | null {
   for (const base of bases) {
@@ -54,7 +73,7 @@ function findExistingAppDir(bases: string[]): string | null {
  * shadowing a live channel.works one.
  */
 function groupRowsByDomain(rows: CookieRow[]): CookieRow[][] {
-  return COOKIE_DOMAINS.map((domain) => rows.filter((row) => row.host_key.includes(domain))).filter(
+  return COOKIE_DOMAINS.map((domain) => rows.filter((row) => hostMatchesDomain(row.host_key, domain))).filter(
     (group) => group.length > 0,
   )
 }

--- a/src/platforms/channeltalk/token-extractor.ts
+++ b/src/platforms/channeltalk/token-extractor.ts
@@ -18,10 +18,10 @@ import type { KeychainVariant } from '@/shared/chromium'
 
 import type { ExtractedChannelToken } from './types'
 
-type CookieRow = { name: string; value: string; encrypted_value: Uint8Array | Buffer }
+type CookieRow = { name: string; value: string; encrypted_value: Uint8Array | Buffer; host_key: string }
 
 const COOKIE_QUERY = `
-  SELECT name, value, encrypted_value FROM cookies
+  SELECT name, value, encrypted_value, host_key FROM cookies
   WHERE name IN ('x-account', 'ch-session-1', 'ch-session')
   AND (host_key LIKE '%.channel.io%' OR host_key LIKE '%.channel.works%')
 `
@@ -31,6 +31,10 @@ const COOKIE_QUERY = `
 // installs (which keep the old directory around) both resolve.
 const APP_DIR_NAMES = ['Channel Works', 'Channel Talk']
 
+// Cookies for the rebranded channel.works domain and the legacy channel.io domain can coexist in
+// one profile, most likely on a browser that was signed in before and after the rebrand.
+const COOKIE_DOMAINS = ['channel.works', 'channel.io']
+
 function findExistingAppDir(bases: string[]): string | null {
   for (const base of bases) {
     for (const name of APP_DIR_NAMES) {
@@ -39,6 +43,20 @@ function findExistingAppDir(bases: string[]): string | null {
     }
   }
   return null
+}
+
+/**
+ * Split cookie rows into one group per domain, newest domain first, dropping domains with no rows.
+ *
+ * Callers resolve a credential pair from a single group rather than from all rows at once. That
+ * keeps `x-account` and its session cookie from being read off different domains, which would pair
+ * an identity with a session that does not belong to it, and it stops a leftover legacy cookie from
+ * shadowing a live channel.works one.
+ */
+function groupRowsByDomain(rows: CookieRow[]): CookieRow[][] {
+  return COOKIE_DOMAINS.map((domain) => rows.filter((row) => row.host_key.includes(domain))).filter(
+    (group) => group.length > 0,
+  )
 }
 
 export class ChannelTokenExtractor {
@@ -231,12 +249,18 @@ export class ChannelTokenExtractor {
     if (rows.length === 0) return null
 
     const localStatePath = this.getLocalStatePath() ?? undefined
-    const accountCookie = this.getDesktopCookieValue(rows, 'x-account', localStatePath)
-    const sessionCookie =
-      this.getDesktopCookieValue(rows, 'ch-session-1', localStatePath) ??
-      this.getDesktopCookieValue(rows, 'ch-session', localStatePath)
+    for (const group of groupRowsByDomain(rows)) {
+      const accountCookie = this.getDesktopCookieValue(group, 'x-account', localStatePath)
+      if (!accountCookie) continue
 
-    return accountCookie ? { accountCookie, sessionCookie } : null
+      const sessionCookie =
+        this.getDesktopCookieValue(group, 'ch-session-1', localStatePath) ??
+        this.getDesktopCookieValue(group, 'ch-session', localStatePath)
+
+      return { accountCookie, sessionCookie }
+    }
+
+    return null
   }
 
   private async extractFromBrowserCookiePath(cookiePath: string): Promise<ExtractedChannelToken | null> {
@@ -244,12 +268,18 @@ export class ChannelTokenExtractor {
     if (rows.length === 0) return null
 
     const localStatePath = findLocalStatePath(cookiePath) ?? undefined
-    const accountCookie = this.getBrowserCookieValue(rows, 'x-account', localStatePath)
-    const sessionCookie =
-      this.getBrowserCookieValue(rows, 'ch-session-1', localStatePath) ??
-      this.getBrowserCookieValue(rows, 'ch-session', localStatePath)
+    for (const group of groupRowsByDomain(rows)) {
+      const accountCookie = this.getBrowserCookieValue(group, 'x-account', localStatePath)
+      if (!accountCookie) continue
 
-    return accountCookie ? { accountCookie, sessionCookie } : null
+      const sessionCookie =
+        this.getBrowserCookieValue(group, 'ch-session-1', localStatePath) ??
+        this.getBrowserCookieValue(group, 'ch-session', localStatePath)
+
+      return { accountCookie, sessionCookie }
+    }
+
+    return null
   }
 
   private getDesktopCookieValue(rows: CookieRow[], name: string, localStatePath?: string): string | undefined {


### PR DESCRIPTION
## Summary

The Channel Talk desktop app has been rebranded to **Channel Works**. The rebrand moved two things that cookie extraction depends on:

- the cookie database now lives under a `Channel Works` directory instead of `Channel Talk`
- the cookies themselves now live on the `channel.works` domain instead of `channel.io`

`ChannelTokenExtractor` still probed only the legacy directory name and filtered on `channel.io`, so on a current install it found nothing at all. `extract()` returned `[]` and every caller surfaced `No credentials. Make sure Channel Talk is logged in to the desktop app or a supported Chromium browser.` — even with the app installed, running, and logged in.

Because every renewal path in the platform bottoms out at `ChannelTokenExtractor.extract()` (`ensure-auth.ts`, the client's 401 retry, and the keepalive cycle all re-extract from the cookie DB), the desktop app path being dead meant credentials could only ever come from a browser that happened to hold a live `channel.io` session. `ch-session-1` is a ~15-minute JWT, so in practice auth broke as soon as no browser tab was keeping that session warm.

The API host is unaffected — `desk-api.channel.io` still serves these cookies, so `BASE_URL` is unchanged. This is purely a local-extraction fix.

## Root Cause

- `COOKIE_QUERY` filtered `host_key LIKE '%.channel.io%'`, which matches none of the app's `.channel.works` cookies.
- `getAppDataDir()` hardcoded the `Channel Talk` directory name for the macOS sandboxed path, the macOS direct path, and the Windows `%APPDATA%` path.

## Changes

### `token-extractor.ts`
- `COOKIE_QUERY` now accepts `host_key LIKE '%.channel.io%' OR host_key LIKE '%.channel.works%'`, so both the rebranded and legacy domains match.
- Add an `APP_DIR_NAMES` constant (`['Channel Works', 'Channel Talk']`) and a `findExistingAppDir(bases)` helper that returns the first directory that exists, probing each base in order and `Channel Works` before `Channel Talk`.
- `getAppDataDir()` now resolves through that helper on both `darwin` (sandboxed container base, then the direct `Application Support` base) and `win32` (`%APPDATA%`). Existing precedence is preserved — sandboxed still wins over direct — and an upgraded install that kept both directories resolves to `Channel Works`. `getCookiesPath()` is untouched and still derives from `getAppDataDir()`.

### `token-extractor.test.ts`
- Add a regression test extracting `x-account` / `ch-session-1` from a real sqlite DB whose cookies are on `.channel.works`. It stubs `extractAllFromBrowserPaths` so a real logged-in browser on the host cannot leak into the assertion.
- Add `getAppDataDir` tests covering the rebranded directory, the legacy fallback, and the both-present case asserting `Channel Works` wins. These drive the `win32` branch via `APPDATA`, and restore the original env afterward.

### `skills/agent-channeltalk/` (`SKILL.md`, `references/authentication.md`)
- Correct the documented desktop-app cookie paths and cookie domain, which were factually stale after the rebrand, and note that both directory names are probed.

## Verification

- [x] `bun test src/` — 3611 pass, **3 fail**. The 3 failures are pre-existing and reproduce identically on unmodified `origin/main` on this machine: `extract` tests that don't stub `extractAllFromBrowserPaths` read the host's real Chromium profiles, so a developer logged into Channel Talk locally sees real cookies leak into the assertions. Not introduced here, and not addressed here to keep this PR scoped; the new test stubs that seam. Happy to fix the other three in a follow-up.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 warnings, 0 errors.
- [x] `bun run build` — clean.
- [x] `bunx oxfmt --check` on the changed files — clean. (Repo-wide `bun run format:check` fails on `docs/src/app/globals.css` resolving `fumadocs-ui/css/neutral.css`; that reproduces on unmodified `origin/main` too and is unrelated.)
- [x] **End-to-end against the real desktop app** (macOS, Mac App Store build, logged in), with browser paths stubbed out to isolate the desktop path:

  | | `getAppDataDir()` | `extractFromDesktopApp()` |
  |---|---|---|
  | `origin/main` | `null` | `null` |
  | this branch | `…/Application Support/Channel Works` | returns `x-account` + `ch-session-1` |

  And `agent-channeltalk auth extract` against a scratch `AGENT_MESSENGER_CONFIG_DIR` now succeeds, discovering all 3 workspaces.

---

## Review round 2 (`fe88a28`)

Both review points were valid and are fixed.

### 1. Mixed / stale credential pair across domains (@typeey, cubic)

Correct, and worse than a precedence problem. `CookieRow` didn't carry `host_key` at all — the query selected only `name, value, encrypted_value` — so `rows.find()` had no domain to reason about and took whatever row the DB returned first. A profile signed in before *and* after the rebrand could therefore hand back a stale `channel.io` cookie while a live one sat unused, or pair an `x-account` from one domain with a `ch-session-1` from the other. That would have left exactly the upgraded profiles this branch targets still failing to authenticate.

I went with grouping rather than the suggested `ORDER BY`, because ordering alone fixes precedence but not mixing: if `channel.works` has an `x-account` and only `channel.io` has a session, `find('ch-session-1')` still reaches across domains and pairs them. So:

- `COOKIE_QUERY` selects `host_key`, and `CookieRow` carries it.
- New `groupRowsByDomain()` splits rows per domain, `channel.works` first, dropping empty groups.
- `extractFromDesktopApp()` / `extractFromBrowserCookiePath()` resolve `x-account` **and** its session from a single group, taking the first group that yields an identity.

An identity is never matched with a session from another domain. Where `channel.works` has an identity but no session, it's returned session-less (already a supported shape) rather than borrowing the legacy session, which wouldn't authenticate it anyway.

Two regression tests, both verified to **fail on `19a1b97` and pass on `fe88a28`**:
- `prefers channel.works cookies over stale legacy channel.io cookies` — legacy rows inserted first so they'd win a naive `find()`.
- `never pairs an x-account with a session cookie from the other domain`.

### 2. `docs/content/docs/cli/channeltalk.mdx` not updated (cubic)

Right, I missed it. Its Troubleshooting section now matches `SKILL.md` and `references/authentication.md`.

### Verification

- [x] `bun test src/` — 3613 pass, 3 fail (the same pre-existing host-cookie-leak failures described above, unchanged and reproducing on `origin/main`).
- [x] `bun run typecheck` / `bun run lint` / `bun run build` — clean.
- [x] `bunx oxfmt --check` on changed files — clean.
- [x] Re-ran the real desktop-app E2E with browser paths stubbed out — still extracts `x-account` + `ch-session-1` from `Channel Works`.


---

## Review round 3 (`bb81734`)

The domain-boundary blocker was real. Confirmed it against a scratch DB before touching anything:

| `host_key` | before | after |
|---|---|---|
| `.channel.works`, `channel.works`, `.desk.channel.works` | pass | pass |
| `.desk.channel.io`, `channel.io` | pass | pass |
| `.channel.works.example.com` | **pass** | blocked |
| `.channel.io.evil.net` | **pass** | blocked |
| `notchannel.works`, `xchannel.io` | blocked | blocked |

`LIKE '%.channel.works%'` is open at both ends, so any host that merely contains the domain matched. Anyone who can set a cookie on a name of that shape could plant an `x-account` that shadows the real one and gets sent to the Channel API as our identity. The runtime side was looser still — a bare `includes('channel.io')` even matches `.evil-channel.io.attacker.net`, which the SQL happened to reject, so the two layers disagreed about what counts as a Channel host.

This flaw predates the PR (`%.channel.io%` had it too), but the rebrand work copied the pattern to a second domain, so it belongs here.

- New `hostMatchesDomain()` accepts the domain itself or a subdomain of it, and nothing else.
- `COOKIE_HOST_FILTER` derives the SQL from the same `COOKIE_DOMAINS` list the runtime check uses, so the two layers can no longer drift apart. The domains are hardcoded constants, never caller input.

Two more regression tests, verified to fail on `fe88a28` and pass on `bb81734`:
- `ignores look-alike hosts that merely contain a channel domain` — imposter rows inserted first so a substring match lets them shadow the real cookies.
- `extracts cookies from a subdomain of a channel domain` — guards against over-tightening and dropping legitimate `.desk.channel.works`.

### Correction on the 3 failing tests

I need to walk back what I said earlier. Those 3 pre-existing failures are **flaky, not deterministic** — they depend on whether the host's Chromium profiles happen to hold Channel cookies at that moment. During this round I saw a clean `3618 pass, 0 fail` run and then `3 fail` again on identical code, purely because the browser's cookie state changed underneath.

So that the comparison is meaningful, I re-ran `origin/main` and this branch back to back in the same window:

```
run#1  origin/main failures=3   this branch failures=3
run#2  origin/main failures=3   this branch failures=3
```

Identical. Not introduced here, and this PR does not fix them either — the isolation flaw is still latent, it just needs a developer logged into Channel to surface. Narrowing the host filter cannot widen the leak, and my own tests stub `extractAllFromBrowserPaths`. Happy to fix the remaining three in a follow-up.

### Verification

- [x] `bun run typecheck` / `bun run lint` / `bun run build` — clean.
- [x] `bunx oxfmt --check` on changed files — clean.
- [x] Real desktop-app E2E with browser paths stubbed out — still extracts `x-account` + `ch-session-1` from `Channel Works`.
