### PR TITLE
fix(kakaotalk): reject invalid LOGINLIST authentication

### DIFF
--- a/src/platforms/kakaotalk/client.test.ts
+++ b/src/platforms/kakaotalk/client.test.ts
@@ -144,6 +144,31 @@ describe('KakaoTalkClient', () => {
         expect((e as KakaoTalkError).code).toBe('missing_user_id')
       }
     })
+
+    it('preserves typed invalid_access_token failures and never proceeds to LCHATLIST', async () => {
+      const authError = Object.assign(new Error('KakaoTalk LOGINLIST rejected'), {
+        code: 'invalid_access_token',
+        serverStatus: -950,
+      })
+      mockLogin.mockRejectedValue(authError)
+      const client = await new KakaoTalkClient().login({
+        oauthToken: 'expired-access-token',
+        userId: 'user1',
+        deviceUuid: 'device1',
+      })
+
+      let error: unknown
+      try {
+        await client.getChats()
+      } catch (cause) {
+        error = cause
+      }
+
+      expect(error).toBeInstanceOf(KakaoTalkError)
+      expect(error).toMatchObject({ code: 'invalid_access_token', serverStatus: -950 })
+      expect(mockGetChatList).not.toHaveBeenCalled()
+      expect(mockClose).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('getChats', () => {

--- a/src/platforms/kakaotalk/client.ts
+++ b/src/platforms/kakaotalk/client.ts
@@ -40,11 +40,13 @@ export type KakaoSessionEventHandler = (event: KakaoSessionEvent) => void
 
 export class KakaoTalkError extends Error {
   code: string
+  readonly serverStatus?: number
 
-  constructor(message: string, code: string, options?: { cause?: unknown }) {
+  constructor(message: string, code: string, options?: { cause?: unknown; serverStatus?: number }) {
     super(message, options)
     this.name = 'KakaoTalkError'
     this.code = code
+    this.serverStatus = options?.serverStatus
   }
 }
 
@@ -278,6 +280,17 @@ function wrapError(error: unknown, code: string): KakaoTalkError {
   if (error instanceof KakaoTalkError) return error
   const message = error instanceof Error ? error.message : String(error)
   return new KakaoTalkError(message, code, { cause: error })
+}
+
+function isLoginResponseError(
+  error: unknown,
+): error is Error & { code: 'invalid_access_token' | 'login_rejected'; serverStatus: number } {
+  if (!(error instanceof Error)) return false
+  const candidate = error as Error & { code?: unknown; serverStatus?: unknown }
+  return (
+    (candidate.code === 'invalid_access_token' || candidate.code === 'login_rejected') &&
+    typeof candidate.serverStatus === 'number'
+  )
 }
 
 const MAX_PAGES = 50
@@ -675,7 +688,11 @@ export class KakaoTalkClient {
       return { session, loginResult }
     } catch (error) {
       session.close()
-      throw new KakaoTalkError(error instanceof Error ? error.message : String(error), 'login_failed', { cause: error })
+      const code = isLoginResponseError(error) ? error.code : 'login_failed'
+      throw new KakaoTalkError(error instanceof Error ? error.message : String(error), code, {
+        cause: error,
+        serverStatus: isLoginResponseError(error) ? error.serverStatus : undefined,
+      })
     }
   }
 

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -6,6 +6,7 @@ export { KakaoTalkListener } from './listener'
 export type { PendingLoginState } from './credential-manager'
 export type {
   KakaoAccountCredentials,
+  KakaoAuthErrorCode,
   KakaoAuthMethod,
   KakaoChat,
   KakaoConfig,

--- a/src/platforms/kakaotalk/protocol/login-response.test.ts
+++ b/src/platforms/kakaotalk/protocol/login-response.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test'
+
+import { validateLoginListResponse } from './login-response'
+import type { LocoPacket } from './types'
+
+function packet(statusCode: number, body: Record<string, unknown>): LocoPacket {
+  return { packetId: 1, statusCode, method: 'LOGINLIST', bodyType: 0, body }
+}
+
+describe('LOGINLIST authentication response contract', () => {
+  it('accepts status=0 and returns the login snapshot', () => {
+    const body = { status: 0, chatDatas: [], eof: true }
+
+    expect(validateLoginListResponse(packet(0, body))).toBe(body)
+  })
+
+  it('accepts a successful response when body.status is omitted', () => {
+    const body = { chatDatas: [], eof: true }
+
+    expect(validateLoginListResponse(packet(0, body))).toBe(body)
+  })
+
+  it('rejects body.status=-950 as invalid_access_token', () => {
+    expect(() => validateLoginListResponse(packet(0, { status: -950 }))).toThrow(
+      expect.objectContaining({ code: 'invalid_access_token', serverStatus: -950 }),
+    )
+  })
+
+  it('rejects unknown non-zero body status as login_rejected', () => {
+    expect(() => validateLoginListResponse(packet(0, { status: -777 }))).toThrow(
+      expect.objectContaining({ code: 'login_rejected', serverStatus: -777 }),
+    )
+  })
+
+  it('rejects non-zero transport status before inspecting the body', () => {
+    expect(() => validateLoginListResponse(packet(-1, { status: -950 }))).toThrow(
+      expect.objectContaining({ code: 'login_rejected', serverStatus: -1 }),
+    )
+  })
+})

--- a/src/platforms/kakaotalk/protocol/login-response.ts
+++ b/src/platforms/kakaotalk/protocol/login-response.ts
@@ -1,0 +1,31 @@
+import type { KakaoAuthErrorCode } from '../types'
+import type { LoginListResponse, LocoPacket } from './types'
+
+export class KakaoLoginResponseError extends Error {
+  readonly code: KakaoAuthErrorCode
+  readonly serverStatus: number
+
+  constructor(code: KakaoAuthErrorCode, serverStatus: number) {
+    const reason = code === 'invalid_access_token' ? 'invalid access token' : 'login rejected'
+    super(`KakaoTalk LOGINLIST ${reason} (status ${serverStatus})`)
+    this.name = 'KakaoLoginResponseError'
+    this.code = code
+    this.serverStatus = serverStatus
+  }
+}
+
+export function validateLoginListResponse(response: LocoPacket): LoginListResponse {
+  if (response.statusCode !== 0) {
+    throw new KakaoLoginResponseError('login_rejected', response.statusCode)
+  }
+
+  const bodyStatus = typeof response.body.status === 'number' ? response.body.status : 0
+  if (bodyStatus === -950) {
+    throw new KakaoLoginResponseError('invalid_access_token', bodyStatus)
+  }
+  if (bodyStatus !== 0) {
+    throw new KakaoLoginResponseError('login_rejected', bodyStatus)
+  }
+
+  return response.body as unknown as LoginListResponse
+}

--- a/src/platforms/kakaotalk/protocol/session.ts
+++ b/src/platforms/kakaotalk/protocol/session.ts
@@ -15,6 +15,7 @@ import {
   getLocoDeviceConfig,
 } from './config'
 import { LocoConnection } from './connection'
+import { validateLoginListResponse } from './login-response'
 import type { BookingResponse, CheckinResponse, LoginListResponse, LocoPacket, SyncState } from './types'
 
 // LOCO opcode string emitted on the wire for typing indicator pulses.
@@ -81,27 +82,34 @@ export class LocoSession {
     const lastTokenId = syncState ? new Long(syncState.lastTokenId.low, syncState.lastTokenId.high) : Long.fromNumber(0)
     const lbk = syncState?.lbk ?? 0
 
-    const response = await this.connection.sendPacket('LOGINLIST', {
-      appVer: deviceConfig.appVersion,
-      prtVer: PROTOCOL_VERSION,
-      os: deviceConfig.os,
-      lang: LANG,
-      dtype: DTYPE,
-      duuid: deviceUuid,
-      oauthToken,
-      ntype: 0,
-      MCCMNC: MCCMNC,
-      revision: syncState?.revision ?? 0,
-      chatIds,
-      maxIds,
-      lastTokenId,
-      lbk,
-      rp: new Binary(Buffer.from([0x00, 0x00, 0xff, 0xff, 0x00, 0x00])),
-      bg: false,
-    })
+    try {
+      const response = await this.connection.sendPacket('LOGINLIST', {
+        appVer: deviceConfig.appVersion,
+        prtVer: PROTOCOL_VERSION,
+        os: deviceConfig.os,
+        lang: LANG,
+        dtype: DTYPE,
+        duuid: deviceUuid,
+        oauthToken,
+        ntype: 0,
+        MCCMNC: MCCMNC,
+        revision: syncState?.revision ?? 0,
+        chatIds,
+        maxIds,
+        lastTokenId,
+        lbk,
+        rp: new Binary(Buffer.from([0x00, 0x00, 0xff, 0xff, 0x00, 0x00])),
+        bg: false,
+      })
 
-    this.startPing()
-    return response.body as unknown as LoginListResponse
+      const loginResult = validateLoginListResponse(response)
+      this.startPing()
+      return loginResult
+    } catch (error) {
+      this.connection.close()
+      this.connection = null
+      throw error
+    }
   }
 
   private async bookAndCheckin(

--- a/src/platforms/kakaotalk/protocol/types.ts
+++ b/src/platforms/kakaotalk/protocol/types.ts
@@ -36,6 +36,7 @@ export interface SyncState {
 
 // LOGINLIST uses short BSON field names: c=chatId, t=type, a=activeMembers, etc.
 export interface LoginListResponse extends ChatListResponse {
+  status?: number
   userId: number
   revision: number
 }

--- a/src/platforms/kakaotalk/types.ts
+++ b/src/platforms/kakaotalk/types.ts
@@ -12,6 +12,7 @@ export interface ExtractedKakaoToken {
 }
 
 export type KakaoAuthMethod = 'login' | 'extract'
+export type KakaoAuthErrorCode = 'invalid_access_token' | 'login_rejected'
 
 export interface KakaoAccountCredentials {
   account_id: string


### PR DESCRIPTION
## Summary

- validate both LOCO packet status and `LOGINLIST` body status before adopting a Kakao session
- classify Kakao status `-950` as `invalid_access_token` and other non-zero statuses as `login_rejected`
- preserve the safe numeric server status on `KakaoTalkError`
- close the provisional LOCO connection and avoid sync-state/LCHATLIST work after rejected authentication

## Why

Kakao can return `LOGINLIST { status: -950 }` and immediately close the socket. The previous implementation treated that body as a successful login, then surfaced only a secondary `EPIPE` from the next request. Callers could not distinguish expired credentials from a network failure.

## Tests

- success with explicit or omitted body status
- `body.status=-950`
- unknown non-zero body status
- non-zero packet transport status
- client error-code/status preservation and no `LCHATLIST` continuation
- `bun test src/platforms/kakaotalk`
- `bun run typecheck`
- `bun run lint`

Related downstream tracking: LLagoon3/openclaw-kakao-bridge#15


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid KakaoTalk `LOGINLIST` authentication and return clear error codes. Prevents expired tokens from being reported as network errors.

- **Bug Fixes**
  - Validate LOCO transport status and `LOGINLIST` body before adopting a session.
  - Map body status `-950` to `invalid_access_token`; other non‑zero to `login_rejected`.
  - Preserve numeric `serverStatus` on `KakaoTalkError`/`KakaoLoginResponseError`.
  - Close the provisional LOCO connection and skip `LCHATLIST`/sync after rejection.
  - Export `KakaoAuthErrorCode`; add optional `status` to `LoginListResponse`.
  - Tests cover success, `-950`, other non‑zero, and non‑zero transport.
  - Docs: `SKILL.md`/docs not updated.

<sup>Written for commit e27a87d801b050f6a5ceb574e0acc426beb9d241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

