### PR TITLE
fix(kakaotalk): fall back to SYNCMSG on empty MCHATLOGS

### DIFF
--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -107,6 +107,7 @@ describe('KakaoTalkClient', () => {
     mockLogin.mockResolvedValue(structuredClone(DEFAULT_LOGIN_RESULT))
     mockGetChatLogs.mockResolvedValue({ body: { status: 0, chatLogs: [], eof: true } })
     mockGetChatInfo.mockResolvedValue({ body: { l: makeLong(99999) } })
+    mockSyncMessages.mockResolvedValue({ body: { status: 0, isOK: true, chatLogs: [] } })
   })
 
   afterEach(() => {
@@ -803,6 +804,34 @@ describe('KakaoTalkClient', () => {
   })
 
   describe('getMessages', () => {
+    it('falls back to SYNCMSG when MCHATLOGS succeeds with an empty result', async () => {
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: { status: 0, chatLogs: [], eof: true },
+      })
+      mockGetChatInfo.mockResolvedValueOnce({
+        body: { status: 0, l: makeLong(10) },
+      })
+      mockSyncMessages.mockResolvedValueOnce({
+        body: {
+          status: 0,
+          isOK: true,
+          chatLogs: [
+            { logId: makeLong(10), chatId: 100, type: 1, authorId: 42, message: 'fallback', sendAt: 1700000001 },
+          ],
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100')
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]?.message).toBe('fallback')
+      expect(mockGetChatInfo).toHaveBeenCalledTimes(1)
+      expect(mockSyncMessages).toHaveBeenCalledTimes(1)
+
+      client.close()
+    })
+
     it('returns formatted messages', async () => {
       mockGetChatLogs.mockResolvedValueOnce({
         body: {

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -850,6 +850,7 @@ export class KakaoTalkClient {
               (log) => longToString(log.chatId) === chatId,
             )
             if (batch.length === 0) {
+              if (allMessages.length === 0) break
               return formatMessages(allMessages, count, chatId, this.nameCache)
             }
 


### PR DESCRIPTION
## Summary

- fall back to the existing `CHATONROOM` + `SYNCMSG` path when the first successful `MCHATLOGS` response contains no matching logs
- add a regression test for successful-but-empty `MCHATLOGS` responses

Fixes #313.

## Root cause

Some KakaoTalk chats return `status: 0`, `eof: true`, and an empty `chatLogs` array from `MCHATLOGS`, while `SYNCMSG` still returns the latest message. `getMessages()` treated that empty batch as a completed fetch and returned `[]`, so the existing fallback below the history loop was skipped.

## Change

When the first `MCHATLOGS` batch is empty and no messages have been accumulated, leave the history loop and continue to the existing fallback. If earlier pages already produced messages, preserve the current return behavior.

The branch is chat-type agnostic. The live reproduction was observed with PlusChat rooms, but no PlusChat-specific behavior is added.

## Validation

- TDD regression test failed before the implementation with `Expected length: 1 / Received length: 0`
- `bun test src/platforms/kakaotalk/client.test.ts` — 94 passed
- `bun test src/` — 3,635 passed
- `bun run typecheck`
- `bun run lint`
- `bun run format:check` after installing root and docs dependencies
- `bun run build`
- `git diff --check`

Manual Docker verification used `node:24-bookworm-slim` and `agent-messenger@2.32.1` with an isolated copy of an authenticated credential volume:

- unmodified CLI result: 0 messages
- protocol observation for the same chat: `MCHATLOGS` 0 messages, `CHATONROOM` last log id present, `SYNCMSG` 1 message
- patched CLI result: 1 message

No chat id or message content is included in the issue or this PR.

## Risk

Low. The only added work is the existing fallback request sequence when the first `MCHATLOGS` response is empty. Non-empty history responses retain their current path.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes KakaoTalk message fetching by falling back to SYNCMSG when the first MCHATLOGS page is empty, so the latest message still returns. Adds a regression test.

- **Bug Fixes**
  - If the first MCHATLOGS batch is empty and no messages were collected, stop the history loop and use the existing CHATONROOM + SYNCMSG path.

- **Migration**
  - No action needed. No SKILL.md or docs changes.

<sup>Written for commit 9054c501fc481f84af0f592931eda39882ed556d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

