### PR TITLE
List Discord community and voice channel types

### DIFF
--- a/skills/agent-discord/SKILL.md
+++ b/skills/agent-discord/SKILL.md
@@ -212,7 +212,9 @@ agent-discord message search "hello" --channel <channel-id> --author <user-id>
 ### Channel Commands
 
 ```bash
-# List channels in current server (text channels only)
+# List channels in current server
+# Includes text, announcement, voice/stage (voice channels carry text chat),
+# forum, media, and directory channels. Categories and threads are excluded.
 agent-discord channel list
 
 # Get channel info
@@ -377,8 +379,10 @@ agent-discord snapshot --full --limit 10
 Default returns brief JSON with:
 
 - Server metadata (id, name)
-- Channels (id, name) — text channels only
+- Channels (id, name) — all listable channels (text, announcement, voice/stage, forum, media, directory; excludes categories and threads)
 - Hint for next commands
+
+> Not every listed channel accepts a direct `message list`. Forum, media, and directory channels are containers or hub views with no direct message timeline — their messages live in child posts/threads. Use text, announcement, voice, or stage channels for `message list`.
 
 With `--full`, returns comprehensive JSON with:
 
@@ -556,7 +560,7 @@ See the [Discord SDK documentation](https://agent-messenger.dev/docs/sdk/discord
 
 ## Limitations
 
-- No voice channel support
+- No voice audio support (voice/stage channels are listed and their embedded text chat is readable, but joining voice or streaming audio is unsupported)
 - No server management (create/delete channels, roles)
 - No slash commands
 - No webhook support

--- a/skills/agent-discord/references/common-patterns.md
+++ b/skills/agent-discord/references/common-patterns.md
@@ -87,12 +87,16 @@ CHANNEL_COUNT=$(echo "$SNAPSHOT" | jq -r '.channels | length')
 echo "Server: $SERVER_NAME"
 echo "Channels: $CHANNEL_COUNT"
 
-# List all text channels
+# List all channels
 echo -e "\nChannels:"
 echo "$SNAPSHOT" | jq -r '.channels[] | "  #\(.name) (\(.id))"'
 
-# Then drill into a specific channel for recent activity
-CHANNEL_ID=$(echo "$SNAPSHOT" | jq -r '.channels[0].id // empty')
+# Then drill into a specific channel for recent activity.
+# Only text (0), announcement (5), voice (2), and stage (13) channels accept
+# `message list`; forum (15), media (16), and directory (14) channels do not.
+# A full snapshot includes `type`, so pick the first message-readable channel.
+FULL=$(agent-discord snapshot --full)
+CHANNEL_ID=$(echo "$FULL" | jq -r '[.channels[] | select(.type == 0 or .type == 5 or .type == 2 or .type == 13)][0].id // empty')
 if [ -n "$CHANNEL_ID" ]; then
   echo -e "\nRecent messages:"
   agent-discord message list "$CHANNEL_ID" --limit 10

--- a/src/platforms/discord/commands/channel.test.ts
+++ b/src/platforms/discord/commands/channel.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
+import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
 
 import { DiscordClient } from '../client'
 import { DiscordCredentialManager } from '../credential-manager'
+import { listAction } from './channel'
 
 let clientListChannelsSpy: ReturnType<typeof spyOn>
 let clientGetChannelSpy: ReturnType<typeof spyOn>
@@ -12,8 +13,10 @@ beforeEach(() => {
   // Spy on DiscordClient.prototype methods
   clientListChannelsSpy = spyOn(DiscordClient.prototype, 'listChannels').mockResolvedValue([
     { id: 'ch-1', guild_id: 'guild-1', name: 'general', type: 0, topic: 'General discussion' },
-    { id: 'ch-2', guild_id: 'guild-1', name: 'announcements', type: 0, topic: 'Announcements' },
+    { id: 'ch-2', guild_id: 'guild-1', name: 'announcements', type: 5, topic: 'Announcements' },
     { id: 'ch-3', guild_id: 'guild-1', name: 'voice-channel', type: 2, topic: undefined },
+    { id: 'ch-4', guild_id: 'guild-1', name: 'Text Channels', type: 4, topic: undefined },
+    { id: 'ch-5', guild_id: 'guild-1', name: 'a-thread', type: 11, topic: undefined },
   ])
 
   clientGetChannelSpy = spyOn(DiscordClient.prototype, 'getChannel').mockImplementation(async (channelId: string) => {
@@ -72,30 +75,37 @@ afterEach(() => {
   credManagerLoadSpy?.mockRestore()
 })
 
-it('list: returns text channels (type=0) from server', async () => {
-  // given: discord client with channels
-  const client = await new DiscordClient().login({ token: 'test-token' })
-  const channels = await client.listChannels('server-1')
+it('list: includes text, announcement, and voice channels but excludes categories and threads', async () => {
+  // given: a server with mixed channel types
+  const consoleSpy = mock(() => {})
+  const originalLog = console.log
+  console.log = consoleSpy
 
-  // when: filtering text channels
-  const textChannels = channels.filter((ch) => ch.type === 0)
+  // when: listing channels
+  await listAction({ pretty: false })
+  console.log = originalLog
 
-  // then: only text channels are returned
-  expect(textChannels).toHaveLength(2)
-  expect(textChannels[0].name).toBe('general')
-  expect(textChannels[1].name).toBe('announcements')
+  // then: only listable channels are output
+  const output = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Array<{ name: string; type: number }>
+  const names = output.map((ch) => ch.name)
+  expect(names).toEqual(['general', 'announcements', 'voice-channel'])
+  expect(names).not.toContain('Text Channels')
+  expect(names).not.toContain('a-thread')
 })
 
 it('list: includes channel metadata', async () => {
-  // given: discord client with channels
-  const client = await new DiscordClient().login({ token: 'test-token' })
-  const channels = await client.listChannels('server-1')
-  const textChannels = channels.filter((ch) => ch.type === 0)
+  // given: a server with channels
+  const consoleSpy = mock(() => {})
+  const originalLog = console.log
+  console.log = consoleSpy
 
-  // when: checking channel properties
-  const channel = textChannels[0]
+  // when: listing channels
+  await listAction({ pretty: false })
+  console.log = originalLog
 
-  // then: channel has id, name, type, topic
+  // then: each channel carries id, name, type, parent_id, topic
+  const output = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Array<Record<string, unknown>>
+  const channel = output[0]
   expect(channel.id).toBeDefined()
   expect(channel.name).toBeDefined()
   expect(channel.type).toBe(0)

--- a/src/platforms/discord/commands/channel.ts
+++ b/src/platforms/discord/commands/channel.ts
@@ -5,6 +5,7 @@ import { formatOutput } from '@/shared/utils/output'
 
 import { DiscordClient } from '../client'
 import { DiscordCredentialManager } from '../credential-manager'
+import { isListableChannel } from '../types'
 
 export async function listAction(options: { pretty?: boolean }): Promise<void> {
   try {
@@ -19,9 +20,9 @@ export async function listAction(options: { pretty?: boolean }): Promise<void> {
     const client = await new DiscordClient().login({ token: config.token })
     const channels = await client.listChannels(config.current_server)
 
-    const textChannels = channels.filter((ch) => ch.type === 0)
+    const listableChannels = channels.filter(isListableChannel)
 
-    const output = textChannels.map((ch) => ({
+    const output = listableChannels.map((ch) => ({
       id: ch.id,
       name: ch.name,
       type: ch.type,

--- a/src/platforms/discord/commands/snapshot.test.ts
+++ b/src/platforms/discord/commands/snapshot.test.ts
@@ -1,6 +1,84 @@
-import { expect, it } from 'bun:test'
+import { afterEach, beforeEach, expect, spyOn, it } from 'bun:test'
 
-import { snapshotCommand } from './snapshot'
+import { DiscordClient } from '../client'
+import { DiscordCredentialManager } from '../credential-manager'
+import { DiscordChannelType } from '../types'
+import { snapshotAction, snapshotCommand } from './snapshot'
+
+let listChannelsSpy: ReturnType<typeof spyOn>
+let getMessagesSpy: ReturnType<typeof spyOn>
+let getServerSpy: ReturnType<typeof spyOn>
+let listUsersSpy: ReturnType<typeof spyOn>
+let credManagerLoadSpy: ReturnType<typeof spyOn>
+
+const mixedChannels = [
+  { id: 'text', guild_id: 'g1', name: 'general', type: DiscordChannelType.GUILD_TEXT },
+  { id: 'announce', guild_id: 'g1', name: 'news', type: DiscordChannelType.GUILD_ANNOUNCEMENT },
+  { id: 'voice', guild_id: 'g1', name: 'lounge', type: DiscordChannelType.GUILD_VOICE },
+  { id: 'forum', guild_id: 'g1', name: 'help', type: DiscordChannelType.GUILD_FORUM },
+  { id: 'directory', guild_id: 'g1', name: 'hub', type: DiscordChannelType.GUILD_DIRECTORY },
+  { id: 'category', guild_id: 'g1', name: 'Section', type: DiscordChannelType.GUILD_CATEGORY },
+  { id: 'thread', guild_id: 'g1', name: 'a-thread', type: DiscordChannelType.PUBLIC_THREAD },
+]
+
+function parseSnapshot(consoleSpy: ReturnType<typeof spyOn>): Record<string, any> {
+  const lastCall = consoleSpy.mock.calls.at(-1)
+  return JSON.parse(lastCall![0] as string)
+}
+
+beforeEach(() => {
+  listChannelsSpy = spyOn(DiscordClient.prototype, 'listChannels').mockResolvedValue(mixedChannels)
+  getMessagesSpy = spyOn(DiscordClient.prototype, 'getMessages').mockResolvedValue([])
+  getServerSpy = spyOn(DiscordClient.prototype, 'getServer').mockResolvedValue({ id: 'g1', name: 'Guild One' })
+  listUsersSpy = spyOn(DiscordClient.prototype, 'listUsers').mockResolvedValue([])
+  credManagerLoadSpy = spyOn(DiscordCredentialManager.prototype, 'load').mockResolvedValue({
+    token: 'test-token',
+    current_server: 'g1',
+    servers: { g1: { server_id: 'g1', server_name: 'Guild One' } },
+  })
+})
+
+afterEach(() => {
+  listChannelsSpy?.mockRestore()
+  getMessagesSpy?.mockRestore()
+  getServerSpy?.mockRestore()
+  listUsersSpy?.mockRestore()
+  credManagerLoadSpy?.mockRestore()
+})
+
+it('snapshot brief: lists listable channels and excludes categories and threads', async () => {
+  // given: a server with mixed channel types
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+
+  // when: running a brief snapshot
+  await snapshotAction({ pretty: false })
+  const snapshot = parseSnapshot(consoleSpy)
+  consoleSpy.mockRestore()
+
+  // then: only listable channels appear, no messages are fetched
+  const names = snapshot.channels.map((ch: { name: string }) => ch.name)
+  expect(names).toEqual(['general', 'news', 'lounge', 'help', 'hub'])
+  expect(getMessagesSpy).not.toHaveBeenCalled()
+})
+
+it('snapshot full: fetches messages only from message-readable channels', async () => {
+  // given: a server with mixed channel types
+  const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})
+
+  // when: running a full snapshot
+  await snapshotAction({ full: true, pretty: false })
+  const snapshot = parseSnapshot(consoleSpy)
+  consoleSpy.mockRestore()
+
+  // then: listing includes containers but getMessages is called only for readable IDs
+  const listedNames = snapshot.channels.map((ch: { name: string }) => ch.name)
+  expect(listedNames).toEqual(['general', 'news', 'lounge', 'help', 'hub'])
+
+  const fetchedIds = getMessagesSpy.mock.calls.map((call) => call[0])
+  expect(fetchedIds.sort()).toEqual(['announce', 'text', 'voice'])
+  expect(fetchedIds).not.toContain('forum')
+  expect(fetchedIds).not.toContain('directory')
+})
 
 it('snapshot: command is defined', () => {
   expect(snapshotCommand).toBeDefined()

--- a/src/platforms/discord/commands/snapshot.ts
+++ b/src/platforms/discord/commands/snapshot.ts
@@ -6,6 +6,7 @@ import { formatOutput } from '@/shared/utils/output'
 
 import { DiscordClient } from '../client'
 import { DiscordCredentialManager } from '../credential-manager'
+import { isListableChannel, isMessageReadableChannel } from '../types'
 import type { DiscordChannel } from '../types'
 
 export async function snapshotAction(options: {
@@ -41,8 +42,9 @@ export async function snapshotAction(options: {
 
       if (!options.usersOnly) {
         const channels = await client.listChannels(serverId)
+        const listableChannels = channels.filter(isListableChannel)
 
-        snapshot.channels = channels.map((ch) => ({
+        snapshot.channels = listableChannels.map((ch) => ({
           id: ch.id,
           name: ch.name,
           type: ch.type,
@@ -50,11 +52,10 @@ export async function snapshotAction(options: {
         }))
 
         if (!options.channelsOnly) {
-          const isTextChannel = (ch: DiscordChannel) => ch.type === 0 || ch.type === 5
-          const textChannels = channels.filter(isTextChannel)
+          const readableChannels = listableChannels.filter(isMessageReadableChannel)
 
           const channelMessages = await parallelMap(
-            textChannels,
+            readableChannels,
             async (channel: DiscordChannel) => {
               const messages = await client.getMessages(channel.id, messageLimit)
               return messages.map((msg) => ({
@@ -88,8 +89,8 @@ export async function snapshotAction(options: {
     } else {
       if (!options.usersOnly) {
         const channels = await client.listChannels(serverId)
-        const textChannels = channels.filter((ch: DiscordChannel) => ch.type === 0 || ch.type === 5)
-        snapshot.channels = textChannels.map((ch) => ({ id: ch.id, name: ch.name }))
+        const listableChannels = channels.filter(isListableChannel)
+        snapshot.channels = listableChannels.map((ch) => ({ id: ch.id, name: ch.name }))
       }
 
       snapshot.hint =

--- a/src/platforms/discord/types.test.ts
+++ b/src/platforms/discord/types.test.ts
@@ -2,6 +2,7 @@ import { expect, it } from 'bun:test'
 
 import {
   DiscordChannelSchema,
+  DiscordChannelType,
   DiscordConfigSchema,
   DiscordCredentialsSchema,
   DiscordError,
@@ -10,6 +11,8 @@ import {
   DiscordMessageSchema,
   DiscordReactionSchema,
   DiscordUserSchema,
+  isListableChannel,
+  isMessageReadableChannel,
 } from './types'
 
 it('DiscordGuildSchema validates correct guild', () => {
@@ -254,4 +257,46 @@ it('DiscordError has correct name and code', () => {
 it('DiscordError is instance of Error', () => {
   const error = new DiscordError('Test error', 'TEST_CODE')
   expect(error instanceof Error).toBe(true)
+})
+
+it('isListableChannel includes text, announcement, voice, stage, forum, media, and directory', () => {
+  const listable = [
+    DiscordChannelType.GUILD_TEXT,
+    DiscordChannelType.GUILD_ANNOUNCEMENT,
+    DiscordChannelType.GUILD_VOICE,
+    DiscordChannelType.GUILD_STAGE_VOICE,
+    DiscordChannelType.GUILD_FORUM,
+    DiscordChannelType.GUILD_MEDIA,
+    DiscordChannelType.GUILD_DIRECTORY,
+  ]
+  expect(listable.every((type) => isListableChannel({ type }))).toBe(true)
+})
+
+it('isListableChannel excludes categories and threads', () => {
+  const excluded = [
+    DiscordChannelType.GUILD_CATEGORY,
+    DiscordChannelType.ANNOUNCEMENT_THREAD,
+    DiscordChannelType.PUBLIC_THREAD,
+    DiscordChannelType.PRIVATE_THREAD,
+  ]
+  expect(excluded.some((type) => isListableChannel({ type }))).toBe(false)
+})
+
+it('isMessageReadableChannel includes text, announcement, voice, and stage', () => {
+  const readable = [
+    DiscordChannelType.GUILD_TEXT,
+    DiscordChannelType.GUILD_ANNOUNCEMENT,
+    DiscordChannelType.GUILD_VOICE,
+    DiscordChannelType.GUILD_STAGE_VOICE,
+  ]
+  expect(readable.every((type) => isMessageReadableChannel({ type }))).toBe(true)
+})
+
+it('isMessageReadableChannel excludes forum, media, and directory containers', () => {
+  const notReadable = [
+    DiscordChannelType.GUILD_FORUM,
+    DiscordChannelType.GUILD_MEDIA,
+    DiscordChannelType.GUILD_DIRECTORY,
+  ]
+  expect(notReadable.some((type) => isMessageReadableChannel({ type }))).toBe(false)
 })

--- a/src/platforms/discord/types.ts
+++ b/src/platforms/discord/types.ts
@@ -27,6 +27,47 @@ export interface DiscordChannel {
   }
 }
 
+// https://discord.com/developers/docs/resources/channel#channel-object-channel-types
+export const DiscordChannelType = {
+  GUILD_TEXT: 0,
+  DM: 1,
+  GUILD_VOICE: 2,
+  GROUP_DM: 3,
+  GUILD_CATEGORY: 4,
+  GUILD_ANNOUNCEMENT: 5,
+  ANNOUNCEMENT_THREAD: 10,
+  PUBLIC_THREAD: 11,
+  PRIVATE_THREAD: 12,
+  GUILD_STAGE_VOICE: 13,
+  GUILD_DIRECTORY: 14,
+  GUILD_FORUM: 15,
+  GUILD_MEDIA: 16,
+} as const
+
+const THREAD_CHANNEL_TYPES: ReadonlySet<number> = new Set([
+  DiscordChannelType.ANNOUNCEMENT_THREAD,
+  DiscordChannelType.PUBLIC_THREAD,
+  DiscordChannelType.PRIVATE_THREAD,
+])
+
+// Channels with no directly fetchable message timeline:
+// forum/media messages live in child posts/threads, and directory channels
+// are hub listings, not message channels. Fetching messages from these aborts.
+const NON_MESSAGE_CHANNEL_TYPES: ReadonlySet<number> = new Set([
+  DiscordChannelType.GUILD_FORUM,
+  DiscordChannelType.GUILD_MEDIA,
+  DiscordChannelType.GUILD_DIRECTORY,
+])
+
+// Voice/stage channels are listed too because they carry embedded text chat.
+export function isListableChannel(channel: Pick<DiscordChannel, 'type'>): boolean {
+  return channel.type !== DiscordChannelType.GUILD_CATEGORY && !THREAD_CHANNEL_TYPES.has(channel.type)
+}
+
+export function isMessageReadableChannel(channel: Pick<DiscordChannel, 'type'>): boolean {
+  return isListableChannel(channel) && !NON_MESSAGE_CHANNEL_TYPES.has(channel.type)
+}
+
 export interface DiscordMessage {
   id: string
   channel_id: string


### PR DESCRIPTION
## Problem

`agent-discord channel list` only showed regular text channels. Community-feature channels (announcements) and voice/stage channels were missing.

Root cause: `channel list` filtered to `ch.type === 0` (`GUILD_TEXT`) only, while `snapshot` used a different, inconsistent `0 || 5` allowlist (and even leaked categories into full-mode listings). Neither surfaced the full set of channels.

Note on **rules channels**: Discord has no dedicated "rules" channel type — a community rules channel is a normal `GUILD_TEXT` (type 0) flagged via `guild.rules_channel_id`, so it already appeared unless it was configured as an announcement channel (type 5), which was being dropped.

## Change

Introduced a single source of truth for Discord channel-type filtering in `types.ts`:

- `DiscordChannelType` — named constants mapped to Discord's official channel-type numbers.
- `isListableChannel()` — everything **except** categories (4) and threads (10/11/12). Includes text (0, covers rules), announcement (5), **voice (2)** and **stage (13)** (they carry embedded text chat), and forum (15) / media (16).
- `isMessageReadableChannel()` — listable minus forum/media containers, whose messages live in child posts/threads (so they can't be message-fetched directly).

Applied consistently:
- `channel list` → `isListableChannel`
- `snapshot` → `isListableChannel` for listing, `isMessageReadableChannel` for the message pull (also fixes categories being included in full mode).

## Tests

- Rewrote the two stale `channel list` tests to exercise the real `listAction` and assert the new behavior: text + announcement + voice included; categories and threads excluded.
- `bun typecheck`, `bun lint`, and the full `bun test` suite (3628 tests) pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Discord channel listing and snapshots to include announcement, voice/stage, forum, media, and directory channels, while excluding categories and threads. Message fetching now skips forum/media/directory containers to avoid errors.

- **Bug Fixes**
  - `channel list` includes text (0), announcement (5), voice (2), stage (13), forum (15), media (16), directory (14); excludes categories (4) and threads (10/11/12).
  - `snapshot` lists the same set and fetches messages only from text, announcement, voice, and stage channels.

- **Refactors**
  - Added `DiscordChannelType`, `isListableChannel`, and `isMessageReadableChannel` in `types.ts` and applied them in `channel` and `snapshot`.
  - Updated tests for `listAction`, `snapshotAction`, and type guards; all pass.
  - Docs: Updated `skills/agent-discord/SKILL.md` and `references/common-patterns.md` to reflect channel types and message-readability.

<sup>Written for commit 912c25342aaae4f4aa2c84a6fa4c8f6e99088dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

