### PR TITLE
Add guarded Teams desktop image downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Build output
 dist/
+/.build/
 
 # Credentials
 .config/agent-slack/

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "commander": "^11.1.0",
         "crypto-js": "^4.2.0",
         "curve25519-js": "^0.0.4",
+        "jpeg-js": "^0.4.4",
         "jsqr": "^1.4.0",
         "node-bignumber": "^1.2.2",
         "node-int64": "^0.4.0",
@@ -525,6 +526,8 @@
     "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
 
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
+
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
     "jsqr": ["jsqr@1.4.0", "", {}, "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="],
 

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
@@ -1,0 +1,608 @@
+import AppKit
+import CommonCrypto
+import Darwin
+import Foundation
+import Security
+import SQLite3
+
+private let bridgeLabel = "com.timiaji.agent-messenger-teams-bridge"
+private let clientRequirement =
+    "anchor apple generic and identifier \"com.timiaji.agent-messenger-teams-bridge-client\" and certificate leaf[subject.OU] = \"9F4ARQ5FJR\""
+
+@objc private protocol TeamsBridgeXPCProtocol {
+    func run(_ requestData: Data, withReply reply: @escaping (Data) -> Void)
+}
+
+private struct BridgeRequest: Codable {
+    let version: Int
+    let id: String
+    let args: [String]
+    let profile: String?
+    let timeout_ms: Int?
+}
+
+private struct BridgeResponse: Codable {
+    let version: Int
+    let id: String
+    let exit_code: Int32
+    let stdout: String
+    let stderr: String
+}
+
+private enum BridgeError: LocalizedError {
+    case invalidRequest(String)
+    case setupRequired(String)
+    case stagingFailed(String)
+    case runtimeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRequest(let message), .setupRequired(let message), .stagingFailed(let message),
+             .runtimeFailed(let message):
+            return message
+        }
+    }
+}
+
+private final class BridgePaths {
+    let support: URL
+    let caches: URL
+    let bookmark: URL
+    let staging: URL
+    let liveConfig: URL
+    let proofConfig: URL
+
+    init() {
+        let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        support = applicationSupport.appendingPathComponent("Agent Messenger Teams Bridge", isDirectory: true)
+        caches = cachesDirectory.appendingPathComponent("Agent Messenger Teams Bridge", isDirectory: true)
+        bookmark = support.appendingPathComponent("teams-ebwebview.bookmark")
+        staging = caches.appendingPathComponent("staging", isDirectory: true)
+        liveConfig = support.appendingPathComponent("live", isDirectory: true)
+        proofConfig = support.appendingPathComponent("proof", isDirectory: true)
+    }
+
+    func prepare() throws {
+        for directory in [support, caches, staging, liveConfig, proofConfig] {
+            try ensureDirectory(directory)
+        }
+        for abandoned in try FileManager.default.contentsOfDirectory(at: staging, includingPropertiesForKeys: nil) {
+            try? FileManager.default.removeItem(at: abandoned)
+        }
+    }
+}
+
+private func ensureDirectory(_ url: URL) throws {
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    guard chmod(url.path, mode_t(0o700)) == 0 else { throw POSIXError(.EACCES) }
+}
+
+private func writePrivate(_ data: Data, to url: URL) throws {
+    try ensureDirectory(url.deletingLastPathComponent())
+    let temporary = url.deletingLastPathComponent().appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString)")
+    try data.write(to: temporary, options: .atomic)
+    guard chmod(temporary.path, mode_t(0o600)) == 0 else {
+        try? FileManager.default.removeItem(at: temporary)
+        throw POSIXError(.EACCES)
+    }
+    try? FileManager.default.removeItem(at: url)
+    try FileManager.default.moveItem(at: temporary, to: url)
+}
+
+private func actualHomeDirectory() throws -> URL {
+    guard let passwordEntry = getpwuid(getuid()), let path = passwordEntry.pointee.pw_dir else {
+        throw BridgeError.setupRequired("Unable to resolve the signed-in user's home directory.")
+    }
+    return URL(fileURLWithPath: String(cString: path), isDirectory: true)
+}
+
+private func isSafeIdentifier(_ value: String) -> Bool {
+    guard !value.isEmpty, value.count <= 64 else { return false }
+    return value.unicodeScalars.allSatisfy {
+        CharacterSet.alphanumerics.contains($0) || $0 == "-" || $0 == "_"
+    }
+}
+
+private func validatedArgs(_ request: BridgeRequest) throws -> [String] {
+    guard request.version == 1, isSafeIdentifier(request.id) else {
+        throw BridgeError.invalidRequest("Invalid Teams bridge request identity.")
+    }
+    guard !request.args.isEmpty, request.args.count <= 64 else {
+        throw BridgeError.invalidRequest("Invalid Teams bridge argument count.")
+    }
+    guard request.args.allSatisfy({ $0.utf8.count <= 16_384 && !$0.contains("\0") }) else {
+        throw BridgeError.invalidRequest("Invalid Teams bridge argument payload.")
+    }
+    if request.args.starts(with: ["auth", "login"]) {
+        throw BridgeError.invalidRequest("Teams device-code login is disabled; the official desktop app owns sign-in.")
+    }
+    if request.args.contains("--token") || request.args.contains(where: { $0.hasPrefix("--token=") }) {
+        throw BridgeError.invalidRequest("Manual Teams token input is disabled.")
+    }
+    if request.args.contains("--browser-profile") || request.args.contains(where: { $0.hasPrefix("--browser-profile=") }) {
+        throw BridgeError.invalidRequest("Browser-profile Teams extraction is disabled.")
+    }
+
+    var args = request.args
+    if args.starts(with: ["auth", "extract"]) {
+        if let index = args.firstIndex(of: "--source"), index + 1 < args.count, args[index + 1] != "desktop" {
+            throw BridgeError.invalidRequest("Only the desktop Teams authentication source is allowed.")
+        }
+        if let inline = args.first(where: { $0.hasPrefix("--source=") }), inline != "--source=desktop" {
+            throw BridgeError.invalidRequest("Only the desktop Teams authentication source is allowed.")
+        }
+        if !args.contains("--source") && !args.contains(where: { $0.hasPrefix("--source=") }) {
+            args.append(contentsOf: ["--source", "desktop"])
+        }
+    }
+    return args
+}
+
+private func selectedConfigDirectory(for request: BridgeRequest, paths: BridgePaths) throws -> URL {
+    switch request.profile ?? "live" {
+    case "live": return paths.liveConfig
+    case "proof": return paths.proofConfig
+    default: throw BridgeError.invalidRequest("Unknown Teams bridge profile.")
+    }
+}
+
+private final class TeamsSourceAccess {
+    private let paths: BridgePaths
+    private var activeURL: URL?
+    private var startedSecurityScope = false
+
+    init(paths: BridgePaths) {
+        self.paths = paths
+    }
+
+    deinit {
+        if startedSecurityScope { activeURL?.stopAccessingSecurityScopedResource() }
+    }
+
+    func resolveExisting() -> URL? {
+        if let activeURL { return activeURL }
+        guard FileManager.default.fileExists(atPath: paths.bookmark.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: paths.bookmark)
+            var stale = false
+            let url = try URL(
+                resolvingBookmarkData: data,
+                options: [.withSecurityScope, .withoutUI],
+                relativeTo: nil,
+                bookmarkDataIsStale: &stale
+            )
+            let started = url.startAccessingSecurityScopedResource()
+            try validate(url)
+            if stale { try persistBookmark(for: url) }
+            activeURL = url
+            startedSecurityScope = started
+            return url
+        } catch {
+            return nil
+        }
+    }
+
+    @MainActor
+    func resolveOrRequest() throws -> URL {
+        if let activeURL { return activeURL }
+        if let existing = resolveExisting() { return existing }
+
+        NSApp.activate(ignoringOtherApps: true)
+        let panel = NSOpenPanel()
+        panel.title = "Allow Agent Messenger to use your Teams desktop sessions"
+        panel.message = "Select the EBWebView folder. The companion receives read-only access to the two sessions already signed in inside Microsoft Teams."
+        panel.prompt = "Grant Access"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        panel.resolvesAliases = true
+        panel.directoryURL = try actualHomeDirectory().appendingPathComponent(
+            "Library/Containers/com.microsoft.teams2/Data/Library/Application Support/Microsoft/MSTeams/EBWebView",
+            isDirectory: true
+        )
+        guard panel.runModal() == .OK, let url = panel.url else {
+            throw BridgeError.setupRequired("Teams desktop access was not granted.")
+        }
+        try validate(url)
+        try persistBookmark(for: url)
+        startedSecurityScope = url.startAccessingSecurityScopedResource()
+        activeURL = url
+        return url
+    }
+
+    private func validate(_ url: URL) throws {
+        guard url.lastPathComponent == "EBWebView" else {
+            throw BridgeError.setupRequired("Select Microsoft Teams' EBWebView folder, not a broader folder.")
+        }
+        _ = try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+    }
+
+    private func persistBookmark(for url: URL) throws {
+        let data = try url.bookmarkData(
+            options: [.withSecurityScope],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+        try writePrivate(data, to: paths.bookmark)
+    }
+}
+
+private let keychainVariants = [
+    ("Microsoft Teams Safe Storage", "Microsoft Teams"),
+    ("Microsoft Teams (work or school) Safe Storage", "Microsoft Teams (work or school)"),
+    ("Teams Safe Storage", "Teams"),
+]
+
+private func deriveTeamsKey(from passwordData: Data) throws -> Data {
+    let password = String(decoding: passwordData, as: UTF8.self)
+    let salt = Array("saltysalt".utf8)
+    var derived = [UInt8](repeating: 0, count: 16)
+    let result = password.withCString { passwordPointer in
+        salt.withUnsafeBytes { saltBytes in
+            CCKeyDerivationPBKDF(
+                CCPBKDFAlgorithm(kCCPBKDF2),
+                passwordPointer,
+                password.utf8.count,
+                saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                salt.count,
+                CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                1003,
+                &derived,
+                derived.count
+            )
+        }
+    }
+    guard result == kCCSuccess else {
+        throw BridgeError.runtimeFailed("Unable to derive the Teams desktop decryption key.")
+    }
+    return Data(derived)
+}
+
+private func ensureDerivedTeamsKey(configDirectory: URL, forceRefresh: Bool = false) throws {
+    let keyPath = configDirectory.appendingPathComponent(".derived-keys/teams.key")
+    if !forceRefresh, let existing = try? Data(contentsOf: keyPath), existing.count == 16 { return }
+    if forceRefresh { try? FileManager.default.removeItem(at: keyPath) }
+
+    for (service, account) in keychainVariants {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { continue }
+        guard status == errSecSuccess, let passwordData = item as? Data else {
+            throw BridgeError.setupRequired("Microsoft Teams Safe Storage access was not granted (Keychain status \(status)).")
+        }
+        try writePrivate(try deriveTeamsKey(from: passwordData), to: keyPath)
+        return
+    }
+    throw BridgeError.setupRequired("Microsoft Teams Safe Storage was not found in Keychain.")
+}
+
+private func findCookieDatabase(in profile: URL) throws -> URL {
+    let direct = [profile.appendingPathComponent("Network/Cookies"), profile.appendingPathComponent("Cookies")]
+    if let match = direct.first(where: { FileManager.default.fileExists(atPath: $0.path) }) { return match }
+    guard let enumerator = FileManager.default.enumerator(
+        at: profile,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles, .skipsPackageDescendants]
+    ) else {
+        throw BridgeError.stagingFailed("Unable to inspect Teams profile \(profile.lastPathComponent).")
+    }
+    var matches: [URL] = []
+    for case let candidate as URL in enumerator where candidate.lastPathComponent == "Cookies" {
+        if candidate.pathComponents.count - profile.pathComponents.count <= 4 { matches.append(candidate) }
+    }
+    guard let match = matches.sorted(by: { $0.path < $1.path }).first else {
+        throw BridgeError.stagingFailed("No cookie database found for Teams profile \(profile.lastPathComponent).")
+    }
+    return match
+}
+
+private func snapshotSQLiteDatabase(_ source: URL, to destination: URL) throws {
+    try ensureDirectory(destination.deletingLastPathComponent())
+    try? FileManager.default.removeItem(at: destination)
+
+    var sourceDatabase: OpaquePointer?
+    var destinationDatabase: OpaquePointer?
+    guard sqlite3_open_v2(source.path, &sourceDatabase, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK,
+          let sourceDatabase else {
+        if let sourceDatabase { sqlite3_close(sourceDatabase) }
+        throw BridgeError.stagingFailed("Unable to open Teams' live cookie database read-only.")
+    }
+    defer { sqlite3_close(sourceDatabase) }
+    guard sqlite3_open_v2(
+        destination.path,
+        &destinationDatabase,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+        nil
+    ) == SQLITE_OK, let destinationDatabase else {
+        if let destinationDatabase { sqlite3_close(destinationDatabase) }
+        throw BridgeError.stagingFailed("Unable to create the private Teams cookie snapshot.")
+    }
+    defer { sqlite3_close(destinationDatabase) }
+    sqlite3_busy_timeout(sourceDatabase, 2_000)
+    sqlite3_busy_timeout(destinationDatabase, 2_000)
+
+    guard let backup = sqlite3_backup_init(destinationDatabase, "main", sourceDatabase, "main") else {
+        throw BridgeError.stagingFailed("Unable to start a consistent Teams cookie snapshot.")
+    }
+    var result = SQLITE_OK
+    var contentionRetries = 0
+    repeat {
+        result = sqlite3_backup_step(backup, 64)
+        if result == SQLITE_BUSY || result == SQLITE_LOCKED {
+            contentionRetries += 1
+            if contentionRetries > 80 { break }
+            sqlite3_sleep(25)
+        }
+    } while result == SQLITE_OK || result == SQLITE_BUSY || result == SQLITE_LOCKED
+    let finishResult = sqlite3_backup_finish(backup)
+    guard result == SQLITE_DONE, finishResult == SQLITE_OK else {
+        throw BridgeError.stagingFailed("Teams' cookie database stayed busy; no inconsistent snapshot was used.")
+    }
+    guard chmod(destination.path, mode_t(0o600)) == 0 else { throw POSIXError(.EACCES) }
+}
+
+private func stageTeamsProfiles(sourceRoot: URL, paths: BridgePaths, requestID: String) throws -> URL {
+    let destinationRoot = paths.staging.appendingPathComponent(requestID, isDirectory: true)
+    try? FileManager.default.removeItem(at: destinationRoot)
+    try ensureDirectory(destinationRoot)
+    do {
+        for profileName in ["WV2Profile_tfw", "WV2Profile_tfl"] {
+            let sourceCookies = try findCookieDatabase(
+                in: sourceRoot.appendingPathComponent(profileName, isDirectory: true)
+            )
+            let destinationCookies = destinationRoot
+                .appendingPathComponent(profileName, isDirectory: true)
+                .appendingPathComponent("Network/Cookies")
+            try snapshotSQLiteDatabase(sourceCookies, to: destinationCookies)
+        }
+        let localState = sourceRoot.appendingPathComponent("Local State")
+        if FileManager.default.fileExists(atPath: localState.path) {
+            try writePrivate(try Data(contentsOf: localState), to: destinationRoot.appendingPathComponent("Local State"))
+        }
+        return destinationRoot
+    } catch {
+        try? FileManager.default.removeItem(at: destinationRoot)
+        throw error
+    }
+}
+
+private func runAgentTeams(
+    args: [String],
+    configDirectory: URL,
+    stagedRoot: URL,
+    timeoutMilliseconds: Int
+) throws -> (Int32, String, String) {
+    guard let resources = Bundle.main.resourceURL else {
+        throw BridgeError.runtimeFailed("Teams bridge resources are unavailable.")
+    }
+    let bun = resources.appendingPathComponent("runtime/bun")
+    let launcher = resources.appendingPathComponent("runtime/launcher")
+    let agentRoot = resources.appendingPathComponent("agent-messenger", isDirectory: true)
+    let cli = agentRoot.appendingPathComponent("dist/src/platforms/teams/cli.js")
+    guard FileManager.default.isExecutableFile(atPath: bun.path),
+          FileManager.default.isExecutableFile(atPath: launcher.path),
+          FileManager.default.fileExists(atPath: cli.path) else {
+        throw BridgeError.runtimeFailed("The embedded Agent Messenger runtime is incomplete.")
+    }
+
+    let process = Process()
+    process.executableURL = launcher
+    process.arguments = [bun.path, cli.path] + args
+    process.currentDirectoryURL = agentRoot
+    process.environment = [
+        "HOME": configDirectory.path,
+        "TMPDIR": NSTemporaryDirectory(),
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "LANG": "en_GB.UTF-8",
+        "LC_ALL": "en_GB.UTF-8",
+        "NO_COLOR": "1",
+        "AGENT_MESSENGER_CONFIG_DIR": configDirectory.path,
+        "AGENT_TEAMS_AUTH_SOURCE": "desktop",
+        "AGENT_TEAMS_COMPANION_MEDIATED": "1",
+        "AGENT_TEAMS_DESKTOP_PROFILE_ROOT": stagedRoot.path,
+        "AGENT_TEAMS_DISABLE_KEYCHAIN_LOOKUP": "1",
+    ]
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+    try process.run()
+
+    let readGroup = DispatchGroup()
+    let lock = NSLock()
+    var stdoutData = Data()
+    var stderrData = Data()
+    var outputExceeded = false
+    let outputLimit = 4 * 1_024 * 1_024
+    let processGroup = process.processIdentifier
+    func collect(_ handle: FileHandle, intoStdout: Bool) {
+        readGroup.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer { readGroup.leave() }
+            while let chunk = try? handle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
+                lock.lock()
+                if stdoutData.count + stderrData.count + chunk.count > outputLimit {
+                    outputExceeded = true
+                    lock.unlock()
+                    kill(-processGroup, SIGKILL)
+                    break
+                }
+                if intoStdout { stdoutData.append(chunk) } else { stderrData.append(chunk) }
+                lock.unlock()
+            }
+        }
+    }
+    collect(outputPipe.fileHandleForReading, intoStdout: true)
+    collect(errorPipe.fileHandleForReading, intoStdout: false)
+
+    let completion = DispatchSemaphore(value: 0)
+    DispatchQueue.global(qos: .userInitiated).async { process.waitUntilExit(); completion.signal() }
+    let boundedTimeout = min(max(timeoutMilliseconds, 5_000), 120_000)
+    if completion.wait(timeout: .now() + .milliseconds(boundedTimeout)) == .timedOut {
+        kill(-processGroup, SIGTERM)
+        if completion.wait(timeout: .now() + .seconds(2)) == .timedOut {
+            kill(-processGroup, SIGKILL)
+            _ = completion.wait(timeout: .now() + .seconds(5))
+        }
+        _ = readGroup.wait(timeout: .now() + .seconds(2))
+        return (124, String(data: stdoutData, encoding: .utf8) ?? "", "Teams bridge request timed out.\n")
+    }
+    _ = readGroup.wait(timeout: .now() + .seconds(2))
+    guard !outputExceeded else {
+        throw BridgeError.runtimeFailed("Teams bridge response exceeded the 4 MiB safety limit.")
+    }
+    return (
+        process.terminationStatus,
+        String(data: stdoutData, encoding: .utf8) ?? "",
+        String(data: stderrData, encoding: .utf8) ?? ""
+    )
+}
+
+private final class TeamsBridgeService: NSObject, TeamsBridgeXPCProtocol {
+    private let paths: BridgePaths
+    private let sourceAccess: TeamsSourceAccess
+    private let queue = DispatchQueue(label: "com.timiaji.agent-messenger-teams-bridge.requests")
+
+    init(paths: BridgePaths, sourceAccess: TeamsSourceAccess) {
+        self.paths = paths
+        self.sourceAccess = sourceAccess
+    }
+
+    func run(_ requestData: Data, withReply reply: @escaping (Data) -> Void) {
+        queue.async {
+            let response: BridgeResponse
+            var responseID = "invalid"
+            var stagedRoot: URL?
+            do {
+                guard requestData.count <= 1_048_576 else {
+                    throw BridgeError.invalidRequest("Teams bridge request exceeded the 1 MiB safety limit.")
+                }
+                let request = try JSONDecoder().decode(BridgeRequest.self, from: requestData)
+                responseID = request.id
+                let args = try validatedArgs(request)
+                let config = try selectedConfigDirectory(for: request, paths: self.paths)
+                let sourceRoot: URL
+                if let existing = self.sourceAccess.resolveExisting() {
+                    sourceRoot = existing
+                } else {
+                    sourceRoot = try DispatchQueue.main.sync {
+                        try MainActor.assumeIsolated { try self.sourceAccess.resolveOrRequest() }
+                    }
+                }
+                try ensureDerivedTeamsKey(configDirectory: config)
+                let stage = try stageTeamsProfiles(sourceRoot: sourceRoot, paths: self.paths, requestID: request.id)
+                stagedRoot = stage
+                var result = try runAgentTeams(
+                    args: args,
+                    configDirectory: config,
+                    stagedRoot: stage,
+                    timeoutMilliseconds: request.timeout_ms ?? 90_000
+                )
+                if result.0 != 0 && result.2.contains("AGENT_TEAMS_CACHED_KEY_REJECTED") {
+                    try ensureDerivedTeamsKey(configDirectory: config, forceRefresh: true)
+                    result = try runAgentTeams(
+                        args: args,
+                        configDirectory: config,
+                        stagedRoot: stage,
+                        timeoutMilliseconds: request.timeout_ms ?? 90_000
+                    )
+                }
+                response = BridgeResponse(version: 1, id: request.id, exit_code: result.0, stdout: result.1, stderr: result.2)
+            } catch {
+                response = BridgeResponse(
+                    version: 1,
+                    id: responseID,
+                    exit_code: 70,
+                    stdout: "",
+                    stderr: "\(error.localizedDescription)\n"
+                )
+            }
+            if let stagedRoot { try? FileManager.default.removeItem(at: stagedRoot) }
+            reply((try? JSONEncoder().encode(response)) ?? Data())
+        }
+    }
+}
+
+private final class ListenerDelegate: NSObject, NSXPCListenerDelegate {
+    private let service: TeamsBridgeService
+
+    init(service: TeamsBridgeService) {
+        self.service = service
+    }
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection connection: NSXPCConnection) -> Bool {
+        guard connection.effectiveUserIdentifier == getuid() else { return false }
+        connection.setCodeSigningRequirement(clientRequirement)
+        connection.exportedInterface = NSXPCInterface(with: TeamsBridgeXPCProtocol.self)
+        connection.exportedObject = service
+        connection.resume()
+        return true
+    }
+}
+
+private final class BridgeDelegate: NSObject, NSApplicationDelegate {
+    private var listener: NSXPCListener?
+    private var listenerDelegate: ListenerDelegate?
+    private var sourceAccess: TeamsSourceAccess?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+        do {
+            let paths = BridgePaths()
+            try paths.prepare()
+            let access = TeamsSourceAccess(paths: paths)
+            _ = access.resolveExisting()
+            let service = TeamsBridgeService(paths: paths, sourceAccess: access)
+            let delegate = ListenerDelegate(service: service)
+            let listener = NSXPCListener(machServiceName: bridgeLabel)
+            listener.delegate = delegate
+            listener.resume()
+            sourceAccess = access
+            listenerDelegate = delegate
+            self.listener = listener
+        } catch {
+            // Stay stopped on a deterministic startup failure. launchd does not KeepAlive this app.
+            NSApp.terminate(nil)
+        }
+    }
+}
+
+private func runSelfTest() throws {
+    let valid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "extract"], profile: "proof", timeout_ms: 5_000)
+    guard try validatedArgs(valid).suffix(2) == ["--source", "desktop"] else {
+        throw BridgeError.invalidRequest("Desktop source injection failed.")
+    }
+    let invalid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "login"], profile: "proof", timeout_ms: 5_000)
+    do {
+        _ = try validatedArgs(invalid)
+        throw BridgeError.invalidRequest("Device-code guard failed.")
+    } catch BridgeError.invalidRequest {
+        // Expected.
+    }
+    print("teams-bridge-self-test: pass")
+}
+
+if CommandLine.arguments.contains("--self-test") {
+    do {
+        try runSelfTest()
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("\(error.localizedDescription)\n".utf8))
+        exit(1)
+    }
+}
+
+private let application = NSApplication.shared
+private let delegate = BridgeDelegate()
+application.delegate = delegate
+application.run()

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
@@ -96,11 +96,6 @@ private func approvedFileCommand(_ args: [String]) throws -> ApprovedFileCommand
             throw BridgeError.invalidRequest("Use: agent-teams file upload <team-id> <channel-id> <path> [--pretty].")
         }
         return .input(argumentIndex: positionals[4].index)
-    case ("chat", "send-image"):
-        guard positionals.count == 4 else {
-            throw BridgeError.invalidRequest("Use: agent-teams chat send-image <chat-id> <path> [--pretty].")
-        }
-        return .input(argumentIndex: positionals[3].index)
     case ("file", "download"):
         guard positionals.count == 6 else {
             throw BridgeError.invalidRequest("Teams bridge file downloads require one staged output path.")

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
@@ -19,6 +19,13 @@ private struct BridgeRequest: Codable {
     let args: [String]
     let profile: String?
     let timeout_ms: Int?
+    let input_files: [BridgeInputFile]?
+}
+
+private struct BridgeInputFile: Codable {
+    let argument_index: Int
+    let filename: String
+    let bytes: Data
 }
 
 private struct BridgeResponse: Codable {
@@ -137,6 +144,26 @@ private func validatedArgs(_ request: BridgeRequest) throws -> [String] {
         }
     }
     return args
+}
+
+private func stagedInputArgs(_ args: [String], request: BridgeRequest, stagedRoot: URL) throws -> [String] {
+    guard let inputs = request.input_files, !inputs.isEmpty else { return args }
+    guard inputs.count == 1 else { throw BridgeError.invalidRequest("Teams bridge accepts one input file per command.") }
+    let input = inputs[0]
+    guard input.argument_index >= 0, input.argument_index < args.count,
+          input.argument_index >= 4,
+          args[input.argument_index - 4] == "file", args[input.argument_index - 3] == "upload",
+          args[input.argument_index - 2].isEmpty == false, args[input.argument_index - 1].isEmpty == false,
+          input.bytes.count <= 20 * 1_024 * 1_024,
+          !input.filename.isEmpty, input.filename == URL(fileURLWithPath: input.filename).lastPathComponent else {
+        throw BridgeError.invalidRequest("Teams bridge input file does not match a file upload command.")
+    }
+    let inputRoot = stagedRoot.appendingPathComponent("input", isDirectory: true)
+    let stagedFile = inputRoot.appendingPathComponent(input.filename, isDirectory: false)
+    try writePrivate(input.bytes, to: stagedFile)
+    var rewritten = args
+    rewritten[input.argument_index] = stagedFile.path
+    return rewritten
 }
 
 private func selectedConfigDirectory(for request: BridgeRequest, paths: BridgePaths) throws -> URL {
@@ -484,8 +511,8 @@ private final class TeamsBridgeService: NSObject, TeamsBridgeXPCProtocol {
             var responseID = "invalid"
             var stagedRoot: URL?
             do {
-                guard requestData.count <= 1_048_576 else {
-                    throw BridgeError.invalidRequest("Teams bridge request exceeded the 1 MiB safety limit.")
+                guard requestData.count <= 28 * 1_024 * 1_024 else {
+                    throw BridgeError.invalidRequest("Teams bridge request exceeded the 28 MiB safety limit.")
                 }
                 let request = try JSONDecoder().decode(BridgeRequest.self, from: requestData)
                 responseID = request.id
@@ -502,8 +529,9 @@ private final class TeamsBridgeService: NSObject, TeamsBridgeXPCProtocol {
                 try ensureDerivedTeamsKey(configDirectory: config)
                 let stage = try stageTeamsProfiles(sourceRoot: sourceRoot, paths: self.paths, requestID: request.id)
                 stagedRoot = stage
+                let runtimeArgs = try stagedInputArgs(args, request: request, stagedRoot: stage)
                 var result = try runAgentTeams(
-                    args: args,
+                    args: runtimeArgs,
                     configDirectory: config,
                     stagedRoot: stage,
                     timeoutMilliseconds: request.timeout_ms ?? 90_000
@@ -511,7 +539,7 @@ private final class TeamsBridgeService: NSObject, TeamsBridgeXPCProtocol {
                 if result.0 != 0 && result.2.contains("AGENT_TEAMS_CACHED_KEY_REJECTED") {
                     try ensureDerivedTeamsKey(configDirectory: config, forceRefresh: true)
                     result = try runAgentTeams(
-                        args: args,
+                        args: runtimeArgs,
                         configDirectory: config,
                         stagedRoot: stage,
                         timeoutMilliseconds: request.timeout_ms ?? 90_000
@@ -578,14 +606,45 @@ private final class BridgeDelegate: NSObject, NSApplicationDelegate {
 }
 
 private func runSelfTest() throws {
-    let valid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "extract"], profile: "proof", timeout_ms: 5_000)
+    let valid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "extract"], profile: "proof", timeout_ms: 5_000, input_files: nil)
     guard try validatedArgs(valid).suffix(2) == ["--source", "desktop"] else {
         throw BridgeError.invalidRequest("Desktop source injection failed.")
     }
-    let invalid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "login"], profile: "proof", timeout_ms: 5_000)
+    let invalid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "login"], profile: "proof", timeout_ms: 5_000, input_files: nil)
     do {
         _ = try validatedArgs(invalid)
         throw BridgeError.invalidRequest("Device-code guard failed.")
+    } catch BridgeError.invalidRequest {
+        // Expected.
+    }
+    let testRoot = FileManager.default.temporaryDirectory
+        .appendingPathComponent("teams-bridge-input-self-test-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: testRoot) }
+    try ensureDirectory(testRoot)
+    let upload = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: ["--account", "work", "file", "upload", "team", "channel", "/outside/approval.png"],
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: [BridgeInputFile(argument_index: 6, filename: "approval.png", bytes: Data("image".utf8))]
+    )
+    let stagedArgs = try stagedInputArgs(upload.args, request: upload, stagedRoot: testRoot)
+    guard stagedArgs[6].hasPrefix(testRoot.path),
+          try Data(contentsOf: URL(fileURLWithPath: stagedArgs[6])) == Data("image".utf8) else {
+        throw BridgeError.invalidRequest("Input file staging self-test failed.")
+    }
+    let mismatched = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: ["message", "send", "team", "channel", "hello", "--file", "/outside/approval.png"],
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: [BridgeInputFile(argument_index: 6, filename: "approval.png", bytes: Data("image".utf8))]
+    )
+    do {
+        _ = try stagedInputArgs(mismatched.args, request: mismatched, stagedRoot: testRoot)
+        throw BridgeError.invalidRequest("Non-upload file staging guard failed.")
     } catch BridgeError.invalidRequest {
         // Expected.
     }

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridge.swift
@@ -20,9 +20,21 @@ private struct BridgeRequest: Codable {
     let profile: String?
     let timeout_ms: Int?
     let input_files: [BridgeInputFile]?
+    let output_files: [BridgeOutputFileRequest]?
 }
 
 private struct BridgeInputFile: Codable {
+    let argument_index: Int
+    let filename: String
+    let bytes: Data
+}
+
+private struct BridgeOutputFileRequest: Codable {
+    let argument_index: Int
+    let filename: String
+}
+
+private struct BridgeOutputFile: Codable {
     let argument_index: Int
     let filename: String
     let bytes: Data
@@ -34,6 +46,171 @@ private struct BridgeResponse: Codable {
     let exit_code: Int32
     let stdout: String
     let stderr: String
+    let output_files: [BridgeOutputFile]?
+}
+
+private enum ApprovedFileCommand {
+    case input(argumentIndex: Int)
+    case output(argumentIndex: Int)
+}
+
+private func approvedFileCommand(_ args: [String]) throws -> ApprovedFileCommand? {
+    var positionals: [(index: Int, value: String)] = []
+    var optionsEnded = false
+    var index = 0
+    while index < args.count {
+        let value = args[index]
+        if !optionsEnded, value == "--" {
+            optionsEnded = true
+            index += 1
+            continue
+        }
+        if !optionsEnded, value == "--pretty" {
+            index += 1
+            continue
+        }
+        if !optionsEnded, value == "--account" || value == "--team" {
+            guard index + 1 < args.count else {
+                throw BridgeError.invalidRequest("Teams bridge command has an option without a value.")
+            }
+            index += 2
+            continue
+        }
+        if !optionsEnded, value.hasPrefix("--account=") || value.hasPrefix("--team=") {
+            guard value.last != "=" else {
+                throw BridgeError.invalidRequest("Teams bridge command has an empty option value.")
+            }
+            index += 1
+            continue
+        }
+        positionals.append((index, value))
+        index += 1
+    }
+
+    guard positionals.count >= 2 else { return nil }
+    let command = positionals[0].value
+    let action = positionals[1].value
+    switch (command, action) {
+    case ("file", "upload"):
+        guard positionals.count == 5 else {
+            throw BridgeError.invalidRequest("Use: agent-teams file upload <team-id> <channel-id> <path> [--pretty].")
+        }
+        return .input(argumentIndex: positionals[4].index)
+    case ("chat", "send-image"):
+        guard positionals.count == 4 else {
+            throw BridgeError.invalidRequest("Use: agent-teams chat send-image <chat-id> <path> [--pretty].")
+        }
+        return .input(argumentIndex: positionals[3].index)
+    case ("file", "download"):
+        guard positionals.count == 6 else {
+            throw BridgeError.invalidRequest("Teams bridge file downloads require one staged output path.")
+        }
+        return .output(argumentIndex: positionals[5].index)
+    case ("chat", "download-image"):
+        guard positionals.count == 4 else {
+            throw BridgeError.invalidRequest("Teams bridge image downloads require one staged output path.")
+        }
+        return .output(argumentIndex: positionals[3].index)
+    default:
+        return nil
+    }
+}
+
+private func stagedFileArgs(
+    _ args: [String],
+    request: BridgeRequest,
+    stagedRoot: URL
+) throws -> ([String], [BridgeOutputFileRequest]) {
+    let inputs = request.input_files ?? []
+    let outputs = request.output_files ?? []
+    var rewritten = args
+
+    switch try approvedFileCommand(args) {
+    case .input(let argumentIndex):
+        guard inputs.count == 1, outputs.isEmpty else {
+            throw BridgeError.invalidRequest("Teams bridge upload commands require exactly one input file declaration.")
+        }
+        let input = inputs[0]
+        guard input.argument_index == argumentIndex, argumentIndex < args.count,
+              input.bytes.count <= 20 * 1_024 * 1_024,
+              args[argumentIndex] == input.filename,
+              !input.filename.isEmpty,
+              input.filename == URL(fileURLWithPath: input.filename).lastPathComponent else {
+            throw BridgeError.invalidRequest("Teams bridge input file does not match the approved upload command.")
+        }
+        let inputRoot = stagedRoot.appendingPathComponent("input", isDirectory: true)
+        let stagedFile = inputRoot.appendingPathComponent(input.filename, isDirectory: false)
+        try writePrivate(input.bytes, to: stagedFile)
+        rewritten[argumentIndex] = stagedFile.path
+        return (rewritten, [])
+    case .output(let argumentIndex):
+        guard inputs.isEmpty, outputs.count == 1 else {
+            throw BridgeError.invalidRequest("Teams bridge download commands require exactly one output file declaration.")
+        }
+        let output = outputs[0]
+        guard output.argument_index == argumentIndex, argumentIndex < args.count,
+              args[argumentIndex] == output.filename,
+              !output.filename.isEmpty,
+              output.filename == URL(fileURLWithPath: output.filename).lastPathComponent else {
+            throw BridgeError.invalidRequest("Teams bridge output file does not match the approved download command.")
+        }
+        let outputRoot = stagedRoot.appendingPathComponent("output", isDirectory: true)
+        try ensureDirectory(outputRoot)
+        rewritten[argumentIndex] = outputRoot.appendingPathComponent(output.filename, isDirectory: false).path
+        return (rewritten, outputs)
+    case nil:
+        guard inputs.isEmpty, outputs.isEmpty else {
+            throw BridgeError.invalidRequest("Teams bridge file declarations are not allowed for this command.")
+        }
+        return (rewritten, [])
+    }
+}
+
+private func collectOutputFiles(_ requests: [BridgeOutputFileRequest], stagedRoot: URL) throws -> [BridgeOutputFile]? {
+    guard !requests.isEmpty else { return nil }
+    let outputRoot = stagedRoot.appendingPathComponent("output", isDirectory: true)
+    let outputRootDescriptor = open(outputRoot.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+    guard outputRootDescriptor >= 0 else {
+        throw BridgeError.runtimeFailed("Teams bridge output directory is unavailable.")
+    }
+    defer { close(outputRootDescriptor) }
+    return try requests.map { request in
+        guard !request.filename.isEmpty,
+              request.filename == URL(fileURLWithPath: request.filename).lastPathComponent else {
+            throw BridgeError.runtimeFailed("Teams bridge output has an invalid name.")
+        }
+        let fileDescriptor = openat(outputRootDescriptor, request.filename, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard fileDescriptor >= 0 else {
+            throw BridgeError.runtimeFailed("Teams bridge output is missing or exceeds 20 MiB.")
+        }
+        defer { close(fileDescriptor) }
+        var status = stat()
+        guard fstat(fileDescriptor, &status) == 0,
+              status.st_mode & S_IFMT == S_IFREG,
+              status.st_size >= 0,
+              status.st_size <= 20 * 1_024 * 1_024 else {
+            throw BridgeError.runtimeFailed("Teams bridge output is missing or exceeds 20 MiB.")
+        }
+        var bytes = Data()
+        bytes.reserveCapacity(Int(status.st_size))
+        var chunk = [UInt8](repeating: 0, count: 64 * 1_024)
+        while true {
+            let count = chunk.withUnsafeMutableBytes { rawBuffer in
+                Darwin.read(fileDescriptor, rawBuffer.baseAddress, rawBuffer.count)
+            }
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0, bytes.count + count <= 20 * 1_024 * 1_024 else {
+                throw BridgeError.runtimeFailed("Teams bridge output is missing or exceeds 20 MiB.")
+            }
+            if count == 0 { break }
+            bytes.append(contentsOf: chunk.prefix(count))
+        }
+        return BridgeOutputFile(
+            argument_index: request.argument_index,
+            filename: request.filename,
+            bytes: bytes
+        )
+    }
 }
 
 private enum BridgeError: LocalizedError {
@@ -144,26 +321,6 @@ private func validatedArgs(_ request: BridgeRequest) throws -> [String] {
         }
     }
     return args
-}
-
-private func stagedInputArgs(_ args: [String], request: BridgeRequest, stagedRoot: URL) throws -> [String] {
-    guard let inputs = request.input_files, !inputs.isEmpty else { return args }
-    guard inputs.count == 1 else { throw BridgeError.invalidRequest("Teams bridge accepts one input file per command.") }
-    let input = inputs[0]
-    guard input.argument_index >= 0, input.argument_index < args.count,
-          input.argument_index >= 4,
-          args[input.argument_index - 4] == "file", args[input.argument_index - 3] == "upload",
-          args[input.argument_index - 2].isEmpty == false, args[input.argument_index - 1].isEmpty == false,
-          input.bytes.count <= 20 * 1_024 * 1_024,
-          !input.filename.isEmpty, input.filename == URL(fileURLWithPath: input.filename).lastPathComponent else {
-        throw BridgeError.invalidRequest("Teams bridge input file does not match a file upload command.")
-    }
-    let inputRoot = stagedRoot.appendingPathComponent("input", isDirectory: true)
-    let stagedFile = inputRoot.appendingPathComponent(input.filename, isDirectory: false)
-    try writePrivate(input.bytes, to: stagedFile)
-    var rewritten = args
-    rewritten[input.argument_index] = stagedFile.path
-    return rewritten
 }
 
 private func selectedConfigDirectory(for request: BridgeRequest, paths: BridgePaths) throws -> URL {
@@ -529,7 +686,7 @@ private final class TeamsBridgeService: NSObject, TeamsBridgeXPCProtocol {
                 try ensureDerivedTeamsKey(configDirectory: config)
                 let stage = try stageTeamsProfiles(sourceRoot: sourceRoot, paths: self.paths, requestID: request.id)
                 stagedRoot = stage
-                let runtimeArgs = try stagedInputArgs(args, request: request, stagedRoot: stage)
+                let (runtimeArgs, outputRequests) = try stagedFileArgs(args, request: request, stagedRoot: stage)
                 var result = try runAgentTeams(
                     args: runtimeArgs,
                     configDirectory: config,
@@ -545,18 +702,40 @@ private final class TeamsBridgeService: NSObject, TeamsBridgeXPCProtocol {
                         timeoutMilliseconds: request.timeout_ms ?? 90_000
                     )
                 }
-                response = BridgeResponse(version: 1, id: request.id, exit_code: result.0, stdout: result.1, stderr: result.2)
+                let outputFiles = result.0 == 0 ? try collectOutputFiles(outputRequests, stagedRoot: stage) : nil
+                response = BridgeResponse(
+                    version: 1,
+                    id: request.id,
+                    exit_code: result.0,
+                    stdout: result.1,
+                    stderr: result.2,
+                    output_files: outputFiles
+                )
             } catch {
                 response = BridgeResponse(
                     version: 1,
                     id: responseID,
                     exit_code: 70,
                     stdout: "",
-                    stderr: "\(error.localizedDescription)\n"
+                    stderr: "\(error.localizedDescription)\n",
+                    output_files: nil
                 )
             }
             if let stagedRoot { try? FileManager.default.removeItem(at: stagedRoot) }
-            reply((try? JSONEncoder().encode(response)) ?? Data())
+            let encodedResponse = try? JSONEncoder().encode(response)
+            if let encodedResponse, encodedResponse.count <= 32 * 1_024 * 1_024 {
+                reply(encodedResponse)
+            } else {
+                let boundedResponse = BridgeResponse(
+                    version: 1,
+                    id: responseID,
+                    exit_code: 70,
+                    stdout: "",
+                    stderr: "Teams bridge response exceeded the 32 MiB safety limit.\n",
+                    output_files: nil
+                )
+                reply((try? JSONEncoder().encode(boundedResponse)) ?? Data())
+            }
         }
     }
 }
@@ -606,11 +785,11 @@ private final class BridgeDelegate: NSObject, NSApplicationDelegate {
 }
 
 private func runSelfTest() throws {
-    let valid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "extract"], profile: "proof", timeout_ms: 5_000, input_files: nil)
+    let valid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "extract"], profile: "proof", timeout_ms: 5_000, input_files: nil, output_files: nil)
     guard try validatedArgs(valid).suffix(2) == ["--source", "desktop"] else {
         throw BridgeError.invalidRequest("Desktop source injection failed.")
     }
-    let invalid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "login"], profile: "proof", timeout_ms: 5_000, input_files: nil)
+    let invalid = BridgeRequest(version: 1, id: "self-test", args: ["auth", "login"], profile: "proof", timeout_ms: 5_000, input_files: nil, output_files: nil)
     do {
         _ = try validatedArgs(invalid)
         throw BridgeError.invalidRequest("Device-code guard failed.")
@@ -624,15 +803,46 @@ private func runSelfTest() throws {
     let upload = BridgeRequest(
         version: 1,
         id: "self-test",
-        args: ["--account", "work", "file", "upload", "team", "channel", "/outside/approval.png"],
+        args: ["--account", "work", "file", "upload", "team", "channel", "approval.png"],
         profile: "proof",
         timeout_ms: 5_000,
-        input_files: [BridgeInputFile(argument_index: 6, filename: "approval.png", bytes: Data("image".utf8))]
+        input_files: [BridgeInputFile(argument_index: 6, filename: "approval.png", bytes: Data("image".utf8))],
+        output_files: nil
     )
-    let stagedArgs = try stagedInputArgs(upload.args, request: upload, stagedRoot: testRoot)
+    let (stagedArgs, _) = try stagedFileArgs(upload.args, request: upload, stagedRoot: testRoot)
     guard stagedArgs[6].hasPrefix(testRoot.path),
           try Data(contentsOf: URL(fileURLWithPath: stagedArgs[6])) == Data("image".utf8) else {
         throw BridgeError.invalidRequest("Input file staging self-test failed.")
+    }
+    let missingInput = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: upload.args,
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: nil,
+        output_files: nil
+    )
+    do {
+        _ = try stagedFileArgs(missingInput.args, request: missingInput, stagedRoot: testRoot)
+        throw BridgeError.invalidRequest("Missing input file declaration guard failed.")
+    } catch BridgeError.invalidRequest {
+        // Expected.
+    }
+    let duplicateInput = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: upload.args,
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: upload.input_files! + upload.input_files!,
+        output_files: nil
+    )
+    do {
+        _ = try stagedFileArgs(duplicateInput.args, request: duplicateInput, stagedRoot: testRoot)
+        throw BridgeError.invalidRequest("Duplicate input file declaration guard failed.")
+    } catch BridgeError.invalidRequest {
+        // Expected.
     }
     let mismatched = BridgeRequest(
         version: 1,
@@ -640,11 +850,71 @@ private func runSelfTest() throws {
         args: ["message", "send", "team", "channel", "hello", "--file", "/outside/approval.png"],
         profile: "proof",
         timeout_ms: 5_000,
-        input_files: [BridgeInputFile(argument_index: 6, filename: "approval.png", bytes: Data("image".utf8))]
+        input_files: [BridgeInputFile(argument_index: 6, filename: "approval.png", bytes: Data("image".utf8))],
+        output_files: nil
     )
     do {
-        _ = try stagedInputArgs(mismatched.args, request: mismatched, stagedRoot: testRoot)
+        _ = try stagedFileArgs(mismatched.args, request: mismatched, stagedRoot: testRoot)
         throw BridgeError.invalidRequest("Non-upload file staging guard failed.")
+    } catch BridgeError.invalidRequest {
+        // Expected.
+    }
+    let download = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: ["--account", "personal", "chat", "download-image", "0-frca-d16-image", "download-image"],
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: nil,
+        output_files: [BridgeOutputFileRequest(argument_index: 5, filename: "download-image")]
+    )
+    let (downloadArgs, downloadOutputs) = try stagedFileArgs(download.args, request: download, stagedRoot: testRoot)
+    guard downloadArgs[5].hasPrefix(testRoot.path) else {
+        throw BridgeError.invalidRequest("Output file staging self-test failed.")
+    }
+    let stagedOutput = URL(fileURLWithPath: downloadArgs[5])
+    try writePrivate(Data("downloaded".utf8), to: stagedOutput)
+    guard try collectOutputFiles(downloadOutputs, stagedRoot: testRoot)?.first?.bytes == Data("downloaded".utf8) else {
+        throw BridgeError.invalidRequest("Output file collection self-test failed.")
+    }
+    try FileManager.default.removeItem(at: stagedOutput)
+    let escapedOutput = testRoot.appendingPathComponent("escaped-output", isDirectory: false)
+    try Data("blocked".utf8).write(to: escapedOutput)
+    try FileManager.default.createSymbolicLink(
+        at: stagedOutput,
+        withDestinationURL: escapedOutput
+    )
+    do {
+        _ = try collectOutputFiles(downloadOutputs, stagedRoot: testRoot)
+        throw BridgeError.invalidRequest("Symbolic-link output guard failed.")
+    } catch BridgeError.runtimeFailed {
+        // Expected.
+    }
+    let fileDownload = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: ["file", "--team", "team", "download", "team", "--account=work", "channel", "file", "--pretty", "download-output"],
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: nil,
+        output_files: [BridgeOutputFileRequest(argument_index: 9, filename: "download-output")]
+    )
+    let (fileDownloadArgs, _) = try stagedFileArgs(fileDownload.args, request: fileDownload, stagedRoot: testRoot)
+    guard fileDownloadArgs[9].hasPrefix(testRoot.path) else {
+        throw BridgeError.invalidRequest("Channel file output staging self-test failed.")
+    }
+    let wrongCommandOutput = BridgeRequest(
+        version: 1,
+        id: "self-test",
+        args: ["chat", "history", "chat"],
+        profile: "proof",
+        timeout_ms: 5_000,
+        input_files: nil,
+        output_files: [BridgeOutputFileRequest(argument_index: 2, filename: "chat")]
+    )
+    do {
+        _ = try stagedFileArgs(wrongCommandOutput.args, request: wrongCommandOutput, stagedRoot: testRoot)
+        throw BridgeError.invalidRequest("Wrong-command output declaration guard failed.")
     } catch BridgeError.invalidRequest {
         // Expected.
     }

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 private let bridgeLabel = "com.timiaji.agent-messenger-teams-bridge"
@@ -15,6 +16,18 @@ struct BridgeRequest: Codable {
     let profile: String?
     let timeout_ms: Int?
     let input_files: [BridgeInputFile]?
+    let output_files: [BridgeOutputFileRequest]?
+}
+
+struct BridgeOutputFileRequest: Codable {
+    let argument_index: Int
+    let filename: String
+}
+
+struct BridgeOutputFile: Codable {
+    let argument_index: Int
+    let filename: String
+    let bytes: Data
 }
 
 struct BridgeInputFile: Codable {
@@ -29,6 +42,195 @@ struct BridgeResponse: Codable {
     let exit_code: Int32
     let stdout: String
     let stderr: String
+    let output_files: [BridgeOutputFile]?
+}
+
+enum FileTransferKind {
+    case channelFile
+    case chatImage
+}
+
+enum FileTransferCommand {
+    case input(argumentIndex: Int, kind: FileTransferKind)
+    case output(argumentIndex: Int?, insertionIndex: Int, kind: FileTransferKind, identifier: String)
+}
+
+func fileTransferCommand(_ args: [String]) -> FileTransferCommand? {
+    var positionals: [(index: Int, value: String)] = []
+    var optionsEnded = false
+    var index = 0
+    while index < args.count {
+        let value = args[index]
+        if !optionsEnded, value == "--" {
+            optionsEnded = true
+            index += 1
+            continue
+        }
+        if !optionsEnded, value == "--pretty" {
+            index += 1
+            continue
+        }
+        if !optionsEnded, value == "--account" || value == "--team" {
+            guard index + 1 < args.count else { return nil }
+            index += 2
+            continue
+        }
+        if !optionsEnded, value.hasPrefix("--account=") || value.hasPrefix("--team=") {
+            guard value.last != "=" else { return nil }
+            index += 1
+            continue
+        }
+        positionals.append((index, value))
+        index += 1
+    }
+
+    guard positionals.count >= 2 else { return nil }
+    switch (positionals[0].value, positionals[1].value) {
+    case ("file", "upload") where positionals.count == 5:
+        return .input(argumentIndex: positionals[4].index, kind: .channelFile)
+    case ("chat", "send-image") where positionals.count == 4:
+        return .input(argumentIndex: positionals[3].index, kind: .chatImage)
+    case ("file", "download") where positionals.count == 5 || positionals.count == 6:
+        return .output(
+            argumentIndex: positionals.count == 6 ? positionals[5].index : nil,
+            insertionIndex: positionals[4].index + 1,
+            kind: .channelFile,
+            identifier: positionals[4].value
+        )
+    case ("chat", "download-image") where positionals.count == 3 || positionals.count == 4:
+        return .output(
+            argumentIndex: positionals.count == 4 ? positionals[3].index : nil,
+            insertionIndex: positionals[2].index + 1,
+            kind: .chatImage,
+            identifier: positionals[2].value
+        )
+    default:
+        return nil
+    }
+}
+
+func runSelfTest() throws {
+    let image = fileTransferCommand(["chat", "--account", "personal", "send-image", "chat", "--pretty", "photo.png"])
+    guard case .input(let imageIndex, .chatImage) = image, imageIndex == 6 else {
+        throw POSIXError(.EINVAL)
+    }
+    let upload = fileTransferCommand(["--team=team", "file", "upload", "team", "--account=work", "channel", "--", "--photo.png"])
+    guard case .input(let uploadIndex, .channelFile) = upload, uploadIndex == 7 else {
+        throw POSIXError(.EINVAL)
+    }
+    let download = fileTransferCommand(["file", "download", "team", "channel", "file", "--pretty"])
+    guard case .output(nil, let insertionIndex, .channelFile, "file") = download, insertionIndex == 5 else {
+        throw POSIXError(.EINVAL)
+    }
+
+    let temporaryPath = FileManager.default.temporaryDirectory.path
+    let physicalTemporaryPath = temporaryPath.hasPrefix("/var/") ? "/private\(temporaryPath)" : temporaryPath
+    let root = URL(fileURLWithPath: physicalTemporaryPath, isDirectory: true)
+        .appendingPathComponent("teams-bridge-client-self-test-\(UUID().uuidString)", isDirectory: true)
+    let directory = root.appendingPathComponent("directory", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let destination = directory.appendingPathComponent("output.bin")
+    try writePrivateAtomically(Data("first".utf8), to: destination)
+    try writePrivateAtomically(Data("second".utf8), to: destination)
+    let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
+    guard try Data(contentsOf: destination) == Data("second".utf8),
+          (attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600 else {
+        throw POSIXError(.EACCES)
+    }
+    let symlink = root.appendingPathComponent("symlink", isDirectory: true)
+    try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: directory)
+    var rejectedSymlink = false
+    do {
+        try writePrivateAtomically(Data("blocked".utf8), to: symlink.appendingPathComponent("blocked.bin"))
+    } catch {
+        rejectedSymlink = true
+    }
+    guard rejectedSymlink,
+          !FileManager.default.fileExists(atPath: directory.appendingPathComponent("blocked.bin").path) else {
+        throw POSIXError(.ELOOP)
+    }
+    print("teams-bridge-client-self-test: pass")
+}
+
+if CommandLine.arguments == [CommandLine.arguments[0], "--self-test"] {
+    do {
+        try runSelfTest()
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("\(error.localizedDescription)\n".utf8))
+        exit(1)
+    }
+}
+
+func openDirectoryWithoutSymlinks(_ url: URL) throws -> Int32 {
+    let components = url.pathComponents.filter { $0 != "/" }
+    guard url.path.hasPrefix("/"), !components.contains("."), !components.contains("..") else {
+        throw POSIXError(.EINVAL)
+    }
+    var descriptor = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+    guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+    do {
+        for component in components {
+            let next = openat(descriptor, component, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+            guard next >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+            close(descriptor)
+            descriptor = next
+        }
+        return descriptor
+    } catch {
+        close(descriptor)
+        throw error
+    }
+}
+
+func destinationURL(_ requested: URL, defaultName: String) throws -> URL {
+    do {
+        let descriptor = try openDirectoryWithoutSymlinks(requested)
+        close(descriptor)
+        return requested.appendingPathComponent(defaultName, isDirectory: false)
+    } catch let error as POSIXError where error.code == .ENOENT || error.code == .ENOTDIR {
+        return requested
+    }
+}
+
+func writePrivateAtomically(_ data: Data, to destination: URL) throws {
+    let parent = destination.deletingLastPathComponent()
+    let filename = destination.lastPathComponent
+    guard !filename.isEmpty, filename != ".", filename != ".." else { throw POSIXError(.EINVAL) }
+    let parentDescriptor = try openDirectoryWithoutSymlinks(parent)
+    defer { close(parentDescriptor) }
+    let temporary = ".\(filename).\(UUID().uuidString)"
+    let fileDescriptor = openat(
+        parentDescriptor,
+        temporary,
+        O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+        mode_t(0o600)
+    )
+    guard fileDescriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+    var keepTemporary = true
+    defer {
+        close(fileDescriptor)
+        if keepTemporary { unlinkat(parentDescriptor, temporary, 0) }
+    }
+    try data.withUnsafeBytes { rawBuffer in
+        guard let base = rawBuffer.baseAddress else { return }
+        var written = 0
+        while written < rawBuffer.count {
+            let result = Darwin.write(fileDescriptor, base.advanced(by: written), rawBuffer.count - written)
+            if result < 0, errno == EINTR { continue }
+            guard result > 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+            written += result
+        }
+    }
+    guard fchmod(fileDescriptor, mode_t(0o600)) == 0, fsync(fileDescriptor) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    guard renameat(parentDescriptor, temporary, parentDescriptor, filename) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    keepTemporary = false
+    guard fsync(parentDescriptor) == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
 }
 
 let profile = ProcessInfo.processInfo.environment["AGENT_TEAMS_BRIDGE_PROFILE"] ?? "live"
@@ -37,20 +239,44 @@ guard profile == "live" || profile == "proof" else {
     exit(64)
 }
 let requestID = UUID().uuidString.lowercased()
-let cliArgs = Array(CommandLine.arguments.dropFirst())
+var cliArgs = Array(CommandLine.arguments.dropFirst())
 var inputFiles: [BridgeInputFile] = []
-if let fileIndex = cliArgs.indices.first(where: {
-    $0 + 4 < cliArgs.count && cliArgs[$0] == "file" && cliArgs[$0 + 1] == "upload"
-}) {
-    let argumentIndex = fileIndex + 4
+var outputFiles: [BridgeOutputFileRequest] = []
+var requestedOutputURL: URL?
+var outputKind: FileTransferKind?
+var outputIdentifier: String?
+var outputWasProvided = false
+switch fileTransferCommand(cliArgs) {
+case .input(let argumentIndex, let kind):
     let fileURL = URL(fileURLWithPath: cliArgs[argumentIndex]).standardizedFileURL
     let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
     guard values?.isRegularFile == true, let size = values?.fileSize, size <= 20 * 1_024 * 1_024,
           let bytes = try? Data(contentsOf: fileURL, options: [.mappedIfSafe]) else {
-        FileHandle.standardError.write(Data("Teams file upload requires a readable regular file no larger than 20 MiB.\n".utf8))
+        let message = kind == .chatImage
+            ? "Teams chat image requires a readable file no larger than 20 MiB.\n"
+            : "Teams file upload requires a readable regular file no larger than 20 MiB.\n"
+        FileHandle.standardError.write(Data(message.utf8))
         exit(66)
     }
+    cliArgs[argumentIndex] = fileURL.lastPathComponent
     inputFiles.append(BridgeInputFile(argument_index: argumentIndex, filename: fileURL.lastPathComponent, bytes: bytes))
+case .output(let existingArgumentIndex, let insertionIndex, let kind, let identifier):
+    let outputIndex: Int
+    if let existingArgumentIndex {
+        outputIndex = existingArgumentIndex
+        requestedOutputURL = URL(fileURLWithPath: cliArgs[existingArgumentIndex]).standardizedFileURL
+        cliArgs[existingArgumentIndex] = "download-output"
+        outputWasProvided = true
+    } else {
+        requestedOutputURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        outputIndex = insertionIndex
+        cliArgs.insert("download-output", at: outputIndex)
+    }
+    outputKind = kind
+    outputIdentifier = identifier
+    outputFiles.append(BridgeOutputFileRequest(argument_index: outputIndex, filename: "download-output"))
+case nil:
+    break
 }
 
 let request = BridgeRequest(
@@ -59,7 +285,8 @@ let request = BridgeRequest(
     args: cliArgs,
     profile: profile,
     timeout_ms: 90_000,
-    input_files: inputFiles.isEmpty ? nil : inputFiles
+    input_files: inputFiles.isEmpty ? nil : inputFiles,
+    output_files: outputFiles.isEmpty ? nil : outputFiles
 )
 guard let requestData = try? JSONEncoder().encode(request), requestData.count <= 28 * 1_024 * 1_024 else {
     FileHandle.standardError.write(Data("Teams bridge request is too large.\n".utf8))
@@ -100,6 +327,7 @@ if let connectionError {
 }
 guard
     let responseData,
+    responseData.count <= 32 * 1_024 * 1_024,
     let response = try? JSONDecoder().decode(BridgeResponse.self, from: responseData),
     response.version == 1,
     response.id == requestID
@@ -107,6 +335,70 @@ else {
     FileHandle.standardError.write(Data("Teams bridge returned an invalid response.\n".utf8))
     exit(70)
 }
-if !response.stdout.isEmpty { FileHandle.standardOutput.write(Data(response.stdout.utf8)) }
+if response.exit_code != 0 {
+    if !response.stdout.isEmpty { FileHandle.standardOutput.write(Data(response.stdout.utf8)) }
+    if !response.stderr.isEmpty { FileHandle.standardError.write(Data(response.stderr.utf8)) }
+    exit(response.exit_code)
+}
+guard requestedOutputURL == nil ? (response.output_files?.isEmpty ?? true) : response.output_files?.count == 1 else {
+    FileHandle.standardError.write(Data("Teams bridge returned an invalid image output count.\n".utf8))
+    exit(70)
+}
+var stdout = response.stdout
+if let output = response.output_files?.first, let requestedOutputURL, let outputKind, let outputIdentifier {
+    guard response.output_files?.count == 1, output.argument_index == outputFiles.first?.argument_index,
+          output.filename == outputFiles.first?.filename,
+          output.bytes.count <= 20 * 1_024 * 1_024,
+          outputKind == .channelFile || !output.bytes.isEmpty else {
+        FileHandle.standardError.write(Data("Teams bridge returned an invalid file output.\n".utf8))
+        exit(70)
+    }
+    let defaultName: String
+    switch outputKind {
+    case .chatImage:
+        let imageExtension: String
+        if output.bytes.starts(with: [137, 80, 78, 71, 13, 10, 26, 10]) {
+            imageExtension = "png"
+        } else if output.bytes.starts(with: [255, 216, 255]) {
+            imageExtension = "jpg"
+        } else {
+            FileHandle.standardError.write(Data("Teams bridge returned an image with an invalid signature.\n".utf8))
+            exit(70)
+        }
+        defaultName = "\(outputIdentifier).\(imageExtension)"
+    case .channelFile:
+        guard let outputJSON = try? JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any],
+              let name = outputJSON["name"] as? String else {
+            FileHandle.standardError.write(Data("Teams bridge returned invalid file download output.\n".utf8))
+            exit(70)
+        }
+        let safeName = URL(fileURLWithPath: name.replacingOccurrences(of: "\\", with: "/")).lastPathComponent
+        guard !safeName.isEmpty, safeName != ".", safeName != ".." else {
+            FileHandle.standardError.write(Data("Teams bridge returned an invalid file name.\n".utf8))
+            exit(70)
+        }
+        defaultName = safeName
+    }
+    do {
+        let destination = try destinationURL(requestedOutputURL, defaultName: defaultName)
+        let finalDestination = outputWasProvided ? destination : requestedOutputURL.appendingPathComponent(defaultName)
+        try writePrivateAtomically(output.bytes, to: finalDestination)
+        guard var outputJSON = try? JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any] else {
+            FileHandle.standardError.write(Data("Teams bridge returned invalid download output.\n".utf8))
+            exit(70)
+        }
+        outputJSON["path"] = finalDestination.path
+        guard let rewrittenJSON = try? JSONSerialization.data(withJSONObject: outputJSON),
+              let rewrittenStdout = String(data: rewrittenJSON, encoding: .utf8) else {
+            FileHandle.standardError.write(Data("Teams bridge could not encode download output.\n".utf8))
+            exit(70)
+        }
+        stdout = rewrittenStdout + "\n"
+    } catch {
+        FileHandle.standardError.write(Data("Unable to write Teams download: \(error.localizedDescription)\n".utf8))
+        exit(74)
+    }
+}
+if !stdout.isEmpty { FileHandle.standardOutput.write(Data(stdout.utf8)) }
 if !response.stderr.isEmpty { FileHandle.standardError.write(Data(response.stderr.utf8)) }
 exit(response.exit_code)

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
@@ -14,6 +14,13 @@ struct BridgeRequest: Codable {
     let args: [String]
     let profile: String?
     let timeout_ms: Int?
+    let input_files: [BridgeInputFile]?
+}
+
+struct BridgeInputFile: Codable {
+    let argument_index: Int
+    let filename: String
+    let bytes: Data
 }
 
 struct BridgeResponse: Codable {
@@ -30,14 +37,31 @@ guard profile == "live" || profile == "proof" else {
     exit(64)
 }
 let requestID = UUID().uuidString.lowercased()
+let cliArgs = Array(CommandLine.arguments.dropFirst())
+var inputFiles: [BridgeInputFile] = []
+if let fileIndex = cliArgs.indices.first(where: {
+    $0 + 4 < cliArgs.count && cliArgs[$0] == "file" && cliArgs[$0 + 1] == "upload"
+}) {
+    let argumentIndex = fileIndex + 4
+    let fileURL = URL(fileURLWithPath: cliArgs[argumentIndex]).standardizedFileURL
+    let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+    guard values?.isRegularFile == true, let size = values?.fileSize, size <= 20 * 1_024 * 1_024,
+          let bytes = try? Data(contentsOf: fileURL, options: [.mappedIfSafe]) else {
+        FileHandle.standardError.write(Data("Teams file upload requires a readable regular file no larger than 20 MiB.\n".utf8))
+        exit(66)
+    }
+    inputFiles.append(BridgeInputFile(argument_index: argumentIndex, filename: fileURL.lastPathComponent, bytes: bytes))
+}
+
 let request = BridgeRequest(
     version: 1,
     id: requestID,
-    args: Array(CommandLine.arguments.dropFirst()),
+    args: cliArgs,
     profile: profile,
-    timeout_ms: 90_000
+    timeout_ms: 90_000,
+    input_files: inputFiles.isEmpty ? nil : inputFiles
 )
-guard let requestData = try? JSONEncoder().encode(request), requestData.count <= 1_048_576 else {
+guard let requestData = try? JSONEncoder().encode(request), requestData.count <= 28 * 1_024 * 1_024 else {
     FileHandle.standardError.write(Data("Teams bridge request is too large.\n".utf8))
     exit(64)
 }

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+private let bridgeLabel = "com.timiaji.agent-messenger-teams-bridge"
+private let serverRequirement =
+    "anchor apple generic and identifier \"com.timiaji.agent-messenger-teams-bridge\" and certificate leaf[subject.OU] = \"9F4ARQ5FJR\""
+
+@objc protocol TeamsBridgeXPCProtocol {
+    func run(_ requestData: Data, withReply reply: @escaping (Data) -> Void)
+}
+
+struct BridgeRequest: Codable {
+    let version: Int
+    let id: String
+    let args: [String]
+    let profile: String?
+    let timeout_ms: Int?
+}
+
+struct BridgeResponse: Codable {
+    let version: Int
+    let id: String
+    let exit_code: Int32
+    let stdout: String
+    let stderr: String
+}
+
+let profile = ProcessInfo.processInfo.environment["AGENT_TEAMS_BRIDGE_PROFILE"] ?? "live"
+guard profile == "live" || profile == "proof" else {
+    FileHandle.standardError.write(Data("AGENT_TEAMS_BRIDGE_PROFILE must be live or proof.\n".utf8))
+    exit(64)
+}
+let requestID = UUID().uuidString.lowercased()
+let request = BridgeRequest(
+    version: 1,
+    id: requestID,
+    args: Array(CommandLine.arguments.dropFirst()),
+    profile: profile,
+    timeout_ms: 90_000
+)
+guard let requestData = try? JSONEncoder().encode(request), requestData.count <= 1_048_576 else {
+    FileHandle.standardError.write(Data("Teams bridge request is too large.\n".utf8))
+    exit(64)
+}
+
+let connection = NSXPCConnection(machServiceName: bridgeLabel, options: [])
+connection.remoteObjectInterface = NSXPCInterface(with: TeamsBridgeXPCProtocol.self)
+connection.setCodeSigningRequirement(serverRequirement)
+let completion = DispatchSemaphore(value: 0)
+var responseData: Data?
+var connectionError: Error?
+connection.invalidationHandler = { completion.signal() }
+connection.interruptionHandler = { completion.signal() }
+connection.resume()
+
+guard let proxy = connection.remoteObjectProxyWithErrorHandler({ error in
+    connectionError = error
+    completion.signal()
+}) as? TeamsBridgeXPCProtocol else {
+    FileHandle.standardError.write(Data("Teams bridge service is unavailable.\n".utf8))
+    exit(69)
+}
+proxy.run(requestData) { data in
+    responseData = data
+    completion.signal()
+}
+
+guard completion.wait(timeout: .now() + .seconds(300)) == .success else {
+    connection.invalidate()
+    FileHandle.standardError.write(Data("Teams bridge did not respond within 300 seconds.\n".utf8))
+    exit(124)
+}
+connection.invalidate()
+if let connectionError {
+    FileHandle.standardError.write(Data("Teams bridge connection failed: \(connectionError.localizedDescription)\n".utf8))
+    exit(69)
+}
+guard
+    let responseData,
+    let response = try? JSONDecoder().decode(BridgeResponse.self, from: responseData),
+    response.version == 1,
+    response.id == requestID
+else {
+    FileHandle.standardError.write(Data("Teams bridge returned an invalid response.\n".utf8))
+    exit(70)
+}
+if !response.stdout.isEmpty { FileHandle.standardOutput.write(Data(response.stdout.utf8)) }
+if !response.stderr.isEmpty { FileHandle.standardError.write(Data(response.stderr.utf8)) }
+exit(response.exit_code)

--- a/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
+++ b/native/macos/teams-bridge/AgentMessengerTeamsBridgeClient.swift
@@ -88,8 +88,6 @@ func fileTransferCommand(_ args: [String]) -> FileTransferCommand? {
     switch (positionals[0].value, positionals[1].value) {
     case ("file", "upload") where positionals.count == 5:
         return .input(argumentIndex: positionals[4].index, kind: .channelFile)
-    case ("chat", "send-image") where positionals.count == 4:
-        return .input(argumentIndex: positionals[3].index, kind: .chatImage)
     case ("file", "download") where positionals.count == 5 || positionals.count == 6:
         return .output(
             argumentIndex: positionals.count == 6 ? positionals[5].index : nil,
@@ -110,8 +108,7 @@ func fileTransferCommand(_ args: [String]) -> FileTransferCommand? {
 }
 
 func runSelfTest() throws {
-    let image = fileTransferCommand(["chat", "--account", "personal", "send-image", "chat", "--pretty", "photo.png"])
-    guard case .input(let imageIndex, .chatImage) = image, imageIndex == 6 else {
+    guard fileTransferCommand(["chat", "--account", "personal", "send-image", "chat", "--pretty", "photo.png"]) == nil else {
         throw POSIXError(.EINVAL)
     }
     let upload = fileTransferCommand(["--team=team", "file", "upload", "team", "--account=work", "channel", "--", "--photo.png"])
@@ -120,6 +117,11 @@ func runSelfTest() throws {
     }
     let download = fileTransferCommand(["file", "download", "team", "channel", "file", "--pretty"])
     guard case .output(nil, let insertionIndex, .channelFile, "file") = download, insertionIndex == 5 else {
+        throw POSIXError(.EINVAL)
+    }
+    let imageDownload = fileTransferCommand(["chat", "--account", "personal", "download-image", "0-frca-d16-image"])
+    guard case .output(nil, let imageInsertionIndex, .chatImage, "0-frca-d16-image") = imageDownload,
+          imageInsertionIndex == 5 else {
         throw POSIXError(.EINVAL)
     }
 
@@ -132,9 +134,15 @@ func runSelfTest() throws {
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     let destination = directory.appendingPathComponent("output.bin")
     try writePrivateAtomically(Data("first".utf8), to: destination)
-    try writePrivateAtomically(Data("second".utf8), to: destination)
+    var rejectedExistingFile = false
+    do {
+        try writePrivateAtomically(Data("second".utf8), to: destination)
+    } catch let error as POSIXError where error.code == .EEXIST {
+        rejectedExistingFile = true
+    }
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
-    guard try Data(contentsOf: destination) == Data("second".utf8),
+    guard rejectedExistingFile,
+          try Data(contentsOf: destination) == Data("first".utf8),
           (attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600 else {
         throw POSIXError(.EACCES)
     }
@@ -226,7 +234,7 @@ func writePrivateAtomically(_ data: Data, to destination: URL) throws {
     guard fchmod(fileDescriptor, mode_t(0o600)) == 0, fsync(fileDescriptor) == 0 else {
         throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
     }
-    guard renameat(parentDescriptor, temporary, parentDescriptor, filename) == 0 else {
+    guard renameatx_np(parentDescriptor, temporary, parentDescriptor, filename, UInt32(RENAME_EXCL)) == 0 else {
         throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
     }
     keepTemporary = false

--- a/native/macos/teams-bridge/Info.plist
+++ b/native/macos/teams-bridge/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>AgentMessengerTeamsBridge</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.timiaji.agent-messenger-teams-bridge</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Agent Messenger Teams Bridge</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSAppDataUsageDescription</key>
+  <string>Reads the two Microsoft Teams desktop session databases you explicitly select so the local Agent Messenger CLI can use those signed-in accounts.</string>
+</dict>
+</plist>

--- a/native/macos/teams-bridge/TeamsBridge.entitlements
+++ b/native/macos/teams-bridge/TeamsBridge.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-only</key>
+  <true/>
+  <key>com.apple.security.files.bookmarks.app-scope</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/native/macos/teams-bridge/TeamsBridgeRuntime.entitlements
+++ b/native/macos/teams-bridge/TeamsBridgeRuntime.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/native/macos/teams-bridge/TeamsBridgeRuntimeLauncher.c
+++ b/native/macos/teams-bridge/TeamsBridgeRuntimeLauncher.c
@@ -1,0 +1,18 @@
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    fputs("Teams bridge runtime path is missing.\n", stderr);
+    return 64;
+  }
+  if (setpgid(0, 0) != 0) {
+    perror("setpgid");
+    return 70;
+  }
+  execv(argv[1], &argv[1]);
+  perror("execv");
+  return errno == ENOENT ? 127 : 70;
+}

--- a/native/macos/teams-bridge/agent-teams
+++ b/native/macos/teams-bridge/agent-teams
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+CLIENT="$HOME/.local/bin/agent-teams-bridge-client"
+if [ ! -x "$CLIENT" ]; then
+  printf 'The signed Agent Messenger Teams Bridge client is not installed.\n' >&2
+  exit 69
+fi
+
+exec "$CLIENT" "$@"

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "commander": "^11.1.0",
     "crypto-js": "^4.2.0",
     "curve25519-js": "^0.0.4",
+    "jpeg-js": "^0.4.4",
     "jsqr": "^1.4.0",
     "node-bignumber": "^1.2.2",
     "node-int64": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-messenger",
-  "version": "2.32.0",
+  "version": "2.32.0-timiaji.1",
   "description": "Multi-platform messaging CLI for AI agents (Slack, Discord, Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, Channel Talk)",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-messenger",
-  "version": "2.32.0-timiaji.1",
+  "version": "2.32.0-timiaji.2",
   "description": "Multi-platform messaging CLI for AI agents (Slack, Discord, Teams, Webex, Telegram, Telegram Bot, WhatsApp, LINE, iMessage, Instagram, KakaoTalk, Channel Talk)",
   "repository": {
     "type": "git",
@@ -163,6 +163,8 @@
   },
   "scripts": {
     "build": "tsc && tsc-alias --resolve-full-paths",
+    "build:teams-bridge:macos": "sh scripts/build-teams-bridge-macos.sh",
+    "install:teams-bridge:macos": "sh scripts/install-teams-bridge-macos.sh",
     "postbuild": "bun scripts/postbuild.ts",
     "test": "bun test src/",
     "test:e2e": "bun --config=bunfig.e2e.toml test",

--- a/scripts/build-teams-bridge-macos.sh
+++ b/scripts/build-teams-bridge-macos.sh
@@ -17,6 +17,7 @@ RESOURCES="$APP/Contents/Resources"
 IDENTITY=${TEAMS_BRIDGE_SIGNING_IDENTITY:-Developer ID Application: Build Context, Inc. (9F4ARQ5FJR)}
 BUN_VERSION=1.3.14
 BUN_ARM64_SHA256=e0c90ec15d33363e6b70713d56bc3b2c7585c17f40a0fe0f8fd9305901d4e233
+BUN_ARM64_TARBALL_SHA512=3a68f6d12ba21c13948d4048caab643634942233ad10e27099b8b1fd9c851f805a43a3994da6915884784e31d5cf4c9a7478258ba94b4e2021d6e6ab9ef0f8f4
 
 expected_version=$(node -p "require('$ROOT/package.json').version")
 if [ ! -d "$ROOT/node_modules" ]; then
@@ -24,13 +25,27 @@ if [ ! -d "$ROOT/node_modules" ]; then
   exit 1
 fi
 
-bun_binary=$(LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 npx -y "bun@$BUN_VERSION" -e 'console.log(process.execPath)')
+if [ "$(uname -m)" != "arm64" ]; then
+  printf 'The reviewed Teams bridge build supports only arm64 macOS.\n' >&2
+  exit 1
+fi
+bun_download_root=$(mktemp -d "${TMPDIR:-/tmp}/teams-bridge-bun.XXXXXX")
+trap 'rm -rf "$bun_download_root"' EXIT HUP INT TERM
+bun_tarball=$(npm pack --silent --pack-destination "$bun_download_root" "@oven/bun-darwin-aarch64@$BUN_VERSION")
+bun_tarball="$bun_download_root/$bun_tarball"
+bun_tarball_sha512=$(/usr/bin/openssl dgst -sha512 "$bun_tarball" | awk '{print $NF}')
+if [ "$bun_tarball_sha512" != "$BUN_ARM64_TARBALL_SHA512" ]; then
+  printf 'The Bun package digest does not match the reviewed arm64 package.\n' >&2
+  exit 1
+fi
+tar -xzf "$bun_tarball" -C "$bun_download_root"
+bun_binary="$bun_download_root/package/bin/bun"
 if [ ! -x "$bun_binary" ]; then
   printf 'Unable to locate the reviewed Bun runtime.\n' >&2
   exit 1
 fi
 bun_sha256=$(/usr/bin/openssl dgst -sha256 "$bun_binary" | awk '{print $NF}')
-if [ "$(uname -m)" = "arm64" ] && [ "$bun_sha256" != "$BUN_ARM64_SHA256" ]; then
+if [ "$bun_sha256" != "$BUN_ARM64_SHA256" ]; then
   printf 'The Bun runtime digest does not match the reviewed arm64 build.\n' >&2
   exit 1
 fi

--- a/scripts/build-teams-bridge-macos.sh
+++ b/scripts/build-teams-bridge-macos.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  printf 'The Teams bridge is available only on macOS.\n' >&2
+  exit 1
+fi
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SOURCE_ROOT="$ROOT/native/macos/teams-bridge"
+BUILD_ROOT="$ROOT/.build/teams-bridge"
+APP="$BUILD_ROOT/Agent Messenger Teams Bridge.app"
+APP_EXECUTABLE="$APP/Contents/MacOS/AgentMessengerTeamsBridge"
+CLIENT="$BUILD_ROOT/agent-teams-bridge-client"
+RESOURCES="$APP/Contents/Resources"
+IDENTITY=${TEAMS_BRIDGE_SIGNING_IDENTITY:-Developer ID Application: Build Context, Inc. (9F4ARQ5FJR)}
+BUN_VERSION=1.3.14
+BUN_ARM64_SHA256=e0c90ec15d33363e6b70713d56bc3b2c7585c17f40a0fe0f8fd9305901d4e233
+
+expected_version=$(node -p "require('$ROOT/package.json').version")
+if [ ! -d "$ROOT/node_modules" ]; then
+  printf 'Install this checkout\047s dependencies before building the companion.\n' >&2
+  exit 1
+fi
+
+bun_binary=$(LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 npx -y "bun@$BUN_VERSION" -e 'console.log(process.execPath)')
+if [ ! -x "$bun_binary" ]; then
+  printf 'Unable to locate the reviewed Bun runtime.\n' >&2
+  exit 1
+fi
+bun_sha256=$(/usr/bin/openssl dgst -sha256 "$bun_binary" | awk '{print $NF}')
+if [ "$(uname -m)" = "arm64" ] && [ "$bun_sha256" != "$BUN_ARM64_SHA256" ]; then
+  printf 'The Bun runtime digest does not match the reviewed arm64 build.\n' >&2
+  exit 1
+fi
+
+"$ROOT/node_modules/.bin/tsc"
+"$ROOT/node_modules/.bin/tsc-alias" --resolve-full-paths
+LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 "$bun_binary" "$ROOT/scripts/postbuild.ts"
+
+rm -rf "$APP" "$CLIENT"
+mkdir -p "$APP/Contents/MacOS" "$RESOURCES/runtime" "$RESOURCES/agent-messenger"
+cp "$SOURCE_ROOT/Info.plist" "$APP/Contents/Info.plist"
+ditto "$ROOT/dist" "$RESOURCES/agent-messenger/dist"
+ditto "$ROOT/node_modules" "$RESOURCES/agent-messenger/node_modules"
+cp "$ROOT/package.json" "$RESOURCES/agent-messenger/package.json"
+cp "$bun_binary" "$RESOURCES/runtime/bun"
+chmod 755 "$RESOURCES/runtime/bun"
+
+if ! cmp -s "$ROOT/package.json" "$RESOURCES/agent-messenger/package.json" || \
+   ! diff -qr "$ROOT/dist" "$RESOURCES/agent-messenger/dist" >/dev/null; then
+  printf 'The embedded Agent Messenger bytes do not match this checkout.\n' >&2
+  exit 1
+fi
+runtime_digest() {
+  (cd "$1" && find package.json dist -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+    /usr/bin/openssl dgst -sha256 "$file"
+  done) | /usr/bin/openssl dgst -sha256 | awk '{print $NF}'
+}
+source_digest=$(runtime_digest "$ROOT")
+embedded_digest=$(runtime_digest "$RESOURCES/agent-messenger")
+if [ "$source_digest" != "$embedded_digest" ]; then
+  printf 'The embedded Agent Messenger content digest does not match this checkout.\n' >&2
+  exit 1
+fi
+source_commit=$(git -C "$ROOT" rev-parse HEAD)
+printf '{"agent_messenger_version":"%s","source_commit":"%s","content_sha256":"%s","bun_version":"%s","bun_sha256":"%s"}\n' \
+  "$expected_version" "$source_commit" "$source_digest" "$BUN_VERSION" "$bun_sha256" \
+  >"$RESOURCES/runtime-manifest.json"
+chmod 644 "$RESOURCES/runtime-manifest.json"
+
+xcrun swiftc -O -framework AppKit -framework Security -lsqlite3 \
+  "$SOURCE_ROOT/AgentMessengerTeamsBridge.swift" -o "$APP_EXECUTABLE"
+xcrun swiftc -O -framework Foundation \
+  "$SOURCE_ROOT/AgentMessengerTeamsBridgeClient.swift" -o "$CLIENT"
+xcrun clang -O2 "$SOURCE_ROOT/TeamsBridgeRuntimeLauncher.c" -o "$RESOURCES/runtime/launcher"
+
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  --entitlements "$SOURCE_ROOT/TeamsBridgeRuntime.entitlements" \
+  --identifier com.timiaji.agent-messenger-teams-bridge.runtime "$RESOURCES/runtime/bun"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  --entitlements "$SOURCE_ROOT/TeamsBridgeRuntime.entitlements" \
+  --identifier com.timiaji.agent-messenger-teams-bridge.launcher "$RESOURCES/runtime/launcher"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  --entitlements "$SOURCE_ROOT/TeamsBridge.entitlements" "$APP"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  --identifier com.timiaji.agent-messenger-teams-bridge-client "$CLIENT"
+
+codesign --verify --deep --strict "$APP"
+codesign --verify --strict "$CLIENT"
+"$APP_EXECUTABLE" --self-test
+printf '%s\n%s\n' "$APP" "$CLIENT"

--- a/scripts/build-teams-bridge-macos.sh
+++ b/scripts/build-teams-bridge-macos.sh
@@ -90,4 +90,5 @@ codesign --force --options runtime --timestamp --sign "$IDENTITY" \
 codesign --verify --deep --strict "$APP"
 codesign --verify --strict "$CLIENT"
 "$APP_EXECUTABLE" --self-test
+"$CLIENT" --self-test
 printf '%s\n%s\n' "$APP" "$CLIENT"

--- a/scripts/install-teams-bridge-macos.sh
+++ b/scripts/install-teams-bridge-macos.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+BUILD_APP="$ROOT/.build/teams-bridge/Agent Messenger Teams Bridge.app"
+BUILD_CLIENT="$ROOT/.build/teams-bridge/agent-teams-bridge-client"
+TARGET_APP="$HOME/Applications/Agent Messenger Teams Bridge.app"
+TARGET_EXECUTABLE="$TARGET_APP/Contents/MacOS/AgentMessengerTeamsBridge"
+TARGET_CLIENT="$HOME/.local/bin/agent-teams-bridge-client"
+TARGET_DISPATCHER="$HOME/.local/bin/agent-teams"
+LABEL=com.timiaji.agent-messenger-teams-bridge
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DOMAIN="gui/$(id -u)"
+
+"$ROOT/scripts/build-teams-bridge-macos.sh" >/dev/null
+launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+rm -rf "$TARGET_APP"
+mkdir -p "$HOME/Applications" "$HOME/.local/bin" "$HOME/Library/LaunchAgents"
+ditto "$BUILD_APP" "$TARGET_APP"
+cp "$BUILD_CLIENT" "$TARGET_CLIENT"
+cp "$ROOT/native/macos/teams-bridge/agent-teams" "$TARGET_DISPATCHER"
+chmod 755 "$TARGET_CLIENT"
+chmod 755 "$TARGET_DISPATCHER"
+
+if ! cmp -s "$BUILD_APP/Contents/Resources/runtime-manifest.json" \
+  "$TARGET_APP/Contents/Resources/runtime-manifest.json"; then
+  printf 'Installed Teams bridge provenance does not match the reviewed build.\n' >&2
+  exit 1
+fi
+
+rm -f "$PLIST"
+plutil -create xml1 "$PLIST"
+plutil -insert Label -string "$LABEL" "$PLIST"
+plutil -insert ProgramArguments -json "[\"$TARGET_EXECUTABLE\"]" "$PLIST"
+plutil -insert MachServices -json "{\"$LABEL\":true}" "$PLIST"
+plutil -insert RunAtLoad -bool true "$PLIST"
+plutil -insert ProcessType -string Interactive "$PLIST"
+plutil -insert LimitLoadToSessionType -string Aqua "$PLIST"
+chmod 600 "$PLIST"
+launchctl bootstrap "$DOMAIN" "$PLIST"
+
+codesign --verify --deep --strict "$TARGET_APP"
+codesign --verify --strict "$TARGET_CLIENT"
+printf 'Installed the sandboxed Teams companion and signed XPC client.\n'

--- a/src/platforms/teams/cli.ts
+++ b/src/platforms/teams/cli.ts
@@ -18,7 +18,15 @@ import {
 } from './commands'
 import { TeamsCredentialManager } from './credential-manager'
 import { ensureTeamsAuth } from './ensure-auth'
+import { assertTeamsOperatorBoundary } from './operator-boundary'
 import type { TeamsAccountType } from './types'
+
+try {
+  assertTeamsOperatorBoundary()
+} catch (error) {
+  process.stderr.write(`${(error as Error).message}\n`)
+  process.exit(64)
+}
 
 function isAuthCommand(command: CommandType): boolean {
   let cmd: CommandType | null = command

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { rmSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { encode as encodeJpeg } from 'jpeg-js'
 import { PNG } from 'pngjs'
 
 import { TeamsClient } from './client'
@@ -17,10 +16,6 @@ const GRAPH_AUDIENCE = 'https://graph.microsoft.com'
 
 function pngFixture(width: number, height: number): Buffer {
   return PNG.sync.write({ width, height, data: Buffer.alloc(width * height * 4, 0xff) })
-}
-
-function jpegFixture(width: number, height: number): Buffer {
-  return encodeJpeg({ width, height, data: Buffer.alloc(width * height * 4, 0xff) }, 80).data
 }
 
 describe('TeamsClient', () => {
@@ -385,68 +380,6 @@ describe('TeamsClient', () => {
     })
   })
 
-  describe('sendChatImage', () => {
-    it('creates, uploads, and sends one inline image object to a chat', async () => {
-      const png = pngFixture(320, 180)
-      await Bun.write('/tmp/test-teams-chat-image.png', png)
-      mockResponse({ id: '0-weu-d1-image' })
-      mockBinaryResponse('', 201)
-      mockResponse({ OriginalArrivalTime: 1704067200000 })
-
-      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
-      const message = await client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')
-
-      expect(fetchCalls[0].url).toBe('https://api.asm.skype.com/v1/objects')
-      expect(fetchCalls[0].options?.body).toBe(
-        JSON.stringify({
-          type: 'pish/image',
-          permissions: { '48:notes': ['read'] },
-          filename: 'test-teams-chat-image.png',
-        }),
-      )
-      expect(fetchCalls[1].url).toBe('https://api.asm.skype.com/v1/objects/0-weu-d1-image/content/original')
-      expect(headerValue(fetchCalls[1].options, 'Content-Type')).toBe('image/png')
-      expect(fetchCalls[2].url).toBe('https://msgapi.teams.live.com/v1/users/ME/conversations/48%3Anotes/messages')
-      expect(String(fetchCalls[2].options?.body)).toContain('RichText/UriObject')
-      expect(String(fetchCalls[2].options?.body)).toContain('width=\\\"320\\\" height=\\\"180\\\"')
-      expect(message.image_object_id).toBe('0-weu-d1-image')
-    })
-
-    it('decodes and uploads a valid JPEG', async () => {
-      const jpeg = jpegFixture(24, 16)
-      await Bun.write('/tmp/test-teams-chat-image.png', jpeg)
-      mockResponse({ id: '0-weu-d1-jpeg' })
-      mockBinaryResponse('', 201)
-      mockResponse({ OriginalArrivalTime: 1704067200000 })
-
-      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
-      await client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')
-
-      expect(headerValue(fetchCalls[1].options, 'Content-Type')).toBe('image/jpeg')
-      expect(String(fetchCalls[2].options?.body)).toContain('width=\\"24\\" height=\\"16\\"')
-    })
-
-    it('rejects malformed image data and an invalid object ID returned by AMS', async () => {
-      const png = pngFixture(1, 1)
-      const corruptPng = Buffer.from(png)
-      corruptPng[corruptPng.length - 1] ^= 0xff
-      await Bun.write('/tmp/test-teams-chat-image.png', corruptPng)
-
-      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
-      await expect(client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')).rejects.toMatchObject({
-        code: 'invalid_chat_image_signature',
-      })
-      expect(fetchCalls).toHaveLength(0)
-
-      await Bun.write('/tmp/test-teams-chat-image.png', png)
-      mockResponse({ id: `0-a-${'b'.repeat(253)}` })
-      await expect(client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')).rejects.toMatchObject({
-        code: 'chat_image_create_failed',
-      })
-      expect(fetchCalls).toHaveLength(1)
-    })
-  })
-
   describe('downloadChatImage', () => {
     it('downloads a bounded PNG from the trusted AMS image view without redirects', async () => {
       const png = pngFixture(320, 180)
@@ -487,6 +420,7 @@ describe('TeamsClient', () => {
         'https://user@eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
         'https://eu-api.asm.skype.com:444/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
         'https://api.asm.skype.com.evil.test/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+        'https://anything-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
         'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-other/views/imgpsh_fullsize_anim',
         'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim?download=1',
         'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim#other',

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -26,7 +26,7 @@ function jpegFixture(width: number, height: number): Buffer {
 describe('TeamsClient', () => {
   const originalFetch = globalThis.fetch
   let fetchCalls: Array<{ url: string; options?: RequestInit }> = []
-  let fetchResponses: Response[] = []
+  let fetchResponses: Array<Response | Error> = []
   let fetchIndex = 0
 
   beforeEach(() => {
@@ -40,6 +40,7 @@ describe('TeamsClient', () => {
       if (!response) {
         throw new Error('No mock response configured')
       }
+      if (response instanceof Error) throw response
       return response
     }
   })
@@ -447,8 +448,13 @@ describe('TeamsClient', () => {
   })
 
   describe('downloadChatImage', () => {
-    it('downloads a bounded PNG from the exact AMS object URL without redirects', async () => {
+    it('downloads a bounded PNG from the trusted AMS image view without redirects', async () => {
       const png = pngFixture(320, 180)
+      mockResponse({
+        content_state: 'ready',
+        view_state: 'ready',
+        view_location: 'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+      })
       fetchResponses.push(
         new Response(png, {
           headers: { 'Content-Type': 'image/png', 'Content-Length': String(png.length) },
@@ -458,11 +464,87 @@ describe('TeamsClient', () => {
       const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
       const image = await client.downloadChatImage('0-frca-d16-image')
 
-      expect(fetchCalls[0].url).toBe('https://api.asm.skype.com/v1/objects/0-frca-d16-image/content/original')
+      expect(fetchCalls[0].url).toBe(
+        'https://api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim/status',
+      )
       expect(fetchCalls[0].options?.redirect).toBe('manual')
+      expect(fetchCalls[0].options?.signal).toBeInstanceOf(AbortSignal)
       expect(headerValue(fetchCalls[0].options, 'Authorization')).toBe('skype_token test-token')
+      expect(fetchCalls[1].url).toBe(
+        'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+      )
+      expect(fetchCalls[1].options?.redirect).toBe('manual')
+      expect(fetchCalls[1].options?.signal).toBe(fetchCalls[0].options?.signal)
+      expect(headerValue(fetchCalls[1].options, 'Authorization')).toBe('skype_token test-token')
       expect(image).toMatchObject({ content_type: 'image/png', extension: 'png', size: png.length })
       expect(image.buffer).toEqual(png)
+    })
+
+    it('rejects untrusted AMS view locations before sending the token', async () => {
+      const locations = [
+        'https://example.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+        'http://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+        'https://user@eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+        'https://eu-api.asm.skype.com:444/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+        'https://api.asm.skype.com.evil.test/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim',
+        'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-other/views/imgpsh_fullsize_anim',
+        'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim?download=1',
+        'https://eu-api.asm.skype.com/v1/objects/0-frca-d16-image/views/imgpsh_fullsize_anim#other',
+      ]
+      for (const view_location of locations) {
+        mockResponse({ content_state: 'ready', view_state: 'ready', view_location })
+      }
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+
+      for (const _location of locations) {
+        await expect(client.downloadChatImage('0-frca-d16-image')).rejects.toMatchObject({
+          code: 'invalid_chat_image_view_location',
+        })
+      }
+      expect(fetchCalls).toHaveLength(locations.length)
+    })
+
+    it('maps request aborts to a stable timeout error', async () => {
+      fetchResponses.push(new DOMException('timed out', 'TimeoutError'))
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+
+      await expect(client.downloadChatImage('0-frca-d16-image')).rejects.toMatchObject({
+        code: 'chat_image_download_timeout',
+      })
+    })
+
+    it('rejects a streamed status response above the size limit', async () => {
+      fetchResponses.push(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(64 * 1_024))
+              controller.enqueue(new Uint8Array(1))
+              controller.close()
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+
+      await expect(client.downloadChatImage('0-frca-d16-image')).rejects.toMatchObject({
+        code: 'invalid_chat_image_status_size',
+      })
+      expect(fetchCalls).toHaveLength(1)
+    })
+
+    it('rejects malformed and non-object image status JSON consistently', async () => {
+      fetchResponses.push(
+        new Response('not-json', { headers: { 'Content-Type': 'application/json' } }),
+        new Response('null', { headers: { 'Content-Type': 'application/json' } }),
+      )
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+
+      for (const id of ['0-frca-d16-malformed', '0-frca-d16-null']) {
+        await expect(client.downloadChatImage(id)).rejects.toMatchObject({ code: 'invalid_chat_image_status' })
+      }
+      expect(fetchCalls).toHaveLength(2)
     })
 
     it('rejects an object ID that can change the AMS URL', async () => {
@@ -484,11 +566,17 @@ describe('TeamsClient', () => {
         0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xff, 0xda, 0x00,
         0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0x01, 0xff, 0xd9,
       ])
-      fetchResponses.push(
-        new Response(png.subarray(0, png.length - 4), { headers: { 'Content-Type': 'image/png' } }),
-        new Response(corruptPng, { headers: { 'Content-Type': 'image/png' } }),
-        new Response(fabricatedJpeg, { headers: { 'Content-Type': 'image/jpeg' } }),
-      )
+      for (const [id, body, contentType] of [
+        ['0-frca-d16-truncated', png.subarray(0, png.length - 4), 'image/png'],
+        ['0-frca-d16-crc', corruptPng, 'image/png'],
+        ['0-frca-d16-jpeg', fabricatedJpeg, 'image/jpeg'],
+      ] as const) {
+        mockResponse({
+          content_state: 'ready',
+          view_location: `https://eu-api.asm.skype.com/v1/objects/${id}/views/imgpsh_fullsize_anim`,
+        })
+        fetchResponses.push(new Response(body, { headers: { 'Content-Type': contentType } }))
+      }
       const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
 
       for (const id of ['0-frca-d16-truncated', '0-frca-d16-crc', '0-frca-d16-jpeg']) {
@@ -497,6 +585,7 @@ describe('TeamsClient', () => {
     })
 
     it('rejects redirects, oversized responses, non-images, and signature mismatches', async () => {
+      const ids = ['redirect', 'large', 'text', 'signature', 'mismatch']
       const cases = [
         new Response(null, { status: 302, headers: { Location: 'https://example.com/image.png' } }),
         new Response(pngFixture(1, 1), {
@@ -506,7 +595,14 @@ describe('TeamsClient', () => {
         new Response(Buffer.from('not-a-png'), { headers: { 'Content-Type': 'image/png' } }),
         new Response(pngFixture(1, 1), { headers: { 'Content-Type': 'image/jpeg' } }),
       ]
-      fetchResponses.push(...cases)
+      for (let index = 0; index < ids.length; index++) {
+        const id = `0-frca-d16-${ids[index]}`
+        mockResponse({
+          content_state: 'ready',
+          view_location: `https://eu-api.asm.skype.com/v1/objects/${id}/views/imgpsh_fullsize_anim`,
+        })
+        fetchResponses.push(cases[index])
+      }
       const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
 
       await expect(client.downloadChatImage('0-frca-d16-redirect')).rejects.toMatchObject({

--- a/src/platforms/teams/client.test.ts
+++ b/src/platforms/teams/client.test.ts
@@ -2,15 +2,26 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { rmSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { encode as encodeJpeg } from 'jpeg-js'
+import { PNG } from 'pngjs'
+
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
 import { TeamsError } from './types'
 
-const TEMP_FILES_TO_CLEANUP = ['/tmp/test-teams-upload.txt']
+const TEMP_FILES_TO_CLEANUP = ['/tmp/test-teams-upload.txt', '/tmp/test-teams-chat-image.png']
 const TEMP_DIRS_TO_CLEANUP: string[] = []
 const SEARCH_TENANT_ID = '11111111-1111-1111-1111-111111111111'
 const SEARCH_USER_ID = '22222222-2222-2222-2222-222222222222'
 const GRAPH_AUDIENCE = 'https://graph.microsoft.com'
+
+function pngFixture(width: number, height: number): Buffer {
+  return PNG.sync.write({ width, height, data: Buffer.alloc(width * height * 4, 0xff) })
+}
+
+function jpegFixture(width: number, height: number): Buffer {
+  return encodeJpeg({ width, height, data: Buffer.alloc(width * height * 4, 0xff) }, 80).data
+}
 
 describe('TeamsClient', () => {
   const originalFetch = globalThis.fetch
@@ -306,6 +317,49 @@ describe('TeamsClient', () => {
         'https://msgapi.teams.live.com/v1/users/ME/conversations/19%3A1on1%40unq.gbl.spaces/messages?startTime=0&view=msnp24Equivalent&pageSize=30',
       )
     })
+
+    it('keeps inline image messages and returns their AMS object ID', async () => {
+      mockResponse({
+        messages: [
+          {
+            id: 'm-image',
+            content: '<URIObject>Photo</URIObject>',
+            from: 'host/users/ME/contacts/8:alice',
+            imdisplayname: 'Alice',
+            composetime: '2024-01-01T00:00:00.000Z',
+            messagetype: 'RichText/UriObject',
+            amsreferences: ['0-frca-d16-image'],
+          },
+        ],
+      })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const messages = await client.getChatMessages('19:group@thread.v2', 30)
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({
+        message_type: 'RichText/UriObject',
+        image_object_id: '0-frca-d16-image',
+      })
+    })
+
+    it('does not expose an invalid AMS image object ID', async () => {
+      mockResponse({
+        messages: [
+          {
+            id: 'm-image',
+            content: '<URIObject>Photo</URIObject>',
+            messagetype: 'RichText/UriObject',
+            amsreferences: [`0-a-${'b'.repeat(253)}`],
+          },
+        ],
+      })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const messages = await client.getChatMessages('19:group@thread.v2', 30)
+
+      expect(messages[0].image_object_id).toBeUndefined()
+    })
   })
 
   describe('sendChatMessage', () => {
@@ -327,6 +381,149 @@ describe('TeamsClient', () => {
           contenttype: 'text',
         }),
       )
+    })
+  })
+
+  describe('sendChatImage', () => {
+    it('creates, uploads, and sends one inline image object to a chat', async () => {
+      const png = pngFixture(320, 180)
+      await Bun.write('/tmp/test-teams-chat-image.png', png)
+      mockResponse({ id: '0-weu-d1-image' })
+      mockBinaryResponse('', 201)
+      mockResponse({ OriginalArrivalTime: 1704067200000 })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const message = await client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')
+
+      expect(fetchCalls[0].url).toBe('https://api.asm.skype.com/v1/objects')
+      expect(fetchCalls[0].options?.body).toBe(
+        JSON.stringify({
+          type: 'pish/image',
+          permissions: { '48:notes': ['read'] },
+          filename: 'test-teams-chat-image.png',
+        }),
+      )
+      expect(fetchCalls[1].url).toBe('https://api.asm.skype.com/v1/objects/0-weu-d1-image/content/original')
+      expect(headerValue(fetchCalls[1].options, 'Content-Type')).toBe('image/png')
+      expect(fetchCalls[2].url).toBe('https://msgapi.teams.live.com/v1/users/ME/conversations/48%3Anotes/messages')
+      expect(String(fetchCalls[2].options?.body)).toContain('RichText/UriObject')
+      expect(String(fetchCalls[2].options?.body)).toContain('width=\\\"320\\\" height=\\\"180\\\"')
+      expect(message.image_object_id).toBe('0-weu-d1-image')
+    })
+
+    it('decodes and uploads a valid JPEG', async () => {
+      const jpeg = jpegFixture(24, 16)
+      await Bun.write('/tmp/test-teams-chat-image.png', jpeg)
+      mockResponse({ id: '0-weu-d1-jpeg' })
+      mockBinaryResponse('', 201)
+      mockResponse({ OriginalArrivalTime: 1704067200000 })
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      await client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')
+
+      expect(headerValue(fetchCalls[1].options, 'Content-Type')).toBe('image/jpeg')
+      expect(String(fetchCalls[2].options?.body)).toContain('width=\\"24\\" height=\\"16\\"')
+    })
+
+    it('rejects malformed image data and an invalid object ID returned by AMS', async () => {
+      const png = pngFixture(1, 1)
+      const corruptPng = Buffer.from(png)
+      corruptPng[corruptPng.length - 1] ^= 0xff
+      await Bun.write('/tmp/test-teams-chat-image.png', corruptPng)
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      await expect(client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')).rejects.toMatchObject({
+        code: 'invalid_chat_image_signature',
+      })
+      expect(fetchCalls).toHaveLength(0)
+
+      await Bun.write('/tmp/test-teams-chat-image.png', png)
+      mockResponse({ id: `0-a-${'b'.repeat(253)}` })
+      await expect(client.sendChatImage('48:notes', '/tmp/test-teams-chat-image.png')).rejects.toMatchObject({
+        code: 'chat_image_create_failed',
+      })
+      expect(fetchCalls).toHaveLength(1)
+    })
+  })
+
+  describe('downloadChatImage', () => {
+    it('downloads a bounded PNG from the exact AMS object URL without redirects', async () => {
+      const png = pngFixture(320, 180)
+      fetchResponses.push(
+        new Response(png, {
+          headers: { 'Content-Type': 'image/png', 'Content-Length': String(png.length) },
+        }),
+      )
+
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      const image = await client.downloadChatImage('0-frca-d16-image')
+
+      expect(fetchCalls[0].url).toBe('https://api.asm.skype.com/v1/objects/0-frca-d16-image/content/original')
+      expect(fetchCalls[0].options?.redirect).toBe('manual')
+      expect(headerValue(fetchCalls[0].options, 'Authorization')).toBe('skype_token test-token')
+      expect(image).toMatchObject({ content_type: 'image/png', extension: 'png', size: png.length })
+      expect(image.buffer).toEqual(png)
+    })
+
+    it('rejects an object ID that can change the AMS URL', async () => {
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+      await expect(client.downloadChatImage('../outside')).rejects.toMatchObject({
+        code: 'invalid_chat_image_object_id',
+      })
+      await expect(client.downloadChatImage(`0-a-${'b'.repeat(253)}`)).rejects.toMatchObject({
+        code: 'invalid_chat_image_object_id',
+      })
+      expect(fetchCalls).toHaveLength(0)
+    })
+
+    it('rejects incomplete and corrupt PNG and JPEG streams', async () => {
+      const png = pngFixture(1, 1)
+      const corruptPng = Buffer.from(png)
+      corruptPng[corruptPng.length - 1] ^= 0xff
+      const fabricatedJpeg = Buffer.from([
+        0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xff, 0xda, 0x00,
+        0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0x01, 0xff, 0xd9,
+      ])
+      fetchResponses.push(
+        new Response(png.subarray(0, png.length - 4), { headers: { 'Content-Type': 'image/png' } }),
+        new Response(corruptPng, { headers: { 'Content-Type': 'image/png' } }),
+        new Response(fabricatedJpeg, { headers: { 'Content-Type': 'image/jpeg' } }),
+      )
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+
+      for (const id of ['0-frca-d16-truncated', '0-frca-d16-crc', '0-frca-d16-jpeg']) {
+        await expect(client.downloadChatImage(id)).rejects.toMatchObject({ code: 'invalid_chat_image_signature' })
+      }
+    })
+
+    it('rejects redirects, oversized responses, non-images, and signature mismatches', async () => {
+      const cases = [
+        new Response(null, { status: 302, headers: { Location: 'https://example.com/image.png' } }),
+        new Response(pngFixture(1, 1), {
+          headers: { 'Content-Type': 'image/png', 'Content-Length': String(20 * 1_024 * 1_024 + 1) },
+        }),
+        new Response('text', { headers: { 'Content-Type': 'text/plain' } }),
+        new Response(Buffer.from('not-a-png'), { headers: { 'Content-Type': 'image/png' } }),
+        new Response(pngFixture(1, 1), { headers: { 'Content-Type': 'image/jpeg' } }),
+      ]
+      fetchResponses.push(...cases)
+      const client = await new TeamsClient().login({ token: 'test-token', accountType: 'personal' })
+
+      await expect(client.downloadChatImage('0-frca-d16-redirect')).rejects.toMatchObject({
+        code: 'chat_image_redirect_refused',
+      })
+      await expect(client.downloadChatImage('0-frca-d16-large')).rejects.toMatchObject({
+        code: 'invalid_chat_image_size',
+      })
+      await expect(client.downloadChatImage('0-frca-d16-text')).rejects.toMatchObject({
+        code: 'invalid_chat_image_content_type',
+      })
+      await expect(client.downloadChatImage('0-frca-d16-signature')).rejects.toMatchObject({
+        code: 'invalid_chat_image_signature',
+      })
+      await expect(client.downloadChatImage('0-frca-d16-mismatch')).rejects.toMatchObject({
+        code: 'chat_image_type_mismatch',
+      })
     })
   })
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -2,6 +2,9 @@ import { randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { basename } from 'node:path'
 
+import { decode as decodeJpeg } from 'jpeg-js'
+import { PNG } from 'pngjs'
+
 import { SUBSTRATE_SEARCH_URL } from './app-config'
 import { TeamsCredentialManager } from './credential-manager'
 import { TeamsTokenProvider } from './token-provider'
@@ -9,6 +12,7 @@ import type {
   TeamsAccountType,
   TeamsChannel,
   TeamsChat,
+  TeamsChatImageDownload,
   TeamsChatType,
   TeamsFile,
   TeamsMessage,
@@ -38,6 +42,11 @@ const BASE_BACKOFF_MS = 100
 const DEFAULT_REGION: TeamsRegion = 'amer'
 const REGIONS: TeamsRegion[] = ['amer', 'emea', 'apac']
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0'
+const AMS_API_BASE = 'https://api.asm.skype.com/v1'
+const MAX_CHAT_IMAGE_BYTES = 20 * 1_024 * 1_024
+const MAX_CHAT_IMAGE_PIXELS = 40_000_000
+const MAX_CHAT_IMAGE_OBJECT_ID_BYTES = 256
+const CHAT_IMAGE_OBJECT_ID = /^0-[a-z0-9]+-[a-z0-9-]+$/i
 
 // Personal (Teams for Life) skypetokens carry a consumer `skypeid` (e.g.
 // "live:..." or "8:live:..."); work/school tokens carry an org identity. Used
@@ -52,6 +61,162 @@ function isPersonalToken(token: string): boolean {
   } catch {
     return false
   }
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeHtml(value).replace(/&quot;/g, '&quot;')
+}
+
+function validImageDimensions(width: number, height: number): boolean {
+  return width > 0 && height > 0 && width <= MAX_CHAT_IMAGE_PIXELS / height
+}
+
+function jpegMetadata(bytes: Buffer): { contentType: 'image/jpeg'; width: number; height: number } | null {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null
+  const frameMarkers = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf])
+  let offset = 2
+  let width = 0
+  let height = 0
+  let sawScan = false
+  let sawScanData = false
+  let inScan = false
+
+  while (offset < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      if (!inScan) return null
+      sawScanData = true
+      offset++
+      continue
+    }
+    while (offset < bytes.length && bytes[offset] === 0xff) offset++
+    if (offset >= bytes.length) return null
+    const marker = bytes[offset++]
+    if (inScan && marker === 0x00) {
+      sawScanData = true
+      continue
+    }
+    if (inScan && marker >= 0xd0 && marker <= 0xd7) continue
+    inScan = false
+    if (marker === 0xd9) {
+      if (offset !== bytes.length || !sawScan || !sawScanData || !validImageDimensions(width, height)) return null
+      try {
+        const decoded = decodeJpeg(bytes, {
+          formatAsRGBA: false,
+          tolerantDecoding: false,
+          maxResolutionInMP: MAX_CHAT_IMAGE_PIXELS / 1_000_000,
+          maxMemoryUsageInMB: 256,
+        })
+        return decoded.width === width && decoded.height === height
+          ? { contentType: 'image/jpeg', width, height }
+          : null
+      } catch {
+        return null
+      }
+    }
+    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) return null
+    if (offset + 2 > bytes.length) return null
+    const length = bytes.readUInt16BE(offset)
+    if (length < 2 || offset + length > bytes.length) return null
+    if (frameMarkers.has(marker)) {
+      if (length < 8 || width !== 0 || height !== 0) return null
+      height = bytes.readUInt16BE(offset + 3)
+      width = bytes.readUInt16BE(offset + 5)
+      const components = bytes[offset + 7]
+      if (length !== 8 + 3 * components || !validImageDimensions(width, height)) return null
+    }
+    if (marker === 0xda) {
+      if (!validImageDimensions(width, height)) return null
+      sawScan = true
+      inScan = true
+    }
+    offset += length
+  }
+  return null
+}
+
+function imageMetadata(bytes: Buffer): { contentType: 'image/jpeg' | 'image/png'; width: number; height: number } {
+  if (
+    bytes.length >= 33 &&
+    bytes.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])) &&
+    bytes.readUInt32BE(8) === 13 &&
+    bytes.toString('ascii', 12, 16) === 'IHDR'
+  ) {
+    const width = bytes.readUInt32BE(16)
+    const height = bytes.readUInt32BE(20)
+    if (validImageDimensions(width, height)) {
+      try {
+        const decoded = PNG.sync.read(bytes, { checkCRC: true })
+        if (decoded.width === width && decoded.height === height) {
+          return { contentType: 'image/png', width, height }
+        }
+      } catch {
+        // Try JPEG before returning the common validation error.
+      }
+    }
+  }
+  const jpeg = jpegMetadata(bytes)
+  if (jpeg) return jpeg
+  throw new TeamsError('Chat image must be a valid PNG or JPEG file.', 'invalid_chat_image_signature')
+}
+
+function validChatImageObjectId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    Buffer.byteLength(value, 'ascii') <= MAX_CHAT_IMAGE_OBJECT_ID_BYTES &&
+    CHAT_IMAGE_OBJECT_ID.test(value)
+  )
+}
+
+function downloadedImageType(bytes: Buffer): Pick<TeamsChatImageDownload, 'content_type' | 'extension'> {
+  const { contentType } = imageMetadata(bytes)
+  return contentType === 'image/png'
+    ? { content_type: 'image/png', extension: 'png' }
+    : { content_type: 'image/jpeg', extension: 'jpg' }
+}
+
+async function readChatImageResponse(response: Response): Promise<Buffer> {
+  if (response.status >= 300 && response.status < 400) {
+    throw new TeamsError('Teams chat image download refused a redirect.', 'chat_image_redirect_refused')
+  }
+  if (!response.ok) {
+    throw new TeamsError(
+      `Teams chat image download failed with HTTP ${response.status}.`,
+      `chat_image_download_${response.status}`,
+    )
+  }
+
+  const contentType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase()
+  if (contentType !== 'image/png' && contentType !== 'image/jpeg') {
+    throw new TeamsError('Teams chat image response must be PNG or JPEG.', 'invalid_chat_image_content_type')
+  }
+  const contentLength = response.headers.get('Content-Length')
+  if (contentLength !== null) {
+    const declaredLength = Number(contentLength)
+    if (!Number.isSafeInteger(declaredLength) || declaredLength < 1 || declaredLength > MAX_CHAT_IMAGE_BYTES) {
+      throw new TeamsError('Teams chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
+    }
+  }
+
+  const reader = response.body?.getReader()
+  if (!reader) {
+    throw new TeamsError('Teams chat image response had no body.', 'chat_image_body_missing')
+  }
+  const chunks: Buffer[] = []
+  let size = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    size += value.byteLength
+    if (size > MAX_CHAT_IMAGE_BYTES) {
+      await reader.cancel()
+      throw new TeamsError('Teams chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
+    }
+    chunks.push(Buffer.from(value))
+  }
+  if (size === 0) {
+    throw new TeamsError('Teams chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
+  }
+  return Buffer.concat(chunks, size)
 }
 
 function stripHtml(content: string | undefined): string | undefined {
@@ -667,6 +832,7 @@ export class TeamsClient {
       composetime?: string
       originalarrivaltime?: string
       messagetype?: string
+      amsreferences?: string[]
     }
     interface MessagesResponse {
       messages: ChatMessage[]
@@ -677,7 +843,7 @@ export class TeamsClient {
       `/users/ME/conversations/${encodedChatId}/messages?startTime=0&view=msnp24Equivalent&pageSize=${limit}`,
     )
 
-    const userMessageTypes = new Set(['Text', 'RichText/Html', 'RichText/Media_CallRecording'])
+    const userMessageTypes = new Set(['Text', 'RichText/Html', 'RichText/Media_CallRecording', 'RichText/UriObject'])
     return (data.messages ?? [])
       .filter((msg) => !msg.messagetype || userMessageTypes.has(msg.messagetype))
       .slice(0, limit)
@@ -690,6 +856,8 @@ export class TeamsClient {
         },
         content: stripHtml(msg.content) ?? '',
         timestamp: msg.composetime ?? msg.originalarrivaltime ?? '',
+        message_type: msg.messagetype,
+        image_object_id: validChatImageObjectId(msg.amsreferences?.[0]) ? msg.amsreferences[0] : undefined,
       }))
   }
 
@@ -711,6 +879,102 @@ export class TeamsClient {
       author: { id: 'ME', displayName: 'Me' },
       content,
       timestamp: arrivalTime ? new Date(arrivalTime).toISOString() : new Date().toISOString(),
+    }
+  }
+
+  async sendChatImage(chatId: string, imagePath: string): Promise<TeamsMessage> {
+    if (this.isTokenExpired()) {
+      throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
+    }
+    const bytes = await readFile(imagePath)
+    if (bytes.length === 0 || bytes.length > MAX_CHAT_IMAGE_BYTES) {
+      throw new TeamsError('Chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
+    }
+    const metadata = imageMetadata(bytes)
+    const filename = basename(imagePath) || `image.${metadata.contentType === 'image/png' ? 'png' : 'jpg'}`
+    const token = this.ensureAuth()
+    const createResponse = await fetch(`${AMS_API_BASE}/objects`, {
+      method: 'POST',
+      headers: {
+        Authorization: `skype_token ${token}`,
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: JSON.stringify({ type: 'pish/image', permissions: { [chatId]: ['read'] }, filename }),
+    })
+    const created = (await createResponse.json().catch(() => null)) as { id?: string } | null
+    if (!createResponse.ok || !validChatImageObjectId(created?.id)) {
+      throw new TeamsError(
+        `Teams image object creation failed with HTTP ${createResponse.status}.`,
+        'chat_image_create_failed',
+      )
+    }
+    const objectId = created.id
+    const uploadResponse = await fetch(`${AMS_API_BASE}/objects/${encodeURIComponent(objectId)}/content/original`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `skype_token ${token}`,
+        'Content-Type': metadata.contentType,
+      },
+      body: bytes,
+    })
+    if (!uploadResponse.ok) {
+      throw new TeamsError(`Teams image upload failed with HTTP ${uploadResponse.status}.`, 'chat_image_upload_failed')
+    }
+
+    const objectUrl = `${AMS_API_BASE}/objects/${objectId}`
+    const safeFilename = escapeXmlAttribute(filename)
+    const content = `<URIObject uri="${objectUrl}" url_thumbnail="${objectUrl}/views/imgt1_anim" type="Picture.1" doc_id="${objectId}" width="${metadata.width}" height="${metadata.height}">To view this shared photo, open it in Teams.<OriginalName v="${safeFilename}"></OriginalName><FileSize v="${bytes.length}"></FileSize><meta type="photo" originalName="${safeFilename}"></meta></URIObject>`
+    interface SendResponse {
+      OriginalArrivalTime?: number
+    }
+    const encodedChatId = encodeURIComponent(chatId)
+    const response = await this.request<SendResponse>('POST', `/users/ME/conversations/${encodedChatId}/messages`, {
+      content,
+      messagetype: 'RichText/UriObject',
+      contenttype: 'text',
+      amsreferences: [objectId],
+    })
+    const arrivalTime = response?.OriginalArrivalTime
+    return {
+      id: arrivalTime ? String(arrivalTime) : '',
+      channel_id: chatId,
+      author: { id: 'ME', displayName: 'Me' },
+      content: filename,
+      timestamp: arrivalTime ? new Date(arrivalTime).toISOString() : new Date().toISOString(),
+      message_type: 'RichText/UriObject',
+      image_object_id: objectId,
+    }
+  }
+
+  async downloadChatImage(imageObjectId: string): Promise<TeamsChatImageDownload> {
+    if (!validChatImageObjectId(imageObjectId)) {
+      throw new TeamsError('Teams chat image object ID is invalid.', 'invalid_chat_image_object_id')
+    }
+    if (this.isTokenExpired()) {
+      throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
+    }
+
+    const response = await fetch(`${AMS_API_BASE}/objects/${imageObjectId}/content/original`, {
+      headers: {
+        Authorization: `skype_token ${this.ensureAuth()}`,
+      },
+      redirect: 'manual',
+    })
+    const buffer = await readChatImageResponse(response)
+    const imageType = downloadedImageType(buffer)
+    const responseType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase()
+    if (responseType !== imageType.content_type) {
+      throw new TeamsError(
+        'Teams chat image content type does not match its file signature.',
+        'chat_image_type_mismatch',
+      )
+    }
+
+    return {
+      image_object_id: imageObjectId,
+      ...imageType,
+      size: buffer.length,
+      buffer,
     }
   }
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -338,8 +338,9 @@ export class TeamsClient {
   }
 
   async getIdToken(): Promise<string | null> {
-    const { TeamsTokenExtractor } = await import('./token-extractor')
-    const extractor = new TeamsTokenExtractor()
+    const { TeamsTokenExtractor, resolveTeamsTokenSource } = await import('./token-extractor')
+    const tokenSource = resolveTeamsTokenSource(process.env.AGENT_TEAMS_AUTH_SOURCE)
+    const extractor = new TeamsTokenExtractor(undefined, undefined, undefined, undefined, tokenSource)
     return extractor.extractIdToken(this.getAccountType())
   }
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -46,6 +46,9 @@ const AMS_API_BASE = 'https://api.asm.skype.com/v1'
 const MAX_CHAT_IMAGE_BYTES = 20 * 1_024 * 1_024
 const MAX_CHAT_IMAGE_PIXELS = 40_000_000
 const MAX_CHAT_IMAGE_OBJECT_ID_BYTES = 256
+const MAX_CHAT_IMAGE_STATUS_BYTES = 64 * 1_024
+const CHAT_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000
+const CHAT_IMAGE_VIEW = 'imgpsh_fullsize_anim'
 const CHAT_IMAGE_OBJECT_ID = /^0-[a-z0-9]+-[a-z0-9-]+$/i
 
 // Personal (Teams for Life) skypetokens carry a consumer `skypeid` (e.g.
@@ -208,7 +211,7 @@ async function readChatImageResponse(response: Response): Promise<Buffer> {
     if (done) break
     size += value.byteLength
     if (size > MAX_CHAT_IMAGE_BYTES) {
-      await reader.cancel()
+      await reader.cancel().catch(() => undefined)
       throw new TeamsError('Teams chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
     }
     chunks.push(Buffer.from(value))
@@ -217,6 +220,77 @@ async function readChatImageResponse(response: Response): Promise<Buffer> {
     throw new TeamsError('Teams chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
   }
   return Buffer.concat(chunks, size)
+}
+
+async function readChatImageViewLocation(response: Response, imageObjectId: string): Promise<string> {
+  if (response.status >= 300 && response.status < 400) {
+    throw new TeamsError('Teams chat image status refused a redirect.', 'chat_image_status_redirect_refused')
+  }
+  if (!response.ok) {
+    throw new TeamsError(
+      `Teams chat image status failed with HTTP ${response.status}.`,
+      `chat_image_status_${response.status}`,
+    )
+  }
+
+  const declaredLength = Number(response.headers.get('Content-Length') ?? 0)
+  if (!Number.isSafeInteger(declaredLength) || declaredLength < 0 || declaredLength > MAX_CHAT_IMAGE_STATUS_BYTES) {
+    throw new TeamsError('Teams chat image status response is too large.', 'invalid_chat_image_status_size')
+  }
+  const reader = response.body?.getReader()
+  if (!reader) {
+    throw new TeamsError('Teams chat image status response had no body.', 'invalid_chat_image_status')
+  }
+  const chunks: Buffer[] = []
+  let size = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    size += value.byteLength
+    if (size > MAX_CHAT_IMAGE_STATUS_BYTES) {
+      await reader.cancel().catch(() => undefined)
+      throw new TeamsError('Teams chat image status response is too large.', 'invalid_chat_image_status_size')
+    }
+    chunks.push(Buffer.from(value))
+  }
+
+  let status: unknown
+  try {
+    status = JSON.parse(Buffer.concat(chunks, size).toString('utf8'))
+  } catch {
+    throw new TeamsError('Teams chat image status response is invalid.', 'invalid_chat_image_status')
+  }
+  if (!status || typeof status !== 'object' || Array.isArray(status)) {
+    throw new TeamsError('Teams chat image status response is invalid.', 'invalid_chat_image_status')
+  }
+  const imageStatus = status as { content_state?: unknown; view_location?: unknown }
+  if (imageStatus.content_state === 'expired') {
+    throw new TeamsError('Teams chat image has expired.', 'chat_image_expired')
+  }
+  if (typeof imageStatus.view_location !== 'string') {
+    throw new TeamsError('Teams chat image status had no view location.', 'chat_image_view_missing')
+  }
+
+  let location: URL
+  try {
+    location = new URL(imageStatus.view_location)
+  } catch {
+    throw new TeamsError('Teams chat image view location is invalid.', 'invalid_chat_image_view_location')
+  }
+  const expectedPath = `/v1/objects/${imageObjectId}/views/${CHAT_IMAGE_VIEW}`
+  if (
+    location.protocol !== 'https:' ||
+    (location.hostname !== 'api.asm.skype.com' && !location.hostname.endsWith('-api.asm.skype.com')) ||
+    location.port !== '' ||
+    location.username !== '' ||
+    location.password !== '' ||
+    location.pathname !== expectedPath ||
+    location.search !== '' ||
+    location.hash !== ''
+  ) {
+    throw new TeamsError('Teams chat image view location is not trusted.', 'invalid_chat_image_view_location')
+  }
+  return location.href
 }
 
 function stripHtml(content: string | undefined): string | undefined {
@@ -954,27 +1028,46 @@ export class TeamsClient {
       throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
     }
 
-    const response = await fetch(`${AMS_API_BASE}/objects/${imageObjectId}/content/original`, {
-      headers: {
-        Authorization: `skype_token ${this.ensureAuth()}`,
-      },
-      redirect: 'manual',
-    })
-    const buffer = await readChatImageResponse(response)
-    const imageType = downloadedImageType(buffer)
-    const responseType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase()
-    if (responseType !== imageType.content_type) {
-      throw new TeamsError(
-        'Teams chat image content type does not match its file signature.',
-        'chat_image_type_mismatch',
-      )
+    const headers = {
+      Authorization: `skype_token ${this.ensureAuth()}`,
     }
+    const signal = AbortSignal.timeout(CHAT_IMAGE_DOWNLOAD_TIMEOUT_MS)
+    try {
+      const statusResponse = await fetch(`${AMS_API_BASE}/objects/${imageObjectId}/views/${CHAT_IMAGE_VIEW}/status`, {
+        headers,
+        redirect: 'manual',
+        signal,
+      })
+      const viewLocation = await readChatImageViewLocation(statusResponse, imageObjectId)
+      const response = await fetch(viewLocation, {
+        headers: {
+          ...headers,
+          Accept: 'image/png,image/jpeg',
+        },
+        redirect: 'manual',
+        signal,
+      })
+      const buffer = await readChatImageResponse(response)
+      const imageType = downloadedImageType(buffer)
+      const responseType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase()
+      if (responseType !== imageType.content_type) {
+        throw new TeamsError(
+          'Teams chat image content type does not match its file signature.',
+          'chat_image_type_mismatch',
+        )
+      }
 
-    return {
-      image_object_id: imageObjectId,
-      ...imageType,
-      size: buffer.length,
-      buffer,
+      return {
+        image_object_id: imageObjectId,
+        ...imageType,
+        size: buffer.length,
+        buffer,
+      }
+    } catch (error) {
+      if (error instanceof DOMException && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+        throw new TeamsError('Teams chat image download timed out.', 'chat_image_download_timeout')
+      }
+      throw error
     }
   }
 

--- a/src/platforms/teams/client.ts
+++ b/src/platforms/teams/client.ts
@@ -50,6 +50,7 @@ const MAX_CHAT_IMAGE_STATUS_BYTES = 64 * 1_024
 const CHAT_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000
 const CHAT_IMAGE_VIEW = 'imgpsh_fullsize_anim'
 const CHAT_IMAGE_OBJECT_ID = /^0-[a-z0-9]+-[a-z0-9-]+$/i
+const CHAT_IMAGE_VIEW_HOSTS = new Set(['api.asm.skype.com', 'eu-api.asm.skype.com'])
 
 // Personal (Teams for Life) skypetokens carry a consumer `skypeid` (e.g.
 // "live:..." or "8:live:..."); work/school tokens carry an org identity. Used
@@ -64,10 +65,6 @@ function isPersonalToken(token: string): boolean {
   } catch {
     return false
   }
-}
-
-function escapeXmlAttribute(value: string): string {
-  return escapeHtml(value).replace(/&quot;/g, '&quot;')
 }
 
 function validImageDimensions(width: number, height: number): boolean {
@@ -280,7 +277,7 @@ async function readChatImageViewLocation(response: Response, imageObjectId: stri
   const expectedPath = `/v1/objects/${imageObjectId}/views/${CHAT_IMAGE_VIEW}`
   if (
     location.protocol !== 'https:' ||
-    (location.hostname !== 'api.asm.skype.com' && !location.hostname.endsWith('-api.asm.skype.com')) ||
+    !CHAT_IMAGE_VIEW_HOSTS.has(location.hostname) ||
     location.port !== '' ||
     location.username !== '' ||
     location.password !== '' ||
@@ -953,70 +950,6 @@ export class TeamsClient {
       author: { id: 'ME', displayName: 'Me' },
       content,
       timestamp: arrivalTime ? new Date(arrivalTime).toISOString() : new Date().toISOString(),
-    }
-  }
-
-  async sendChatImage(chatId: string, imagePath: string): Promise<TeamsMessage> {
-    if (this.isTokenExpired()) {
-      throw new TeamsError('Token has expired. Run "auth extract" to refresh.', 'token_expired')
-    }
-    const bytes = await readFile(imagePath)
-    if (bytes.length === 0 || bytes.length > MAX_CHAT_IMAGE_BYTES) {
-      throw new TeamsError('Chat image must be between 1 byte and 20 MiB.', 'invalid_chat_image_size')
-    }
-    const metadata = imageMetadata(bytes)
-    const filename = basename(imagePath) || `image.${metadata.contentType === 'image/png' ? 'png' : 'jpg'}`
-    const token = this.ensureAuth()
-    const createResponse = await fetch(`${AMS_API_BASE}/objects`, {
-      method: 'POST',
-      headers: {
-        Authorization: `skype_token ${token}`,
-        'Content-Type': 'application/json; charset=UTF-8',
-      },
-      body: JSON.stringify({ type: 'pish/image', permissions: { [chatId]: ['read'] }, filename }),
-    })
-    const created = (await createResponse.json().catch(() => null)) as { id?: string } | null
-    if (!createResponse.ok || !validChatImageObjectId(created?.id)) {
-      throw new TeamsError(
-        `Teams image object creation failed with HTTP ${createResponse.status}.`,
-        'chat_image_create_failed',
-      )
-    }
-    const objectId = created.id
-    const uploadResponse = await fetch(`${AMS_API_BASE}/objects/${encodeURIComponent(objectId)}/content/original`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `skype_token ${token}`,
-        'Content-Type': metadata.contentType,
-      },
-      body: bytes,
-    })
-    if (!uploadResponse.ok) {
-      throw new TeamsError(`Teams image upload failed with HTTP ${uploadResponse.status}.`, 'chat_image_upload_failed')
-    }
-
-    const objectUrl = `${AMS_API_BASE}/objects/${objectId}`
-    const safeFilename = escapeXmlAttribute(filename)
-    const content = `<URIObject uri="${objectUrl}" url_thumbnail="${objectUrl}/views/imgt1_anim" type="Picture.1" doc_id="${objectId}" width="${metadata.width}" height="${metadata.height}">To view this shared photo, open it in Teams.<OriginalName v="${safeFilename}"></OriginalName><FileSize v="${bytes.length}"></FileSize><meta type="photo" originalName="${safeFilename}"></meta></URIObject>`
-    interface SendResponse {
-      OriginalArrivalTime?: number
-    }
-    const encodedChatId = encodeURIComponent(chatId)
-    const response = await this.request<SendResponse>('POST', `/users/ME/conversations/${encodedChatId}/messages`, {
-      content,
-      messagetype: 'RichText/UriObject',
-      contenttype: 'text',
-      amsreferences: [objectId],
-    })
-    const arrivalTime = response?.OriginalArrivalTime
-    return {
-      id: arrivalTime ? String(arrivalTime) : '',
-      channel_id: chatId,
-      author: { id: 'ME', displayName: 'Me' },
-      content: filename,
-      timestamp: arrivalTime ? new Date(arrivalTime).toISOString() : new Date().toISOString(),
-      message_type: 'RichText/UriObject',
-      image_object_id: objectId,
     }
   }
 

--- a/src/platforms/teams/commands/auth.test.ts
+++ b/src/platforms/teams/commands/auth.test.ts
@@ -105,6 +105,12 @@ it('no-token message mentions desktop app and browser fallback', () => {
   expect(getNoTeamsTokenFoundMessage()).toContain('desktop app or a supported Chromium browser')
 })
 
+it('desktop-only no-token message does not suggest a browser fallback', () => {
+  const message = getNoTeamsTokenFoundMessage('desktop')
+  expect(message).toContain('Microsoft Teams desktop app')
+  expect(message).not.toContain('Chromium browser')
+})
+
 it('login pending hint preserves explicit account type', async () => {
   const completeSpy = spyOn(deviceLogin, 'completeDeviceCode').mockRejectedValue(new deviceLogin.PendingApprovalError())
   const consoleSpy = spyOn(console, 'log').mockImplementation(() => {})

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -10,7 +10,7 @@ import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import { completeDeviceCode, loginWithDeviceCode, PendingApprovalError, startDeviceCode } from '../device-login'
 import { probeAccountType } from '../realm-discovery'
-import { TeamsTokenExtractor, resolveTeamsTokenSource } from '../token-extractor'
+import { TeamsCachedKeyRejectedError, TeamsTokenExtractor, resolveTeamsTokenSource } from '../token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from '../types'
 
 interface LoginOptions {
@@ -252,6 +252,7 @@ export async function extractAction(options: {
     const extracted = await extractor.extract()
 
     if (extracted.length === 0) {
+      if (extractor.didCachedKeyFail()) throw new TeamsCachedKeyRejectedError()
       console.log(
         formatOutput(
           {

--- a/src/platforms/teams/commands/auth.ts
+++ b/src/platforms/teams/commands/auth.ts
@@ -10,7 +10,7 @@ import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
 import { completeDeviceCode, loginWithDeviceCode, PendingApprovalError, startDeviceCode } from '../device-login'
 import { probeAccountType } from '../realm-discovery'
-import { TeamsTokenExtractor } from '../token-extractor'
+import { TeamsTokenExtractor, resolveTeamsTokenSource } from '../token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from '../types'
 
 interface LoginOptions {
@@ -213,6 +213,7 @@ export async function extractAction(options: {
   debug?: boolean
   token?: string
   browserProfile?: string[]
+  source?: string
 }): Promise<void> {
   try {
     if (options.token) {
@@ -220,8 +221,12 @@ export async function extractAction(options: {
       return
     }
 
+    const tokenSource = resolveTeamsTokenSource(options.source ?? process.env.AGENT_TEAMS_AUTH_SOURCE)
+    if (tokenSource === 'desktop' && options.browserProfile?.length) {
+      throw new Error('--browser-profile cannot be used with the desktop-only Teams token source.')
+    }
     const debugLog = options.debug ? (msg: string) => debug(`[debug] ${msg}`) : undefined
-    const extractor = new TeamsTokenExtractor(undefined, undefined, debugLog, options.browserProfile)
+    const extractor = new TeamsTokenExtractor(undefined, undefined, debugLog, options.browserProfile, tokenSource)
 
     if (process.platform === 'darwin') {
       console.log('')
@@ -250,7 +255,7 @@ export async function extractAction(options: {
       console.log(
         formatOutput(
           {
-            error: getNoTeamsTokenFoundMessage(),
+            error: getNoTeamsTokenFoundMessage(tokenSource),
             hint: 'Run with --token <token> to manually provide a token, or --debug for more info.',
           },
           options.pretty,
@@ -462,8 +467,10 @@ async function extractManualToken(token: string, options: { pretty?: boolean; de
   }
 }
 
-export function getNoTeamsTokenFoundMessage(): string {
-  return 'No Teams token found. Make sure you are logged in to Microsoft Teams via the desktop app or a supported Chromium browser.'
+export function getNoTeamsTokenFoundMessage(source: 'all' | 'desktop' = 'all'): string {
+  return source === 'desktop'
+    ? 'No Teams token found. Make sure both required accounts are open and signed in through the Microsoft Teams desktop app.'
+    : 'No Teams token found. Make sure you are logged in to Microsoft Teams via the desktop app or a supported Chromium browser.'
 }
 
 export async function logoutAction(options: { pretty?: boolean }): Promise<void> {
@@ -611,6 +618,7 @@ export const authCommand = new Command('auth')
       .description('Extract token from Microsoft Teams desktop app or a supported Chromium browser')
       .option('--pretty', 'Pretty print JSON output')
       .option('--debug', 'Show debug output for troubleshooting')
+      .option('--source <source>', 'Token source: all or desktop')
       .option('--token <token>', 'Manually provide a token (bypasses auto-extraction)')
       .option(
         '--browser-profile <path>',

--- a/src/platforms/teams/commands/chat.test.ts
+++ b/src/platforms/teams/commands/chat.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, expect, mock, spyOn, it } from 'bun:test'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
-import { editAction, historyAction, listAction, sendAction } from './chat'
+import { downloadImageAction, editAction, historyAction, listAction, sendAction, sendImageAction } from './chat'
 
 let clientListChatsSpy: ReturnType<typeof spyOn>
 let clientGetChatMessagesSpy: ReturnType<typeof spyOn>
 let clientSendChatMessageSpy: ReturnType<typeof spyOn>
 let clientEditChatMessageSpy: ReturnType<typeof spyOn>
+let clientSendChatImageSpy: ReturnType<typeof spyOn>
+let clientDownloadChatImageSpy: ReturnType<typeof spyOn>
 let credManagerLoadSpy: ReturnType<typeof spyOn>
 const originalConsoleLog = console.log
 
@@ -42,6 +45,22 @@ beforeEach(() => {
     content: 'Edited content',
     timestamp: '2025-01-29T10:05:00Z',
   })
+  clientSendChatImageSpy = spyOn(TeamsClient.prototype, 'sendChatImage').mockResolvedValue({
+    id: '1704067200001',
+    channel_id: '48:notes',
+    author: { id: 'ME', displayName: 'Me' },
+    content: 'approval.png',
+    timestamp: '2025-01-29T10:01:00Z',
+    message_type: 'RichText/UriObject',
+    image_object_id: '0-weu-d1-image',
+  })
+  clientDownloadChatImageSpy = spyOn(TeamsClient.prototype, 'downloadChatImage').mockResolvedValue({
+    image_object_id: '0-frca-d16-image',
+    content_type: 'image/png',
+    extension: 'png',
+    size: 8,
+    buffer: Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+  })
 
   credManagerLoadSpy = spyOn(TeamsCredentialManager.prototype, 'loadConfig').mockResolvedValue({
     current_account: 'personal',
@@ -61,8 +80,11 @@ afterEach(() => {
   clientGetChatMessagesSpy?.mockRestore()
   clientSendChatMessageSpy?.mockRestore()
   clientEditChatMessageSpy?.mockRestore()
+  clientSendChatImageSpy?.mockRestore()
+  clientDownloadChatImageSpy?.mockRestore()
   credManagerLoadSpy?.mockRestore()
   console.log = originalConsoleLog
+  rmSync('/tmp/test-teams-chat-download.png', { force: true })
 })
 
 it('list: returns array of chats', async () => {
@@ -107,6 +129,27 @@ it('send: returns sent message', async () => {
   expect(consoleSpy).toHaveBeenCalled()
   const output = consoleSpy.mock.calls[0][0]
   expect(output).toContain('Hello world')
+})
+
+it('send-image: sends an image to an exact chat', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+  await sendImageAction('48:notes', '/tmp/approval.png', { pretty: false })
+  expect(clientSendChatImageSpy).toHaveBeenCalledWith('48:notes', '/tmp/approval.png')
+  expect(consoleSpy.mock.calls[0][0]).toContain('0-weu-d1-image')
+})
+
+it('download-image: writes the verified image to the exact output path', async () => {
+  const consoleSpy = mock((_msg: string) => {})
+  console.log = consoleSpy
+  const outputPath = '/tmp/test-teams-chat-download.png'
+
+  await downloadImageAction('0-frca-d16-image', outputPath, { pretty: false })
+
+  expect(clientDownloadChatImageSpy).toHaveBeenCalledWith('0-frca-d16-image')
+  expect(existsSync(outputPath)).toBe(true)
+  expect(readFileSync(outputPath)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+  expect(consoleSpy.mock.calls[0][0]).toContain(outputPath)
 })
 
 it('edit: edits a chat message and returns updated content', async () => {

--- a/src/platforms/teams/commands/chat.test.ts
+++ b/src/platforms/teams/commands/chat.test.ts
@@ -3,15 +3,15 @@ import { existsSync, readFileSync, rmSync } from 'node:fs'
 
 import { TeamsClient } from '../client'
 import { TeamsCredentialManager } from '../credential-manager'
-import { downloadImageAction, editAction, historyAction, listAction, sendAction, sendImageAction } from './chat'
+import { chatCommand, downloadImageAction, editAction, historyAction, listAction, sendAction } from './chat'
 
 let clientListChatsSpy: ReturnType<typeof spyOn>
 let clientGetChatMessagesSpy: ReturnType<typeof spyOn>
 let clientSendChatMessageSpy: ReturnType<typeof spyOn>
 let clientEditChatMessageSpy: ReturnType<typeof spyOn>
-let clientSendChatImageSpy: ReturnType<typeof spyOn>
 let clientDownloadChatImageSpy: ReturnType<typeof spyOn>
 let credManagerLoadSpy: ReturnType<typeof spyOn>
+let processExitSpy: ReturnType<typeof spyOn>
 const originalConsoleLog = console.log
 
 beforeEach(() => {
@@ -45,15 +45,6 @@ beforeEach(() => {
     content: 'Edited content',
     timestamp: '2025-01-29T10:05:00Z',
   })
-  clientSendChatImageSpy = spyOn(TeamsClient.prototype, 'sendChatImage').mockResolvedValue({
-    id: '1704067200001',
-    channel_id: '48:notes',
-    author: { id: 'ME', displayName: 'Me' },
-    content: 'approval.png',
-    timestamp: '2025-01-29T10:01:00Z',
-    message_type: 'RichText/UriObject',
-    image_object_id: '0-weu-d1-image',
-  })
   clientDownloadChatImageSpy = spyOn(TeamsClient.prototype, 'downloadChatImage').mockResolvedValue({
     image_object_id: '0-frca-d16-image',
     content_type: 'image/png',
@@ -73,6 +64,9 @@ beforeEach(() => {
       },
     },
   })
+  processExitSpy = spyOn(process, 'exit').mockImplementation((code?: string | number | null): never => {
+    throw new Error(`process.exit:${code ?? 0}`)
+  })
 })
 
 afterEach(() => {
@@ -80,9 +74,9 @@ afterEach(() => {
   clientGetChatMessagesSpy?.mockRestore()
   clientSendChatMessageSpy?.mockRestore()
   clientEditChatMessageSpy?.mockRestore()
-  clientSendChatImageSpy?.mockRestore()
   clientDownloadChatImageSpy?.mockRestore()
   credManagerLoadSpy?.mockRestore()
+  processExitSpy?.mockRestore()
   console.log = originalConsoleLog
   rmSync('/tmp/test-teams-chat-download.png', { force: true })
 })
@@ -131,12 +125,8 @@ it('send: returns sent message', async () => {
   expect(output).toContain('Hello world')
 })
 
-it('send-image: sends an image to an exact chat', async () => {
-  const consoleSpy = mock((_msg: string) => {})
-  console.log = consoleSpy
-  await sendImageAction('48:notes', '/tmp/approval.png', { pretty: false })
-  expect(clientSendChatImageSpy).toHaveBeenCalledWith('48:notes', '/tmp/approval.png')
-  expect(consoleSpy.mock.calls[0][0]).toContain('0-weu-d1-image')
+it('does not register the out-of-scope send-image command', () => {
+  expect(chatCommand.commands.map((command) => command.name())).not.toContain('send-image')
 })
 
 it('download-image: writes the verified image to the exact output path', async () => {
@@ -150,6 +140,15 @@ it('download-image: writes the verified image to the exact output path', async (
   expect(existsSync(outputPath)).toBe(true)
   expect(readFileSync(outputPath)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
   expect(consoleSpy.mock.calls[0][0]).toContain(outputPath)
+})
+
+it('download-image: refuses to replace an existing output file', async () => {
+  const outputPath = '/tmp/test-teams-chat-download.png'
+  await Bun.write(outputPath, 'keep')
+
+  await expect(downloadImageAction('0-frca-d16-image', outputPath, { pretty: false })).rejects.toThrow('process.exit:1')
+
+  expect(readFileSync(outputPath, 'utf8')).toBe('keep')
 })
 
 it('edit: edits a chat message and returns updated content', async () => {

--- a/src/platforms/teams/commands/chat.ts
+++ b/src/platforms/teams/commands/chat.ts
@@ -1,3 +1,7 @@
+import { chmodSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { resolve } from 'node:path'
+
 import { Command } from 'commander'
 
 import { handleError } from '@/shared/utils/error-handler'
@@ -62,6 +66,8 @@ export async function historyAction(chatId: string, options: { limit?: number; p
       author: msg.author.displayName,
       content: msg.content,
       timestamp: msg.timestamp,
+      message_type: msg.message_type,
+      image_object_id: msg.image_object_id,
     }))
 
     console.log(formatOutput(output, options.pretty))
@@ -95,6 +101,81 @@ export async function sendAction(chatId: string, content: string, options: { pre
     }
 
     console.log(formatOutput(output, options.pretty))
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export async function sendImageAction(chatId: string, path: string, options: { pretty?: boolean }): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const message = await client.sendChatImage(chatId, resolve(path))
+    console.log(
+      formatOutput(
+        {
+          id: message.id,
+          timestamp: message.timestamp,
+          message_type: message.message_type,
+          image_object_id: message.image_object_id,
+        },
+        options.pretty,
+      ),
+    )
+  } catch (error) {
+    handleError(error as Error)
+  }
+}
+
+export async function downloadImageAction(
+  imageObjectId: string,
+  outputPath: string | undefined,
+  options: { pretty?: boolean },
+): Promise<void> {
+  try {
+    const credManager = new TeamsCredentialManager()
+    const cred = await credManager.getTokenWithExpiry()
+    if (!cred) {
+      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
+      process.exit(1)
+    }
+    const client = await new TeamsClient().login({
+      token: cred.token,
+      tokenExpiresAt: cred.tokenExpiresAt,
+      accountType: cred.accountType,
+      region: cred.region,
+    })
+    const image = await client.downloadChatImage(imageObjectId)
+    const defaultName = `${imageObjectId}.${image.extension}`
+    let destination = outputPath ? resolve(outputPath) : resolve(defaultName)
+    try {
+      if (statSync(destination).isDirectory()) destination = join(destination, defaultName)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+    writeFileSync(destination, image.buffer, { mode: 0o600 })
+    chmodSync(destination, 0o600)
+    console.log(
+      formatOutput(
+        {
+          image_object_id: image.image_object_id,
+          content_type: image.content_type,
+          size: image.size,
+          path: destination,
+        },
+        options.pretty,
+      ),
+    )
   } catch (error) {
     handleError(error as Error)
   }
@@ -137,6 +218,22 @@ export async function editAction(
 
 export const chatCommand = new Command('chat')
   .description('Chat commands (1:1, group, and self chats)')
+  .addCommand(
+    new Command('download-image')
+      .description('Download a PNG or JPEG image from a chat')
+      .argument('<image-object-id>', 'AMS image object ID')
+      .argument('[output-path]', 'Output file or directory path')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(downloadImageAction),
+  )
+  .addCommand(
+    new Command('send-image')
+      .description('Send a PNG or JPEG image to a chat')
+      .argument('<chat-id>', 'Chat ID')
+      .argument('<path>', 'Image path')
+      .option('--pretty', 'Pretty print JSON output')
+      .action(sendImageAction),
+  )
   .addCommand(
     new Command('list')
       .description('List 1:1, group, and self chats')

--- a/src/platforms/teams/commands/chat.ts
+++ b/src/platforms/teams/commands/chat.ts
@@ -1,4 +1,4 @@
-import { chmodSync, statSync, writeFileSync } from 'node:fs'
+import { statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { resolve } from 'node:path'
 
@@ -106,37 +106,6 @@ export async function sendAction(chatId: string, content: string, options: { pre
   }
 }
 
-export async function sendImageAction(chatId: string, path: string, options: { pretty?: boolean }): Promise<void> {
-  try {
-    const credManager = new TeamsCredentialManager()
-    const cred = await credManager.getTokenWithExpiry()
-    if (!cred) {
-      console.log(formatOutput({ error: 'Not authenticated. Run "auth extract" first.' }, options.pretty))
-      process.exit(1)
-    }
-    const client = await new TeamsClient().login({
-      token: cred.token,
-      tokenExpiresAt: cred.tokenExpiresAt,
-      accountType: cred.accountType,
-      region: cred.region,
-    })
-    const message = await client.sendChatImage(chatId, resolve(path))
-    console.log(
-      formatOutput(
-        {
-          id: message.id,
-          timestamp: message.timestamp,
-          message_type: message.message_type,
-          image_object_id: message.image_object_id,
-        },
-        options.pretty,
-      ),
-    )
-  } catch (error) {
-    handleError(error as Error)
-  }
-}
-
 export async function downloadImageAction(
   imageObjectId: string,
   outputPath: string | undefined,
@@ -163,8 +132,7 @@ export async function downloadImageAction(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     }
-    writeFileSync(destination, image.buffer, { mode: 0o600 })
-    chmodSync(destination, 0o600)
+    writeFileSync(destination, image.buffer, { flag: 'wx', mode: 0o600 })
     console.log(
       formatOutput(
         {
@@ -225,14 +193,6 @@ export const chatCommand = new Command('chat')
       .argument('[output-path]', 'Output file or directory path')
       .option('--pretty', 'Pretty print JSON output')
       .action(downloadImageAction),
-  )
-  .addCommand(
-    new Command('send-image')
-      .description('Send a PNG or JPEG image to a chat')
-      .argument('<chat-id>', 'Chat ID')
-      .argument('<path>', 'Image path')
-      .option('--pretty', 'Pretty print JSON output')
-      .action(sendImageAction),
   )
   .addCommand(
     new Command('list')

--- a/src/platforms/teams/ensure-auth.test.ts
+++ b/src/platforms/teams/ensure-auth.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, it } from 'bun:test'
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
 import { ensureTeamsAuth } from './ensure-auth'
-import { TeamsTokenExtractor } from './token-extractor'
+import { TeamsCachedKeyRejectedError, TeamsTokenExtractor } from './token-extractor'
 
 let loadConfigSpy: ReturnType<typeof spyOn>
 let extractSpy: ReturnType<typeof spyOn>
@@ -191,6 +191,15 @@ describe('ensureTeamsAuth', () => {
     // then
     expect(testAuthSpy).not.toHaveBeenCalled()
     expect(saveConfigSpy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a rejected application-supplied key for one bounded companion retry', async () => {
+    extractSpy.mockResolvedValue([])
+    const staleKeySpy = spyOn(TeamsTokenExtractor.prototype, 'didCachedKeyFail').mockReturnValue(true)
+
+    await expect(ensureTeamsAuth()).rejects.toBeInstanceOf(TeamsCachedKeyRejectedError)
+
+    staleKeySpy.mockRestore()
   })
 
   it('keeps an authenticated work account when team discovery is empty', async () => {

--- a/src/platforms/teams/ensure-auth.test.ts
+++ b/src/platforms/teams/ensure-auth.test.ts
@@ -124,6 +124,36 @@ describe('ensureTeamsAuth', () => {
     )
   })
 
+  it('re-extracts when Microsoft rejects an unexpired token', async () => {
+    loadConfigSpy.mockResolvedValue({
+      current_account: 'work',
+      accounts: {
+        work: {
+          token: 'rejected-token',
+          token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+          account_type: 'work',
+          current_team: 'team-1',
+          teams: { 'team-1': { team_id: 'team-1', team_name: 'Team One' } },
+        },
+      },
+    })
+    testAuthSpy
+      .mockRejectedValueOnce(new Error('Authentication failed'))
+      .mockResolvedValueOnce({ id: 'user-123', displayName: 'Test User' })
+
+    await ensureTeamsAuth()
+
+    expect(extractSpy).toHaveBeenCalled()
+    expect(saveConfigSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        current_account: 'work',
+        accounts: expect.objectContaining({
+          work: expect.objectContaining({ token: 'test-teams-token' }),
+        }),
+      }),
+    )
+  })
+
   it('sets first team as current', async () => {
     // when
     await ensureTeamsAuth()
@@ -163,7 +193,7 @@ describe('ensureTeamsAuth', () => {
     expect(saveConfigSpy).not.toHaveBeenCalled()
   })
 
-  it('does not save when no teams found', async () => {
+  it('keeps an authenticated work account when team discovery is empty', async () => {
     // given
     listTeamsSpy.mockResolvedValue([])
 
@@ -171,7 +201,13 @@ describe('ensureTeamsAuth', () => {
     await ensureTeamsAuth()
 
     // then
-    expect(saveConfigSpy).not.toHaveBeenCalled()
+    expect(saveConfigSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accounts: expect.objectContaining({
+          work: expect.objectContaining({ token: 'test-teams-token', current_team: null, teams: {} }),
+        }),
+      }),
+    )
   })
 
   it('silently handles extraction failure', async () => {

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -3,7 +3,7 @@ import { warn } from '@/shared/utils/stderr'
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
 import { refreshDeviceCodeAccount } from './device-login'
-import { TeamsTokenExtractor, resolveTeamsTokenSource } from './token-extractor'
+import { TeamsCachedKeyRejectedError, TeamsTokenExtractor, resolveTeamsTokenSource } from './token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from './types'
 
 export async function ensureTeamsAuth(): Promise<void> {
@@ -18,7 +18,10 @@ export async function ensureTeamsAuth(): Promise<void> {
     const tokenSource = resolveTeamsTokenSource(process.env.AGENT_TEAMS_AUTH_SOURCE)
     const extractor = new TeamsTokenExtractor(undefined, undefined, undefined, undefined, tokenSource)
     const extracted = await extractor.extract()
-    if (extracted.length === 0) return
+    if (extracted.length === 0) {
+      if (extractor.didCachedKeyFail()) throw new TeamsCachedKeyRejectedError()
+      return
+    }
 
     const invalidAccountKey = config ? resolveSelectedAccountKey(config) : null
     const newConfig: TeamsConfig = {
@@ -71,7 +74,9 @@ export async function ensureTeamsAuth(): Promise<void> {
     if (Object.keys(newConfig.accounts).length > 0) {
       await credManager.saveConfig(newConfig)
     }
-  } catch {}
+  } catch (error) {
+    if (error instanceof TeamsCachedKeyRejectedError) throw error
+  }
 }
 
 async function resolveAccountType(

--- a/src/platforms/teams/ensure-auth.ts
+++ b/src/platforms/teams/ensure-auth.ts
@@ -3,7 +3,7 @@ import { warn } from '@/shared/utils/stderr'
 import { TeamsClient } from './client'
 import { TeamsCredentialManager } from './credential-manager'
 import { refreshDeviceCodeAccount } from './device-login'
-import { TeamsTokenExtractor } from './token-extractor'
+import { TeamsTokenExtractor, resolveTeamsTokenSource } from './token-extractor'
 import type { TeamsAccount, TeamsAccountType, TeamsConfig } from './types'
 
 export async function ensureTeamsAuth(): Promise<void> {
@@ -11,17 +11,22 @@ export async function ensureTeamsAuth(): Promise<void> {
     const credManager = new TeamsCredentialManager()
     const config = await credManager.loadConfig()
 
-    if (config && hasValidToken(config)) return
+    if (config && (await hasUsableToken(config, credManager))) return
 
     if (config && (await trySilentRefresh(config, credManager))) return
 
-    const extractor = new TeamsTokenExtractor()
+    const tokenSource = resolveTeamsTokenSource(process.env.AGENT_TEAMS_AUTH_SOURCE)
+    const extractor = new TeamsTokenExtractor(undefined, undefined, undefined, undefined, tokenSource)
     const extracted = await extractor.extract()
     if (extracted.length === 0) return
 
+    const invalidAccountKey = config ? resolveSelectedAccountKey(config) : null
     const newConfig: TeamsConfig = {
       current_account: config?.current_account ?? null,
       accounts: { ...config?.accounts },
+    }
+    if (invalidAccountKey) {
+      delete newConfig.accounts[invalidAccountKey]
     }
     const addedTypes = new Set<TeamsAccountType>()
 
@@ -33,8 +38,6 @@ export async function ensureTeamsAuth(): Promise<void> {
         if (addedTypes.has(accountType)) continue
 
         const teams = await client.listTeams()
-        if (accountType !== 'personal' && teams.length === 0) continue
-
         const teamMap: Record<string, { team_id: string; team_name: string }> = {}
         for (const team of teams) {
           teamMap[team.id] = { team_id: team.id, team_name: team.name }
@@ -59,6 +62,10 @@ export async function ensureTeamsAuth(): Promise<void> {
       } catch (error) {
         warn(`[agent-teams] Skipping ${extractedType} account: ${(error as Error).message}`)
       }
+    }
+
+    if (newConfig.current_account && !newConfig.accounts[newConfig.current_account]) {
+      newConfig.current_account = (Object.keys(newConfig.accounts)[0] as TeamsAccountType | undefined) ?? null
     }
 
     if (Object.keys(newConfig.accounts).length > 0) {
@@ -96,17 +103,34 @@ async function resolveAccountType(
 }
 
 async function trySilentRefresh(config: TeamsConfig, credManager: TeamsCredentialManager): Promise<boolean> {
-  const key = TeamsCredentialManager.accountOverride ?? config.current_account
+  const key = resolveSelectedAccountKey(config)
   if (!key) return false
   const account = config.accounts[key]
   if (account?.auth_method !== 'device-code' || !account.aad_refresh_token) return false
-  return refreshDeviceCodeAccount(key as TeamsAccountType, credManager)
+  return refreshDeviceCodeAccount(key, credManager)
 }
 
-function hasValidToken(config: TeamsConfig): boolean {
-  const key = TeamsCredentialManager.accountOverride ?? config.current_account
+function resolveSelectedAccountKey(config: TeamsConfig): TeamsAccountType | null {
+  return (TeamsCredentialManager.accountOverride ?? config.current_account) as TeamsAccountType | null
+}
+
+async function hasUsableToken(config: TeamsConfig, credManager: TeamsCredentialManager): Promise<boolean> {
+  const key = resolveSelectedAccountKey(config)
   if (!key) return false
   const account = config.accounts[key]
   if (!account?.token || !account.token_expires_at) return false
-  return new Date(account.token_expires_at).getTime() > Date.now()
+  if (new Date(account.token_expires_at).getTime() <= Date.now()) return false
+
+  try {
+    const client = await new TeamsClient(credManager).login({
+      token: account.token,
+      tokenExpiresAt: account.token_expires_at,
+      accountType: account.account_type,
+      region: account.region,
+    })
+    await client.testAuth()
+    return true
+  } catch {
+    return false
+  }
 }

--- a/src/platforms/teams/operator-boundary.test.ts
+++ b/src/platforms/teams/operator-boundary.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test'
+
+import { assertTeamsOperatorBoundary, TEAMS_COMPANION_REQUIRED } from './operator-boundary'
+
+describe('Teams macOS operator boundary', () => {
+  it('rejects the raw macOS CLI', () => {
+    expect(() => assertTeamsOperatorBoundary('darwin', undefined)).toThrow(TEAMS_COMPANION_REQUIRED)
+  })
+
+  it('accepts the signed companion child', () => {
+    expect(() => assertTeamsOperatorBoundary('darwin', '1')).not.toThrow()
+  })
+
+  it('leaves the upstream Windows lane unchanged', () => {
+    expect(() => assertTeamsOperatorBoundary('win32', undefined)).not.toThrow()
+  })
+})

--- a/src/platforms/teams/operator-boundary.ts
+++ b/src/platforms/teams/operator-boundary.ts
@@ -1,0 +1,11 @@
+export const TEAMS_COMPANION_REQUIRED =
+  'On macOS, Teams operations must use the signed Agent Messenger Teams Bridge dispatcher.'
+
+export function assertTeamsOperatorBoundary(
+  platform: NodeJS.Platform = process.platform,
+  companionMediated = process.env.AGENT_TEAMS_COMPANION_MEDIATED,
+): void {
+  if (platform === 'darwin' && companionMediated !== '1') {
+    throw new Error(TEAMS_COMPANION_REQUIRED)
+  }
+}

--- a/src/platforms/teams/token-extractor.test.ts
+++ b/src/platforms/teams/token-extractor.test.ts
@@ -224,6 +224,18 @@ describe('TeamsTokenExtractor', () => {
       expect(desktopOnly.getTeamsCookiesPaths()).toEqual(desktopOnly.getDesktopCookiesPaths())
       expect(desktopOnly.getTeamsCookiesPaths().some((entry) => entry.path.includes('Google/Chrome'))).toBe(false)
     })
+
+    it('can read a companion-staged Teams desktop profile instead of the protected app container', () => {
+      const stagedRoot = join(tmpdir(), 'teams-bridge-stage')
+      const staged = new TeamsTokenExtractor('darwin', undefined, undefined, undefined, 'desktop', stagedRoot)
+
+      expect(staged.getDesktopCookiesPaths()).toContainEqual({
+        path: join(stagedRoot, 'WV2Profile_tfw', 'Network', 'Cookies'),
+        accountType: 'work',
+        accountTypeKnown: true,
+      })
+      expect(staged.getLocalStatePath()).toBe(join(stagedRoot, 'Local State'))
+    })
   })
 
   describe('getLocalStatePath', () => {

--- a/src/platforms/teams/token-extractor.test.ts
+++ b/src/platforms/teams/token-extractor.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { TeamsTokenExtractor } from './token-extractor'
+import { TeamsTokenExtractor, resolveTeamsTokenSource } from './token-extractor'
 
 describe('TeamsTokenExtractor', () => {
   let extractor: TeamsTokenExtractor
@@ -217,6 +217,13 @@ describe('TeamsTokenExtractor', () => {
 
       expect(paths).toEqual([])
     })
+
+    it('returns only official Teams desktop paths in desktop mode', () => {
+      const desktopOnly = new TeamsTokenExtractor('darwin', undefined, undefined, undefined, 'desktop')
+
+      expect(desktopOnly.getTeamsCookiesPaths()).toEqual(desktopOnly.getDesktopCookiesPaths())
+      expect(desktopOnly.getTeamsCookiesPaths().some((entry) => entry.path.includes('Google/Chrome'))).toBe(false)
+    })
   })
 
   describe('getLocalStatePath', () => {
@@ -276,6 +283,26 @@ describe('TeamsTokenExtractor', () => {
       const teamsIdx = variants.findIndex((v) => v.service === 'Microsoft Teams Safe Storage')
       const chromeIdx = variants.findIndex((v) => v.service === 'Chrome Safe Storage')
       expect(teamsIdx).toBeLessThan(chromeIdx)
+    })
+
+    it('uses only Teams Keychain entries in desktop mode', () => {
+      const desktopOnly = new TeamsTokenExtractor('darwin', undefined, undefined, undefined, 'desktop')
+      const variants = desktopOnly.getKeychainVariants()
+
+      expect(variants).toContainEqual({ service: 'Microsoft Teams Safe Storage', account: 'Microsoft Teams' })
+      expect(variants.some((variant) => variant.service.includes('Chrome'))).toBe(false)
+      expect(variants.some((variant) => variant.service.includes('Edge'))).toBe(false)
+    })
+  })
+
+  describe('resolveTeamsTokenSource', () => {
+    it('defaults to all and accepts desktop', () => {
+      expect(resolveTeamsTokenSource()).toBe('all')
+      expect(resolveTeamsTokenSource('desktop')).toBe('desktop')
+    })
+
+    it('rejects unknown sources', () => {
+      expect(() => resolveTeamsTokenSource('browser')).toThrow('Invalid Teams token source')
     })
   })
 

--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -30,6 +30,15 @@ export interface ExtractedTeamsToken {
 
 export type TeamsTokenSource = 'all' | 'desktop'
 
+export const TEAMS_CACHED_KEY_REJECTED = 'AGENT_TEAMS_CACHED_KEY_REJECTED'
+
+export class TeamsCachedKeyRejectedError extends Error {
+  constructor() {
+    super(`${TEAMS_CACHED_KEY_REJECTED}: the cached Teams desktop decryption key no longer matches`)
+    this.name = 'TeamsCachedKeyRejectedError'
+  }
+}
+
 export function resolveTeamsTokenSource(value?: string): TeamsTokenSource {
   if (!value || value === 'all') return 'all'
   if (value === 'desktop') return 'desktop'
@@ -79,6 +88,7 @@ export class TeamsTokenExtractor {
   private debugLog: ((message: string) => void) | null
   private customBrowserProfileDirs: string[]
   private tokenSource: TeamsTokenSource
+  private desktopProfileRoot: string | null
 
   constructor(
     platform?: NodeJS.Platform,
@@ -86,17 +96,23 @@ export class TeamsTokenExtractor {
     debugLog?: (message: string) => void,
     customBrowserProfileDirs?: string[],
     tokenSource: TeamsTokenSource = 'all',
+    desktopProfileRoot?: string,
   ) {
     this.platform = platform ?? process.platform
     this.debugLog = debugLog ?? null
     this.customBrowserProfileDirs = customBrowserProfileDirs ?? []
     this.tokenSource = tokenSource
+    this.desktopProfileRoot = desktopProfileRoot ?? process.env.AGENT_TEAMS_DESKTOP_PROFILE_ROOT ?? null
 
     const resolvedKeyCache = keyCache ?? new DerivedKeyCache()
     this.decryptor = new ChromiumCookieDecryptor({
       platform: this.platform,
       appKeychainVariants: TEAMS_KEYCHAIN_VARIANTS,
       includeBrowserKeychainVariants: tokenSource !== 'desktop',
+      // macOS Teams credentials are application-mediated in this fork. The
+      // signed companion supplies a derived key; the library never shells out
+      // to `security`, even if somebody bypasses the guarded dispatcher.
+      allowKeychainLookup: this.platform !== 'darwin' && process.env.AGENT_TEAMS_DISABLE_KEYCHAIN_LOOKUP !== '1',
       keyCache: resolvedKeyCache,
       keyCachePlatform: 'teams',
     })
@@ -110,18 +126,20 @@ export class TeamsTokenExtractor {
   getDesktopCookiesPaths(): TeamsCookiePath[] {
     switch (this.platform) {
       case 'darwin': {
-        const ebWebViewBase = join(
-          homedir(),
-          'Library',
-          'Containers',
-          'com.microsoft.teams2',
-          'Data',
-          'Library',
-          'Application Support',
-          'Microsoft',
-          'MSTeams',
-          'EBWebView',
-        )
+        const ebWebViewBase =
+          this.desktopProfileRoot ??
+          join(
+            homedir(),
+            'Library',
+            'Containers',
+            'com.microsoft.teams2',
+            'Data',
+            'Library',
+            'Application Support',
+            'Microsoft',
+            'MSTeams',
+            'EBWebView',
+          )
         return [
           { path: join(ebWebViewBase, 'WV2Profile_tfw', 'Cookies'), accountType: 'work', accountTypeKnown: true },
           {
@@ -224,7 +242,9 @@ export class TeamsTokenExtractor {
   getLocalStatePath(): string {
     switch (this.platform) {
       case 'darwin':
-        return join(homedir(), 'Library', 'Application Support', 'Microsoft', 'Teams', 'Local State')
+        return this.desktopProfileRoot
+          ? join(this.desktopProfileRoot, 'Local State')
+          : join(homedir(), 'Library', 'Application Support', 'Microsoft', 'Teams', 'Local State')
       case 'linux':
         return join(homedir(), '.config', 'Microsoft', 'Microsoft Teams', 'Local State')
       case 'win32': {
@@ -339,6 +359,10 @@ export class TeamsTokenExtractor {
 
   async clearKeyCache(): Promise<void> {
     await this.decryptor.clearKeyCache()
+  }
+
+  didCachedKeyFail(): boolean {
+    return this.decryptor.didCachedKeyFail()
   }
 
   private async extractFromCookiesDB(): Promise<ExtractedTeamsToken[]> {

--- a/src/platforms/teams/token-extractor.ts
+++ b/src/platforms/teams/token-extractor.ts
@@ -28,6 +28,14 @@ export interface ExtractedTeamsToken {
   accountTypeKnown: boolean
 }
 
+export type TeamsTokenSource = 'all' | 'desktop'
+
+export function resolveTeamsTokenSource(value?: string): TeamsTokenSource {
+  if (!value || value === 'all') return 'all'
+  if (value === 'desktop') return 'desktop'
+  throw new Error(`Invalid Teams token source: ${value}. Use "all" or "desktop".`)
+}
+
 interface TeamsCookiePath {
   path: string
   accountType: TeamsAccountType
@@ -70,21 +78,25 @@ export class TeamsTokenExtractor {
   private cookieReader: ChromiumCookieReader
   private debugLog: ((message: string) => void) | null
   private customBrowserProfileDirs: string[]
+  private tokenSource: TeamsTokenSource
 
   constructor(
     platform?: NodeJS.Platform,
     keyCache?: DerivedKeyCache,
     debugLog?: (message: string) => void,
     customBrowserProfileDirs?: string[],
+    tokenSource: TeamsTokenSource = 'all',
   ) {
     this.platform = platform ?? process.platform
     this.debugLog = debugLog ?? null
     this.customBrowserProfileDirs = customBrowserProfileDirs ?? []
+    this.tokenSource = tokenSource
 
     const resolvedKeyCache = keyCache ?? new DerivedKeyCache()
     this.decryptor = new ChromiumCookieDecryptor({
       platform: this.platform,
       appKeychainVariants: TEAMS_KEYCHAIN_VARIANTS,
+      includeBrowserKeychainVariants: tokenSource !== 'desktop',
       keyCache: resolvedKeyCache,
       keyCachePlatform: 'teams',
     })
@@ -205,7 +217,8 @@ export class TeamsTokenExtractor {
   }
 
   getTeamsCookiesPaths(): TeamsCookiePath[] {
-    return [...this.getDesktopCookiesPaths(), ...this.getBrowserCookiesPaths()]
+    const desktopPaths = this.getDesktopCookiesPaths()
+    return this.tokenSource === 'desktop' ? desktopPaths : [...desktopPaths, ...this.getBrowserCookiesPaths()]
   }
 
   getLocalStatePath(): string {
@@ -236,7 +249,9 @@ export class TeamsTokenExtractor {
   }
 
   getKeychainVariants(): KeychainVariant[] {
-    return [...TEAMS_KEYCHAIN_VARIANTS, ...BROWSER_KEYCHAIN_VARIANTS]
+    return this.tokenSource === 'desktop'
+      ? [...TEAMS_KEYCHAIN_VARIANTS]
+      : [...TEAMS_KEYCHAIN_VARIANTS, ...BROWSER_KEYCHAIN_VARIANTS]
   }
 
   isValidSkypeToken(token: string): boolean {
@@ -264,7 +279,8 @@ export class TeamsTokenExtractor {
     const desktopPaths = this.getDesktopCookiesPaths().filter(
       (p) => accountType === undefined || !p.accountTypeKnown || p.accountType === accountType,
     )
-    const candidatePaths = [...desktopPaths, ...this.getBrowserCookiesPaths()]
+    const candidatePaths =
+      this.tokenSource === 'desktop' ? desktopPaths : [...desktopPaths, ...this.getBrowserCookiesPaths()]
 
     for (const { path: dbPath } of candidatePaths) {
       if (!dbPath || !existsSync(dbPath)) continue

--- a/src/platforms/teams/types.ts
+++ b/src/platforms/teams/types.ts
@@ -29,6 +29,16 @@ export interface TeamsMessage {
   root_message_id?: string
   parent_message_id?: string
   is_thread_reply?: boolean
+  message_type?: string
+  image_object_id?: string
+}
+
+export interface TeamsChatImageDownload {
+  image_object_id: string
+  content_type: 'image/jpeg' | 'image/png'
+  extension: 'jpg' | 'png'
+  size: number
+  buffer: Buffer
 }
 
 export interface TeamsSearchResult {
@@ -154,6 +164,8 @@ export const TeamsMessageSchema = z.object({
   root_message_id: z.string().optional(),
   parent_message_id: z.string().optional(),
   is_thread_reply: z.boolean().optional(),
+  message_type: z.string().optional(),
+  image_object_id: z.string().optional(),
 })
 
 export const TeamsSearchResultSchema = z.object({

--- a/src/shared/chromium/cookie-reader.test.ts
+++ b/src/shared/chromium/cookie-reader.test.ts
@@ -31,6 +31,27 @@ describe('ChromiumCookieReader', () => {
   })
 
   describe('queryAll', () => {
+    it('reads rows that exist only in an active WAL snapshot', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'chromium-cookie-reader-'))
+      tempDirs.push(tempDir)
+      const dbPath = join(tempDir, 'Cookies')
+      const db = new Database(dbPath)
+      db.run('PRAGMA journal_mode=WAL')
+      db.run('PRAGMA wal_autocheckpoint=0')
+      db.run('CREATE TABLE cookies (name TEXT, value TEXT, encrypted_value BLOB)')
+      db.run("INSERT INTO cookies VALUES ('wal-session', 'fresh', NULL)")
+
+      try {
+        const result = await new ChromiumCookieReader().queryAll<{ name: string; value: string }>(
+          dbPath,
+          'SELECT name, value FROM cookies',
+        )
+        expect(result).toEqual([{ name: 'wal-session', value: 'fresh' }])
+      } finally {
+        db.close()
+      }
+    })
+
     it('returns all matching rows from a real SQLite database', async () => {
       // given
       const tempDir = mkdtempSync(join(tmpdir(), 'chromium-cookie-reader-'))

--- a/src/shared/chromium/cookie-reader.ts
+++ b/src/shared/chromium/cookie-reader.ts
@@ -19,7 +19,7 @@ export class ChromiumCookieReader {
     const tempPath = this.createTempPath()
 
     try {
-      copyFileSync(dbPath, tempPath)
+      this.copySnapshot(dbPath, tempPath)
     } catch {
       return []
     }
@@ -43,7 +43,7 @@ export class ChromiumCookieReader {
     const tempPath = this.createTempPath()
 
     try {
-      copyFileSync(dbPath, tempPath)
+      this.copySnapshot(dbPath, tempPath)
     } catch {
       return null
     }
@@ -59,6 +59,14 @@ export class ChromiumCookieReader {
 
   private createTempPath(): string {
     return join(tmpdir(), `chromium-cookies-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+  }
+
+  private copySnapshot(sourcePath: string, destinationPath: string): void {
+    copyFileSync(sourcePath, destinationPath)
+    for (const suffix of ['-wal', '-shm']) {
+      const sourceSidecar = `${sourcePath}${suffix}`
+      if (existsSync(sourceSidecar)) copyFileSync(sourceSidecar, `${destinationPath}${suffix}`)
+    }
   }
 
   private executeQuery<T>(tempPath: string, sql: string, params: unknown[] | undefined, mode: 'all'): T[]
@@ -87,6 +95,8 @@ export class ChromiumCookieReader {
   private cleanupTemp(tempPath: string): void {
     try {
       rmSync(tempPath, { force: true })
+      rmSync(`${tempPath}-wal`, { force: true })
+      rmSync(`${tempPath}-shm`, { force: true })
     } catch {
       // Temp file cleanup failure is non-critical
     }

--- a/src/shared/chromium/decryptor.test.ts
+++ b/src/shared/chromium/decryptor.test.ts
@@ -58,6 +58,47 @@ describe('ChromiumCookieDecryptor', () => {
 
       expect((decryptor as any).keychainVariants).toEqual(appVariants)
     })
+
+    it('can forbid direct Keychain reads for an application-mediated caller', () => {
+      const decryptor = new ChromiumCookieDecryptor({
+        platform: 'darwin',
+        appKeychainVariants: [{ service: 'App Safe Storage', account: 'App' }],
+        allowKeychainLookup: false,
+      })
+      const keychainLookup = spyOn(decryptor as any, 'execKeychainLookup')
+
+      expect(decryptor.decryptMacCookieRaw(Buffer.from('v10-encrypted-value'))).toBeNull()
+      expect(keychainLookup).not.toHaveBeenCalled()
+    })
+
+    it('reports a cached key that fails every attempted decryption', async () => {
+      const wrongKey = pbkdf2Sync('wrong-password', 'saltysalt', 1003, 16, 'sha1')
+      const decryptor = new ChromiumCookieDecryptor({
+        platform: 'darwin',
+        allowKeychainLookup: false,
+        keyCache: { get: async () => wrongKey } as any,
+        keyCachePlatform: 'teams',
+      })
+      const encrypted = encryptAESCBC('test-value', pbkdf2Sync('correct-password', 'saltysalt', 1003, 16, 'sha1'))
+
+      await decryptor.loadCachedKey()
+      expect(decryptor.decryptMacCookieRaw(encrypted)).toBeNull()
+      expect(decryptor.didCachedKeyFail()).toBe(true)
+    })
+
+    it('does not reject a cached key after a successful decryption', async () => {
+      const key = pbkdf2Sync('correct-password', 'saltysalt', 1003, 16, 'sha1')
+      const decryptor = new ChromiumCookieDecryptor({
+        platform: 'darwin',
+        allowKeychainLookup: false,
+        keyCache: { get: async () => key } as any,
+        keyCachePlatform: 'teams',
+      })
+
+      await decryptor.loadCachedKey()
+      expect(decryptor.decryptMacCookieRaw(encryptAESCBC('test-value', key))?.toString()).toBe('test-value')
+      expect(decryptor.didCachedKeyFail()).toBe(false)
+    })
   })
 
   describe('isEncryptedValue', () => {

--- a/src/shared/chromium/decryptor.test.ts
+++ b/src/shared/chromium/decryptor.test.ts
@@ -47,6 +47,17 @@ describe('ChromiumCookieDecryptor', () => {
       // then
       expect((decryptor as any).keychainVariants).toEqual(BROWSER_KEYCHAIN_VARIANTS)
     })
+
+    it('can disable browser variants for an app-owned profile', () => {
+      const appVariants = [{ service: 'App Safe Storage', account: 'App' }]
+      const decryptor = new ChromiumCookieDecryptor({
+        platform: 'darwin',
+        appKeychainVariants: appVariants,
+        includeBrowserKeychainVariants: false,
+      })
+
+      expect((decryptor as any).keychainVariants).toEqual(appVariants)
+    })
   })
 
   describe('isEncryptedValue', () => {
@@ -437,6 +448,29 @@ describe('ChromiumCookieDecryptor', () => {
   })
 
   describe('loadCachedKey / clearKeyCache', () => {
+    it('uses a persisted macOS key without attempting another Keychain lookup', async () => {
+      // given
+      const key = Buffer.from('0123456789abcdef')
+      const keyCache = { get: async () => key, clear: async () => {} }
+      const decryptor = new ChromiumCookieDecryptor({
+        platform: 'darwin',
+        appKeychainVariants: [{ service: 'Microsoft Teams Safe Storage', account: 'Microsoft Teams' }],
+        includeBrowserKeychainVariants: false,
+        keyCache: keyCache as any,
+        keyCachePlatform: 'teams',
+      })
+      const keychainLookup = spyOn(decryptor as any, 'execKeychainLookup')
+      const encrypted = encryptAESCBC('desktop-session', key, 'v10')
+      await decryptor.loadCachedKey()
+
+      // when
+      const result = decryptor.decryptMacCookieRaw(encrypted)
+
+      // then
+      expect(result?.toString('utf8')).toBe('desktop-session')
+      expect(keychainLookup).not.toHaveBeenCalled()
+    })
+
     it('loadCachedKey is no-op on non-darwin platform', async () => {
       // given
       const keyCache = {

--- a/src/shared/chromium/decryptor.ts
+++ b/src/shared/chromium/decryptor.ts
@@ -12,6 +12,8 @@ export interface ChromiumDecryptorOptions {
   platform: NodeJS.Platform
   /** App-specific keychain entries, prepended before browser variants */
   appKeychainVariants?: KeychainVariant[]
+  /** Disable browser Keychain fallbacks when the caller only reads an app-owned profile. */
+  includeBrowserKeychainVariants?: boolean
   /** Optional key cache for avoiding repeated macOS Keychain prompts */
   keyCache?: DerivedKeyCache
   /** Platform identifier for key cache (e.g. 'slack', 'discord') */
@@ -32,7 +34,8 @@ export class ChromiumCookieDecryptor {
   constructor(options: ChromiumDecryptorOptions) {
     this.platform = options.platform
     // App-specific variants come first, browser variants as fallback
-    this.keychainVariants = [...(options.appKeychainVariants ?? []), ...BROWSER_KEYCHAIN_VARIANTS]
+    const browserVariants = options.includeBrowserKeychainVariants === false ? [] : BROWSER_KEYCHAIN_VARIANTS
+    this.keychainVariants = [...(options.appKeychainVariants ?? []), ...browserVariants]
     this.keyCache = options.keyCache ?? null
     this.keyCachePlatform = options.keyCachePlatform ?? null
     this.linuxKeyringAppNames = options.linuxKeyringAppNames ?? []

--- a/src/shared/chromium/decryptor.ts
+++ b/src/shared/chromium/decryptor.ts
@@ -14,6 +14,8 @@ export interface ChromiumDecryptorOptions {
   appKeychainVariants?: KeychainVariant[]
   /** Disable browser Keychain fallbacks when the caller only reads an app-owned profile. */
   includeBrowserKeychainVariants?: boolean
+  /** Disable direct Keychain reads when an owning companion has supplied the derived key. */
+  allowKeychainLookup?: boolean
   /** Optional key cache for avoiding repeated macOS Keychain prompts */
   keyCache?: DerivedKeyCache
   /** Platform identifier for key cache (e.g. 'slack', 'discord') */
@@ -28,8 +30,11 @@ export class ChromiumCookieDecryptor {
   private keyCache: DerivedKeyCache | null
   private keyCachePlatform: Platform | null
   private linuxKeyringAppNames: string[]
+  private allowKeychainLookup: boolean
   private cachedKey: Buffer | null = null
   private usedCachedKey = false
+  private cachedKeyDecryptAttempts = 0
+  private cachedKeyDecryptSuccesses = 0
 
   constructor(options: ChromiumDecryptorOptions) {
     this.platform = options.platform
@@ -39,6 +44,7 @@ export class ChromiumCookieDecryptor {
     this.keyCache = options.keyCache ?? null
     this.keyCachePlatform = options.keyCachePlatform ?? null
     this.linuxKeyringAppNames = options.linuxKeyringAppNames ?? []
+    this.allowKeychainLookup = options.allowKeychainLookup ?? true
   }
 
   isEncryptedValue(value: Buffer): boolean {
@@ -62,6 +68,12 @@ export class ChromiumCookieDecryptor {
     }
     this.cachedKey = null
     this.usedCachedKey = false
+    this.cachedKeyDecryptAttempts = 0
+    this.cachedKeyDecryptSuccesses = 0
+  }
+
+  didCachedKeyFail(): boolean {
+    return this.usedCachedKey && this.cachedKeyDecryptAttempts > 0 && this.cachedKeyDecryptSuccesses === 0
   }
 
   decryptCookie(encryptedValue: Buffer, localStatePath?: string): string | null {
@@ -88,9 +100,15 @@ export class ChromiumCookieDecryptor {
 
   decryptMacCookieRaw(encryptedData: Buffer): Buffer | null {
     if (this.cachedKey) {
+      this.cachedKeyDecryptAttempts += 1
       const decrypted = this.decryptAESCBCRaw(encryptedData, this.cachedKey)
-      if (decrypted) return decrypted
+      if (decrypted) {
+        this.cachedKeyDecryptSuccesses += 1
+        return decrypted
+      }
     }
+
+    if (!this.allowKeychainLookup) return null
 
     for (const variant of this.keychainVariants) {
       const password = this.execKeychainLookup(variant.service, variant.account)


### PR DESCRIPTION
## Summary
- use the official Teams desktop sessions through a signed, sandboxed macOS companion
- add guarded `chat download-image` support for approved Skype image-view hosts
- stage downloads to private output files without replacing existing paths
- keep chat image sending outside the released command surface

## Verification
- `bun run test` (3,720 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `bun run build:teams-bridge:macos` (bridge and client self-tests passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a signed, sandboxed macOS companion for Teams operations and introduces guarded `chat download-image` for approved Skype image hosts. Previously, the CLI accessed Teams desktop data directly and had no safe image download path; now macOS calls run through the bridge, and image downloads are staged to private files with bounds checks and format validation.

**Review focus**
- macOS bridge: new native app (`native/macos/teams-bridge/*`) and XPC client enforce a sandboxed operator boundary; `src/platforms/teams/cli.ts` exits on macOS without mediation, and `scripts/*teams-bridge-macos.sh` handle build/install and the `agent-teams` dispatcher.
- Guarded image downloads: `TeamsClient` adds AMS image fetch, validates object IDs, size (≤20MB) and pixels (≤40M), decodes via `jpeg-js`, and avoids overwrites; `chat download-image` is added, while image sending remains out of the command surface.
- Auth changes: token extraction can be restricted to desktop via `resolveTeamsTokenSource` (`--source desktop` or `AGENT_TEAMS_AUTH_SOURCE=desktop`), and `ensure-auth` re-extracts when the cached desktop key is rejected.
- Shared modules: Chromium cookie reader now snapshots WAL/SHM for reliable reads; decryptor can disable browser Keychain variants and direct Keychain lookup when mediated by the companion; tests updated accordingly.

**Rollout and migration**
- macOS required: install and use the bridge. Run `bun run install:teams-bridge:macos`, then invoke Teams via `agent-teams` (or `agent-teams-bridge-client`). Direct macOS CLI execution will fail the operator boundary check.
- Windows and CI: no change.
- Optional: set `AGENT_TEAMS_AUTH_SOURCE=desktop` (or pass `--source desktop`) to force desktop-only token extraction.
- Docs: SKILL.md and docs were not updated; add macOS bridge and `chat download-image` notes in follow-up.

<sup>Written for commit 148b9c7db9e920581b4d5ae998cf6b59ccd30158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agent-messenger/agent-messenger/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

