### PR TITLE
fix(kakaotalk): avoid room entry during message fallback

### DIFF
--- a/skills/agent-kakaotalk/references/common-patterns.md
+++ b/skills/agent-kakaotalk/references/common-patterns.md
@@ -185,7 +185,7 @@ NEW_MESSAGES=$(agent-kakaotalk message list "$CHAT_ID" --from "$LAST_SEEN")
 
 **When to use**: Reading long chat histories, catching up on new messages since last check.
 
-**Pagination details**: The CLI now prefers KakaoTalk's `MCHATLOGS` flow for history reads, fetching message batches from the requested `--from` point and returning the last N messages after deduplication and ascending sort. If that path cannot provide results, it falls back to `CHATONROOM` + `SYNCMSG` for compatibility. As a safety net, both paths are capped at 50 internal pages. A warning is printed to stderr only when that cap is actually hit and the returned history may be incomplete.
+**Pagination details**: The CLI prefers KakaoTalk's `MCHATLOGS` flow for history reads, fetching message batches from the requested `--from` point and returning the last N messages after deduplication and ascending sort. If that path cannot provide results, it reads the maximum log ID from the login chat-list watermark (`ll`, falling back to `l.logId`) and calls `SYNCMSG` directly only when that watermark is ahead of the current cursor. The history path never uses `CHATONROOM`, which avoids room-entry side effects. If the watermark is missing or is not ahead of the cursor, the fallback fails closed and returns `[]`. As a safety net, both message flows are capped at 50 internal pages. A warning is printed to stderr only when that cap is actually hit and the returned history may be incomplete.
 
 ## Pattern 7: Multi-Chat Broadcast
 

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -877,6 +877,37 @@ describe('KakaoTalkClient', () => {
       client.close()
     })
 
+    it('uses the last-message log ID when the primary chat-list watermark is missing', async () => {
+      const loginResult = structuredClone(DEFAULT_LOGIN_RESULT)
+      const chat = loginResult.chatDatas[0]! as Record<string, unknown>
+      delete chat.ll
+      chat.l = { logId: makeLong(12) }
+      mockLogin.mockResolvedValueOnce(loginResult)
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: { status: 0, chatLogs: [], eof: true },
+      })
+      mockSyncMessages.mockResolvedValueOnce({
+        body: {
+          status: 0,
+          isOK: true,
+          chatLogs: [
+            { logId: makeLong(12), chatId: 100, type: 1, authorId: 42, message: 'last-log', sendAt: 1700000001 },
+          ],
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100', { from: '11' })
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]?.message).toBe('last-log')
+      expect(mockGetChatInfo).not.toHaveBeenCalled()
+      expect(mockSyncMessages.mock.calls[0]?.[2]?.toString()).toBe('11')
+      expect(mockSyncMessages.mock.calls[0]?.[3]?.toString()).toBe('12')
+
+      client.close()
+    })
+
     it('returns empty without entering the room when no chat-list watermark is available', async () => {
       mockLogin.mockResolvedValueOnce({ ...structuredClone(DEFAULT_LOGIN_RESULT), chatDatas: [] })
       mockGetChatLogs.mockResolvedValueOnce({

--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -805,11 +805,11 @@ describe('KakaoTalkClient', () => {
 
   describe('getMessages', () => {
     it('falls back to SYNCMSG when MCHATLOGS succeeds with an empty result', async () => {
+      const loginResult = structuredClone(DEFAULT_LOGIN_RESULT)
+      loginResult.chatDatas[0]!.ll = makeLong(10)
+      mockLogin.mockResolvedValueOnce(loginResult)
       mockGetChatLogs.mockResolvedValueOnce({
         body: { status: 0, chatLogs: [], eof: true },
-      })
-      mockGetChatInfo.mockResolvedValueOnce({
-        body: { status: 0, l: makeLong(10) },
       })
       mockSyncMessages.mockResolvedValueOnce({
         body: {
@@ -826,8 +826,69 @@ describe('KakaoTalkClient', () => {
 
       expect(messages).toHaveLength(1)
       expect(messages[0]?.message).toBe('fallback')
-      expect(mockGetChatInfo).toHaveBeenCalledTimes(1)
+      expect(mockGetChatInfo).not.toHaveBeenCalled()
       expect(mockSyncMessages).toHaveBeenCalledTimes(1)
+      expect(mockSyncMessages.mock.calls[0]?.[3]?.toString()).toBe('10')
+
+      client.close()
+    })
+
+    it('does not enter or sync a room when the MCHATLOGS cursor is already current', async () => {
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: { status: 0, chatLogs: [], eof: true },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100', { from: '999' })
+
+      expect(messages).toEqual([])
+      expect(mockGetChatInfo).not.toHaveBeenCalled()
+      expect(mockSyncMessages).not.toHaveBeenCalled()
+
+      client.close()
+    })
+
+    it('uses SYNCMSG without entering the room when the chat-list watermark is ahead of the cursor', async () => {
+      const loginResult = structuredClone(DEFAULT_LOGIN_RESULT)
+      loginResult.chatDatas[0]!.ll = makeLong(10)
+      mockLogin.mockResolvedValueOnce(loginResult)
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: { status: 0, chatLogs: [], eof: true },
+      })
+      mockSyncMessages.mockResolvedValueOnce({
+        body: {
+          status: 0,
+          isOK: true,
+          chatLogs: [
+            { logId: makeLong(10), chatId: 100, type: 1, authorId: 42, message: 'incremental', sendAt: 1700000001 },
+          ],
+        },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100', { from: '9' })
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]?.message).toBe('incremental')
+      expect(mockGetChatInfo).not.toHaveBeenCalled()
+      expect(mockSyncMessages.mock.calls[0]?.[2]?.toString()).toBe('9')
+      expect(mockSyncMessages.mock.calls[0]?.[3]?.toString()).toBe('10')
+
+      client.close()
+    })
+
+    it('returns empty without entering the room when no chat-list watermark is available', async () => {
+      mockLogin.mockResolvedValueOnce({ ...structuredClone(DEFAULT_LOGIN_RESULT), chatDatas: [] })
+      mockGetChatLogs.mockResolvedValueOnce({
+        body: { status: 0, chatLogs: [], eof: true },
+      })
+
+      const client = await new KakaoTalkClient().login({ oauthToken: 'token', userId: 'user1', deviceUuid: 'device1' })
+      const messages = await client.getMessages('100')
+
+      expect(messages).toEqual([])
+      expect(mockGetChatInfo).not.toHaveBeenCalled()
+      expect(mockSyncMessages).not.toHaveBeenCalled()
 
       client.close()
     })

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -242,6 +242,14 @@ function getOpenLinkId(chat: ChatData): Long | null {
   return bsonToLong(chat.li) ?? null
 }
 
+function getLoginMaxLogId(loginResult: LoginListResponse, chatId: string): Long | null {
+  const chat = (loginResult.chatDatas ?? []).find((entry) => longToString(entry.c) === chatId)
+  if (!chat) return null
+
+  const lastLog = chat.l as Record<string, unknown> | null | undefined
+  return bsonToLong(chat.ll) ?? bsonToLong(lastLog?.logId) ?? null
+}
+
 function matchesSearch(chat: ChatData, term: string): boolean {
   const names = (chat.k ?? []) as string[]
   const lower = term.toLowerCase()
@@ -827,7 +835,7 @@ export class KakaoTalkClient {
   }
 
   async getMessages(chatId: string, options?: { count?: number; from?: string }): Promise<KakaoMessage[]> {
-    return this.executeWithReconnect(async ({ session }) => {
+    return this.executeWithReconnect(async ({ session, loginResult }) => {
       try {
         const count = options?.count ?? 20
         const cursor = options?.from ? parseLong(options.from) : undefined
@@ -880,10 +888,13 @@ export class KakaoTalkClient {
           return formatMessages(allMessages, count, chatId, this.nameCache)
         }
 
-        // Fetch fresh lastLogId via CHATONROOM (not the stale login-time snapshot)
-        const chatInfo = await session.getChatInfo(cid)
-        const chatBody = chatInfo.body as Record<string, unknown>
-        const maxLogId = bsonToLong(chatBody.l)
+        // CHATONROOM represents entering a room and can advance unread state on
+        // the server. Use the login-time chat-list watermark for the read-only
+        // SYNCMSG fallback instead, and skip sync when the cursor is current.
+        const maxLogId = getLoginMaxLogId(loginResult, chatId)
+        if (!maxLogId || maxLogId.lessThanOrEqual(cur)) {
+          return []
+        }
 
         let reachedEnd = false
         for (let page = 0; page < MAX_PAGES; page++) {


### PR DESCRIPTION
## Summary

- remove `CHATONROOM` from the KakaoTalk message-history fallback
- use the login chat-list `ll` / `l.logId` watermark as the `SYNCMSG` upper bound
- skip fallback work when the caller's cursor is current or no safe watermark exists
- cover bootstrap, current-cursor, behind-cursor, and missing-watermark behavior

Fixes #315.

## Background

#314 made a successful empty first `MCHATLOGS` response enter the existing `CHATONROOM` + `SYNCMSG` fallback. That fixes the PlusChat response shape from #313, but an empty response is also normal when an incremental `from` cursor is already current.

As a result, routine polling can repeatedly issue `CHATONROOM` for idle chats. In a Dockerized collector using the same fallback logic, aggregate unread state was cleared even though the collector never called `markRead()` / `NOTIREAD`.

## Implementation

`getMessages()` now finds the target chat in the login response and reads its maximum log ID from:

1. `chatDatas[].ll`
2. `chatDatas[].l.logId` as a fallback

If that watermark is absent or not ahead of the current cursor, the method returns `[]`. Otherwise it calls `SYNCMSG` directly. The message-history path no longer calls `getChatInfo()` / `CHATONROOM`.

This intentionally fails closed when no safe watermark is available. A future chat-list refresh can improve long-lived session freshness without reintroducing room-entry side effects.

## TDD evidence

The test-only commit fails four new/updated cases against `2.32.2`, each because `getChatInfo()` is called unexpectedly. The implementation commit makes all four pass.

## Validation

- `bun test src/platforms/kakaotalk/client.test.ts` — 97 passed
- `bun test src/` — 3,638 passed
- `bun run typecheck`
- `bun run lint` — 0 warnings, 0 errors
- `bun run build`
- `bun run format:check`
- `git diff --check`

Live validation used a local Docker bridge with no chat IDs, names, or message contents included here:

- seven consecutive polling cycles completed with no failed chats
- unread counts remained present and increased as new messages arrived instead of resetting to zero
- regular, open, and PlusChat unread counts all remained visible
- open-chat message bodies continued to be collected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented unintended room entry during KakaoTalk message-history fallback by removing `CHATONROOM` and bounding `SYNCMSG` with the login chat-list watermark (`ll`, falling back to `l.logId`). This keeps unread counts stable and only syncs when the cursor is behind a safe watermark.

- **Bug Fixes**
  - Removed `CHATONROOM` from fallback; use login watermark to bound `SYNCMSG`.
  - Added fallback to last-message `l.logId` when `ll` is missing.
  - Skip fallback when the cursor is current or no safe watermark exists.
  - Added tests for empty-log fallback, current/behind-cursor cases, missing watermark, and last-log watermark.

- **Docs**
  - Updated `skills/agent-kakaotalk/references/common-patterns.md` to document the read-safe fallback. `SKILL.md` unchanged.

<sup>Written for commit eba4bf67270075aab3f819efed056620ed282007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

