### PR TITLE
feat(kakaotalk): add explicit OAuth token refresh primitive

### DIFF
--- a/docs/content/docs/sdk/kakaotalk.mdx
+++ b/docs/content/docs/sdk/kakaotalk.mdx
@@ -194,6 +194,38 @@ client.close()
 
 Once closed, any subsequent method call throws a `KakaoTalkError` with code `client_closed`. Create a new client if you need to reconnect.
 
+## OAuth Token Refresh
+
+`refreshKakaoOAuthToken()` explicitly exchanges a stored Android sub-device refresh token for a new token set. It is stateless and caller-invoked: it does not update credential files, retry `LOGINLIST`, or run automatically after an authentication failure.
+
+```typescript
+import { refreshKakaoOAuthToken } from 'agent-messenger/kakaotalk'
+
+if (!account.refresh_token) throw new Error('No KakaoTalk refresh token')
+
+const refreshed = await refreshKakaoOAuthToken(
+  {
+    accessToken: account.oauth_token,
+    refreshToken: account.refresh_token,
+    deviceUuid: account.device_uuid,
+  },
+  { timeoutMs: 15_000 },
+)
+
+const nextAccount = {
+  ...account,
+  oauth_token: refreshed.accessToken,
+  refresh_token: refreshed.refreshToken,
+  updated_at: new Date().toISOString(),
+}
+
+await persistAccountAtomically(nextAccount) // Application-defined durable storage
+```
+
+The result always includes both tokens. Kakao may rotate the refresh token, so persist the entire returned token set atomically before the process exits or another client uses the credential. Never refresh a copied production credential and discard the result.
+
+Failures throw `KakaoOAuthRefreshError` with a safe `code` and optional `serverStatus` or `httpStatus`; token values and raw response bodies are not retained. This uses an undocumented Android endpoint and may change without notice.
+
 ## KakaoTalkListener
 
 Real-time event listener that receives push events from KakaoTalk via the LOCO protocol. Subscribes to the underlying client's LOCO session.

--- a/skills/agent-kakaotalk/SKILL.md
+++ b/skills/agent-kakaotalk/SKILL.md
@@ -599,6 +599,32 @@ if (!account) throw new Error('Not authenticated')
 const client = await new KakaoTalkClient().login({ oauthToken: account.oauth_token, userId: account.user_id, deviceUuid: account.device_uuid })
 ```
 
+For caller-managed token renewal, use the explicit SDK primitive:
+
+```typescript
+import { refreshKakaoOAuthToken } from 'agent-messenger/kakaotalk'
+
+if (!account.refresh_token) throw new Error('No KakaoTalk refresh token')
+
+const refreshed = await refreshKakaoOAuthToken({
+  accessToken: account.oauth_token,
+  refreshToken: account.refresh_token,
+  deviceUuid: account.device_uuid,
+})
+
+const nextAccount = {
+  ...account,
+  oauth_token: refreshed.accessToken,
+  refresh_token: refreshed.refreshToken,
+  updated_at: new Date().toISOString(),
+}
+
+// Persist nextAccount atomically before another client uses this credential.
+// The refresh primitive intentionally does not write credential files or retry login.
+```
+
+Kakao can rotate the refresh token. Never refresh a copied production credential and discard the returned token set. See [references/authentication.md](references/authentication.md) for error codes and the controlled canary procedure.
+
 ### Example
 
 ```typescript

--- a/skills/agent-kakaotalk/references/authentication.md
+++ b/skills/agent-kakaotalk/references/authentication.md
@@ -262,6 +262,36 @@ KakaoTalk OAuth tokens can expire or be invalidated when:
 - The token naturally expires
 - KakaoTalk's server revokes the session
 
+### Explicit SDK Refresh
+
+The SDK exports `refreshKakaoOAuthToken()` for callers that need to exchange a stored Android sub-device refresh token for a new token set:
+
+```typescript
+import { refreshKakaoOAuthToken } from 'agent-messenger/kakaotalk'
+
+const refreshed = await refreshKakaoOAuthToken({
+  accessToken: account.oauth_token,
+  refreshToken: account.refresh_token,
+  deviceUuid: account.device_uuid,
+})
+```
+
+This is an explicit, stateless operation. It does not retry `LOGINLIST`, update the credentials file, or run automatically when a command receives `invalid_access_token`.
+
+The result always contains an access token and refresh token. Kakao may rotate the refresh token; if the response omits it, the SDK preserves the input refresh token in the returned value. The caller must persist both returned tokens atomically before the process exits or another client uses the same credential.
+
+Do not refresh a copied production credential and discard the result. A successful refresh can invalidate the previously stored refresh token on the server.
+
+Failures throw `KakaoOAuthRefreshError` with safe metadata only:
+
+- `refresh_credentials_missing` — an access token, refresh token, or device UUID was not provided.
+- `refresh_rejected` — Kakao returned an explicit non-zero status; inspect `serverStatus`.
+- `refresh_http_error` — the endpoint returned an HTTP failure without a Kakao status; inspect `httpStatus`.
+- `refresh_timeout` / `refresh_request_failed` — the request did not complete.
+- `refresh_malformed_response` — a successful response did not contain a usable access token.
+
+Token values, authorization headers, and raw response bodies are not included in these errors. The endpoint is an undocumented Android API and can change without notice.
+
 ### Re-authentication
 
 If commands start failing with auth errors:

--- a/skills/agent-kakaotalk/references/authentication.md
+++ b/skills/agent-kakaotalk/references/authentication.md
@@ -282,6 +282,19 @@ The result always contains an access token and refresh token. Kakao may rotate t
 
 Do not refresh a copied production credential and discard the result. A successful refresh can invalidate the previously stored refresh token on the server.
 
+#### Controlled Live Canary
+
+Use a dedicated test account and device when possible. If a production credential is the only available canary, use this sequence:
+
+1. Stop every collector, CLI process, and service that can use the credential. Confirm there is only one refresh caller.
+2. Prepare an atomic persistence path before making the request. Credential files must keep `0600` permissions.
+3. Call `refreshKakaoOAuthToken()` exactly once. Record only success, token-rotation booleans, and expiry metadata — never tokens, authorization headers, account IDs, or the raw response.
+4. If a token set is returned, immediately persist both returned tokens with a temporary file, `fsync`, and atomic rename. Do not let the process exit or another client start first.
+5. Start a fresh process, reload the persisted credential, and verify that `LOGINLIST` and a minimal chat-list request succeed.
+6. Scan application logs and temporary files for the old and new token values, confirm the credential still has `0600` permissions, then restart the stopped caller.
+
+If the refresh request fails before returning a token set, leave the stored credential unchanged and stop the canary. Do not loop blindly: an ambiguous network failure may have occurred after server-side rotation, in which case re-authentication can be required.
+
 Failures throw `KakaoOAuthRefreshError` with safe metadata only:
 
 - `refresh_credentials_missing` — an access token, refresh token, or device UUID was not provided.

--- a/src/platforms/kakaotalk/auth/kakao-login.ts
+++ b/src/platforms/kakaotalk/auth/kakao-login.ts
@@ -7,8 +7,8 @@ import type { KakaoDeviceType, KakaoLoginResult } from '../types'
 const ANDROID_APP_VERSION = '25.9.2'
 const ANDROID_OS_VERSION = '13'
 const ANDROID_API_LEVEL = '33'
-const ANDROID_AGENT = `android/${ANDROID_APP_VERSION}/ko`
-const ANDROID_USER_AGENT = `KT/${ANDROID_APP_VERSION} An/${ANDROID_OS_VERSION} ko`
+export const ANDROID_AGENT = `android/${ANDROID_APP_VERSION}/ko`
+export const ANDROID_USER_AGENT = `KT/${ANDROID_APP_VERSION} An/${ANDROID_OS_VERSION} ko`
 const ANDROID_LOGIN_URL = 'https://katalk.kakao.com/android/account/login.json'
 const ANDROID_PASSCODE_URL = 'https://katalk.kakao.com/android/account/passcodeLogin/generate'
 const ANDROID_REGISTER_URL = 'https://katalk.kakao.com/android/account/passcodeLogin/registerDevice'

--- a/src/platforms/kakaotalk/auth/oauth-refresh.test.ts
+++ b/src/platforms/kakaotalk/auth/oauth-refresh.test.ts
@@ -165,6 +165,52 @@ describe('refreshKakaoOAuthToken', () => {
     expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken)
   })
 
+  it('keeps the timeout active while consuming a stalled response body', async () => {
+    const fetchImpl = mock(async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const fallback = setTimeout(() => {
+            controller.error(Object.assign(new Error('stalled body access-secret'), { name: 'AbortError' }))
+          }, 50)
+
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(fallback)
+              controller.error(Object.assign(new Error('stalled body access-secret'), { name: 'AbortError' }))
+            },
+            { once: true },
+          )
+        },
+      })
+
+      return new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl, timeoutMs: 5 }))
+
+    expect(error).toMatchObject({ code: 'refresh_timeout' })
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken)
+  })
+
+  it('classifies response body transport failures without retaining a secret-bearing cause', async () => {
+    const fetchImpl = mock(async (): Promise<Response> => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error(`body failure ${credentials.accessToken} ${credentials.refreshToken}`))
+        },
+      })
+
+      return new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_request_failed' })
+    expect(error.cause).toBeUndefined()
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken)
+  })
+
   it('classifies network failures without retaining a secret-bearing cause', async () => {
     const fetchImpl = mock(async () => {
       throw new Error(`network failure ${credentials.accessToken} ${credentials.refreshToken}`)

--- a/src/platforms/kakaotalk/auth/oauth-refresh.test.ts
+++ b/src/platforms/kakaotalk/auth/oauth-refresh.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, mock } from 'bun:test'
+
+import { KakaoOAuthRefreshError, refreshKakaoOAuthToken } from './oauth-refresh'
+
+const HEX_DEVICE_UUID = 'a'.repeat(64)
+const credentials = {
+  accessToken: 'access-secret',
+  refreshToken: 'refresh-secret',
+  deviceUuid: HEX_DEVICE_UUID,
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function captureError(promise: Promise<unknown>): Promise<KakaoOAuthRefreshError> {
+  return promise.then(
+    () => {
+      throw new Error('Expected refresh to fail')
+    },
+    (error: unknown) => {
+      expect(error).toBeInstanceOf(KakaoOAuthRefreshError)
+      return error as KakaoOAuthRefreshError
+    },
+  )
+}
+
+function expectSecretsRedacted(error: Error, ...secrets: string[]): void {
+  const rendered = `${String(error)}\n${error.stack ?? ''}\n${JSON.stringify(error)}`
+  for (const secret of secrets) {
+    expect(rendered).not.toContain(secret)
+  }
+}
+
+describe('refreshKakaoOAuthToken', () => {
+  it('sends the Android sub-device refresh request and returns rotated tokens', async () => {
+    const fetchImpl = mock(async () =>
+      jsonResponse({
+        status: 0,
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        token_type: 'bearer',
+        expires_in: 3600,
+      }),
+    )
+
+    const result = await refreshKakaoOAuthToken(credentials, {
+      fetchImpl,
+      requestId: () => 'request-id',
+    })
+
+    expect(result).toEqual({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      tokenType: 'bearer',
+      expiresIn: 3600,
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://katalk.kakao.com/android/account/oauth2_token.json')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toEqual({
+      A: 'android/25.9.2/ko',
+      Authorization: `access-secret-${HEX_DEVICE_UUID}`,
+      'User-Agent': 'KT/25.9.2 An/13 ko',
+      'Accept-Language': 'ko',
+      'Content-Type': 'application/json; charset=utf-8',
+      C: 'request-id',
+      Connection: 'Close',
+    })
+    expect(JSON.parse(String(init.body))).toEqual({
+      access_token: credentials.accessToken,
+      refresh_token: credentials.refreshToken,
+      grant_type: 'refresh_token',
+    })
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('derives the Android device id for a non-hex UUID', async () => {
+    const fetchImpl = mock(async () => jsonResponse({ status: 0, access_token: 'new-access' }))
+
+    await refreshKakaoOAuthToken({ ...credentials, deviceUuid: 'device-uuid' }, { fetchImpl })
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit]
+    expect(init.headers).toMatchObject({
+      Authorization: 'access-secret-db214b8bbba42ef7a5fbc4c1bbba91305178ade87b29f1378f55b69fc04caac5',
+    })
+  })
+
+  it('preserves the input refresh token when Kakao does not rotate it', async () => {
+    const fetchImpl = mock(async () => jsonResponse({ status: 0, access_token: 'new-access' }))
+
+    await expect(refreshKakaoOAuthToken(credentials, { fetchImpl })).resolves.toEqual({
+      accessToken: 'new-access',
+      refreshToken: credentials.refreshToken,
+      tokenType: undefined,
+      expiresIn: undefined,
+    })
+  })
+
+  it('rejects missing credentials before making a request', async () => {
+    const fetchImpl = mock(async () => jsonResponse({ status: 0, access_token: 'unused' }))
+
+    const error = await captureError(refreshKakaoOAuthToken({ ...credentials, refreshToken: '' }, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_credentials_missing' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('classifies a Kakao rejection with safe status metadata', async () => {
+    const fetchImpl = mock(async () =>
+      jsonResponse({ status: -950, message: 'rejected', raw: 'raw-response-secret' }, 401),
+    )
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_rejected', serverStatus: -950, httpStatus: 401 })
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken, 'raw-response-secret')
+  })
+
+  it('classifies an HTTP failure without a Kakao status', async () => {
+    const fetchImpl = mock(async () => jsonResponse({ message: 'unavailable' }, 503))
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_http_error', httpStatus: 503 })
+    expect(error.serverStatus).toBeUndefined()
+  })
+
+  it('rejects a malformed successful response without exposing the body', async () => {
+    const fetchImpl = mock(async () => jsonResponse({ status: 0, access_token: '', raw: 'do-not-log' }))
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_malformed_response', httpStatus: 200 })
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken, 'do-not-log')
+  })
+
+  it('rejects a non-JSON response without exposing its text', async () => {
+    const fetchImpl = mock(async () => new Response('body-secret', { status: 200 }))
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_malformed_response', httpStatus: 200 })
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken, 'body-secret')
+  })
+
+  it('aborts a request after the configured timeout', async () => {
+    const fetchImpl = mock(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        await new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('timed out with access-secret'), { name: 'AbortError' }))
+          })
+        }),
+    )
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl, timeoutMs: 5 }))
+
+    expect(error).toMatchObject({ code: 'refresh_timeout' })
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken)
+  })
+
+  it('classifies network failures without retaining a secret-bearing cause', async () => {
+    const fetchImpl = mock(async () => {
+      throw new Error(`network failure ${credentials.accessToken} ${credentials.refreshToken}`)
+    })
+
+    const error = await captureError(refreshKakaoOAuthToken(credentials, { fetchImpl }))
+
+    expect(error).toMatchObject({ code: 'refresh_request_failed' })
+    expect(error.cause).toBeUndefined()
+    expectSecretsRedacted(error, credentials.accessToken, credentials.refreshToken)
+  })
+})

--- a/src/platforms/kakaotalk/auth/oauth-refresh.ts
+++ b/src/platforms/kakaotalk/auth/oauth-refresh.ts
@@ -1,0 +1,137 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+import { ANDROID_AGENT, ANDROID_USER_AGENT } from './kakao-login'
+
+const ANDROID_OAUTH_REFRESH_URL = 'https://katalk.kakao.com/android/account/oauth2_token.json'
+const DEFAULT_REFRESH_TIMEOUT_MS = 15_000
+
+export type KakaoOAuthRefreshErrorCode =
+  | 'refresh_credentials_missing'
+  | 'refresh_http_error'
+  | 'refresh_malformed_response'
+  | 'refresh_rejected'
+  | 'refresh_request_failed'
+  | 'refresh_timeout'
+
+export class KakaoOAuthRefreshError extends Error {
+  readonly code: KakaoOAuthRefreshErrorCode
+  readonly serverStatus?: number
+  readonly httpStatus?: number
+
+  constructor(code: KakaoOAuthRefreshErrorCode, options?: { serverStatus?: number; httpStatus?: number }) {
+    super(`KakaoTalk OAuth token refresh failed (${code})`)
+    this.name = 'KakaoOAuthRefreshError'
+    this.code = code
+    this.serverStatus = options?.serverStatus
+    this.httpStatus = options?.httpStatus
+  }
+}
+
+export interface KakaoOAuthRefreshInput {
+  accessToken: string
+  refreshToken: string
+  deviceUuid: string
+}
+
+export interface KakaoOAuthRefreshResult {
+  accessToken: string
+  refreshToken: string
+  tokenType?: string
+  expiresIn?: number
+}
+
+interface KakaoOAuthRefreshOptions {
+  fetchImpl?: typeof fetch
+  requestId?: () => string
+  timeoutMs?: number
+}
+
+function buildDeviceId(deviceUuid: string): string {
+  if (/^[a-f0-9]{40,64}$/i.test(deviceUuid)) return deviceUuid
+  return createHash('sha256').update(`dkljleskljfeisflssljeif ${deviceUuid}`, 'utf8').digest('hex')
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+export async function refreshKakaoOAuthToken(
+  input: KakaoOAuthRefreshInput,
+  options: KakaoOAuthRefreshOptions = {},
+): Promise<KakaoOAuthRefreshResult> {
+  if (!input.accessToken || !input.refreshToken || !input.deviceUuid) {
+    throw new KakaoOAuthRefreshError('refresh_credentials_missing')
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetchImpl(ANDROID_OAUTH_REFRESH_URL, {
+      method: 'POST',
+      headers: {
+        A: ANDROID_AGENT,
+        Authorization: `${input.accessToken}-${buildDeviceId(input.deviceUuid)}`,
+        'User-Agent': ANDROID_USER_AGENT,
+        'Accept-Language': 'ko',
+        'Content-Type': 'application/json; charset=utf-8',
+        C: (options.requestId ?? randomUUID)(),
+        Connection: 'Close',
+      },
+      body: JSON.stringify({
+        access_token: input.accessToken,
+        refresh_token: input.refreshToken,
+        grant_type: 'refresh_token',
+      }),
+      signal: controller.signal,
+    })
+  } catch (error) {
+    const timedOut = controller.signal.aborted || (error instanceof Error && error.name === 'AbortError')
+    throw new KakaoOAuthRefreshError(timedOut ? 'refresh_timeout' : 'refresh_request_failed')
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  let body: Record<string, unknown> | null
+  try {
+    body = readRecord(await response.json())
+  } catch {
+    body = null
+  }
+
+  const serverStatus = body && typeof body.status === 'number' ? body.status : undefined
+  if (!response.ok) {
+    throw new KakaoOAuthRefreshError(
+      serverStatus !== undefined && serverStatus !== 0 ? 'refresh_rejected' : 'refresh_http_error',
+      { serverStatus: serverStatus !== 0 ? serverStatus : undefined, httpStatus: response.status },
+    )
+  }
+
+  if (!body) {
+    throw new KakaoOAuthRefreshError('refresh_malformed_response', { httpStatus: response.status })
+  }
+
+  if (serverStatus !== undefined && serverStatus !== 0) {
+    throw new KakaoOAuthRefreshError('refresh_rejected', {
+      serverStatus,
+      httpStatus: response.status,
+    })
+  }
+
+  const accessToken = typeof body.access_token === 'string' ? body.access_token : ''
+  if (!accessToken) {
+    throw new KakaoOAuthRefreshError('refresh_malformed_response', { httpStatus: response.status })
+  }
+
+  return {
+    accessToken,
+    refreshToken:
+      typeof body.refresh_token === 'string' && body.refresh_token ? body.refresh_token : input.refreshToken,
+    tokenType: typeof body.token_type === 'string' && body.token_type ? body.token_type : undefined,
+    expiresIn: typeof body.expires_in === 'number' ? body.expires_in : undefined,
+  }
+}

--- a/src/platforms/kakaotalk/auth/oauth-refresh.ts
+++ b/src/platforms/kakaotalk/auth/oauth-refresh.ts
@@ -40,7 +40,7 @@ export interface KakaoOAuthRefreshResult {
   expiresIn?: number
 }
 
-interface KakaoOAuthRefreshOptions {
+export interface KakaoOAuthRefreshOptions {
   fetchImpl?: typeof fetch
   requestId?: () => string
   timeoutMs?: number
@@ -57,6 +57,11 @@ function readRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
+function transportError(error: unknown, signal: AbortSignal): KakaoOAuthRefreshError {
+  const timedOut = signal.aborted || (error instanceof Error && error.name === 'AbortError')
+  return new KakaoOAuthRefreshError(timedOut ? 'refresh_timeout' : 'refresh_request_failed')
+}
+
 export async function refreshKakaoOAuthToken(
   input: KakaoOAuthRefreshInput,
   options: KakaoOAuthRefreshOptions = {},
@@ -69,69 +74,71 @@ export async function refreshKakaoOAuthToken(
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS)
 
-  let response: Response
   try {
-    response = await fetchImpl(ANDROID_OAUTH_REFRESH_URL, {
-      method: 'POST',
-      headers: {
-        A: ANDROID_AGENT,
-        Authorization: `${input.accessToken}-${buildDeviceId(input.deviceUuid)}`,
-        'User-Agent': ANDROID_USER_AGENT,
-        'Accept-Language': 'ko',
-        'Content-Type': 'application/json; charset=utf-8',
-        C: (options.requestId ?? randomUUID)(),
-        Connection: 'Close',
-      },
-      body: JSON.stringify({
-        access_token: input.accessToken,
-        refresh_token: input.refreshToken,
-        grant_type: 'refresh_token',
-      }),
-      signal: controller.signal,
-    })
-  } catch (error) {
-    const timedOut = controller.signal.aborted || (error instanceof Error && error.name === 'AbortError')
-    throw new KakaoOAuthRefreshError(timedOut ? 'refresh_timeout' : 'refresh_request_failed')
+    let response: Response
+    try {
+      response = await fetchImpl(ANDROID_OAUTH_REFRESH_URL, {
+        method: 'POST',
+        headers: {
+          A: ANDROID_AGENT,
+          Authorization: `${input.accessToken}-${buildDeviceId(input.deviceUuid)}`,
+          'User-Agent': ANDROID_USER_AGENT,
+          'Accept-Language': 'ko',
+          'Content-Type': 'application/json; charset=utf-8',
+          C: (options.requestId ?? randomUUID)(),
+          Connection: 'Close',
+        },
+        body: JSON.stringify({
+          access_token: input.accessToken,
+          refresh_token: input.refreshToken,
+          grant_type: 'refresh_token',
+        }),
+        signal: controller.signal,
+      })
+    } catch (error) {
+      throw transportError(error, controller.signal)
+    }
+
+    let body: Record<string, unknown> | null
+    try {
+      body = readRecord(await response.json())
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw transportError(error, controller.signal)
+      body = null
+    }
+
+    const serverStatus = body && typeof body.status === 'number' ? body.status : undefined
+    if (!response.ok) {
+      throw new KakaoOAuthRefreshError(
+        serverStatus !== undefined && serverStatus !== 0 ? 'refresh_rejected' : 'refresh_http_error',
+        { serverStatus: serverStatus !== 0 ? serverStatus : undefined, httpStatus: response.status },
+      )
+    }
+
+    if (!body) {
+      throw new KakaoOAuthRefreshError('refresh_malformed_response', { httpStatus: response.status })
+    }
+
+    if (serverStatus !== undefined && serverStatus !== 0) {
+      throw new KakaoOAuthRefreshError('refresh_rejected', {
+        serverStatus,
+        httpStatus: response.status,
+      })
+    }
+
+    const accessToken = typeof body.access_token === 'string' ? body.access_token : ''
+    if (!accessToken) {
+      throw new KakaoOAuthRefreshError('refresh_malformed_response', { httpStatus: response.status })
+    }
+
+    return {
+      accessToken,
+      refreshToken:
+        typeof body.refresh_token === 'string' && body.refresh_token ? body.refresh_token : input.refreshToken,
+      tokenType: typeof body.token_type === 'string' && body.token_type ? body.token_type : undefined,
+      expiresIn: typeof body.expires_in === 'number' ? body.expires_in : undefined,
+    }
   } finally {
     clearTimeout(timeout)
-  }
-
-  let body: Record<string, unknown> | null
-  try {
-    body = readRecord(await response.json())
-  } catch {
-    body = null
-  }
-
-  const serverStatus = body && typeof body.status === 'number' ? body.status : undefined
-  if (!response.ok) {
-    throw new KakaoOAuthRefreshError(
-      serverStatus !== undefined && serverStatus !== 0 ? 'refresh_rejected' : 'refresh_http_error',
-      { serverStatus: serverStatus !== 0 ? serverStatus : undefined, httpStatus: response.status },
-    )
-  }
-
-  if (!body) {
-    throw new KakaoOAuthRefreshError('refresh_malformed_response', { httpStatus: response.status })
-  }
-
-  if (serverStatus !== undefined && serverStatus !== 0) {
-    throw new KakaoOAuthRefreshError('refresh_rejected', {
-      serverStatus,
-      httpStatus: response.status,
-    })
-  }
-
-  const accessToken = typeof body.access_token === 'string' ? body.access_token : ''
-  if (!accessToken) {
-    throw new KakaoOAuthRefreshError('refresh_malformed_response', { httpStatus: response.status })
-  }
-
-  return {
-    accessToken,
-    refreshToken:
-      typeof body.refresh_token === 'string' && body.refresh_token ? body.refresh_token : input.refreshToken,
-    tokenType: typeof body.token_type === 'string' && body.token_type ? body.token_type : undefined,
-    expiresIn: typeof body.expires_in === 'number' ? body.expires_in : undefined,
   }
 }

--- a/src/platforms/kakaotalk/index.test.ts
+++ b/src/platforms/kakaotalk/index.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from 'bun:test'
 
+import type { KakaoOAuthRefreshOptions } from '@/platforms/kakaotalk/index'
 import {
   classifyKakaoChat,
   CredentialManager,
@@ -93,4 +94,7 @@ it('KakaoTypingResultSchema is exported from barrel', () => {
 it('Kakao OAuth refresh API is exported from barrel', () => {
   expect(typeof refreshKakaoOAuthToken).toBe('function')
   expect(typeof KakaoOAuthRefreshError).toBe('function')
+
+  const options: KakaoOAuthRefreshOptions = { timeoutMs: 5_000 }
+  expect(options.timeoutMs).toBe(5_000)
 })

--- a/src/platforms/kakaotalk/index.test.ts
+++ b/src/platforms/kakaotalk/index.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from 'bun:test'
 import {
   classifyKakaoChat,
   CredentialManager,
+  KakaoOAuthRefreshError,
   KakaoAccountCredentialsSchema,
   KakaoCredentialManager,
   KakaoChatSchema,
@@ -18,6 +19,7 @@ import {
   KakaoProfileSchema,
   KakaoTalkPushReadEventSchema,
   KakaoTypingResultSchema,
+  refreshKakaoOAuthToken,
 } from '@/platforms/kakaotalk/index'
 
 it('KakaoTalkClient is exported from barrel', () => {
@@ -86,4 +88,9 @@ it('KakaoLeaveChatResultSchema is exported from barrel', () => {
 
 it('KakaoTypingResultSchema is exported from barrel', () => {
   expect(typeof KakaoTypingResultSchema.parse).toBe('function')
+})
+
+it('Kakao OAuth refresh API is exported from barrel', () => {
+  expect(typeof refreshKakaoOAuthToken).toBe('function')
+  expect(typeof KakaoOAuthRefreshError).toBe('function')
 })

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -55,6 +55,8 @@ export {
 } from './types'
 export { attemptLogin, generateDeviceUuid, loginFlow, registerDevice, requestPasscode } from './auth/kakao-login'
 export type { LoginCredentials } from './auth/kakao-login'
+export { KakaoOAuthRefreshError, refreshKakaoOAuthToken } from './auth/oauth-refresh'
+export type { KakaoOAuthRefreshErrorCode, KakaoOAuthRefreshInput, KakaoOAuthRefreshResult } from './auth/oauth-refresh'
 export { sha1Hex } from './media-upload'
 export { detectImageDimensions } from './image-meta'
 export type { AttachmentInput, AttachmentPlan, ResolvedAttachment, SingleAttachmentKind } from './attachment-router'

--- a/src/platforms/kakaotalk/index.ts
+++ b/src/platforms/kakaotalk/index.ts
@@ -56,7 +56,12 @@ export {
 export { attemptLogin, generateDeviceUuid, loginFlow, registerDevice, requestPasscode } from './auth/kakao-login'
 export type { LoginCredentials } from './auth/kakao-login'
 export { KakaoOAuthRefreshError, refreshKakaoOAuthToken } from './auth/oauth-refresh'
-export type { KakaoOAuthRefreshErrorCode, KakaoOAuthRefreshInput, KakaoOAuthRefreshResult } from './auth/oauth-refresh'
+export type {
+  KakaoOAuthRefreshErrorCode,
+  KakaoOAuthRefreshInput,
+  KakaoOAuthRefreshOptions,
+  KakaoOAuthRefreshResult,
+} from './auth/oauth-refresh'
 export { sha1Hex } from './media-upload'
 export { detectImageDimensions } from './image-meta'
 export type { AttachmentInput, AttachmentPlan, ResolvedAttachment, SingleAttachmentKind } from './attachment-router'

--- a/src/platforms/kakaotalk/protocol/NOTICE.md
+++ b/src/platforms/kakaotalk/protocol/NOTICE.md
@@ -1,8 +1,9 @@
 # Third-Party Notices
 
-This LOCO protocol implementation was written from scratch for agent-messenger.
-The protocol knowledge used to build it comes from the following open-source
-projects and their documentation. No code was copied from these projects.
+This KakaoTalk protocol and Android authentication implementation was written
+from scratch for agent-messenger. The protocol knowledge used to build it comes
+from the following open-source projects and their documentation. No code was
+copied from these projects.
 
 ---
 
@@ -37,7 +38,21 @@ Android sub-device login flow, and connection patterns.
 - Copyright (c) 2020 storycraft
 
 Referenced for: LOCO packet format, BSON command schemas, authentication flow,
-X-VC signature algorithm, channel/chat type enumerations.
+Android OAuth refresh request/response behavior, X-VC signature algorithm,
+channel/chat type enumerations.
+
+---
+
+## KakaoForge
+
+- Repository: https://github.com/play2fly/KakaoForge
+- Reference commit: 4b774ea40b1347280fadb685415436584093118b
+- License: KakaoForge Non-Commercial / No Abuse License
+- Copyright (c) 2026 aodjo
+
+Referenced for: current Android `oauth2_token.json` request fields, client
+headers, device-id handling, and token rotation/expiry response fields. Protocol
+behavior only; no source code was copied or adapted.
 
 ---
 


### PR DESCRIPTION
## Summary

- add an explicit, caller-invoked KakaoTalk Android OAuth token refresh primitive
- return the rotated access/refresh token set and expiry metadata without writing credentials or retrying login
- expose safe typed refresh failures without retaining tokens, authorization headers, raw responses, or secret-bearing causes
- document caller-owned atomic persistence and attribute the protocol references used

Closes #324.

## Scope

This PR intentionally does **not** add automatic refresh, `LOGINLIST` retry, credential-file mutation, singleflight/CAS, backoff, or `auth_required` state. Those lifecycle policies remain the responsibility of the long-running caller.

## Commits

1. `test(kakaotalk): specify Android OAuth token refresh contract`
2. `feat(kakaotalk): add explicit OAuth token refresh primitive`
3. `docs(kakaotalk): document caller-managed token refresh`
4. `test(kakaotalk): cover stalled OAuth response bodies`
5. `fix(kakaotalk): cover OAuth response body timeouts`
6. `docs(kakaotalk): add safe refresh canary procedure`

The test-only commit was run against its parent (`main`) before implementation and failed as expected: 0 passed, 2 failed because the module/export did not exist.

## Automated verification

- targeted KakaoTalk refresh/export tests: 30 passed, 0 failed
- full suite: 3,680 passed, 0 failed across 262 files
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- production docs build passed
- packed tarball installed in clean npm and Bun projects; root and KakaoTalk CLI smoke tests passed in both
- generated package declarations expose `KakaoOAuthRefreshOptions`
- `git diff --check`
- production-secret comparison against the complete PR diff: no matches

## Controlled live E2E

The live canary was run with the looping collector stopped so no competing process could use the credential.

1. Confirmed the stored access token baseline was rejected by Kakao as `INVALID_ACCESS_TOKEN` (`-950`).
2. Called `refreshKakaoOAuthToken()` exactly once against the Android endpoint.
3. Kakao returned a new access token, a rotated refresh token, bearer token type, and expiry metadata.
4. An external, uncommitted E2E harness immediately persisted the complete returned token set atomically with mode `0600`.
5. A fresh process reloaded the persisted credential and completed `LOGINLIST` plus chat-list retrieval successfully.
6. Restarted the production collector; its first reconciliation completed with 0 failed chats, API health remained OK, and database freshness advanced.
7. Scanned the PR diff and collector logs against the active credential values; no token, device, user, or account identifiers were present.

No token values, account identifiers, chat identifiers, message bodies, or raw Kakao responses are included in this PR or its logs.

## Protocol references

- node-kakao stable: Android OAuth refresh request/response behavior
- KakaoForge commit `4b774ea40b1347280fadb685415436584093118b`: current request fields, Android headers, device-id handling, and rotation/expiry response fields

The endpoint is undocumented and can change without notice. The implementation was written from scratch; no third-party source was copied or adapted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit KakaoTalk Android OAuth token refresh API that returns rotated tokens and expiry info without writing credentials or retrying login. Improves timeout handling and stalled-response robustness. Closes #324.

- New Features
  - `refreshKakaoOAuthToken()` to exchange a stored refresh token for a new token set.
  - Returns access token, refresh token (rotated when provided), token type, and expiry.
  - Typed failures via `KakaoOAuthRefreshError` with safe metadata: `refresh_credentials_missing`, `refresh_rejected`, `refresh_http_error`, `refresh_malformed_response`, `refresh_request_failed`, `refresh_timeout`.

- Migration
  - No automatic refresh. Call `refreshKakaoOAuthToken()` and persist the returned tokens atomically before reuse.
  - No credential-file writes or `LOGINLIST` retries; callers own the lifecycle policy.

Docs updated: skills/agent-kakaotalk/SKILL.md, skills/agent-kakaotalk/references/authentication.md, docs/content/docs/sdk/kakaotalk.mdx.

<sup>Written for commit fde53ab6a390bfaa559623e3c9892f9d2c9dbac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

